### PR TITLE
Improve language detection to include case-insensitive matches; Add JS/Py/TS to supported languages

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
@@ -1,10 +1,13 @@
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
-// One language supported as of today, but this will be extended as more language features
+// This will be extended as more language features
 // are integrated into the language server and clients.
-const supportedFileTypes = ['csharp']
+const supportedFileTypes = ['csharp', 'javascript', 'python', 'typescript']
 const supportedExtensions: { [key: string]: string } = {
-    '.cs': 'csharp'
+    '.cs': 'csharp',
+    '.js': 'javascript',
+    '.py': 'python',
+    '.ts': 'typescript',
 }
 
 export const getSupportedLanguageId = (textDocument: TextDocument | undefined): string | undefined => {
@@ -12,8 +15,9 @@ export const getSupportedLanguageId = (textDocument: TextDocument | undefined): 
         return
     }
 
-    if (textDocument.languageId && supportedFileTypes.includes(textDocument.languageId)) {
-        return textDocument.languageId
+    const langaugeId = getCodeWhispererLanguageIdByTextDocumentLanguageId(textDocument.languageId)
+    if (langaugeId !== undefined) {
+        return langaugeId
     }
 
     for (const extension in supportedExtensions) {
@@ -21,4 +25,31 @@ export const getSupportedLanguageId = (textDocument: TextDocument | undefined): 
             return supportedExtensions[extension]
         }
     }
+}
+
+/**
+ * Used to map different IDE values for TextDocument languageIds to CodeWhisperer languageIds.
+ * Examples of the CodeWhisperer defined language ids can be found in service-2.json, near "ProgrammingLanguageLanguageNameString"
+ * @param textDocumentLanguageId Value of the TextDocument's language id, provided by the IDE
+ * @returns Corresponding CodeWhisperer language id
+ */
+function getCodeWhispererLanguageIdByTextDocumentLanguageId(textDocumentLanguageId: string): string | undefined {
+    if (textDocumentLanguageId === undefined) {
+        return undefined
+    }
+
+    if (supportedFileTypes.includes(textDocumentLanguageId)) {
+        return textDocumentLanguageId
+    }
+
+    // IDEs can identify a file's languageId using non-standardized values
+    // Eg: 'CSHARP', 'CSharp' => 'csharp'
+    // Try to map case-insensitive matches to increase the likelihood of supporting the file in an IDE.
+    for (const supportedFileType of supportedFileTypes) {
+        if (textDocumentLanguageId.toLowerCase() === supportedFileType.toLowerCase()) {
+            return supportedFileType
+        }
+    }
+
+    return undefined
 }


### PR DESCRIPTION
I've recently done some destination development work that needed to use python and typescript, so we might as well codify that into the language server now.

I also know that IDEs do not consistently identify a file's "language Id", so I have introduced a case insensitive match, to increase the likelihood of the server supporting a file from an IDE.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
