### PR TITLE
Pin aws/language-server-runtimes to minor version range.

### DIFF
--- a/app/aws-lsp-codewhisperer-binary/package.json
+++ b/app/aws-lsp-codewhisperer-binary/package.json
@@ -11,7 +11,7 @@
         "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --out-path bin --compress GZip ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.x",
+        "@aws/language-server-runtimes": "^0.1.1",
         "@aws/lsp-codewhisperer": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-binary/package.json
+++ b/app/aws-lsp-yaml-json-binary/package.json
@@ -11,7 +11,7 @@
         "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --out-path bin --compress GZip ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.x",
+        "@aws/language-server-runtimes": "^0.1.1",
         "@aws/aws-lsp-yaml-json": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-binary/package.json
+++ b/app/hello-world-lsp-binary/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.x"
+        "@aws/language-server-runtimes": "^0.1.1"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
             "name": "@aws/lsp-codewhisperer-binary",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.x",
+                "@aws/language-server-runtimes": "^0.1.1",
                 "@aws/lsp-codewhisperer": "*"
             },
             "bin": {
@@ -86,7 +86,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/aws-lsp-yaml-json": "*",
-                "@aws/language-server-runtimes": "^0.x"
+                "@aws/language-server-runtimes": "^0.1.1"
             },
             "bin": {
                 "aws-lsp-yaml-json-binary": "out/index.js"
@@ -100,7 +100,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.x"
+                "@aws/language-server-runtimes": "^0.1.1"
             },
             "bin": {
                 "hello-world-lsp-binary": "out/index.js"
@@ -7671,7 +7671,7 @@
             "version": "0.0.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.x",
+                "@aws/language-server-runtimes": "^0.1.1",
                 "adm-zip": "^0.5.10",
                 "aws-sdk": "^2.1403.0",
                 "got": "^11.8.5",
@@ -7708,7 +7708,7 @@
             "name": "@aws/aws-lsp-yaml-json",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.x",
+                "@aws/language-server-runtimes": "^0.1.1",
                 "@aws/lsp-core": "^0.0.1",
                 "@aws/lsp-json-common": "^0.0.1",
                 "@aws/lsp-yaml-common": "^0.0.1",
@@ -7720,7 +7720,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.x",
+                "@aws/language-server-runtimes": "^0.1.1",
                 "vscode-languageserver": "^9.0.1"
             }
         }

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -22,7 +22,7 @@
         "fix:prettier": "prettier . --write"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.x",
+        "@aws/language-server-runtimes": "^0.1.1",
         "adm-zip": "^0.5.10",
         "aws-sdk": "^2.1403.0",
         "got": "^11.8.5",

--- a/server/aws-lsp-yaml-json/package.json
+++ b/server/aws-lsp-yaml-json/package.json
@@ -8,7 +8,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.x",
+        "@aws/language-server-runtimes": "^0.1.1",
         "@aws/lsp-core": "^0.0.1",
         "@aws/lsp-json-common": "^0.0.1",
         "@aws/lsp-yaml-common": "^0.0.1",

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -8,7 +8,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.x",
+        "@aws/language-server-runtimes": "^0.1.1",
         "vscode-languageserver": "^9.0.1"
     }
 }


### PR DESCRIPTION
## Problem

We are preparing refactoring in `aws-language-runtimes` package, which will introduce breaking changes to imports structure to dependant packages https://github.com/aws/language-server-runtimes/pull/76. 

## Solution

New version of `aws-language-runtimes` will be next minor bump. To avoid current packages breaking on new minor, pin versions to currently used `0.1.x` minor version range.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
