### PR TITLE
Add code owners from language server runtime team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aws/aws-ides-team
+* @aws/aws-ides-team @kmile @ege0zcan @viktorsaws


### PR DESCRIPTION
This change adds @kmile @ege0zcan and @viktorsaws to the owners.
This way, PRs can be merged into the repo that have been approved by the language server runtime team.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
