### PR TITLE
Add unit tests for User Decision metric

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.test.ts
@@ -648,4 +648,43 @@ describe('SessionManager', function () {
             assert.strictEqual(resultSession, undefined)
         })
     })
+
+    describe('getSuggestionState()', function () {
+        const SUGGESTIONS = [
+            { itemId: 'id1', content: 'recommendation 1' },
+            { itemId: 'id2', content: 'recommendation 2' },
+            { itemId: 'id3', content: 'recommendation 3' },
+            { itemId: 'id4', content: 'recommendation 4' },
+        ]
+
+        it('should return the state of suggestion with the associated ID', function () {
+            const session = new CodeWhispererSession(data)
+            session.activate()
+            session.suggestions = SUGGESTIONS
+            session.setSuggestionState('id1', 'Discard')
+            session.setSuggestionState('id2', 'Empty')
+            session.setSuggestionState('id3', 'Filter')
+            session.setSuggestionState('id4', 'Discard')
+
+            assert.equal(session.getSuggestionState('id1'), 'Discard')
+            assert.equal(session.getSuggestionState('id2'), 'Empty')
+            assert.equal(session.getSuggestionState('id3'), 'Filter')
+            assert.equal(session.getSuggestionState('id4'), 'Discard')
+        })
+
+        it('should return the undefined if no suggestion has the associated ID', function () {
+            const session = new CodeWhispererSession(data)
+            session.activate()
+            session.suggestions = SUGGESTIONS
+            session.setSuggestionState('id1', 'Discard')
+            session.setSuggestionState('id2', 'Empty')
+            session.setSuggestionState('id3', 'Filter')
+            session.setSuggestionState('id4', 'Discard')
+
+            assert.equal(session.getSuggestionState('id1'), 'Discard')
+            assert.equal(session.getSuggestionState('id2'), 'Empty')
+            assert.equal(session.getSuggestionState('id3'), 'Filter')
+            assert.equal(session.getSuggestionState('id4'), 'Discard')
+        })
+    })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
@@ -35,7 +35,6 @@ export class CodeWhispererSession {
     suggestions: Suggestion[] = []
     suggestionsStates = new Map<string, UserDecision>()
     acceptedSuggestionId?: string = undefined
-    acceptedSuggestionIndex?: number
     responseContext?: ResponseContext
     triggerType: CodewhispererTriggerType
     autoTriggerType?: CodewhispererAutomatedTriggerType
@@ -141,7 +140,6 @@ export class CodeWhispererSession {
         for (let [itemId, states] of sessionResults) {
             if (states.accepted) {
                 this.acceptedSuggestionId = itemId
-                this.acceptedSuggestionIndex = sessionResults.indexOf([itemId, states])
                 hasAcceptedSuggestion = true
                 continue
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
@@ -73,6 +73,4 @@ export interface CodeWhispererUserDecisionEvent {
     codewhispererSuggestionState?: UserDecision
     codewhispererSuggestionReferences?: string[]
     codewhispererSuggestionReferenceCount: number
-    // TODO: After Pagination is implemented
-    codewhispererPaginationProgress?: number
 }


### PR DESCRIPTION
Follow up of https://github.com/aws/aws-language-servers/pull/98

## Problem
We have no unit tests for User Decision metric yet

## Solution
Create tests for the metric based on suggestions

Additional: cleanup code from previous PR

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
