### PR TITLE
Moved services to lsp-common folder, added tests for mutually exclusive Service

### DIFF
--- a/lsp-common/aws-lsp-common/package.json
+++ b/lsp-common/aws-lsp-common/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "@lsp-placeholder/aws-lsp-common",
+    "version": "0.0.1",
+    "description": "Core library, contains common code and utilities",
+    "main": "out/index.js",
+    "scripts": {
+        "compile": "tsc --build",
+        "test": "npm run test-unit",
+        "test-unit": "mocha './out/**/*.test.js'"
+    },
+    "dependencies": {
+        "jose": "^4.14.4",
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3",
+        "request-light": "^0.5.7"
+    },
+    "devDependencies": {
+        "@types/chai": "^4.3.5",
+        "@types/chai-as-promised": "^7.1.5",
+        "@types/mocha": "^10.0.1",
+        "@types/mock-fs": "^4.13.1",
+        "chai": "^4.3.7",
+        "chai-as-promised": "^7.1.1",
+        "mocha": "^10.2.0",
+        "mock-fs": "^5.2.0",
+        "sinon": "^15.1.0",
+        "ts-sinon": "^2.0.2"
+    }
+}

--- a/lsp-common/aws-lsp-common/src/index.ts
+++ b/lsp-common/aws-lsp-common/src/index.ts
@@ -1,0 +1,2 @@
+export * from './language-service/awsLanguageService'
+export * from './language-service/mutuallyExclusiveLanguageService'

--- a/lsp-common/aws-lsp-common/src/language-service/awsLanguageService.ts
+++ b/lsp-common/aws-lsp-common/src/language-service/awsLanguageService.ts
@@ -1,0 +1,16 @@
+import { Position, Range, TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
+import { CompletionList, Diagnostic, FormattingOptions, Hover } from 'vscode-languageserver-types'
+
+// Where possible, this interface should follow the (VS Code) JSON Language Server's interface,
+// (https://github.com/microsoft/vscode-json-languageservice/blob/v5.3.5/src/jsonLanguageService.ts#L38)
+// which closely resembles the core (VS Code) language server implementations.
+// We would prefer to leverage truly core types (like those from vscode-languageserver-textdocument),
+// since the JSON Language Service is a specific product and not a generalized interface type,
+// we have an explicit interface here for use in language services (and consumers).
+export interface AwsLanguageService {
+    isSupported(document: TextDocument): boolean
+    doValidation(textDocument: TextDocument): PromiseLike<Diagnostic[]>
+    doComplete(textDocument: TextDocument, position: Position): PromiseLike<CompletionList | null>
+    doHover(textDocument: TextDocument, position: Position): PromiseLike<Hover | null>
+    format(textDocument: TextDocument, range: Range, options: FormattingOptions): TextEdit[]
+}

--- a/lsp-common/aws-lsp-common/src/language-service/emptyLanguageService.ts
+++ b/lsp-common/aws-lsp-common/src/language-service/emptyLanguageService.ts
@@ -1,0 +1,29 @@
+import { Position, Range, TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
+import { CompletionList, Diagnostic, FormattingOptions, Hover } from 'vscode-languageserver-types'
+import { AwsLanguageService } from './awsLanguageService'
+
+/**
+ * Provides a stock "no-op" language service, which returns
+ * the "empty" equivalent for each call.
+ */
+export class EmptyLanguageService implements AwsLanguageService {
+    public isSupported(document: TextDocument): boolean {
+        return true
+    }
+
+    public doValidation(textDocument: TextDocument): PromiseLike<Diagnostic[]> {
+        return Promise.resolve([])
+    }
+
+    public doComplete(textDocument: TextDocument, position: Position): PromiseLike<CompletionList | null> {
+        return Promise.resolve(null)
+    }
+
+    public doHover(textDocument: TextDocument, position: Position): PromiseLike<Hover | null> {
+        return Promise.resolve(null)
+    }
+
+    public format(textDocument: TextDocument, range: Range, options: FormattingOptions): TextEdit[] {
+        return []
+    }
+}

--- a/lsp-common/aws-lsp-common/src/language-service/mutuallyExclusiveLanguageService.test.ts
+++ b/lsp-common/aws-lsp-common/src/language-service/mutuallyExclusiveLanguageService.test.ts
@@ -1,0 +1,69 @@
+import * as chai from 'chai'
+import { expect } from 'chai'
+import { TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
+import { CompletionList, Diagnostic, FormattingOptions, Hover, Position, Range } from 'vscode-languageserver-types'
+import * as chaiAsPromised from 'chai-as-promised'
+import { AwsLanguageService } from './awsLanguageService'
+import { beforeEach, describe, it } from 'node:test'
+import { MutuallyExclusiveLanguageService } from './mutuallyExclusiveLanguageService'
+
+const knownLanguageId = 'test-yaml'
+const diagnosticMessage = 'test diagnostic message'
+
+export class TestLanguageService implements AwsLanguageService {
+    public isSupported(document: TextDocument): boolean {
+        return document.languageId == knownLanguageId
+    }
+
+    public doValidation(textDocument: TextDocument): PromiseLike<Diagnostic[]> {
+        const testRange = Range.create(textDocument.positionAt(0), textDocument.positionAt(1))
+        const testDiagnostic = Diagnostic.create(testRange, diagnosticMessage)
+        return Promise.resolve([testDiagnostic])
+    }
+
+    public doComplete(textDocument: TextDocument, position: Position): PromiseLike<CompletionList | null> {
+        return Promise.resolve(null)
+    }
+
+    public doHover(textDocument: TextDocument, position: Position): PromiseLike<Hover | null> {
+        return Promise.resolve(null)
+    }
+
+    public format(textDocument: TextDocument, range: Range, options: FormattingOptions): TextEdit[] {
+        return []
+    }
+}
+
+chai.use(chaiAsPromised)
+
+describe('Test mutuallyExclusiveLanguageService', async () => {
+    let languageService: AwsLanguageService
+
+    beforeEach(async () => {
+        languageService = new MutuallyExclusiveLanguageService([new TestLanguageService()])
+    })
+
+    it('languageId is unknown, isSupported, should recognize', async () => {
+        const testTextDocument = TextDocument.create('test-uri', 'unknown-language-id', 1, 'some content')
+        expect(languageService.isSupported(testTextDocument)).to.equal(true)
+    })
+
+    it('languageId is known, isSupported, should recognize', async () => {
+        const testTextDocument = TextDocument.create('test-uri', knownLanguageId, 1, 'some content')
+        expect(languageService.isSupported(testTextDocument)).to.equal(true)
+    })
+
+    it('languageId is unknown, validate, should return empty diagnostic list', async () => {
+        const testTextDocument = TextDocument.create('test-uri', 'unknown-language-id', 1, 'some content')
+        const actualResult = await languageService.doValidation(testTextDocument)
+        expect(actualResult).to.be.empty
+    })
+
+    it('languageId is known, validate, should return 1 diagnostic', async () => {
+        const testTextDocument = TextDocument.create('test-uri', knownLanguageId, 1, 'some content')
+        const actualResult = await languageService.doValidation(testTextDocument)
+
+        expect(actualResult).to.have.length(1)
+        expect(actualResult[0].message).to.be.equal(diagnosticMessage)
+    })
+})

--- a/lsp-common/aws-lsp-common/src/language-service/mutuallyExclusiveLanguageService.ts
+++ b/lsp-common/aws-lsp-common/src/language-service/mutuallyExclusiveLanguageService.ts
@@ -1,0 +1,38 @@
+import { Position, Range, TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
+import { CompletionList, Diagnostic, FormattingOptions, Hover } from 'vscode-languageserver-types'
+import { AwsLanguageService } from './awsLanguageService'
+import { EmptyLanguageService } from './emptyLanguageService'
+
+/**
+ * This is a language service composed of other services provided through the constructor.
+ * It is expected that no more than one of the services will support a given document.
+ * In cases where no service supports a document, the "empty" service will be used.
+ */
+export class MutuallyExclusiveLanguageService implements AwsLanguageService {
+    private readonly services: AwsLanguageService[]
+
+    constructor(services: AwsLanguageService[]) {
+        // Empty language service assures that we will *always* have a default handler (which does nothing)
+        this.services = [...services, new EmptyLanguageService()]
+    }
+
+    public isSupported(document: TextDocument): boolean {
+        return this.services.some(service => service.isSupported(document))
+    }
+
+    public doValidation(textDocument: TextDocument): PromiseLike<Diagnostic[]> {
+        return this.services.find(service => service.isSupported(textDocument))!.doValidation(textDocument)
+    }
+
+    public doComplete(textDocument: TextDocument, position: Position): PromiseLike<CompletionList | null> {
+        return this.services.find(service => service.isSupported(textDocument))!.doComplete(textDocument, position)
+    }
+
+    public doHover(textDocument: TextDocument, position: Position): PromiseLike<Hover | null> {
+        return this.services.find(service => service.isSupported(textDocument))!.doHover(textDocument, position)
+    }
+
+    public format(textDocument: TextDocument, range: Range, options: FormattingOptions): TextEdit[] {
+        return this.services.find(service => service.isSupported(textDocument))!.format(textDocument, range, options)
+    }
+}

--- a/lsp-common/aws-lsp-common/tsconfig.json
+++ b/lsp-common/aws-lsp-common/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./out"
+    },
+    "include": ["src"]
+}

--- a/lsp-common/aws-lsp-json/package.json
+++ b/lsp-common/aws-lsp-json/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@lsp-placeholder/aws-lsp-json",
+    "version": "0.0.1",
+    "description": "JSON Language Server common code library",
+    "main": "out/index.js",
+    "scripts": {
+        "compile": "tsc --build"
+    },
+    "dependencies": {
+        "@lsp-placeholder/aws-lsp-common": "^0.0.1",
+        "vscode-json-languageservice": "^5.3.5",
+        "vscode-languageserver": "8.0.1",
+        "vscode-languageserver-textdocument": "^1.0.8"
+    }
+}

--- a/lsp-common/aws-lsp-json/src/index.ts
+++ b/lsp-common/aws-lsp-json/src/index.ts
@@ -1,0 +1,1 @@
+export * from './language-server/jsonLanguageService'

--- a/lsp-common/aws-lsp-json/src/language-server/jsonLanguageService.ts
+++ b/lsp-common/aws-lsp-json/src/language-server/jsonLanguageService.ts
@@ -1,0 +1,67 @@
+import { AwsLanguageService } from '@lsp-placeholder/aws-lsp-common'
+import { JSONDocument, LanguageService, getLanguageService, SchemaRequestService } from 'vscode-json-languageservice'
+import { CompletionList, Diagnostic, FormattingOptions, Hover, Range } from 'vscode-languageserver'
+import { Position, TextDocument, TextEdit } from 'vscode-languageserver-textdocument'
+
+export type JsonLanguageServiceProps = {
+    defaultSchemaUri?: string
+    schemaRequestService?: SchemaRequestService
+    allowComments: boolean
+}
+
+/**
+ * This is a thin wrapper around the VS Code Json Language Service
+ * https://github.com/microsoft/vscode-json-languageservice/
+ */
+export class JsonLanguageService implements AwsLanguageService {
+    private jsonService: LanguageService
+
+    constructor(private readonly props: JsonLanguageServiceProps) {
+        this.jsonService = getLanguageService({
+            schemaRequestService: props.schemaRequestService?.bind(this),
+        })
+
+        const schemas = props.defaultSchemaUri ? [{ fileMatch: ['*.json'], uri: props.defaultSchemaUri }] : undefined
+
+        this.jsonService.configure({ allowComments: props.allowComments, schemas })
+    }
+
+    public isSupported(document: TextDocument): boolean {
+        const languageId = document.languageId
+        // placeholder-test-json comes from the sample Visual Studio Client (Extension) in the repo
+        // see client/visualStudio/IdesLspPoc/ContentDefinitions/JsonContentType.cs
+        return languageId === 'json' || languageId === 'placeholder-test-json'
+    }
+
+    public doValidation(textDocument: TextDocument): Thenable<Diagnostic[]> {
+        const jsonDocument = this.parse(textDocument)
+
+        return this.jsonService.doValidation(textDocument, jsonDocument)
+    }
+
+    public doComplete(textDocument: TextDocument, position: Position): Thenable<CompletionList | null> {
+        const jsonDocument = this.parse(textDocument)
+
+        return this.jsonService.doComplete(textDocument, position, jsonDocument)
+    }
+
+    public doHover(textDocument: TextDocument, position: Position): Thenable<Hover | null> {
+        const jsonDocument = this.parse(textDocument)
+
+        return this.jsonService.doHover(textDocument, position, jsonDocument)
+    }
+
+    public format(textDocument: TextDocument, range: Range, options: FormattingOptions): TextEdit[] {
+        return this.jsonService.format(textDocument, range, options)
+    }
+
+    private parse(textDocument: TextDocument): JSONDocument {
+        const jsonDocument = this.jsonService.parseJSONDocument(textDocument)
+
+        if (!jsonDocument) {
+            throw new Error(`Unable to parse document with uri: ${textDocument.uri}`)
+        }
+
+        return jsonDocument
+    }
+}

--- a/lsp-common/aws-lsp-json/tsconfig.json
+++ b/lsp-common/aws-lsp-json/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./out"
+    },
+    "include": ["src"]
+}

--- a/lsp-common/aws-lsp-yaml/package.json
+++ b/lsp-common/aws-lsp-yaml/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "@lsp-placeholder/aws-lsp-yaml",
+    "version": "0.0.1",
+    "description": "YAML Language Server common code library",
+    "main": "out/index.js",
+    "scripts": {
+        "compile": "tsc --build"
+    },
+    "dependencies": {
+        "@lsp-placeholder/aws-lsp-common": "^0.0.1",
+        "vscode-languageserver": "8.0.1",
+        "yaml-language-server": "^1.13.0"
+    }
+}

--- a/lsp-common/aws-lsp-yaml/src/index.ts
+++ b/lsp-common/aws-lsp-yaml/src/index.ts
@@ -1,0 +1,1 @@
+export * from './language-server/yamlLanguageService'

--- a/lsp-common/aws-lsp-yaml/src/language-server/yamlLanguageService.ts
+++ b/lsp-common/aws-lsp-yaml/src/language-server/yamlLanguageService.ts
@@ -1,0 +1,83 @@
+import { AwsLanguageService } from '@lsp-placeholder/aws-lsp-common'
+import { CompletionList, Diagnostic, Hover, Position, Range, TextEdit } from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import {
+    FormattingOptions,
+    CustomFormatterOptions,
+    LanguageService,
+    getLanguageService,
+    SchemaRequestService,
+} from 'yaml-language-server'
+
+export interface YamlFormattingOptions extends FormattingOptions, CustomFormatterOptions {}
+
+export type YamlLanguageServiceProps = {
+    displayName: string
+    defaultSchemaUri: string
+    schemaRequestService: SchemaRequestService
+}
+
+/**
+ * This is a thin wrapper around the Redhat Yaml Language Service
+ * https://github.com/redhat-developer/yaml-language-server/
+ */
+export class YamlLanguageService implements AwsLanguageService {
+    private yamlService: LanguageService
+
+    constructor(private readonly props: YamlLanguageServiceProps) {
+        const workspaceContext = {
+            resolveRelativePath(relativePath: string, resource: string) {
+                return new URL(relativePath, resource).href
+            },
+        }
+
+        this.yamlService = getLanguageService({
+            schemaRequestService: this.props.schemaRequestService,
+            workspaceContext,
+        })
+
+        this.yamlService.configure({ schemas: [{ fileMatch: ['*.yml'], uri: this.props.defaultSchemaUri }] })
+    }
+
+    public isSupported(document: TextDocument): boolean {
+        return document.languageId === 'yaml'
+    }
+
+    public doValidation(document: TextDocument): Promise<Diagnostic[]> {
+        this.updateSchemaMapping(document.uri)
+        return this.yamlService.doValidation(document, false)
+    }
+
+    public doComplete(document: TextDocument, position: Position): Promise<CompletionList> {
+        this.updateSchemaMapping(document.uri)
+        return this.yamlService.doComplete(document, position, false)
+    }
+
+    public doHover(document: TextDocument, position: Position): Promise<Hover | null> {
+        this.updateSchemaMapping(document.uri)
+        return this.yamlService.doHover(document, position)
+    }
+
+    public format(document: TextDocument, range: Range, options: YamlFormattingOptions): TextEdit[] {
+        this.updateSchemaMapping(document.uri)
+        return this.yamlService.doFormat(document, options)
+    }
+
+    private updateSchemaMapping(documentUri: string): void {
+        // Temporary commented
+        // this.yamlService.configure({
+        //     hover: true,
+        //     completion: true,
+        //     validate: true,
+        //     customTags: [],
+        //     schemas: [
+        //         {
+        //             fileMatch: [documentUri],
+        //             uri: this.props.defaultSchemaUri,
+        //             name: this.props.displayName,
+        //             description: 'some description,',
+        //         },
+        //     ],
+        // })
+    }
+}

--- a/lsp-common/aws-lsp-yaml/tsconfig.json
+++ b/lsp-common/aws-lsp-yaml/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./out"
+    },
+    "include": ["src"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
                 "app/*",
                 "client/**",
                 "core/*",
-                "server/*"
+                "server/*",
+                "lsp-common/*"
             ],
             "dependencies": {
                 "typescript": "^5.0.4"
@@ -156,6 +157,47 @@
             "version": "0.0.1",
             "dependencies": {
                 "@lsp-placeholder/aws-lsp-core": "^0.0.1",
+                "vscode-languageserver": "8.0.1",
+                "yaml-language-server": "^1.13.0"
+            }
+        },
+        "lsp-common/aws-lsp-common": {
+            "name": "@lsp-placeholder/aws-lsp-common",
+            "version": "0.0.1",
+            "dependencies": {
+                "jose": "^4.14.4",
+                "request-light": "^0.5.7",
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3"
+            },
+            "devDependencies": {
+                "@types/chai": "^4.3.5",
+                "@types/chai-as-promised": "^7.1.5",
+                "@types/mocha": "^10.0.1",
+                "@types/mock-fs": "^4.13.1",
+                "chai": "^4.3.7",
+                "chai-as-promised": "^7.1.1",
+                "mocha": "^10.2.0",
+                "mock-fs": "^5.2.0",
+                "sinon": "^15.1.0",
+                "ts-sinon": "^2.0.2"
+            }
+        },
+        "lsp-common/aws-lsp-json": {
+            "name": "@lsp-placeholder/aws-lsp-json",
+            "version": "0.0.1",
+            "dependencies": {
+                "@lsp-placeholder/aws-lsp-common": "^0.0.1",
+                "vscode-json-languageservice": "^5.3.5",
+                "vscode-languageserver": "8.0.1",
+                "vscode-languageserver-textdocument": "^1.0.8"
+            }
+        },
+        "lsp-common/aws-lsp-yaml": {
+            "name": "@lsp-placeholder/aws-lsp-yaml",
+            "version": "0.0.1",
+            "dependencies": {
+                "@lsp-placeholder/aws-lsp-common": "^0.0.1",
                 "vscode-languageserver": "8.0.1",
                 "yaml-language-server": "^1.13.0"
             }
@@ -3093,8 +3135,16 @@
             "resolved": "app/aws-lsp-codewhisperer-binary",
             "link": true
         },
+        "node_modules/@lsp-placeholder/aws-lsp-common": {
+            "resolved": "lsp-common/aws-lsp-common",
+            "link": true
+        },
         "node_modules/@lsp-placeholder/aws-lsp-core": {
             "resolved": "core/aws-lsp-core",
+            "link": true
+        },
+        "node_modules/@lsp-placeholder/aws-lsp-json": {
+            "resolved": "lsp-common/aws-lsp-json",
             "link": true
         },
         "node_modules/@lsp-placeholder/aws-lsp-json-common": {
@@ -3107,6 +3157,10 @@
         },
         "node_modules/@lsp-placeholder/aws-lsp-s3-binary": {
             "resolved": "app/aws-lsp-s3-binary",
+            "link": true
+        },
+        "node_modules/@lsp-placeholder/aws-lsp-yaml": {
+            "resolved": "lsp-common/aws-lsp-yaml",
             "link": true
         },
         "node_modules/@lsp-placeholder/aws-lsp-yaml-common": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
         "app/*",
         "client/**",
         "core/*",
-        "server/*"
+        "server/*",
+        "lsp-common/*"
     ],
     "scripts": {
         "prepare": "husky install .husky",
-        "lint": "eslint app/ client/ core/ script/ server/ --ext .ts,.tsx && prettier --check .",
+        "lint": "eslint app/ client/ core/ script/ server/ lsp-common/ --ext .ts,.tsx && prettier --check .",
         "format": "prettier --write .",
         "format-staged": "npx pretty-quick --staged",
         "clean": "ts-node ./script/clean.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,15 @@
             "path": "./core/aws-lsp-yaml-common"
         },
         {
+            "path": "./lsp-common/aws-lsp-common"
+        },
+        {
+            "path": "./lsp-common/aws-lsp-yaml"
+        },
+        {
+            "path": "./lsp-common/aws-lsp-json"
+        },
+        {
             "path": "./server/aws-lsp-buildspec"
         },
         {


### PR DESCRIPTION
First commit for LSP servers project. 

## Problem
We need to develop JSON and YAML LSP DEXP servers. This commit adds a part of Language Services logic to `lsp-common` folder from `core` folder.
Later `core`, `server/aws-lsp-buildspec` and `server/aws-lsp-cloudformation` packages will be cleaned out, because these packages are not used and were added to the repository before DEXP platform development started.

## Solution
- Picked out components from unused `core` folder to provide main features for future JSON and YAML DEXP LSP Servers   
  - picked out common components for services
  - picked out YamlLanguageService and JsonLanguageService
- Added test cases for Mutually Exclusive Service
- Added code to compile packages from new `lsp-common` folder

## Testing
ran 
```
npm install
npm run compile
npm test
```
- checked that lsp-common package compiled
- all tests passed locally 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
