### PR TITLE
Throw an exception on missing Bearer token

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -88,6 +88,9 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
                 req => {
                     req.on('build', ({ httpRequest }) => {
                         const creds = credentialsProvider.getCredentials('bearer') as BearerCredentials
+                        if (!creds?.token) {
+                            throw new Error('Authorization failed, bearer token is not set')
+                        }
                         httpRequest.headers['Authorization'] = `Bearer ${creds.token}`
                         if (!this.shareCodeWhispererContentWithAWS) {
                             httpRequest.headers['x-amzn-codewhisperer-optout'] = ''


### PR DESCRIPTION
## Problem

There is a bug in token-based CodeWhisperer server, when inline completion requests is received and bearer token is not available.

## Solution
Catch missing bearer token value in credentials provider and throw explicit exception.

Server processes exceptions gracefully and returns empty list of recommendations.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
