### PR TITLE
Fix reading bearer token from credentials provider for CodeWhisperer LSP

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -1,4 +1,5 @@
 import { CredentialsProvider } from '@aws-placeholder/aws-language-server-runtimes/out/features'
+import { BearerCredentials } from '@aws-placeholder/aws-language-server-runtimes/out/features/auth/auth'
 import { CredentialProviderChain, Credentials } from 'aws-sdk'
 import { createCodeWhispererSigv4Client } from '../client/sigv4/codewhisperer'
 import {
@@ -77,7 +78,8 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
             onRequestSetup: [
                 req => {
                     req.on('build', ({ httpRequest }) => {
-                        httpRequest.headers['Authorization'] = `Bearer ${credentialsProvider.getCredentials('bearer')}`
+                        const creds = credentialsProvider.getCredentials('bearer') as BearerCredentials
+                        httpRequest.headers['Authorization'] = `Bearer ${creds.token}`
                     })
                 },
             ],


### PR DESCRIPTION
## Problem
Reading Bearer token in CodeWhisperer LSP is broken. Fixing reading the token shape correctly.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
