### PR TITLE
Added support for format, hover and onDidOpenTextDocument capabilities

### DIFF
--- a/server/aws-lsp-yaml-json/src/language-server/testUtils.ts
+++ b/server/aws-lsp-yaml-json/src/language-server/testUtils.ts
@@ -1,4 +1,5 @@
 import { TextDocument } from 'vscode-languageserver-textdocument'
+import { TextDocumentItem } from 'vscode-languageserver-types'
 
 const JSON_COMPLETION_CONTENT = `{
     "greet"
@@ -16,8 +17,42 @@ const JSON_VALIDATION_CONTENT = `{
     "testNumber": 100nm500
 }`
 export const JSON_VALIDATION_FILE = TextDocument.create(
-    'file:///testJSONvalidation.yml',
+    'file:///testJSONvalidation.json',
     'json',
     1,
     JSON_VALIDATION_CONTENT
 )
+
+export const JSON_VALIDATION_OPEN_FILE_ITEM = TextDocumentItem.create(
+    'file:///testJSONnewfilevalidation.json',
+    'json',
+    1,
+    JSON_VALIDATION_CONTENT
+)
+export const JSON_VALIDATION_OPEN_FILE = TextDocument.create(
+    'file:///testJSONnewfilevalidation.json',
+    'json',
+    1,
+    JSON_VALIDATION_CONTENT
+)
+
+const JSON_HOVER_CONTENT = `{
+    "testHover": "Test hover field"
+}`
+export const JSON_HOVER_POSITION = { line: 2, character: 5 }
+export const JSON_HOVER_FILE = TextDocument.create('file:///testJSONhover.json', 'json', 1, JSON_HOVER_CONTENT)
+
+const JSON_FORMAT_CONTENT = `{
+    "testFormat": 'test format field"
+}`
+export const JSON_FORMAT_FILE = TextDocument.create('file:///testJSONformat.json', 'json', 1, JSON_FORMAT_CONTENT)
+export const JSON_FORMAT_RANGE = {
+    start: {
+        line: 0,
+        character: 0,
+    },
+    end: {
+        line: 3,
+        character: 0,
+    },
+}

--- a/server/aws-lsp-yaml-json/src/language-server/yamlJsonServer.test.ts
+++ b/server/aws-lsp-yaml-json/src/language-server/yamlJsonServer.test.ts
@@ -2,8 +2,18 @@ import { Server } from '@aws/language-server-runtimes/server-interface'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import { AwsLanguageService } from '@aws/lsp-core/out/base'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
-import { CancellationToken } from 'vscode-languageserver'
-import { JSON_COMPLETION_FILE, JSON_COMPLETION_POSITION, JSON_VALIDATION_FILE } from './testUtils'
+import { CancellationToken, FormattingOptions } from 'vscode-languageserver'
+import {
+    JSON_COMPLETION_FILE,
+    JSON_COMPLETION_POSITION,
+    JSON_VALIDATION_FILE,
+    JSON_VALIDATION_OPEN_FILE,
+    JSON_VALIDATION_OPEN_FILE_ITEM,
+    JSON_HOVER_FILE,
+    JSON_HOVER_POSITION,
+    JSON_FORMAT_FILE,
+    JSON_FORMAT_RANGE,
+} from './testUtils'
 import { YamlJsonServerFactory } from './yamlJsonServer'
 export { YamlJsonServerFactory } from './yamlJsonServer'
 
@@ -26,31 +36,53 @@ describe('YamlJson Server', () => {
         await features.start(server)
 
         features.openDocument(JSON_COMPLETION_FILE)
+        features.openDocument(JSON_VALIDATION_FILE)
+        features.openDocument(JSON_HOVER_FILE)
+        features.openDocument(JSON_FORMAT_FILE)
     })
 
     afterEach(() => {
         features.dispose()
     })
 
-    it('should validate', async () => {
-        features.workspace.getTextDocument.returns(Promise.resolve(JSON_COMPLETION_FILE))
-
+    it('should validate when change document', async () => {
         await features.doChangeTextDocument({
             textDocument: JSON_VALIDATION_FILE,
             contentChanges: [],
         })
 
-        sinon.assert.calledOnceWithExactly(service.doValidation, JSON_COMPLETION_FILE)
+        sinon.assert.calledOnceWithExactly(service.doValidation, JSON_VALIDATION_FILE)
+    })
+
+    it('should validate when open document', async () => {
+        await features.doOpenTextDocument({
+            textDocument: JSON_VALIDATION_OPEN_FILE_ITEM,
+        })
+
+        sinon.assert.calledOnceWithExactly(service.doValidation, JSON_VALIDATION_OPEN_FILE)
     })
 
     it('should complete', async () => {
-        features.workspace.getTextDocument.returns(Promise.resolve(JSON_COMPLETION_FILE))
-
         await features.doCompletion(
             { textDocument: JSON_COMPLETION_FILE, position: JSON_COMPLETION_POSITION },
             CancellationToken.None
         )
 
         sinon.assert.calledOnceWithExactly(service.doComplete, JSON_COMPLETION_FILE, JSON_COMPLETION_POSITION)
+    })
+
+    it('should hover', async () => {
+        await features.doHover({ textDocument: JSON_HOVER_FILE, position: JSON_HOVER_POSITION }, CancellationToken.None)
+
+        sinon.assert.calledOnceWithExactly(service.doHover, JSON_HOVER_FILE, JSON_HOVER_POSITION)
+    })
+
+    it('should format', async () => {
+        await features.doFormat(
+            { textDocument: JSON_FORMAT_FILE, options: {} as FormattingOptions },
+            CancellationToken.None
+        )
+
+        sinon.assert.calledOnceWithExactly(service.format, JSON_FORMAT_FILE, JSON_FORMAT_RANGE, {} as FormattingOptions)
     })
 })


### PR DESCRIPTION
## Problem
YAML JSON LSP server needs to support more capabilities.

## Solution

- Added onDidOpenTextDocument, onHover, onDidFormatDocument capabilities support 
- Added tests for new capabilities

## Testing

- Added more tests for new capabilities
- ran `npm install && npm run compile && npm test`
- ran YAML JSON server in vscode instance and tested manually

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
