### PR TITLE
Rename package in amzn namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "monorepo-language-servers",
+    "name": "@amzn/monorepo-language-servers",
     "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "monorepo-language-servers",
+            "name": "@amzn/monorepo-language-servers",
             "version": "1.0.0",
             "workspaces": [
                 "app/*",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "monorepo-language-servers",
+    "name": "@amzn/monorepo-language-servers",
     "version": "1.0.0",
     "description": "A monorepo for Language Servers for AWS",
     "private": true,


### PR DESCRIPTION
## Problem
Open source team requires the package name to be in @aws (for publishing) or @amzn (not for publishing) namespaces

## Solution
Rename root pacakge

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
