### PR TITLE
Prevent emitting PerceivedLatency on insufficient related data

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -1378,6 +1378,28 @@ static void Main()
             sinon.assert.calledWithExactly(features.telemetry.emitMetric, expectedPerceivedLatencyMetric)
         })
 
+        it('should not emit Perceived Latency metric when firstCompletionDisplayLatency is absent', async () => {
+            const sessionResultDataWithoutLatency = {
+                ...sessionResultData,
+                firstCompletionDisplayLatency: undefined,
+            }
+            await features.doInlineCompletionWithReferences(
+                {
+                    textDocument: { uri: SOME_FILE.uri },
+                    position: { line: 0, character: 0 },
+                    context: { triggerKind: InlineCompletionTriggerKind.Invoked },
+                },
+                CancellationToken.None
+            )
+
+            // deletes history of service invocation being emitted
+            features.telemetry.emitMetric.resetHistory()
+
+            await features.doLogInlineCompletionSessionResults(sessionResultDataWithoutLatency)
+
+            sinon.assert.notCalled(features.telemetry.emitMetric)
+        })
+
         describe('Connection metadata credentialStartUrl field', () => {
             it('should attach credentialStartUrl field if available in credentialsProvider', async () => {
                 features.credentialsProvider.getConnectionMetadata.returns({

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -350,7 +350,7 @@ export const CodewhispererServerFactory =
                 sessionManager.closeSession(session)
             }
 
-            emitPerceivedLatencyTelemetry(telemetry, session)
+            if (firstCompletionDisplayLatency) emitPerceivedLatencyTelemetry(telemetry, session)
         }
         const updateConfiguration = async () =>
             lsp.workspace


### PR DESCRIPTION
## Problem
Currently the PerceivedLatency metrics is emitted regardless of the data provided, we only want to emit it if `firstCompletionDisplayLatency` is supplied in the session result

## Solution
Add conditional to only emit the metric if the data needed is provided


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
