### PR TITLE
Fix to enable codewhisperer version bumping

### DIFF
--- a/app/aws-lsp-codewhisperer-binary/package.json
+++ b/app/aws-lsp-codewhisperer-binary/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@aws-placeholder/aws-language-server-runtimes": "file:../../bin/aws-placeholder-aws-language-server-runtimes-0.1.0.tgz",
-        "@lsp-placeholder/aws-lsp-codewhisperer": "^0.0.1"
+        "@lsp-placeholder/aws-lsp-codewhisperer": "*"
     },
     "devDependencies": {
         "pkg": "^5.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws-placeholder/aws-language-server-runtimes": "file:../../bin/aws-placeholder-aws-language-server-runtimes-0.1.0.tgz",
-                "@lsp-placeholder/aws-lsp-codewhisperer": "^0.0.1"
+                "@lsp-placeholder/aws-lsp-codewhisperer": "*"
             },
             "bin": {
                 "aws-lsp-codewhisperer-binary": "out/index.js"


### PR DESCRIPTION
## Problem
npm considers a major version “the leftmost non zero digit”. So "^0.0.1" cannot be resolved to "0.0.2" because it's a major version change from npm's point of view. 
That resultis in error when bumping a version of codewhisperer as npm can't resolve the version after the bump.

More info - https://docs.npmjs.com/cli/v6/using-npm/semver#caret-ranges-123-025-004
```
^0.0.3 := >=0.0.3 <0.0.4
```
## Solution
Putting "*" as the version unblocks all types of bumps and it's safe because we only really depend in a monorepo sense. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
