### PR TITLE
Update ServiceInvocation event name

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -850,7 +850,7 @@ class HelloWorld
             )
 
             const expectedServiceInvocationMetric = {
-                name: 'ServiceInvocation',
+                name: 'codewhisperer_serviceInvocation',
                 data: {
                     codewhispererRequestId: 'cwspr-request-id',
                     codewhispererSessionId: 'cwspr-session-id',
@@ -893,7 +893,7 @@ class HelloWorld
             )
 
             const expectedServiceInvocationMetric = {
-                name: 'ServiceInvocation',
+                name: 'codewhisperer_serviceInvocation',
                 data: {
                     codewhispererRequestId: 'cwspr-request-id',
                     codewhispererSessionId: 'cwspr-session-id',
@@ -925,7 +925,7 @@ class HelloWorld
             )
 
             const expectedServiceInvocationMetric = {
-                name: 'ServiceInvocation',
+                name: 'codewhisperer_serviceInvocation',
                 data: {
                     codewhispererRequestId: undefined,
                     codewhispererSessionId: undefined,
@@ -969,7 +969,7 @@ class HelloWorld
             await getCompletionsPromise
 
             const expectedServiceInvocationMetric = {
-                name: 'ServiceInvocation',
+                name: 'codewhisperer_serviceInvocation',
                 data: {
                     codewhispererRequestId: 'failed-request-id',
                     codewhispererSessionId: undefined,

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -89,7 +89,7 @@ const emitServiceInvocationTelemetry =
             credentialStartUrl: '',
         }
         telemetry.emitMetric({
-            name: 'ServiceInvocation',
+            name: 'codewhisperer_serviceInvocation',
             data,
         })
 
@@ -120,7 +120,7 @@ const emitServiceInvocationFailure =
         }
 
         telemetry.emitMetric({
-            name: 'ServiceInvocation',
+            name: 'codewhisperer_serviceInvocation',
             data,
         })
 


### PR DESCRIPTION
## Problem
ServiceInvocation metric name is not correct.

## Solution

Fix event name to match value defined in https://github.com/aws/aws-toolkit-common/blob/main/telemetry/definitions/commonDefinitions.json#L2759C35-L2759C35

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
