### PR TITLE
Make vs code client use inlineCompletionWithReferences

### DIFF
--- a/client/vscode/src/futureTypes.ts
+++ b/client/vscode/src/futureTypes.ts
@@ -43,3 +43,41 @@ export const inlineCompletionRequestType = new ProtocolRequestType<
     void,
     InlineCompletionRegistrationOptions
 >('aws/textDocument/inlineCompletion')
+
+export type InlineCompletionWithReferencesParams = InlineCompletionParams & {
+    // No added parameters
+}
+
+/**
+ * Extend InlineCompletionItem to include optional references.
+ */
+export type InlineCompletionItemWithReferences = InlineCompletionItem & {
+    references?: {
+        referenceName?: string
+        referenceUrl?: string
+        licenseName?: string
+        position?: {
+            startCharacter?: number
+            endCharacter?: number
+        }
+    }[]
+}
+
+/**
+ * Extend InlineCompletionList to include optional references. This is not inheriting from `InlineCompletionList`
+ * since the `items` arrays are incompatible.
+ */
+export type InlineCompletionListWithReferences = {
+    /**
+     * The inline completion items with optional references
+     */
+    items: InlineCompletionItemWithReferences[]
+}
+
+export const inlineCompletionWithReferencesRequestType = new ProtocolRequestType<
+    InlineCompletionWithReferencesParams,
+    InlineCompletionListWithReferences | InlineCompletionItemWithReferences[] | null,
+    InlineCompletionItemWithReferences[],
+    void,
+    InlineCompletionRegistrationOptions
+>('aws/textDocument/inlineCompletionWithReferences')

--- a/client/vscode/src/inlineCompletionActivation.ts
+++ b/client/vscode/src/inlineCompletionActivation.ts
@@ -9,7 +9,7 @@ import {
     languages,
 } from 'vscode'
 import { LanguageClient } from 'vscode-languageclient/node'
-import { InlineCompletionParams, inlineCompletionRequestType } from './futureTypes'
+import { InlineCompletionParams, inlineCompletionWithReferencesRequestType } from './futureTypes'
 
 export function registerInlineCompletion(languageClient: LanguageClient) {
     const inlineCompletionProvider = new CodeWhispererInlineCompletionItemProvider(languageClient)
@@ -33,7 +33,11 @@ class CodeWhispererInlineCompletionItemProvider implements InlineCompletionItemP
             context,
         }
 
-        const response = await this.languageClient.sendRequest(inlineCompletionRequestType, request, token)
+        const response = await this.languageClient.sendRequest(
+            inlineCompletionWithReferencesRequestType,
+            request,
+            token
+        )
 
         const list: InlineCompletionList = response as InlineCompletionList
         this.languageClient.info(`Client: Received ${list.items.length} suggestions`)


### PR DESCRIPTION
## Problem
VSCode Client uses an LSP method that is no longer supported by the CodeWhisperer Server. 

## Solution
Switched VSCode client from inlineCompletion to inlineCompletionWithReferences
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
