### PR TITLE
Configure SDK to use available proxy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,6 +48,7 @@
                 "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-codewhisperer-binary/out/index.js",
                 "ENABLE_INLINE_COMPLETION": "true",
                 "ENABLE_TOKEN_PROVIDER": "true"
+                // "HTTPS_PROXY": "http://127.0.0.1:8888",
             },
             "preLaunchTask": "npm: compile"
         },

--- a/app/aws-lsp-codewhisperer-binary/src/index.ts
+++ b/app/aws-lsp-codewhisperer-binary/src/index.ts
@@ -1,6 +1,6 @@
 import { standalone } from '@aws-placeholder/aws-language-server-runtimes'
 import { RuntimeProps } from '@aws-placeholder/aws-language-server-runtimes/out/runtimes/runtime'
-import { CodeWhispererServerToken } from '@lsp-placeholder/aws-lsp-codewhisperer'
+import { CodeWhispererServerTokenProxy } from '@lsp-placeholder/aws-lsp-codewhisperer/out/language-server/proxy-server'
 
 const MAJOR = 0
 const MINOR = 1
@@ -9,6 +9,6 @@ const VERSION = `${MAJOR}.${MINOR}.${PATCH}`
 
 const props: RuntimeProps = {
     version: VERSION,
-    servers: [CodeWhispererServerToken],
+    servers: [CodeWhispererServerTokenProxy],
 }
 standalone(props)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4254,14 +4254,14 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "6.0.2",
-            "dev": true,
-            "license": "MIT",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
             "dependencies": {
-                "debug": "4"
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -4851,7 +4851,6 @@
         },
         "node_modules/debug": {
             "version": "4.3.4",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "2.1.2"
@@ -5700,15 +5699,15 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
             "dependencies": {
-                "agent-base": "6",
+                "agent-base": "^7.0.2",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -6456,7 +6455,6 @@
         },
         "node_modules/ms": {
             "version": "2.1.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/multimatch": {
@@ -6989,6 +6987,18 @@
                 "pkg-fetch": "lib-es5/bin.js"
             }
         },
+        "node_modules/pkg-fetch/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/pkg-fetch/node_modules/chalk": {
             "version": "4.1.2",
             "dev": true,
@@ -7002,6 +7012,19 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/pkg-fetch/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/pkg/node_modules/chalk": {
@@ -8454,6 +8477,7 @@
                 "@aws-placeholder/aws-language-server-runtimes": "file:../../bin/aws-placeholder-aws-language-server-runtimes-0.1.1.tgz",
                 "@lsp-placeholder/aws-lsp-core": "^0.0.1",
                 "aws-sdk": "^2.1403.0",
+                "https-proxy-agent": "^7.0.2",
                 "uuid": "^9.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-codewhisperer/README.md
+++ b/server/aws-lsp-codewhisperer/README.md
@@ -1,0 +1,19 @@
+# CodeWhisperer Server
+
+## Guides
+
+### Proxy
+To use the CodeWhisperer server behind a proxy, import the [`CodeWhispererServerTokenProxy`](./src/language-server/proxy-server.ts) as the server and set up the environment variable `HTTPS_PROXY` or `https_proxy` to the proxy URL you are using.
+You can pass the environment variable to the process or just set it up globally on your system.
+
+```
+export HTTPS_PROXY=https://proxy.example.com:5678
+export https_proxy=https://proxy.example.com:5678
+```
+
+or
+
+```
+export HTTPS_PROXY=http://username:password@proxy.example.com:5678
+export https_proxy=http://username:password@proxy.example.com:5678
+```

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -16,6 +16,7 @@
         "@aws-placeholder/aws-language-server-runtimes": "file:../../bin/aws-placeholder-aws-language-server-runtimes-0.1.1.tgz",
         "@lsp-placeholder/aws-lsp-core": "^0.0.1",
         "aws-sdk": "^2.1403.0",
+        "https-proxy-agent": "^7.0.2",
         "uuid": "^9.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -563,5 +563,5 @@ export const CodeWhispererServerIAM = CodewhispererServerFactory(
     credentialsProvider => new CodeWhispererServiceIAM(credentialsProvider)
 )
 export const CodeWhispererServerToken = CodewhispererServerFactory(
-    credentialsProvider => new CodeWhispererServiceToken(credentialsProvider)
+    credentialsProvider => new CodeWhispererServiceToken(credentialsProvider, {})
 )

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -34,6 +34,7 @@ export interface GenerateSuggestionsResponse {
 
 import CodeWhispererSigv4Client = require('../client/sigv4/codewhispererclient')
 import CodeWhispererTokenClient = require('../client/token/codewhispererclient')
+import AWS = require('aws-sdk')
 
 // Right now the only difference between the token client and the IAM client for codewhsiperer is the difference in function name
 // This abstract class can grow in the future to account for any additional changes across the clients
@@ -51,6 +52,7 @@ export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
 
     constructor(credentialsProvider: CredentialsProvider) {
         super()
+
         const options: CodeWhispererTokenClientConfigurationOptions = {
             region: this.codeWhispererRegion,
             endpoint: this.codeWhispererEndpoint,
@@ -97,8 +99,9 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
     private readonly codeWhispererRegion = 'us-east-1'
     private readonly codeWhispererEndpoint = 'https://codewhisperer.us-east-1.amazonaws.com/'
 
-    constructor(credentialsProvider: CredentialsProvider) {
+    constructor(credentialsProvider: CredentialsProvider, additionalAwsConfig: any) {
         super()
+        this.updateAwsConfiguration(additionalAwsConfig)
 
         const options: CodeWhispererTokenClientConfigurationOptions = {
             region: this.codeWhispererRegion,
@@ -137,6 +140,14 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
         return {
             suggestions: response.completions as Suggestion[],
             responseContext,
+        }
+    }
+
+    updateAwsConfiguration = (awsConfig: any) => {
+        if (awsConfig.proxy) {
+            AWS.config.update({
+                httpOptions: { agent: awsConfig.proxy },
+            })
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -1,0 +1,16 @@
+import { HttpsProxyAgent } from 'https-proxy-agent'
+import { CodewhispererServerFactory } from './codeWhispererServer'
+import { CodeWhispererServiceToken } from './codeWhispererService'
+
+export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credentialsProvider => {
+    let additionalAwsConfig = {}
+    const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
+
+    if (proxyUrl) {
+        const proxyAgent = new HttpsProxyAgent(proxyUrl)
+        additionalAwsConfig = {
+            proxy: proxyAgent,
+        }
+    }
+    return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
+})


### PR DESCRIPTION
## Problem
CodeWhisperer could not be used when client uses a proxy

## Solution
Add proxy configuration to the SDK when clients set `HTTPS_PROXY` or `HTTP_PROXY` environment variable

Tested by creating a local proxy with Charles and seeing CW requests going through the proxy 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
