### PR TITLE
Scope down assertion for emitting perceivedLatency

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -1392,12 +1392,12 @@ static void Main()
                 CancellationToken.None
             )
 
-            // deletes history of service invocation being emitted
-            features.telemetry.emitMetric.resetHistory()
-
             await features.doLogInlineCompletionSessionResults(sessionResultDataWithoutLatency)
 
-            sinon.assert.notCalled(features.telemetry.emitMetric)
+            sinon.assert.neverCalledWith(
+                features.telemetry.emitMetric,
+                sinon.match.has('name', 'codewhisperer_perceivedLatency')
+            )
         })
 
         describe('Connection metadata credentialStartUrl field', () => {


### PR DESCRIPTION
Follow-up for https://github.com/aws/aws-language-servers/pull/91

## Problem
Test might fail when new metrics are added in Session Result handler

## Solution
Scope down assertion used

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
