### PR TITLE
Attach boolean value to the x-amzn-codewhisperer-optout header

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -60,9 +60,7 @@ export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
             onRequestSetup: [
                 req => {
                     req.on('build', ({ httpRequest }) => {
-                        if (!this.shareCodeWhispererContentWithAWS) {
-                            httpRequest.headers['x-amzn-codewhisperer-optout'] = ''
-                        }
+                        httpRequest.headers['x-amzn-codewhisperer-optout'] = `${!this.shareCodeWhispererContentWithAWS}`
                     })
                 },
             ],
@@ -113,9 +111,7 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
                             throw new Error('Authorization failed, bearer token is not set')
                         }
                         httpRequest.headers['Authorization'] = `Bearer ${creds.token}`
-                        if (!this.shareCodeWhispererContentWithAWS) {
-                            httpRequest.headers['x-amzn-codewhisperer-optout'] = ''
-                        }
+                        httpRequest.headers['x-amzn-codewhisperer-optout'] = `${!this.shareCodeWhispererContentWithAWS}`
                     })
                 },
             ],


### PR DESCRIPTION
## Problem
`x-amzn-codewhisperer-optout` can't be empty string and must be string value "true" | "false" based on the `shareCodeWhispererContentWithAWS` setting value.
When empty string header is added, CW API returns ValidationException: Improperly formed request
## Solution
Attach boolean value to the `x-amzn-codewhisperer-optout` header and always pass it with a CW request

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
