### PR TITLE
Replace crypto module with uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4372,6 +4372,12 @@
             "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
             "dev": true
         },
+        "node_modules/@types/uuid": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+            "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
+            "dev": true
+        },
         "node_modules/@types/vscode": {
             "version": "1.78.1",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.1.tgz",
@@ -9233,14 +9239,28 @@
                 "@aws-placeholder/aws-language-server-runtimes": "file:../../bin/aws-placeholder-aws-language-server-runtimes-0.1.0.tgz",
                 "@lsp-placeholder/aws-lsp-core": "^0.0.1",
                 "aws-sdk": "^2.1403.0",
+                "uuid": "^9.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
             },
             "devDependencies": {
+                "@types/uuid": "^9.0.7",
                 "assert": "^2.1.0",
                 "copyfiles": "^2.4.1",
                 "ts-mocha": "^10.0.0",
                 "ts-sinon": "^2.0.2"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "server/aws-lsp-codewhisperer/node_modules/vscode-jsonrpc": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -16,10 +16,12 @@
         "@aws-placeholder/aws-language-server-runtimes": "file:../../bin/aws-placeholder-aws-language-server-runtimes-0.1.0.tgz",
         "@lsp-placeholder/aws-lsp-core": "^0.0.1",
         "aws-sdk": "^2.1403.0",
+        "uuid": "^9.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"
     },
     "devDependencies": {
+        "@types/uuid": "^9.0.7",
         "assert": "^2.1.0",
         "copyfiles": "^2.4.1",
         "ts-mocha": "^10.0.0",

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -7,7 +7,7 @@ import {
     LogInlineCompelitionSessionResultsParams,
 } from '@aws-placeholder/aws-language-server-runtimes/out/features/lsp/inline-completions/protocolExtensions'
 import { AWSError } from 'aws-sdk'
-import { randomUUID } from 'crypto'
+import { v4 as uuidv4 } from 'uuid'
 import { CancellationToken, InlineCompletionTriggerKind, Range } from 'vscode-languageserver'
 import { Position, TextDocument } from 'vscode-languageserver-textdocument'
 import {
@@ -166,7 +166,7 @@ const filterReferences = (
     }
 }
 
-export const createSessionId = () => randomUUID()
+export const createSessionId = () => uuidv4()
 
 export const CodewhispererServerFactory =
     (service: (credentials: CredentialsProvider) => CodeWhispererServiceBase): Server =>

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -1,7 +1,7 @@
 import { CredentialsProvider } from '@aws-placeholder/aws-language-server-runtimes/out/features'
 import { BearerCredentials } from '@aws-placeholder/aws-language-server-runtimes/out/features/auth/auth'
 import { CredentialProviderChain, Credentials } from 'aws-sdk'
-import { randomUUID } from 'crypto'
+import { v4 as uuidv4 } from 'uuid'
 import { createCodeWhispererSigv4Client } from '../client/sigv4/codewhisperer'
 import {
     CodeWhispererTokenClientConfigurationOptions,
@@ -89,7 +89,7 @@ export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
         }
     }
 
-    generateItemId = () => randomUUID()
+    generateItemId = () => uuidv4()
 }
 
 export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
@@ -142,5 +142,5 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
         }
     }
 
-    generateItemId = () => randomUUID()
+    generateItemId = () => uuidv4()
 }


### PR DESCRIPTION
## Problem
Webpack >= 5 does not include polyfills for built-in modules by default anymore. This causes errors while trying to bundle the servers

## Solution
Replace crypto for uuid


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
