### PR TITLE
feat: emit telemetry for code percentage

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -18,7 +18,7 @@ describe('CodeWhisperer Server', () => {
 
     before(() => {
         const StubSessionIdGenerator = () => {
-            let id = 'some-random-session-uuid-' + SESSION_IDS_LOG.length
+            const id = 'some-random-session-uuid-' + SESSION_IDS_LOG.length
             SESSION_IDS_LOG.push(id)
 
             return id
@@ -129,6 +129,10 @@ class HelloWorld
                 .openDocument(SOME_UNSUPPORTED_FILE)
                 .openDocument(SOME_FILE_WITH_EXTENSION)
                 .openDocument(SOME_SINGLE_LINE_FILE)
+        })
+
+        afterEach(() => {
+            features.dispose()
         })
 
         it('should return recommendations', async () => {
@@ -591,6 +595,10 @@ class HelloWorld
             features = new TestFeatures()
         })
 
+        afterEach(() => {
+            features.dispose()
+        })
+
         it('should return all recommendations if no settings are specificed', async () => {
             features.lsp.workspace.getConfiguration.returns(Promise.resolve({}))
             await features.start(server)
@@ -907,6 +915,10 @@ class HelloWorld
             features.openDocument(SOME_FILE)
         })
 
+        afterEach(() => {
+            features.dispose()
+        })
+
         it('should return recommendations on an above-threshold auto-trigger position', async () => {
             const result = await features.doInlineCompletionWithReferences(
                 {
@@ -1009,6 +1021,10 @@ class HelloWorld
             await features.start(server)
 
             features.openDocument(SOME_FILE)
+        })
+
+        afterEach(() => {
+            features.dispose()
         })
 
         it('should deactivate current session when session result for current session is sent', async () => {
@@ -1134,6 +1150,7 @@ static void Main()
 
         afterEach(async () => {
             clock.restore()
+            features.dispose()
         })
 
         it('should emit Success ServiceInvocation telemetry on successful response', async () => {
@@ -1469,6 +1486,10 @@ static void Main()
             features.openDocument(SOME_FILE).openDocument(SOME_FILE_WITH_ALT_CASED_LANGUAGE_ID)
         })
 
+        afterEach(() => {
+            features.dispose()
+        })
+
         it('should cache new session on new request when no session exists', async () => {
             let activeSession = sessionManager.getCurrentSession()
             assert.equal(activeSession, undefined)
@@ -1571,7 +1592,7 @@ static void Main()
                 })
             )
 
-            let activeSession = sessionManager.getCurrentSession()
+            const activeSession = sessionManager.getCurrentSession()
             assert.equal(activeSession, undefined)
 
             await features.doInlineCompletionWithReferences(

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -19,6 +19,7 @@ import {
 import { CodewhispererLanguage, getSupportedLanguageId } from './languageDetection'
 import { getPrefixSuffixOverlap, truncateOverlapWithRightContext } from './mergeRightUtils'
 import { CodeWhispererSession, SessionManager } from './session/sessionManager'
+import { CodePercentageTracker } from './telemetry/codePercentage'
 import { CodeWhispererPerceivedLatencyEvent, CodeWhispererServiceInvocationEvent } from './telemetry/types'
 import { getCompletionType, isAwsError } from './utils'
 
@@ -175,6 +176,8 @@ export const CodewhispererServerFactory =
         // the context of a single response.
         let includeSuggestionsWithCodeReferences = false
 
+        const codePercentageTracker = new CodePercentageTracker(telemetry)
+
         const onInlineCompletionHandler = async (
             params: InlineCompletionWithReferencesParams,
             _token: CancellationToken
@@ -247,6 +250,8 @@ export const CodewhispererServerFactory =
                     autoTriggerType: autoTriggerType,
                     credentialStartUrl: credentialsProvider.getConnectionMetadata()?.sso?.startUrl ?? undefined,
                 })
+
+                codePercentageTracker.countInvocation(inferredLanguageId)
 
                 return codeWhispererService
                     .generateSuggestions({
@@ -325,6 +330,18 @@ export const CodewhispererServerFactory =
                 return
             }
 
+            const acceptedItemId = Object.keys(params.completionSessionResult).find(
+                k => params.completionSessionResult[k].accepted
+            )
+            const acceptedSuggestion = session.suggestions.find(s => s.itemId === acceptedItemId)
+
+            if (acceptedSuggestion !== undefined) {
+                if (acceptedSuggestion) {
+                    codePercentageTracker.countSuccess(session.language)
+                    codePercentageTracker.countAcceptedTokens(session.language, acceptedSuggestion.content)
+                }
+            }
+
             session.setClientResultData(completionSessionResult, firstCompletionDisplayLatency, totalSessionDisplayTime)
 
             if (currentSession?.id == sessionId) {
@@ -361,10 +378,23 @@ export const CodewhispererServerFactory =
         lsp.onInitialized(updateConfiguration)
         lsp.didChangeConfiguration(updateConfiguration)
 
+        lsp.onDidChangeTextDocument(async p => {
+            const textDocument = await workspace.getTextDocument(p.textDocument.uri)
+            const languageId = getSupportedLanguageId(textDocument)
+
+            if (!textDocument || !languageId) {
+                return
+            }
+
+            p.contentChanges.forEach(change => {
+                codePercentageTracker.countTokens(languageId, change.text)
+            })
+        })
+
         logging.log('Codewhisperer server has been initialised')
 
         return () => {
-            /* do nothing */
+            codePercentageTracker.dispose()
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
@@ -1,0 +1,119 @@
+import { Server } from '@aws-placeholder/aws-language-server-runtimes'
+import { InlineCompletionListWithReferences } from '@aws-placeholder/aws-language-server-runtimes/out/features/lsp/inline-completions/protocolExtensions'
+import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
+import { CancellationToken, InlineCompletionTriggerKind } from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { TestFeatures } from './TestFeatures'
+import { CodewhispererServerFactory } from './codeWhispererServer'
+import { CodeWhispererServiceBase, ResponseContext, Suggestion } from './codeWhispererService'
+
+describe('CodeWhisperer Server', () => {
+    const HELLO_WORLD_IN_CSHARP = `
+class HelloWorld
+{
+    static void Main()
+    {
+        Console.WriteLine("Hello World!");
+    }
+}
+`
+    const SOME_FILE = TextDocument.create('file:///test.cs', 'csharp', 1, HELLO_WORLD_IN_CSHARP)
+    const SOME_TYPING = '// this is the end of the file\n'
+    const EXPECTED_SUGGESTION: Suggestion[] = [{ itemId: 'cwspr-item-id', content: '// a recommendation' }]
+    const EXPECTED_RESPONSE_CONTEXT: ResponseContext = {
+        requestId: 'cwspr-request-id',
+        codewhispererSessionId: 'cwspr-session-id',
+    }
+
+    describe('Telemetry', () => {
+        let features: TestFeatures
+        let server: Server
+        // TODO move more of the service code out of the stub and into the testable realm
+        // See: https://aws.amazon.com/blogs/developer/mocking-modular-aws-sdk-for-javascript-v3-in-unit-tests/
+        // for examples on how to mock just the SDK client
+        let service: StubbedInstance<CodeWhispererServiceBase>
+        let clock: sinon.SinonFakeTimers
+
+        beforeEach(async () => {
+            clock = sinon.useFakeTimers()
+
+            // Set up the server with a mock service, returning predefined recommendations
+            service = stubInterface<CodeWhispererServiceBase>()
+            service.generateSuggestions.returns(
+                Promise.resolve({
+                    suggestions: EXPECTED_SUGGESTION,
+                    responseContext: EXPECTED_RESPONSE_CONTEXT,
+                })
+            )
+
+            server = CodewhispererServerFactory(_auth => service)
+
+            // Initialize the features, but don't start server yet
+            features = new TestFeatures()
+
+            // Return no specific configuration for CodeWhisperer
+            features.lsp.workspace.getConfiguration.returns(Promise.resolve({}))
+
+            // Start the server and open a document
+            await features.start(server)
+
+            features.openDocument(SOME_FILE)
+        })
+
+        afterEach(() => {
+            clock.restore()
+            features.dispose()
+        })
+
+        it('should emit Code Percentage telemetry event every 5 minutes', async () => {
+            await features.simulateTyping(SOME_FILE.uri, SOME_TYPING)
+
+            const updatedDocument = features.documents[SOME_FILE.uri]
+            const endPosition = updatedDocument.positionAt(updatedDocument.getText().length)
+
+            const result = (await features.doInlineCompletionWithReferences(
+                {
+                    textDocument: { uri: SOME_FILE.uri },
+                    position: { line: 0, character: 0 },
+                    context: { triggerKind: InlineCompletionTriggerKind.Invoked },
+                },
+                CancellationToken.None
+            )) as InlineCompletionListWithReferences
+
+            await features.doChangeTextDocument({
+                textDocument: { uri: SOME_FILE.uri, version: updatedDocument.version },
+                contentChanges: [
+                    { range: { start: endPosition, end: endPosition }, text: EXPECTED_SUGGESTION[0].content },
+                ],
+            })
+
+            await features.doLogInlineCompletionSessionResults({
+                sessionId: result?.sessionId,
+                completionSessionResult: {
+                    [result.items[0].itemId]: {
+                        accepted: true,
+                        seen: true,
+                        discarded: false,
+                    },
+                },
+            })
+
+            const totalInsertCharacters = SOME_TYPING.length + EXPECTED_SUGGESTION[0].content.length
+            const codeWhispererCharacters = EXPECTED_SUGGESTION[0].content.length
+            const codePercentage = Math.round((codeWhispererCharacters / totalInsertCharacters) * 10000) / 100
+
+            clock.tick(5000 * 60)
+
+            sinon.assert.calledWithExactly(features.telemetry.emitMetric, {
+                name: 'codewhisperer_codePercentage',
+                data: {
+                    codewhispererTotalTokens: totalInsertCharacters,
+                    codewhispererLanguage: 'csharp',
+                    codewhispererAcceptedTokens: codeWhispererCharacters,
+                    codewhispererPercentage: codePercentage,
+                    successCount: 1,
+                },
+            })
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.test.ts
@@ -1,0 +1,101 @@
+import { Telemetry } from '@aws-placeholder/aws-language-server-runtimes/out/features'
+import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
+import { CodePercentageTracker } from './codePercentage'
+import assert = require('assert')
+
+describe('CodePercentage', () => {
+    const LANGUAGE_ID = 'python'
+    const OTHER_LANGUAGE_ID = 'typescript'
+
+    // 10 characters each for easy math
+    const SOME_CONTENT = 'some text\n'
+    const SOME_ACCEPTED_CONTENT = 'accepted.\n'
+
+    let tracker: CodePercentageTracker
+    let telemetry: StubbedInstance<Telemetry>
+    let clock: sinon.SinonFakeTimers
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers()
+        telemetry = stubInterface<Telemetry>()
+        tracker = new CodePercentageTracker(telemetry)
+    })
+
+    afterEach(() => {
+        tracker.dispose()
+        clock.reset()
+    })
+
+    it('does not send telemetry without edits', () => {
+        clock.tick(5000 * 60)
+        sinon.assert.notCalled(telemetry.emitMetric)
+    })
+
+    it('emits metrics every 5 minutes while editing', () => {
+        tracker.countTokens(LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countAcceptedTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countInvocation(LANGUAGE_ID)
+        tracker.countSuccess(LANGUAGE_ID)
+
+        clock.tick(5000 * 60)
+
+        sinon.assert.calledWith(telemetry.emitMetric, {
+            name: 'codewhisperer_codePercentage',
+            data: {
+                codewhispererTotalTokens: 20,
+                codewhispererLanguage: LANGUAGE_ID,
+                codewhispererAcceptedTokens: 10,
+                codewhispererPercentage: 50.0,
+                successCount: 1,
+            },
+        })
+    })
+
+    it('emits no metrics without invocations', () => {
+        tracker.countTokens(OTHER_LANGUAGE_ID, SOME_CONTENT)
+
+        clock.tick(5000 * 60)
+
+        sinon.assert.notCalled(telemetry.emitMetric)
+    })
+
+    it('emits separate metrics for different languages', () => {
+        tracker.countTokens(LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countAcceptedTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countInvocation(LANGUAGE_ID)
+        tracker.countSuccess(LANGUAGE_ID)
+
+        tracker.countTokens(OTHER_LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTokens(OTHER_LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTokens(OTHER_LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countAcceptedTokens(OTHER_LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countInvocation(OTHER_LANGUAGE_ID)
+        tracker.countSuccess(OTHER_LANGUAGE_ID)
+
+        clock.tick(5000 * 60)
+
+        sinon.assert.calledWith(telemetry.emitMetric, {
+            name: 'codewhisperer_codePercentage',
+            data: {
+                codewhispererTotalTokens: 20,
+                codewhispererLanguage: LANGUAGE_ID,
+                codewhispererAcceptedTokens: 10,
+                codewhispererPercentage: 50.0,
+                successCount: 1,
+            },
+        })
+
+        sinon.assert.calledWith(telemetry.emitMetric, {
+            name: 'codewhisperer_codePercentage',
+            data: {
+                codewhispererTotalTokens: 30,
+                codewhispererLanguage: OTHER_LANGUAGE_ID,
+                codewhispererAcceptedTokens: 10,
+                codewhispererPercentage: 33.33,
+                successCount: 1,
+            },
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.ts
@@ -1,0 +1,106 @@
+import { Telemetry } from '@aws-placeholder/aws-language-server-runtimes/out/features'
+import { CodeWhispererCodePercentageEvent } from './types'
+
+const CODE_PERCENTAGE_INTERVAL = 5 * 60 * 1000
+const CODE_PERCENTAGE_EVENT_NAME = 'codewhisperer_codePercentage'
+
+type TelemetryBuckets = {
+    [languageId: string]: {
+        totalTokens: number
+        acceptedTokens: number
+        invocationCount: number
+        successCount: number
+    }
+}
+
+export class CodePercentageTracker {
+    private buckets: TelemetryBuckets
+    private intervalId: NodeJS.Timer
+    private telemetry: Telemetry
+
+    constructor(telemetry: Telemetry) {
+        this.buckets = {}
+        this.telemetry = telemetry
+
+        this.intervalId = this.startListening()
+    }
+
+    private startListening() {
+        return setInterval(() => {
+            this.getEventDataAndRotate().forEach(event => {
+                this.telemetry.emitMetric({
+                    name: CODE_PERCENTAGE_EVENT_NAME,
+                    data: event,
+                })
+            })
+        }, CODE_PERCENTAGE_INTERVAL)
+    }
+
+    private getEventDataAndRotate(): CodeWhispererCodePercentageEvent[] {
+        const previousBuckets = this.rotate()
+        return Object.keys(previousBuckets)
+            .filter(languageId => previousBuckets[languageId]?.invocationCount > 0)
+            .map(languageId => {
+                const bucket = previousBuckets[languageId]
+                const percentage = this.roundTwoDecimals((bucket.acceptedTokens / bucket.totalTokens) * 100)
+                return {
+                    codewhispererTotalTokens: bucket.totalTokens,
+                    codewhispererLanguage: languageId,
+                    codewhispererAcceptedTokens: bucket.acceptedTokens,
+                    codewhispererPercentage: percentage,
+                    successCount: bucket.successCount,
+                }
+            })
+    }
+
+    private roundTwoDecimals(n: number) {
+        // Number.EPSILON isn't perfect, but good enough for our purposes.
+        // Only works correctly for positive numbers in the 0-100 order of magnitude
+        return Math.round((n + Number.EPSILON) * 100) / 100
+    }
+
+    private rotate() {
+        const previous = this.buckets
+        this.buckets = {}
+        return previous
+    }
+
+    private getLanguageBucket(languageId: string): TelemetryBuckets[string] {
+        if (!this.buckets[languageId]) {
+            this.buckets[languageId] = {
+                totalTokens: 0,
+                acceptedTokens: 0,
+                invocationCount: 0,
+                successCount: 0,
+            }
+        }
+
+        return this.buckets[languageId]
+    }
+
+    countTokens(languageId: string, tokens: string): void {
+        const languageBucket = this.getLanguageBucket(languageId)
+        const tokenCount = tokens.length
+        languageBucket.totalTokens += tokenCount
+    }
+
+    countAcceptedTokens(languageId: string, tokens: string): void {
+        const languageBucket = this.getLanguageBucket(languageId)
+        const tokenCount = tokens.length
+        languageBucket.acceptedTokens += tokenCount
+    }
+
+    countInvocation(languageId: string): void {
+        const languageBucket = this.getLanguageBucket(languageId)
+        languageBucket.invocationCount++
+    }
+
+    countSuccess(languageId: string): void {
+        const languageBucket = this.getLanguageBucket(languageId)
+        languageBucket.successCount++
+    }
+
+    dispose(): void {
+        clearInterval(this.intervalId)
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
@@ -28,3 +28,11 @@ export interface CodeWhispererPerceivedLatencyEvent {
     codewhispererLanguage: CodewhispererLanguage
     credentialStartUrl?: string
 }
+
+export interface CodeWhispererCodePercentageEvent {
+    codewhispererTotalTokens: number
+    codewhispererLanguage: string
+    codewhispererAcceptedTokens: number
+    codewhispererPercentage: number
+    successCount: number
+}


### PR DESCRIPTION
## Problem
Emit a code percentage metric for every language in a 5 minute interval.

## Solution
Emit every 5 minutes, for every language that had at least one invocation. Calculate the percentage based on tokens typed vs tokens accepted. This does currently also count automated edits, pasting, reformats, etc since we are not able to detect or filter those server side.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
