### PR TITLE
Attach credentialStartUrl cached in credentialsProvider feature to telemetry events

### DIFF
--- a/client/vscode/src/credentialsActivation.ts
+++ b/client/vscode/src/credentialsActivation.ts
@@ -11,7 +11,7 @@ import {
     RequestType,
     ResponseMessage,
 } from 'vscode-languageclient/node'
-import { BuilderIdConnectionBuilder } from './sso/builderId'
+import { BuilderIdConnectionBuilder, SsoConnection } from './sso/builderId'
 
 /**
  * Request for custom notifications that Update Credentials and tokens.
@@ -36,7 +36,18 @@ export interface UpdateIamCredentialsRequestData {
     sessionToken?: string
 }
 
+export interface ConnectionMetadata {
+    sso?: {
+        startUrl?: string
+    }
+}
+
 const encryptionKey = crypto.randomBytes(32)
+
+/**
+ * Cached builderId connection to setup getConnectionMetadata request handled in the client
+ */
+let activeBuilderIdConnection: SsoConnection | undefined
 
 // See core\aws-lsp-core\src\credentials\credentialsProvider.ts for the server's
 // custom method names and intents.
@@ -45,6 +56,7 @@ const lspMethodNames = {
     iamCredentialsDelete: 'aws/credentials/iam/delete',
     iamBearerTokenUpdate: 'aws/credentials/token/update',
     iamBearerTokenDelete: 'aws/credentials/token/delete',
+    getConnectionMetadata: 'aws/credentials/getConnectionMetadata',
 }
 
 const notificationTypes = {
@@ -56,6 +68,7 @@ const notificationTypes = {
         lspMethodNames.iamBearerTokenUpdate
     ),
     deleteBearerToken: new NotificationType(lspMethodNames.iamBearerTokenDelete),
+    getConnectionMetadata: new RequestType<undefined, ConnectionMetadata, Error>(lspMethodNames.getConnectionMetadata),
 }
 
 /**
@@ -111,6 +124,8 @@ export async function registerBearerTokenProviderSupport(
     languageClient: LanguageClient,
     extensionContext: ExtensionContext
 ): Promise<void> {
+    createGetConnectionMetadataRequestHandler(languageClient)
+
     extensionContext.subscriptions.push(
         ...[
             commands.registerCommand('awslsp.resolveBearerToken', createResolveBearerTokenCommand(languageClient)),
@@ -190,6 +205,23 @@ async function sendBearerTokenUpdate(request: UpdateCredentialsRequest, language
 }
 
 /**
+ * Set getConnectionMetadata request handler.
+ *
+ * This request is send from server to client to request current auth connection metadata.
+ */
+function createGetConnectionMetadataRequestHandler(languageClient: LanguageClient) {
+    languageClient.onRequest<ConnectionMetadata, Error>(lspMethodNames.getConnectionMetadata, () => {
+        languageClient.info(`Client: The language server requested SSO connection metadata`)
+
+        return {
+            sso: {
+                startUrl: activeBuilderIdConnection?.startUrl ?? undefined,
+            },
+        }
+    })
+}
+
+/**
  * This command simulates an extension's credentials state changing, and pushing updated
  * credentials to the server.
  *
@@ -198,9 +230,9 @@ async function sendBearerTokenUpdate(request: UpdateCredentialsRequest, language
  */
 function createResolveBearerTokenCommand(languageClient: LanguageClient) {
     return async () => {
-        const builderIdConnection = await BuilderIdConnectionBuilder.build()
+        activeBuilderIdConnection = await BuilderIdConnectionBuilder.build()
 
-        const token = await builderIdConnection.getToken()
+        const token = await activeBuilderIdConnection.getToken()
 
         const request = await createUpdateCredentialsRequest({
             token: token.accessToken,
@@ -214,10 +246,12 @@ function createResolveBearerTokenCommand(languageClient: LanguageClient) {
 /**
  * This command simulates an extension's credentials expiring (or the user configuring "no credentials").
  *
- * The server's credentials are cleared.
+ * The server's credentials are cleared and cached buildedId connection is cleared.
  */
 function createClearTokenCommand(languageClient: LanguageClient) {
     return async () => {
+        activeBuilderIdConnection = undefined
+
         await languageClient.sendNotification(notificationTypes.deleteBearerToken)
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -980,7 +980,7 @@ class HelloWorld
                     codewhispererLineNumber: 0,
                     codewhispererCursorOffset: 0,
                     codewhispererLanguage: 'csharp',
-                    credentialStartUrl: '',
+                    credentialStartUrl: undefined,
                 },
             }
             sinon.assert.calledOnceWithExactly(features.telemetry.emitMetric, expectedServiceInvocationMetric)
@@ -1023,7 +1023,7 @@ class HelloWorld
                     codewhispererLineNumber: 0,
                     codewhispererCursorOffset: 0,
                     codewhispererLanguage: 'csharp',
-                    credentialStartUrl: '',
+                    credentialStartUrl: undefined,
                 },
             }
             sinon.assert.calledOnceWithExactly(features.telemetry.emitMetric, expectedServiceInvocationMetric)
@@ -1057,7 +1057,7 @@ class HelloWorld
                     codewhispererLineNumber: 0,
                     codewhispererCursorOffset: 0,
                     codewhispererLanguage: 'csharp',
-                    credentialStartUrl: '',
+                    credentialStartUrl: undefined,
                 },
                 errorData: {
                     reason: 'TestError',
@@ -1094,7 +1094,7 @@ class HelloWorld
                     codewhispererLineNumber: 0,
                     codewhispererCursorOffset: 0,
                     codewhispererLanguage: 'csharp',
-                    credentialStartUrl: '',
+                    credentialStartUrl: undefined,
                 },
                 errorData: {
                     reason: 'UnknownError',
@@ -1144,7 +1144,7 @@ class HelloWorld
                     codewhispererLineNumber: 0,
                     codewhispererCursorOffset: 0,
                     codewhispererLanguage: 'csharp',
-                    credentialStartUrl: '',
+                    credentialStartUrl: undefined,
                 },
                 errorData: {
                     reason: 'TestAWSError',
@@ -1153,6 +1153,45 @@ class HelloWorld
                 },
             }
             sinon.assert.calledOnceWithExactly(features.telemetry.emitMetric, expectedServiceInvocationMetric)
+        })
+
+        describe('Connection metadata credentialStartUrl field', () => {
+            it('should attach credentialStartUrl field if available in credentialsProvider', async () => {
+                features.credentialsProvider.getConnectionMetadata.returns({
+                    sso: {
+                        startUrl: 'http://teststarturl',
+                    },
+                })
+
+                await features.doInlineCompletionWithReferences(
+                    {
+                        textDocument: { uri: SOME_FILE.uri },
+                        position: { line: 0, character: 0 },
+                        context: { triggerKind: InlineCompletionTriggerKind.Invoked },
+                    },
+                    CancellationToken.None
+                )
+
+                assert.equal(
+                    features.telemetry.emitMetric.getCall(0).args[0].data.credentialStartUrl,
+                    'http://teststarturl'
+                )
+            })
+
+            it('should send empty credentialStartUrl field if not available in credentialsProvider', async () => {
+                features.credentialsProvider.getConnectionMetadata.returns(undefined)
+
+                await features.doInlineCompletionWithReferences(
+                    {
+                        textDocument: { uri: SOME_FILE.uri },
+                        position: { line: 0, character: 0 },
+                        context: { triggerKind: InlineCompletionTriggerKind.Invoked },
+                    },
+                    CancellationToken.None
+                )
+
+                assert.equal(features.telemetry.emitMetric.getCall(0).args[0].data.credentialStartUrl, undefined)
+            })
         })
     })
 })


### PR DESCRIPTION
## Problem
We need too attach `credentialStartUrl` field to every telemetry event for CodeWhisperer server.

## Solution

Read SSO connection metadata cached in Runtime `credentialsProvider` feature and attach `startUrl` value to ServiceInvocation telemetry events.

Updated test VSCode extension to respond to new server `getConnectionMetadata` request for fetching auth connection metadata from the client.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
