### PR TITLE
Emit UserDecision telemetry

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
@@ -6,7 +6,7 @@ import { GenerateSuggestionsRequest, ResponseContext, Suggestion } from '../code
 import { CodewhispererLanguage } from '../languageDetection'
 
 type SessionState = 'REQUESTING' | 'ACTIVE' | 'CLOSED' | 'ERROR' | 'DISCARD'
-type UserDecision = 'Empty' | 'Filter' | 'Discard' | 'Accept' | 'Ignore' | 'Reject' | 'Unseen'
+export type UserDecision = 'Empty' | 'Filter' | 'Discard' | 'Accept' | 'Ignore' | 'Reject' | 'Unseen'
 type UserTriggerDecision = 'Accept' | 'Reject' | 'Empty' | 'Discard'
 
 export interface SessionData {
@@ -35,6 +35,7 @@ export class CodeWhispererSession {
     suggestions: Suggestion[] = []
     suggestionsStates = new Map<string, UserDecision>()
     acceptedSuggestionId?: string = undefined
+    acceptedSuggestionIndex?: number
     responseContext?: ResponseContext
     triggerType: CodewhispererTriggerType
     autoTriggerType?: CodewhispererAutomatedTriggerType
@@ -136,9 +137,11 @@ export class CodeWhispererSession {
         this.completionSessionResult = completionSessionResult
 
         let hasAcceptedSuggestion = false
-        for (let [itemId, states] of Object.entries(completionSessionResult)) {
+        const sessionResults = Object.entries(completionSessionResult)
+        for (let [itemId, states] of sessionResults) {
             if (states.accepted) {
                 this.acceptedSuggestionId = itemId
+                this.acceptedSuggestionIndex = sessionResults.indexOf([itemId, states])
                 hasAcceptedSuggestion = true
                 continue
             }
@@ -179,6 +182,10 @@ export class CodeWhispererSession {
 
     setSuggestionState(id: string, state: UserDecision) {
         this.suggestionsStates.set(id, state)
+    }
+
+    getSuggestionState(id: string): UserDecision | undefined {
+        return this.suggestionsStates.get(id)
     }
 
     /**

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
@@ -1,4 +1,5 @@
 import { CodewhispererLanguage } from '../languageDetection'
+import { UserDecision } from '../session/sessionManager'
 
 export type CodewhispererCompletionType = 'Block' | 'Line'
 
@@ -59,4 +60,19 @@ export interface CodeWhispererCodePercentageEvent {
     codewhispererAcceptedTokens: number
     codewhispererPercentage: number
     successCount: number
+}
+
+export interface CodeWhispererUserDecisionEvent {
+    codewhispererRequestId?: string
+    codewhispererSessionId?: string
+    codewhispererCompletionType?: CodewhispererCompletionType
+    codewhispererTriggerType: string
+    codewhispererLanguage: CodewhispererLanguage
+    credentialStartUrl?: string
+    codewhispererSuggestionIndex: number
+    codewhispererSuggestionState?: UserDecision
+    codewhispererSuggestionReferences?: string[]
+    codewhispererSuggestionReferenceCount: number
+    // TODO: After Pagination is implemented
+    codewhispererPaginationProgress?: number
 }


### PR DESCRIPTION
## Problem
We want to emit a metric that records the user decision on each of the suggestion returned

## Solution
Emit the metric for each of the suggestions shown to the user

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
