### PR TITLE
use LF as line breaks in requests for suggestions

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -230,10 +230,8 @@ export const CodewhispererServerFactory =
                         ...requestContext,
                         fileContext: {
                             ...requestContext.fileContext,
-                            ...{
-                                leftFileContent: requestContext.fileContext.leftFileContent.replaceAll('\r\n', '\n'),
-                                rightFileContent: requestContext.fileContext.leftFileContent.replaceAll('\r\n', '\n'),
-                            },
+                            leftFileContent: requestContext.fileContext.leftFileContent.replaceAll('\r\n', '\n'),
+                            rightFileContent: requestContext.fileContext.rightFileContent.replaceAll('\r\n', '\n'),
                         },
                     })
                     .catch(emitServiceInvocationFailure({ telemetry, invocationContext }))


### PR DESCRIPTION
## Problem
the model doesn't handle `\r\n` very well and result in more empty suggestions
## Solution
replace the line breaks to `\n` when sending request to service, when suggestions are later inserted into the editors the editors will adjust the line breaks accordingly so no change necessary there.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
