### PR TITLE
add diagnostics, cancel handler and telemetry for security scan

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -1,21 +1,40 @@
 import { Server } from '@aws/language-server-runtimes'
 import { CredentialsProvider } from '@aws/language-server-runtimes/out/features'
-import { SecurityScanRequestParams } from '@aws/language-server-runtimes/out/features/securityScan/securityScan'
 import { pathToFileURL } from 'url'
 import { CancellationToken, ExecuteCommandParams } from 'vscode-languageserver'
 import { ArtifactMap } from '../client/token/codewhispererbearertokenclient'
 import { CodeWhispererServiceToken } from './codeWhispererService'
 import { DependencyGraphFactory } from './dependencyGraph/dependencyGraphFactory'
-import { SecurityScanHandler } from './securityScan/securityScanHandler'
-import { SecurityScanResponseParams } from './securityScan/types'
+import { getSupportedLanguageId, supportedSecurityScanLanguages } from './languageDetection'
+import SecurityScanDiagnosticsProvider from './securityScan/securityScanDiagnosticsProvider'
+import { SecurityScanCancelledError, SecurityScanHandler } from './securityScan/securityScanHandler'
+import { SecurityScanRequestParams, SecurityScanResponseParams } from './securityScan/types'
 import { parseJson } from './utils'
+import { SecurityScanEvent } from './telemetry/types'
 
 export const SecurityScanServerToken =
     (service: (credentialsProvider: CredentialsProvider) => CodeWhispererServiceToken): Server =>
-    ({ credentialsProvider, workspace, logging, lsp }) => {
+    ({ credentialsProvider, workspace, logging, lsp, telemetry }) => {
         const codewhispererclient = service(credentialsProvider)
+        const diagnosticsProvider = new SecurityScanDiagnosticsProvider(lsp, logging)
+        const scanHandler = new SecurityScanHandler(codewhispererclient, workspace, logging)
         let jobStatus: string
-        const runSecurityScan = async (params: SecurityScanRequestParams) => {
+        const securityScanStartTime = performance.now()
+        let serviceInvocationStartTime = 0
+        const securityScanTelemetryEntry: Partial<SecurityScanEvent> = {
+            codewhispererCodeScanSrcPayloadBytes: 0,
+            codewhispererCodeScanSrcZipFileBytes: 0,
+            codewhispererCodeScanLines: 0,
+            duration: 0,
+            contextTruncationDuration: 0,
+            artifactsUploadDuration: 0,
+            codeScanServiceInvocationsDuration: 0,
+            result: 'Succeeded',
+            codewhispererCodeScanTotalIssues: 0,
+            codewhispererCodeScanIssuesWithFixes: 0,
+            credentialStartUrl: credentialsProvider.getConnectionMetadata()?.sso?.startUrl ?? undefined,
+        }
+        const runSecurityScan = async (params: SecurityScanRequestParams, token: CancellationToken) => {
             logging.log(`Starting security scan`)
             try {
                 if (!credentialsProvider.hasCredentials('bearer')) {
@@ -32,6 +51,7 @@ export const SecurityScanServerToken =
                 }
                 const activeFilePathUri = pathToFileURL(activeFilePath).href
                 const document = await workspace.getTextDocument(activeFilePathUri)
+                securityScanTelemetryEntry.codewhispererLanguage = getSupportedLanguageId(document)
                 if (!document) {
                     throw new Error('Text document for given activeFilePath is undefined.')
                 }
@@ -52,13 +72,21 @@ export const SecurityScanServerToken =
                         `Selected file larger than ${dependencyGraph.getReadableSizeLimit()}. Try a different file.`
                     )
                 }
+                const contextTruncationStartTime = performance.now()
                 const truncation = await dependencyGraph.generateTruncation(activeFilePath)
-                const scanHandler = new SecurityScanHandler(codewhispererclient, workspace, logging)
+                securityScanTelemetryEntry.contextTruncationDuration = performance.now() - contextTruncationStartTime
+                securityScanTelemetryEntry.codewhispererCodeScanSrcPayloadBytes = truncation.srcPayloadSizeInBytes
+                securityScanTelemetryEntry.codewhispererCodeScanBuildPayloadBytes = truncation.buildPayloadSizeInBytes
+                securityScanTelemetryEntry.codewhispererCodeScanSrcZipFileBytes = truncation.zipFileSizeInBytes
+                securityScanTelemetryEntry.codewhispererCodeScanLines = truncation.lines
+                scanHandler.throwIfCancelled(token)
+
                 logging.log(`Complete project context processing.`)
 
                 /**
                  * Step 2: Get presigned Url, upload and clean up
                  */
+                const uploadStartTime = performance.now()
                 let artifactMap: ArtifactMap = {}
                 try {
                     artifactMap = await scanHandler.createCodeResourcePresignedUrlHandler(truncation.zipFileBuffer)
@@ -67,12 +95,17 @@ export const SecurityScanServerToken =
                     throw error
                 } finally {
                     await dependencyGraph.removeTmpFiles()
+                    securityScanTelemetryEntry.artifactsUploadDuration = performance.now() - uploadStartTime
                 }
+                scanHandler.throwIfCancelled(token)
                 /**
                  * Step 3:  Create scan job
                  */
+                serviceInvocationStartTime = performance.now()
                 const scanJob = await scanHandler.createScanJob(artifactMap, document.languageId.toLowerCase())
-                logging.log(`Created security scan job.`)
+                logging.log(`Created security scan job id: ${scanJob.jobId}`)
+                securityScanTelemetryEntry.codewhispererCodeScanJobId = scanJob.jobId
+                scanHandler.throwIfCancelled(token)
 
                 /**
                  * Step 4:  Polling mechanism on scan job status
@@ -81,6 +114,7 @@ export const SecurityScanServerToken =
                 if (jobStatus === 'Failed') {
                     throw new Error('security scan job failed.')
                 }
+                scanHandler.throwIfCancelled(token)
 
                 /**
                  * Step 5: Process and render scan results
@@ -96,45 +130,83 @@ export const SecurityScanServerToken =
                     { total: 0, withFixes: 0 }
                 )
                 logging.log(`Security scan totally found ${total} issues. ${withFixes} of them have fixes.`)
+                securityScanTelemetryEntry.codewhispererCodeScanTotalIssues = total
+                securityScanTelemetryEntry.codewhispererCodeScanIssuesWithFixes = withFixes
+                scanHandler.throwIfCancelled(token)
 
                 /**
                  * Step 6: send results to diagnostics
                  */
-                // Todo: update diagnostics to add securityRecommendationCollection
+                await diagnosticsProvider.createDiagnostics(securityRecommendationCollection)
 
                 logging.log(`Security scan completed.`)
+                truncation.scannedFiles.forEach(file => logging.log(`Scanned file: ${file}`))
                 return {
                     result: {
                         status: jobStatus,
+                        scannedFiles: Array.from(truncation.scannedFiles.values()).join(','),
                     },
                 } as SecurityScanResponseParams
             } catch (error) {
+                if (error instanceof SecurityScanCancelledError) {
+                    logging.log(`Security scan has been cancelled. ${error}`)
+                    securityScanTelemetryEntry.result = 'Cancelled'
+                    return {
+                        result: {
+                            status: 'Cancelled',
+                        },
+                    } as SecurityScanResponseParams
+                }
                 logging.log(`Security scan failed. ${error}`)
-                // Todo: notify client about scan job failure.
+                securityScanTelemetryEntry.result = 'Failed'
                 return {
                     result: {
                         status: 'Failed',
                     },
                     error,
                 } as SecurityScanResponseParams
+            } finally {
+                securityScanTelemetryEntry.duration = performance.now() - securityScanStartTime
+                securityScanTelemetryEntry.codeScanServiceInvocationsDuration =
+                    performance.now() - serviceInvocationStartTime
+                telemetry.emitMetric({
+                    name: 'codewhisperer_securityScan',
+                    result: securityScanTelemetryEntry.result,
+                    data: securityScanTelemetryEntry,
+                })
             }
         }
+
         const onExecuteCommandHandler = async (
             params: ExecuteCommandParams,
             _token: CancellationToken
         ): Promise<any> => {
+            logging.log(params.command)
             switch (params.command) {
                 case 'aws/codewhisperer/runSecurityScan':
-                    return runSecurityScan(params as SecurityScanRequestParams)
+                    return runSecurityScan(params as SecurityScanRequestParams, scanHandler.tokenSource.token)
                 case 'aws/codewhisperer/cancelSecurityScan':
-                // Todo: cancel command
+                    scanHandler.cancelSecurityScan()
             }
             return
         }
-        lsp.onExecuteCommand(onExecuteCommandHandler)
         logging.log('SecurityScan server has been initialized')
+        lsp.onExecuteCommand(onExecuteCommandHandler)
+        lsp.onDidChangeTextDocument(async p => {
+            const textDocument = await workspace.getTextDocument(p.textDocument.uri)
+            const languageId = getSupportedLanguageId(textDocument)
+
+            if (!textDocument || !languageId || !supportedSecurityScanLanguages.includes(languageId)) {
+                return
+            }
+
+            p.contentChanges.forEach(async change => {
+                await diagnosticsProvider.validateDiagnostics(p.textDocument.uri, change)
+            })
+        })
 
         return () => {
             // dispose function
+            scanHandler.tokenSource.dispose()
         }
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -9,8 +9,8 @@ import { getSupportedLanguageId, supportedSecurityScanLanguages } from './langua
 import SecurityScanDiagnosticsProvider from './securityScan/securityScanDiagnosticsProvider'
 import { SecurityScanCancelledError, SecurityScanHandler } from './securityScan/securityScanHandler'
 import { SecurityScanRequestParams, SecurityScanResponseParams } from './securityScan/types'
-import { parseJson } from './utils'
 import { SecurityScanEvent } from './telemetry/types'
+import { parseJson } from './utils'
 
 export const SecurityScanServerToken =
     (service: (credentialsProvider: CredentialsProvider) => CodeWhispererServiceToken): Server =>
@@ -18,24 +18,25 @@ export const SecurityScanServerToken =
         const codewhispererclient = service(credentialsProvider)
         const diagnosticsProvider = new SecurityScanDiagnosticsProvider(lsp, logging)
         const scanHandler = new SecurityScanHandler(codewhispererclient, workspace, logging)
-        let jobStatus: string
-        const securityScanStartTime = performance.now()
-        let serviceInvocationStartTime = 0
-        const securityScanTelemetryEntry: Partial<SecurityScanEvent> = {
-            codewhispererCodeScanSrcPayloadBytes: 0,
-            codewhispererCodeScanSrcZipFileBytes: 0,
-            codewhispererCodeScanLines: 0,
-            duration: 0,
-            contextTruncationDuration: 0,
-            artifactsUploadDuration: 0,
-            codeScanServiceInvocationsDuration: 0,
-            result: 'Succeeded',
-            codewhispererCodeScanTotalIssues: 0,
-            codewhispererCodeScanIssuesWithFixes: 0,
-            credentialStartUrl: credentialsProvider.getConnectionMetadata()?.sso?.startUrl ?? undefined,
-        }
+
         const runSecurityScan = async (params: SecurityScanRequestParams, token: CancellationToken) => {
             logging.log(`Starting security scan`)
+            let jobStatus: string
+            const securityScanStartTime = performance.now()
+            let serviceInvocationStartTime = 0
+            const securityScanTelemetryEntry: Partial<SecurityScanEvent> = {
+                codewhispererCodeScanSrcPayloadBytes: 0,
+                codewhispererCodeScanSrcZipFileBytes: 0,
+                codewhispererCodeScanLines: 0,
+                duration: 0,
+                contextTruncationDuration: 0,
+                artifactsUploadDuration: 0,
+                codeScanServiceInvocationsDuration: 0,
+                result: 'Succeeded',
+                codewhispererCodeScanTotalIssues: 0,
+                codewhispererCodeScanIssuesWithFixes: 0,
+                credentialStartUrl: credentialsProvider.getConnectionMetadata()?.sso?.startUrl ?? undefined,
+            }
             try {
                 if (!credentialsProvider.hasCredentials('bearer')) {
                     throw new Error('credentialsrProvider does not have bearer token credentials')

--- a/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
@@ -26,6 +26,7 @@ export type CodewhispererLanguage =
 // are integrated into the language server and clients.
 // See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocumentItem
 const supportedFileTypes: CodewhispererLanguage[] = ['c', 'cpp', 'csharp', 'javascript', 'python', 'typescript']
+export const supportedSecurityScanLanguages: CodewhispererLanguage[] = ['csharp']
 const supportedExtensions: { [key: string]: CodewhispererLanguage } = {
     '.c': 'c',
     '.h': 'c',

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
@@ -1,0 +1,130 @@
+import { Logging, Lsp } from '@aws/language-server-runtimes/out/features'
+import { Diagnostic, Hover, Position, Range, TextDocumentContentChangeEvent } from 'vscode-languageserver'
+import { URI } from 'vscode-uri'
+import { AggregatedCodeScanIssue, CodeScanIssue } from './types'
+
+class SecurityScanDiagnosticsProvider {
+    private diagnostics: Map<string, Diagnostic[]>
+    private lsp: Lsp
+    private logging: Logging
+
+    constructor(lsp: Lsp, logging: Logging) {
+        this.diagnostics = new Map()
+        this.lsp = lsp
+        this.logging = logging
+    }
+
+    async createDiagnostics(findings: AggregatedCodeScanIssue[]) {
+        for (const finding of findings) {
+            const path = URI.file(finding.filePath).path
+            const diagnostics = finding.issues.map(issue => this.mapScanIssueToDiagnostics(issue))
+            if (!this.diagnostics.has(path)) {
+                this.diagnostics.set(path, diagnostics)
+            }
+            this.diagnostics.set(path, [...(this.diagnostics.get(finding.filePath) || []), ...diagnostics])
+            await this.publishDiagnostics(finding.filePath, diagnostics)
+        }
+    }
+
+    mapScanIssueToDiagnostics(issue: CodeScanIssue): Diagnostic {
+        return Diagnostic.create(
+            this.createDiagnosticsRange(issue.startLine, issue.endLine),
+            `${issue.title} - ${issue.description.text}`,
+            2,
+            issue.relatedVulnerabilities.join(','),
+            'Detected by CodeWhisperer'
+        )
+    }
+
+    async validateDiagnostics(uri: string, e: TextDocumentContentChangeEvent) {
+        const path = URI.parse(uri).path
+        const currentDiagnostics = this.diagnostics.get(path)
+        if (!currentDiagnostics) {
+            return
+        }
+        const nextDiagnostics: Diagnostic[] = currentDiagnostics.map(diagnostic => {
+            if ((e as any).range.start.line > diagnostic.range.end.line) {
+                // change has no overlap with diagnostic
+                return diagnostic
+            } else if ((e as any).range.end.line < diagnostic.range.start.line) {
+                // change is before diagnostic range, update diagnostic range
+                const lineOffset = this.getLineOffset((e as any).range, e.text)
+                return {
+                    ...diagnostic,
+                    range: this.createDiagnosticsRange(
+                        diagnostic.range.start.line + lineOffset,
+                        diagnostic.range.end.line + lineOffset
+                    ),
+                }
+            } else {
+                // change is within diagnostic range, update range and messaging to re-scan
+                const newRange = this.getChangedDiagnosticRange(diagnostic.range, (e as any).range)
+                return diagnostic.severity === 2
+                    ? {
+                          ...diagnostic,
+                          severity: 3,
+                          message: `Re-scan to validate the fix: ${diagnostic.message}`,
+                          range: newRange,
+                      }
+                    : diagnostic
+            }
+        })
+        this.diagnostics.set(path, nextDiagnostics)
+        await this.publishDiagnostics(uri, nextDiagnostics)
+    }
+
+    getChangedDiagnosticRange(diagnosticRange: Range, documentChangeRange: Range): Range {
+        const start = Math.max(diagnosticRange.start.line, documentChangeRange.start.line)
+        const end = Math.min(diagnosticRange.end.line, documentChangeRange.end.line)
+        return this.createDiagnosticsRange(start, end === start ? start + 1 : end)
+    }
+
+    isPositionInRange = (position: Position, range: Range) => {
+        if (position.line < range.start.line || position.line > range.end.line) {
+            return false
+        }
+        return true
+    }
+
+    handleHover = (uri: string, diagnostics: Diagnostic[]) => {
+        this.lsp.onHover(({ position }) => {
+            for (const diagnostic of diagnostics) {
+                if (this.isPositionInRange(position, diagnostic.range)) {
+                    const hover: Hover = {
+                        contents: diagnostic.message,
+                        range: diagnostic.range,
+                    }
+                    return hover
+                }
+            }
+        })
+    }
+
+    getLineOffset(range: Range, text: string) {
+        const originLines = range.end.line - range.start.line + 1
+        const changedLines = text.split('\n').length
+        return changedLines - originLines
+    }
+
+    createDiagnosticsRange(startLine: number, endLine: number) {
+        return {
+            start: {
+                line: startLine,
+                character: 0,
+            },
+            end: {
+                line: endLine,
+                character: 0,
+            },
+        }
+    }
+
+    async publishDiagnostics(uri: string, diagnostics: Diagnostic[]) {
+        await this.lsp.publishDiagnostics({
+            uri,
+            diagnostics: diagnostics,
+        })
+        this.handleHover(uri, diagnostics)
+    }
+}
+export default SecurityScanDiagnosticsProvider

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/types.ts
@@ -52,7 +52,7 @@ export interface AggregatedCodeScanIssue {
     issues: CodeScanIssue[]
 }
 
-export type SecurityScanStatus = 'Succeeded' | 'Failed' | 'InProgress'
+export type SecurityScanStatus = 'Succeeded' | 'Failed' | 'InProgress' | 'Cancelled'
 export interface SecurityScanRequestParams extends ExecuteCommandParams {
     command: 'aws/codewhisperer/runSecurityScan'
 }
@@ -62,4 +62,5 @@ export interface SecurityScanResponseParams {
 }
 export interface SecurityScanResult {
     status: SecurityScanStatus
+    scannedFiles?: string
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
@@ -74,3 +74,25 @@ export interface CodeWhispererUserDecisionEvent {
     codewhispererSuggestionReferences?: string[]
     codewhispererSuggestionReferenceCount: number
 }
+
+export type Result = 'Succeeded' | 'Failed' | 'Cancelled'
+
+export interface SecurityScanEvent {
+    codewhispererCodeScanJobId?: string
+    codewhispererLanguage: CodewhispererLanguage
+    codewhispererCodeScanProjectBytes?: number
+    codewhispererCodeScanSrcPayloadBytes: number
+    codewhispererCodeScanBuildPayloadBytes?: number
+    codewhispererCodeScanSrcZipFileBytes: number
+    codewhispererCodeScanBuildZipFileBytes?: number
+    codewhispererCodeScanLines: number
+    duration: number
+    contextTruncationDuration: number
+    artifactsUploadDuration: number
+    codeScanServiceInvocationsDuration: number
+    result: Result
+    reason?: string
+    codewhispererCodeScanTotalIssues: number
+    codewhispererCodeScanIssuesWithFixes: number
+    credentialStartUrl: string | undefined
+}


### PR DESCRIPTION
## Problem
need to publish diagnostics, handle hover for security scan findings, add handler for cancel scan and publish the security scan telemetry event
## Solution
verified that diagnostics, hover and cancel works and telemetry event being sent as expected
![Screenshot (10)](https://github.com/aws/language-servers/assets/60411978/b9260b54-6f02-48d6-af14-439e636f4ada)


<!---


    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
