### PR TITLE
Send x-amzn-codewhisperer-optout header when the setting is set

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -327,6 +327,34 @@ class HelloWorld
             )
             assert.deepEqual(result, EXPECTED_RESULT)
         })
+
+        // TODO: mock http request and verify the headers are passed
+        // or spawn an http server and pass it as an endpoint to the sdk client,
+        // mock responses and verify that correct headers are receieved on the server side.
+        // Currently the suite just checks whether the boolean is passed to codeWhispererService
+        describe('Opting out of sending data to CodeWhisperer', () => {
+            it('should send opt-out header when the setting is disabled', async () => {
+                features.lsp.workspace.getConfiguration.returns(
+                    Promise.resolve({ shareCodeWhispererContentWithAWS: false })
+                )
+                await features.start(server)
+
+                assert(service.shareCodeWhispererContentWithAWS === false)
+            })
+
+            it('should not send opt-out header when the setting is enabled after startup', async () => {
+                features.lsp.workspace.getConfiguration.returns(
+                    Promise.resolve({ shareCodeWhispererContentWithAWS: false })
+                )
+                await features.start(server)
+                features.lsp.workspace.getConfiguration.returns(
+                    Promise.resolve({ shareCodeWhispererContentWithAWS: true })
+                )
+                await features.openDocument(SOME_FILE).doChangeConfiguration()
+
+                assert(service.shareCodeWhispererContentWithAWS === true)
+            })
+        })
     })
     describe('Recommendations With References', () => {
         const HELLO_WORLD_IN_CSHARP = `

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -124,6 +124,13 @@ export const CodewhispererServerFactory =
                         includeSuggestionsWithCodeReferences = true
                         logging.log('Configuration updated to include suggestions with code references')
                     }
+                    if (config && config['shareCodeWhispererContentWithAWS'] === false) {
+                        codeWhispererService.shareCodeWhispererContentWithAWS = false
+                        logging.log('Configuration updated to not share code whisperer content with AWS')
+                    } else {
+                        codeWhispererService.shareCodeWhispererContentWithAWS = true
+                        logging.log('Configuration updated to share code whisperer content with AWS')
+                    }
                 })
                 .catch(reason => logging.log(`Error in GetConfiguration: ${reason}`))
 


### PR DESCRIPTION
## Problem
Customers currently don't have an opportunity to opt-out of sending CodeWhisperer data to AWS

## Solution
Use `shareCodeWhispererContentWithAWS` configuration setting to decided whether to send data to AWS. 
To opt out `x-amzn-codewhisperer-optout` header is added to the HTTP requests 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
