### PR TITLE
Increment aws-lsp-codewhisperer version to 0.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9242,7 +9242,7 @@
         },
         "server/aws-lsp-codewhisperer": {
             "name": "@lsp-placeholder/aws-lsp-codewhisperer",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "dependencies": {
                 "@aws-placeholder/aws-language-server-runtimes": "file:../../bin/aws-placeholder-aws-language-server-runtimes-0.1.1.tgz",
                 "@lsp-placeholder/aws-lsp-core": "^0.0.1",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lsp-placeholder/aws-lsp-codewhisperer",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "CodeWhisperer Language Server",
     "main": "out/index.js",
     "scripts": {


### PR DESCRIPTION
## Problem
We need to bump a version of CodeWhisperer server for release (dry-run)
## Solution
Version is bumped to 0.0.2

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
