### PR TITLE
Assume default false values for  shareCodeWhispererContentWithAWS and includeSuggestionsWithCodeReferences settings

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -177,7 +177,7 @@ export const CodewhispererServerFactory =
         // the response. No locking or concurrency controls, filtering is done
         // right before returning and is only guaranteed to be consistent within
         // the context of a single response.
-        let includeSuggestionsWithCodeReferences = true
+        let includeSuggestionsWithCodeReferences = false
 
         const onInlineCompletionHandler = async (
             params: InlineCompletionWithReferencesParams,
@@ -271,19 +271,19 @@ export const CodewhispererServerFactory =
             lsp.workspace
                 .getConfiguration('aws.codeWhisperer')
                 .then(config => {
-                    if (config && config['includeSuggestionsWithCodeReferences'] === false) {
-                        includeSuggestionsWithCodeReferences = false
-                        logging.log('Configuration updated to exclude suggestions with code references')
-                    } else {
+                    if (config && config['includeSuggestionsWithCodeReferences'] === true) {
                         includeSuggestionsWithCodeReferences = true
                         logging.log('Configuration updated to include suggestions with code references')
-                    }
-                    if (config && config['shareCodeWhispererContentWithAWS'] === false) {
-                        codeWhispererService.shareCodeWhispererContentWithAWS = false
-                        logging.log('Configuration updated to not share code whisperer content with AWS')
                     } else {
+                        includeSuggestionsWithCodeReferences = false
+                        logging.log('Configuration updated to exclude suggestions with code references')
+                    }
+                    if (config && config['shareCodeWhispererContentWithAWS'] === true) {
                         codeWhispererService.shareCodeWhispererContentWithAWS = true
                         logging.log('Configuration updated to share code whisperer content with AWS')
+                    } else {
+                        codeWhispererService.shareCodeWhispererContentWithAWS = false
+                        logging.log('Configuration updated to not share code whisperer content with AWS')
                     }
                 })
                 .catch(reason => logging.log(`Error in GetConfiguration: ${reason}`))

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -36,7 +36,7 @@ import CodeWhispererTokenClient = require('../client/token/codewhispererclient')
 // Right now the only difference between the token client and the IAM client for codewhsiperer is the difference in function name
 // This abstract class can grow in the future to account for any additional changes across the clients
 export abstract class CodeWhispererServiceBase {
-    public shareCodeWhispererContentWithAWS: boolean = true
+    public shareCodeWhispererContentWithAWS: boolean = false
     abstract client: CodeWhispererSigv4Client | CodeWhispererTokenClient
 
     abstract generateSuggestions(request: GenerateSuggestionsRequest): Promise<GenerateSuggestionsResponse>


### PR DESCRIPTION
## Problem
Currently the defaults for these values are true. We should change this to "assume false if not explicitly true" since some destinations may serialize the messages to exclude fields with default values, which would mean false fields would not be present.
## Solution
Set values to true only if successfully read from the client configuration 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
