### PR TITLE
Add repo owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aws/aws-ides-team @kmile @ege0zcan @viktorsaws @rtarcr @rahmaniaam @imykhai
+* @aws/aws-ides-team @kmile @ege0zcan @viktorsaws @rtarcr @rahmaniaam @imykhai @volodkevych


### PR DESCRIPTION
## Problem
volodkevych@ is not in codeowners settings yet

## Solution
Add to `.github/CODEOWNERS`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
