### PR TITLE
Change proxy agent module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3987,7 +3987,6 @@
         },
         "node_modules/@types/node": {
             "version": "20.2.5",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/semver": {
@@ -4016,6 +4015,14 @@
             "version": "8.1.2",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/tunnel": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+            "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/vscode": {
             "version": "1.78.1",
@@ -4251,17 +4258,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -4851,6 +4847,7 @@
         },
         "node_modules/debug": {
             "version": "4.3.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "2.1.2"
@@ -5698,18 +5695,6 @@
                 "he": "bin/he"
             }
         },
-        "node_modules/https-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/human-signals": {
             "version": "1.1.1",
             "dev": true,
@@ -6455,6 +6440,7 @@
         },
         "node_modules/ms": {
             "version": "2.1.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/multimatch": {
@@ -7127,6 +7113,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/proxy-http-agent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/proxy-http-agent/-/proxy-http-agent-1.0.1.tgz",
+            "integrity": "sha512-dUJ41k7hBE9OMGbyQZl6sZdYjR5li+jqm7X3gfiyCxmZbE2W19Hq3dC8NjapU/09xie6brymZnqcWFtWU9shQQ==",
+            "dependencies": {
+                "@types/tunnel": "0.0.1",
+                "tunnel": "0.0.6"
             }
         },
         "node_modules/pump": {
@@ -7948,6 +7943,14 @@
                 "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
             }
         },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "dev": true,
@@ -8477,7 +8480,7 @@
                 "@aws-placeholder/aws-language-server-runtimes": "file:../../bin/aws-placeholder-aws-language-server-runtimes-0.1.1.tgz",
                 "@lsp-placeholder/aws-lsp-core": "^0.0.1",
                 "aws-sdk": "^2.1403.0",
-                "https-proxy-agent": "^7.0.2",
+                "proxy-http-agent": "^1.0.1",
                 "uuid": "^9.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -16,7 +16,7 @@
         "@aws-placeholder/aws-language-server-runtimes": "file:../../bin/aws-placeholder-aws-language-server-runtimes-0.1.1.tgz",
         "@lsp-placeholder/aws-lsp-core": "^0.0.1",
         "aws-sdk": "^2.1403.0",
-        "https-proxy-agent": "^7.0.2",
+        "proxy-http-agent": "^1.0.1",
         "uuid": "^9.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -1,4 +1,3 @@
-import { HttpsProxyAgent } from 'https-proxy-agent'
 import { CodewhispererServerFactory } from './codeWhispererServer'
 import { CodeWhispererServiceToken } from './codeWhispererService'
 
@@ -7,7 +6,10 @@ export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credenti
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
 
     if (proxyUrl) {
-        const proxyAgent = new HttpsProxyAgent(proxyUrl)
+        const { getProxyHttpAgent } = require('proxy-http-agent')
+        const proxyAgent = getProxyHttpAgent({
+            proxy: proxyUrl,
+        })
         additionalAwsConfig = {
             proxy: proxyAgent,
         }


### PR DESCRIPTION
## Problem
Module `https-proxy-agent` breaks in the bundle and executable with the following error:
```
"agent-base" has no default implementation, you must subclass and override `callback()`
```

## Solution
Could not find a definitive cause for the error, so we opt to change the module for another instead.

Code has been bundled and tested in VSCode, VS, and browser

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
