### PR TITLE
Increment aws-lsp-codewhisperer version to 0.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8472,7 +8472,7 @@
         },
         "server/aws-lsp-codewhisperer": {
             "name": "@lsp-placeholder/aws-lsp-codewhisperer",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "dependencies": {
                 "@aws-placeholder/aws-language-server-runtimes": "file:../../bin/aws-placeholder-aws-language-server-runtimes-0.1.1.tgz",
                 "@lsp-placeholder/aws-lsp-core": "^0.0.1",

--- a/server/aws-lsp-codewhisperer/CHANGELOG.md
+++ b/server/aws-lsp-codewhisperer/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
-## [0.0.2] - 2023-11-21
+## [0.0.3] - 2024-02-01
+- Add support for using AWS SDK through proxy
 
+## [0.0.2] - 2023-11-21
 - Initial release supporting telemetry, session management, authentication, context matching and auto-trigger

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lsp-placeholder/aws-lsp-codewhisperer",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "CodeWhisperer Language Server",
     "main": "out/index.js",
     "scripts": {


### PR DESCRIPTION
## Problem
We need to bump a version of CodeWhisperer server for release
## Solution
Version is bumped to 0.0.3

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.