### PR TITLE
feat: support C and C++ languages

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -40,7 +40,7 @@ class HelloWorld
             1,
             'INPUT HELLO ; OUTPUT WORLD'
         )
-        const SOME_FILE_WITH_EXTENSION = TextDocument.create('file:///missing.cs', '', 1, HELLO_WORLD_IN_CSHARP)
+        const SOME_FILE_WITH_EXTENSION = TextDocument.create('file:///missing.hpp', '', 1, HELLO_WORLD_IN_CSHARP)
 
         const HELLO_WORLD_LINE = `Console.WriteLine("Hello World!");`
         // Single line file will not have the full line contents
@@ -255,7 +255,7 @@ class HelloWorld
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
                     filename: SOME_FILE_WITH_EXTENSION.uri,
-                    programmingLanguage: { languageName: 'csharp' },
+                    programmingLanguage: { languageName: 'cpp' },
                     leftFileContent: '',
                     rightFileContent: HELLO_WORLD_IN_CSHARP,
                 },
@@ -1117,8 +1117,7 @@ class HelloWorld
         })
 
         it('should emit Failure ServiceInvocation telemetry with request metadata on failed response with AWSError error type', async () => {
-            // @ts-ignore
-            const error: AWSError = new Error('Fake Error')
+            const error: AWSError = new Error('Fake Error') as AWSError
             error.name = 'TestAWSError'
             error.code = 'TestErrorStatusCode'
             error.statusCode = 500

--- a/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
@@ -24,8 +24,13 @@ export type CodewhispererLanguage =
 
 // This will be extended as more language features
 // are integrated into the language server and clients.
-const supportedFileTypes: CodewhispererLanguage[] = ['csharp', 'javascript', 'python', 'typescript']
+// See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocumentItem
+const supportedFileTypes: CodewhispererLanguage[] = ['c', 'cpp', 'csharp', 'javascript', 'python', 'typescript']
 const supportedExtensions: { [key: string]: CodewhispererLanguage } = {
+    '.c': 'c',
+    '.h': 'c',
+    '.cpp': 'cpp',
+    '.hpp': 'cpp',
     '.cs': 'csharp',
     '.js': 'javascript',
     '.py': 'python',


### PR DESCRIPTION
## Problem
Support C and C++ languages

## Solution
Add the languages to the supported file type array, and the most common file extensions for each of the two languages.

Removed a `ts-ignore` comment that was unnecessary.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
