### PR TITLE
feat: use previous decision in the auto trigger

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -293,13 +293,14 @@ export const CodewhispererServerFactory =
                 // This picks the last non-whitespace character, if any, before the cursor
                 const triggerCharacter = fileContext.leftFileContent.trim().at(-1) ?? ''
                 const codewhispererAutoTriggerType = triggerType(fileContext)
-                let autoTriggerResult = autoTrigger({
+                const previousDecision = sessionManager.getPreviousSession()?.getAggregatedUserTriggerDecision() ?? ''
+                const autoTriggerResult = autoTrigger({
                     fileContext, // The left/right file context and programming language
                     lineNum: params.position.line, // the line number of the invocation, this is the line of the cursor
                     char: triggerCharacter, // Add the character just inserted, if any, before the invication position
                     ide: '', // TODO: Fetch the IDE in a platform-agnostic way (from the initialize request?)
                     os: '', // TODO: We should get this in a platform-agnostic way (i.e., compatible with the browser)
-                    previousDecision: '', // TODO: Once we implement telemetry integration
+                    previousDecision, // The last decision by the user on the previous invocation
                     triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
                 })
 


### PR DESCRIPTION
## Problem
The user's previous decision on whether to accept, reject, or discard a suggestion has a significant impact on whether future suggestions will be accepted.

## Solution
This passes the state of the previous invocation to the auto trigger.

I did not write integration tests for this since the auto-trigger will depend heavily on all the coefficients, it will be almost impossible to isolate one specific coefficient, let alone force a specific outcome based on previous decision alone. We could write a unit test that spells out:

`sessionManager.getPreviousSession().returns(expectedSession); autoTrigger.expect({...args, previousDecision})`

But that's literally what the implementation already specifies.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
