### PR TITLE
Fix ServiceInvocation telemetry events payload

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
@@ -9,7 +9,6 @@ export interface CodeWhispererServiceInvocationEvent {
     codewhispererCompletionType?: CodewhispererCompletionType
     codewhispererTriggerType: string
     codewhispererAutomatedTriggerType?: string
-    result: 'Succeeded' | 'Failed'
     duration?: number
     codewhispererLineNumber?: number
     codewhispererCursorOffset?: number


### PR DESCRIPTION
## Problem
Initial payload for ServiceInvocation event was not fully compatible with expect shape

## Solution

Fixed how `result` and `errorData` fields are set in the ServiceInvocation metric event

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
