### PR TITLE
Check for secrets on commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,6 @@
 echo [pre-commit] formatting staged files...
 npm run format-staged
 echo [pre-commit] done formatting staged files
+
+git secrets --register-aws || (echo 'Please install git-secrets https://github.com/awslabs/git-secrets to check for accidentally commited secrets!' && exit 1)
+git secrets --scan


### PR DESCRIPTION
## Problem
AWS secrets can be leaked unintentionally on public repos.

## Solution
Install git secrets as pre-commit hook

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
