### PR TITLE
add request-light to lsp-core dependency

### DIFF
--- a/core/aws-lsp-core/package.json
+++ b/core/aws-lsp-core/package.json
@@ -13,7 +13,7 @@
         "vscode-languageserver-textdocument": "^1.0.8",
         "vscode-languageserver-types": "^3.17.3",
         "vscode-uri": "^3.0.7",
-        "yaml-language-server": "^1.13.0"
+        "request-light": "^0.5.7"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,10 +121,10 @@
             "version": "0.0.1",
             "dependencies": {
                 "jose": "^4.14.4",
+                "request-light": "^0.5.7",
                 "vscode-languageserver-textdocument": "^1.0.8",
                 "vscode-languageserver-types": "^3.17.3",
-                "vscode-uri": "^3.0.7",
-                "yaml-language-server": "^1.13.0"
+                "vscode-uri": "^3.0.7"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",


### PR DESCRIPTION
## Problem
`aws-lsp-core/src/http` is missing a dependency that is installed from another package.

## Solution
Added `request-light` to the `aws-lsp-core` package.json.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
