### PR TITLE
Suppress dependabot PRs in staging repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Documentation for configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:


### PR DESCRIPTION

This change prevents dependabot from creating PRs in the staging repo/branch. These changes should be made upstream in this repo instead, avoiding propagation conflicts.

See also: https://github.com/aws/aws-toolkit-vscode/pull/1706


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
