### PR TITLE
CodeWhisperer language detection

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -4,6 +4,7 @@ import { InlineCompletionList } from '@aws-placeholder/aws-language-server-runti
 import { Server } from '@aws-placeholder/aws-language-server-runtimes/out/runtimes'
 import { CancellationToken } from 'vscode-languageserver'
 import { CodeWhispererServiceBase, CodeWhispererServiceIAM, CodeWhispererServiceToken } from './codeWhispererService'
+import { getSupportedLanguageId } from './languageDetection'
 
 export const CodewhispererServerFactory = (service: (auth: Auth) => CodeWhispererServiceBase): Server =>
     ({ auth, lsp, workspace, logging }) => {
@@ -18,13 +19,14 @@ export const CodewhispererServerFactory = (service: (auth: Auth) => CodeWhispere
             }
 
             const textDocument = await workspace.getTextDocument(params.textDocument.uri)
-            // todo determine file type and check if supported
-            if (textDocument) {
+            const languageId = getSupportedLanguageId(textDocument)
+            if (textDocument && languageId) {
                 try {
                     const recommendations = await codeWhispererService.doInlineCompletion({
                         textDocument,
                         position: params.position,
                         context: { triggerKind: params.context.triggerKind },
+                        inferredLanguageId: languageId
                     })
                     if (recommendations) {
                         return recommendations

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -54,6 +54,7 @@ interface DoInlineCompletionParams {
     position: Position
     context: InlineCompletionContext
     token?: CancellationToken
+    inferredLanguageId: string
 }
 
 interface GetRecommendationsParams {
@@ -61,6 +62,7 @@ interface GetRecommendationsParams {
     position: Position
     maxResults: number
     token: CancellationToken
+    inferredLanguageId: string
 }
 
 export abstract class CodeWhispererServiceBase implements AwsLanguageService {
@@ -85,6 +87,7 @@ export abstract class CodeWhispererServiceBase implements AwsLanguageService {
             position: params.position,
             maxResults: params.context.triggerKind == InlineCompletionTriggerKind.Automatic ? 1 : 5,
             token: params.token || CancellationToken.None,
+            inferredLanguageId: params.inferredLanguageId
         })
 
         const items: InlineCompletionItem[] = recommendations.map<InlineCompletionItem>(r => {
@@ -121,7 +124,7 @@ export abstract class CodeWhispererServiceBase implements AwsLanguageService {
             fileContext: {
                 filename: params.textDocument.uri,
                 programmingLanguage: {
-                    languageName: 'typescript',
+                    languageName: params.inferredLanguageId,
                 },
                 leftFileContent: left,
                 rightFileContent: right,

--- a/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
@@ -1,0 +1,24 @@
+import { TextDocument } from 'vscode-languageserver-textdocument'
+
+// One language supported as of today, but this will be extended as more language features
+// are integrated into the language server and clients.
+const supportedFileTypes = ['csharp']
+const supportedExtensions: { [key: string]: string } = {
+    '.cs': 'csharp'
+}
+
+export const getSupportedLanguageId = (textDocument: TextDocument | undefined): string | undefined => {
+    if (!textDocument) {
+        return
+    }
+
+    if (textDocument.languageId && supportedFileTypes.includes(textDocument.languageId)) {
+        return textDocument.languageId
+    }
+
+    for (const extension in supportedExtensions) {
+        if (textDocument.uri.endsWith(extension)) {
+            return supportedExtensions[extension]
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Only allow recommendations for supported languages. Only CSharp, for now.

## Solution
Use the LSP `languageId` when available and known. If not, look at the extension and do the same. This is a naive implementation that can be extended with more complex detection if this proves too limited.

Unsupported languages will return empty recommendation lists without calling the CodeWhisperer API.

This relies on #21 being merged first.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
