### PR TITLE
Migrate to runtimes v0.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,6 +305,8 @@ To build and test Language Servers with AWS Runtime, follow these steps:
     cd language-server-runtimes && npm install && npm run compile && npm link
     ```
 
+**Note**: Since v0.2.0, we need to create a link to `/language-server-runtimes/out` directory to preserve correct imports structure. A package published to NPM uses sources from `out` folder, not the repository root.
+
 3. Install dependencies in `language-servers` folder:
 
     **Note:** We are temporarily commiting a snapshot of `language-server-runtimes` package as zip archive and use it as npm dependency for some servers. To develop and build language servers with local checkout of `language-server-runtimes`, for servers develped in ./server directory change `"@aws/language-server-runtimes"` dependency to point to `"*"` instead of file path before running `npm install`.

--- a/app/aws-lsp-codewhisperer-binary/package.json
+++ b/app/aws-lsp-codewhisperer-binary/package.json
@@ -11,7 +11,7 @@
         "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --out-path bin --compress GZip ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.1.1",
+        "@aws/language-server-runtimes": "^0.2.0",
         "@aws/lsp-codewhisperer": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-codewhisperer-binary/src/index.ts
+++ b/app/aws-lsp-codewhisperer-binary/src/index.ts
@@ -1,5 +1,5 @@
-import { standalone } from '@aws/language-server-runtimes'
-import { RuntimeProps } from '@aws/language-server-runtimes/out/runtimes/runtime'
+import { standalone } from '@aws/language-server-runtimes/runtimes'
+import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
 import {
     CodeWhispererSecurityScanServerTokenProxy,
     CodeWhispererServerTokenProxy,

--- a/app/aws-lsp-yaml-json-binary/package.json
+++ b/app/aws-lsp-yaml-json-binary/package.json
@@ -11,8 +11,8 @@
         "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --out-path bin --compress GZip ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.1.1",
-        "@aws/aws-lsp-yaml-json": "*"
+        "@aws/aws-lsp-yaml-json": "*",
+        "@aws/language-server-runtimes": "^0.2.0"
     },
     "devDependencies": {
         "pkg": "^5.8.1"

--- a/app/aws-lsp-yaml-json-binary/src/index.ts
+++ b/app/aws-lsp-yaml-json-binary/src/index.ts
@@ -1,5 +1,5 @@
-import { standalone } from '@aws/language-server-runtimes'
-import { RuntimeProps } from '@aws/language-server-runtimes/out/runtimes/runtime'
+import { standalone } from '@aws/language-server-runtimes/runtimes'
+import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
 import { YamlLanguageServer } from '@aws/aws-lsp-yaml-json'
 
 const MAJOR = 0

--- a/app/hello-world-lsp-binary/package.json
+++ b/app/hello-world-lsp-binary/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.1.1"
+        "@aws/language-server-runtimes": "^0.2.0"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/app/hello-world-lsp-binary/src/index.ts
+++ b/app/hello-world-lsp-binary/src/index.ts
@@ -1,5 +1,5 @@
-import { standalone } from '@aws/language-server-runtimes/out/runtimes'
-import { RuntimeProps } from '@aws/language-server-runtimes/out/runtimes/runtime'
+import { standalone } from '@aws/language-server-runtimes/runtimes'
+import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
 import { HelloWorldServer } from '@aws/hello-world-lsp'
 
 const MAJOR = 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
             "name": "@aws/lsp-codewhisperer-binary",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.1.1",
+                "@aws/language-server-runtimes": "^0.2.0",
                 "@aws/lsp-codewhisperer": "*"
             },
             "bin": {
@@ -86,7 +86,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/aws-lsp-yaml-json": "*",
-                "@aws/language-server-runtimes": "^0.1.1"
+                "@aws/language-server-runtimes": "^0.2.0"
             },
             "bin": {
                 "aws-lsp-yaml-json-binary": "out/index.js"
@@ -100,7 +100,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.1.1"
+                "@aws/language-server-runtimes": "^0.2.0"
             },
             "bin": {
                 "hello-world-lsp-binary": "out/index.js"
@@ -1464,17 +1464,44 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.1.1.tgz",
-            "integrity": "sha512-ILJmyB/nOK9SHd0kgkFoDgIwJ7xL1qaw8W4kGkbJ85Q5WfgQwjDPLhWOH10YqrSoWJVUPl3cE80omurIdFS0kw==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.0.tgz",
+            "integrity": "sha512-Bk5+4c+bjONgR4F0zO8LC4wpjVgB3FN4a27vhnmNFNUmS1MlesJ4gxy6Ul9XyvcV3DtB2Il1muDiENftlTADug==",
             "dependencies": {
-                "jose": "^4.14.4",
+                "jose": "^5.2.3",
                 "rxjs": "^7.8.1",
                 "vscode-languageserver": "^9.0.1",
-                "vscode-languageserver-textdocument": "^1.0.11"
+                "vscode-languageserver-protocol": "^3.17.5",
+                "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-languageserver-types": "^3.17.5"
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/jose": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.3.tgz",
+            "integrity": "sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/vscode-jsonrpc": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.2.0",
+                "vscode-languageserver-types": "3.17.5"
             }
         },
         "node_modules/@aws/lsp-buildspec": {
@@ -4344,20 +4371,6 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -7671,7 +7684,7 @@
             "version": "0.0.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.1.1",
+                "@aws/language-server-runtimes": "^0.2.0",
                 "adm-zip": "^0.5.10",
                 "aws-sdk": "^2.1403.0",
                 "got": "^11.8.5",
@@ -7707,7 +7720,7 @@
             "name": "@aws/aws-lsp-yaml-json",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.1.1",
+                "@aws/language-server-runtimes": "^0.2.0",
                 "@aws/lsp-core": "^0.0.1",
                 "@aws/lsp-json-common": "^0.0.1",
                 "@aws/lsp-yaml-common": "^0.0.1",
@@ -7719,7 +7732,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.1.1",
+                "@aws/language-server-runtimes": "^0.2.0",
                 "vscode-languageserver": "^9.0.1"
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7677,9 +7677,7 @@
                 "got": "^11.8.5",
                 "js-md5": "^0.8.3",
                 "proxy-http-agent": "^1.0.1",
-                "uuid": "^9.0.1",
-                "vscode-languageserver": "^9.0.1",
-                "vscode-languageserver-textdocument": "^1.0.8"
+                "uuid": "^9.0.1"
             },
             "devDependencies": {
                 "@types/adm-zip": "^0.4.34",
@@ -7687,7 +7685,8 @@
                 "assert": "^2.1.0",
                 "copyfiles": "^2.4.1",
                 "ts-mocha": "^10.0.0",
-                "ts-sinon": "^2.0.2"
+                "ts-sinon": "^2.0.2",
+                "vscode-languageserver-textdocument": "^1.0.11"
             },
             "engines": {
                 "node": ">=18.0.0"

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -28,9 +28,7 @@
         "got": "^11.8.5",
         "js-md5": "^0.8.3",
         "proxy-http-agent": "^1.0.1",
-        "uuid": "^9.0.1",
-        "vscode-languageserver": "^9.0.1",
-        "vscode-languageserver-textdocument": "^1.0.8"
+        "uuid": "^9.0.1"
     },
     "devDependencies": {
         "@types/adm-zip": "^0.4.34",
@@ -38,7 +36,8 @@
         "assert": "^2.1.0",
         "copyfiles": "^2.4.1",
         "ts-mocha": "^10.0.0",
-        "ts-sinon": "^2.0.2"
+        "ts-sinon": "^2.0.2",
+        "vscode-languageserver-textdocument": "^1.0.11"
     },
     "prettier": {
         "printWidth": 120,

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -22,7 +22,7 @@
         "fix:prettier": "prettier . --write"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.1.1",
+        "@aws/language-server-runtimes": "^0.2.0",
         "adm-zip": "^0.5.10",
         "aws-sdk": "^2.1403.0",
         "got": "^11.8.5",

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -1,7 +1,7 @@
 import { Server } from '@aws/language-server-runtimes'
 import { CredentialsProvider } from '@aws/language-server-runtimes/out/features'
 import { pathToFileURL } from 'url'
-import { CancellationToken, ExecuteCommandParams } from 'vscode-languageserver'
+import { CancellationToken, ExecuteCommandParams } from '@aws/language-server-runtimes/out/protocol'
 import { ArtifactMap } from '../client/token/codewhispererbearertokenclient'
 import { CodeWhispererServiceToken } from './codeWhispererService'
 import { DependencyGraphFactory } from './dependencyGraph/dependencyGraphFactory'

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -1,7 +1,10 @@
-import { Server } from '@aws/language-server-runtimes'
-import { CredentialsProvider } from '@aws/language-server-runtimes/out/features'
+import {
+    Server,
+    CredentialsProvider,
+    CancellationToken,
+    ExecuteCommandParams,
+} from '@aws/language-server-runtimes/out/features'
 import { pathToFileURL } from 'url'
-import { CancellationToken, ExecuteCommandParams } from '@aws/language-server-runtimes/out/protocol'
 import { ArtifactMap } from '../client/token/codewhispererbearertokenclient'
 import { CodeWhispererServiceToken } from './codeWhispererService'
 import { DependencyGraphFactory } from './dependencyGraph/dependencyGraphFactory'

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -3,7 +3,7 @@ import {
     CredentialsProvider,
     CancellationToken,
     ExecuteCommandParams,
-} from '@aws/language-server-runtimes/out/features'
+} from '@aws/language-server-runtimes/server-interface'
 import { pathToFileURL } from 'url'
 import { ArtifactMap } from '../client/token/codewhispererbearertokenclient'
 import { CodeWhispererServiceToken } from './codeWhispererService'

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -1,14 +1,15 @@
-import { Server } from '@aws/language-server-runtimes'
-import { MetricEvent } from '@aws/language-server-runtimes/out/features/telemetry/telemetry'
+import {
+    Server,
+    CancellationToken,
+    InlineCompletionTriggerKind,
+    TextDocument,
+    MetricEvent,
+} from '@aws/language-server-runtimes/out/features'
+// import {  } from '@aws/language-server-runtimes/out/features/telemetry/telemetry'
 import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
 import * as assert from 'assert'
 import { AWSError } from 'aws-sdk'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
-import {
-    CancellationToken,
-    InlineCompletionTriggerKind,
-    TextDocument,
-} from '@aws/language-server-runtimes/out/protocol'
 import { CONTEXT_CHARACTERS_LIMIT, CodewhispererServerFactory } from './codeWhispererServer'
 import { CodeWhispererServiceBase, ResponseContext, Suggestion } from './codeWhispererService'
 import { CodeWhispererSession, SessionData, SessionManager } from './session/sessionManager'

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -4,9 +4,8 @@ import {
     InlineCompletionTriggerKind,
     TextDocument,
     MetricEvent,
-} from '@aws/language-server-runtimes/out/features'
-// import {  } from '@aws/language-server-runtimes/out/features/telemetry/telemetry'
-import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
+} from '@aws/language-server-runtimes/server-interface'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as assert from 'assert'
 import { AWSError } from 'aws-sdk'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -4,8 +4,11 @@ import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
 import * as assert from 'assert'
 import { AWSError } from 'aws-sdk'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
-import { CancellationToken, InlineCompletionTriggerKind } from 'vscode-languageserver'
-import { TextDocument } from 'vscode-languageserver-textdocument'
+import {
+    CancellationToken,
+    InlineCompletionTriggerKind,
+    TextDocument,
+} from '@aws/language-server-runtimes/out/protocol'
 import { CONTEXT_CHARACTERS_LIMIT, CodewhispererServerFactory } from './codeWhispererServer'
 import { CodeWhispererServiceBase, ResponseContext, Suggestion } from './codeWhispererService'
 import { CodeWhispererSession, SessionData, SessionManager } from './session/sessionManager'

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -11,7 +11,7 @@ import {
     Position,
     Range,
     TextDocument,
-} from '@aws/language-server-runtimes/out/server-interface'
+} from '@aws/language-server-runtimes/server-interface'
 import { AWSError } from 'aws-sdk'
 import { autoTrigger, triggerType } from './auto-trigger/autoTrigger'
 import {

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -10,7 +10,7 @@ import {
     Position,
     Range,
     TextDocument,
-} from '@aws/language-server-runtimes/out/protocol'
+} from '@aws/language-server-runtimes/out/features'
 import { AWSError } from 'aws-sdk'
 import { autoTrigger, triggerType } from './auto-trigger/autoTrigger'
 import {

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -1,14 +1,17 @@
 import { Server } from '@aws/language-server-runtimes'
 import { CredentialsProvider, Telemetry } from '@aws/language-server-runtimes/out/features'
 import {
+    CancellationToken,
     InlineCompletionItemWithReferences,
     InlineCompletionListWithReferences,
     InlineCompletionWithReferencesParams,
     LogInlineCompletionSessionResultsParams,
-} from '@aws/language-server-runtimes/out/features/lsp/inline-completions/protocolExtensions'
+    InlineCompletionTriggerKind,
+    Position,
+    Range,
+    TextDocument,
+} from '@aws/language-server-runtimes/out/protocol'
 import { AWSError } from 'aws-sdk'
-import { CancellationToken, InlineCompletionTriggerKind, Range } from 'vscode-languageserver'
-import { Position, TextDocument } from 'vscode-languageserver-textdocument'
 import { autoTrigger, triggerType } from './auto-trigger/autoTrigger'
 import {
     CodeWhispererServiceBase,

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -1,6 +1,7 @@
-import { Server } from '@aws/language-server-runtimes'
-import { CredentialsProvider, Telemetry } from '@aws/language-server-runtimes/out/features'
 import {
+    Server,
+    CredentialsProvider,
+    Telemetry,
     CancellationToken,
     InlineCompletionItemWithReferences,
     InlineCompletionListWithReferences,
@@ -10,7 +11,7 @@ import {
     Position,
     Range,
     TextDocument,
-} from '@aws/language-server-runtimes/out/features'
+} from '@aws/language-server-runtimes/out/server-interface'
 import { AWSError } from 'aws-sdk'
 import { autoTrigger, triggerType } from './auto-trigger/autoTrigger'
 import {

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -1,5 +1,4 @@
-import { CredentialsProvider } from '@aws/language-server-runtimes/out/features'
-import { BearerCredentials } from '@aws/language-server-runtimes/out/protocol'
+import { CredentialsProvider, BearerCredentials } from '@aws/language-server-runtimes/out/features'
 import { AWSError, CredentialProviderChain, Credentials } from 'aws-sdk'
 import { PromiseResult } from 'aws-sdk/lib/request'
 import { v4 as uuidv4 } from 'uuid'

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -1,4 +1,4 @@
-import { CredentialsProvider, BearerCredentials } from '@aws/language-server-runtimes/out/features'
+import { CredentialsProvider, BearerCredentials } from '@aws/language-server-runtimes/server-interface'
 import { AWSError, CredentialProviderChain, Credentials } from 'aws-sdk'
 import { PromiseResult } from 'aws-sdk/lib/request'
 import { v4 as uuidv4 } from 'uuid'

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -1,5 +1,5 @@
 import { CredentialsProvider } from '@aws/language-server-runtimes/out/features'
-import { BearerCredentials } from '@aws/language-server-runtimes/out/features/auth/auth'
+import { BearerCredentials } from '@aws/language-server-runtimes/out/protocol'
 import { AWSError, CredentialProviderChain, Credentials } from 'aws-sdk'
 import { PromiseResult } from 'aws-sdk/lib/request'
 import { v4 as uuidv4 } from 'uuid'

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/csharpDependencyGraph.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/csharpDependencyGraph.test.ts
@@ -1,4 +1,4 @@
-import { Logging } from '@aws/language-server-runtimes/out/features'
+import { Logging } from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import * as path from 'path'
 import * as Sinon from 'sinon'

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/csharpDependencyGraph.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/csharpDependencyGraph.ts
@@ -1,4 +1,4 @@
-import { Logging, Workspace } from '@aws/language-server-runtimes/out/features'
+import { Logging, Workspace } from '@aws/language-server-runtimes/server-interface'
 import * as path from 'path'
 import { sleep } from './commonUtil'
 import * as CodeWhispererConstants from './constants'

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraph.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraph.ts
@@ -1,4 +1,4 @@
-import { Logging, Workspace } from '@aws/language-server-runtimes/out/features'
+import { Logging, Workspace } from '@aws/language-server-runtimes/server-interface'
 import * as admZip from 'adm-zip'
 import * as path from 'path'
 import * as CodeWhispererConstants from './constants'

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraphFactory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraphFactory.ts
@@ -1,5 +1,4 @@
-import { Logging, Workspace } from '@aws/language-server-runtimes/out/features'
-import { TextDocument } from '@aws/language-server-runtimes/out/protocol'
+import { Logging, Workspace, TextDocument } from '@aws/language-server-runtimes/out/features'
 import { CsharpDependencyGraph } from './csharpDependencyGraph'
 
 const languageMap = {

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraphFactory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraphFactory.ts
@@ -1,4 +1,4 @@
-import { Logging, Workspace, TextDocument } from '@aws/language-server-runtimes/out/features'
+import { Logging, Workspace, TextDocument } from '@aws/language-server-runtimes/server-interface'
 import { CsharpDependencyGraph } from './csharpDependencyGraph'
 
 const languageMap = {

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraphFactory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraphFactory.ts
@@ -1,5 +1,5 @@
 import { Logging, Workspace } from '@aws/language-server-runtimes/out/features'
-import { TextDocument } from 'vscode-languageserver-textdocument'
+import { TextDocument } from '@aws/language-server-runtimes/out/protocol'
 import { CsharpDependencyGraph } from './csharpDependencyGraph'
 
 const languageMap = {

--- a/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
@@ -1,4 +1,4 @@
-import { TextDocument } from '@aws/language-server-runtimes/out/features'
+import { TextDocument } from '@aws/language-server-runtimes/server-interface'
 
 export type CodewhispererLanguage =
     | 'java'

--- a/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
@@ -1,4 +1,4 @@
-import { TextDocument } from '@aws/language-server-runtimes/out/protocol'
+import { TextDocument } from '@aws/language-server-runtimes/out/features'
 
 export type CodewhispererLanguage =
     | 'java'

--- a/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
@@ -1,4 +1,4 @@
-import { TextDocument } from 'vscode-languageserver-textdocument'
+import { TextDocument } from '@aws/language-server-runtimes/out/protocol'
 
 export type CodewhispererLanguage =
     | 'java'

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -3,7 +3,7 @@ import {
     CredentialsProvider,
     CancellationToken,
     ExecuteCommandParams,
-} from '@aws/language-server-runtimes/out/features'
+} from '@aws/language-server-runtimes/server-interface'
 import { CodeWhispererServiceToken } from './codeWhispererService'
 
 /**

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -1,6 +1,9 @@
-import { Server } from '@aws/language-server-runtimes'
-import { CredentialsProvider } from '@aws/language-server-runtimes/out/features/auth/auth'
-import { CancellationToken, ExecuteCommandParams } from '@aws/language-server-runtimes/out/protocol'
+import {
+    Server,
+    CredentialsProvider,
+    CancellationToken,
+    ExecuteCommandParams,
+} from '@aws/language-server-runtimes/out/features'
 import { CodeWhispererServiceToken } from './codeWhispererService'
 
 /**

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -1,6 +1,6 @@
 import { Server } from '@aws/language-server-runtimes'
 import { CredentialsProvider } from '@aws/language-server-runtimes/out/features/auth/auth'
-import { CancellationToken, ExecuteCommandParams } from 'vscode-languageserver'
+import { CancellationToken, ExecuteCommandParams } from '@aws/language-server-runtimes/out/protocol'
 import { CodeWhispererServiceToken } from './codeWhispererService'
 
 /**

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
@@ -6,7 +6,7 @@ import {
     Position,
     Range,
     TextDocumentContentChangeEvent,
-} from '@aws/language-server-runtimes/out/features'
+} from '@aws/language-server-runtimes/server-interface'
 import { URI } from 'vscode-uri'
 import { AggregatedCodeScanIssue, CodeScanIssue } from './types'
 

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
@@ -1,11 +1,12 @@
-import { Logging, Lsp } from '@aws/language-server-runtimes/out/features'
 import {
+    Logging,
+    Lsp,
     Diagnostic,
     Hover,
     Position,
     Range,
     TextDocumentContentChangeEvent,
-} from '@aws/language-server-runtimes/out/protocol'
+} from '@aws/language-server-runtimes/out/features'
 import { URI } from 'vscode-uri'
 import { AggregatedCodeScanIssue, CodeScanIssue } from './types'
 

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
@@ -1,5 +1,11 @@
 import { Logging, Lsp } from '@aws/language-server-runtimes/out/features'
-import { Diagnostic, Hover, Position, Range, TextDocumentContentChangeEvent } from 'vscode-languageserver'
+import {
+    Diagnostic,
+    Hover,
+    Position,
+    Range,
+    TextDocumentContentChangeEvent,
+} from '@aws/language-server-runtimes/out/protocol'
 import { URI } from 'vscode-uri'
 import { AggregatedCodeScanIssue, CodeScanIssue } from './types'
 

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.test.ts
@@ -1,4 +1,4 @@
-import { Logging, Workspace } from '@aws/language-server-runtimes/out/features'
+import { Logging, Workspace } from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import { HttpResponse } from 'aws-sdk'
 import got from 'got'

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.ts
@@ -3,7 +3,7 @@ import {
     Workspace,
     CancellationToken,
     CancellationTokenSource,
-} from '@aws/language-server-runtimes/out/features'
+} from '@aws/language-server-runtimes/server-interface'
 import got from 'got'
 import { md5 } from 'js-md5'
 import * as path from 'path'

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.ts
@@ -1,9 +1,13 @@
-import { Logging, Workspace } from '@aws/language-server-runtimes/out/features'
+import {
+    Logging,
+    Workspace,
+    CancellationToken,
+    CancellationTokenSource,
+} from '@aws/language-server-runtimes/out/features'
 import got from 'got'
 import { md5 } from 'js-md5'
 import * as path from 'path'
 
-import { CancellationToken, CancellationTokenSource } from '@aws/language-server-runtimes/out/protocol'
 import {
     ArtifactMap,
     CreateUploadUrlRequest,

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.ts
@@ -3,7 +3,7 @@ import got from 'got'
 import { md5 } from 'js-md5'
 import * as path from 'path'
 
-import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver'
+import { CancellationToken, CancellationTokenSource } from '@aws/language-server-runtimes/out/protocol'
 import {
     ArtifactMap,
     CreateUploadUrlRequest,

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/types.ts
@@ -1,4 +1,4 @@
-import { ExecuteCommandParams } from '@aws/language-server-runtimes/out/protocol'
+import { ExecuteCommandParams } from '@aws/language-server-runtimes/out/features'
 export interface RecommendationDescription {
     text: string
     markdown: string

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/types.ts
@@ -1,4 +1,4 @@
-import { ExecuteCommandParams } from 'vscode-languageserver'
+import { ExecuteCommandParams } from '@aws/language-server-runtimes/out/protocol'
 export interface RecommendationDescription {
     text: string
     markdown: string

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/types.ts
@@ -1,4 +1,4 @@
-import { ExecuteCommandParams } from '@aws/language-server-runtimes/out/features'
+import { ExecuteCommandParams } from '@aws/language-server-runtimes/server-interface'
 export interface RecommendationDescription {
     text: string
     markdown: string

--- a/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
@@ -1,4 +1,4 @@
-import { InlineCompletionStates, Position } from '@aws/language-server-runtimes/out/protocol'
+import { InlineCompletionStates, Position } from '@aws/language-server-runtimes/out/features'
 import { v4 as uuidv4 } from 'uuid'
 import { CodewhispererAutomatedTriggerType, CodewhispererTriggerType } from '../auto-trigger/autoTrigger'
 import { GenerateSuggestionsRequest, ResponseContext, Suggestion } from '../codeWhispererService'

--- a/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
@@ -1,4 +1,4 @@
-import { InlineCompletionStates, Position } from '@aws/language-server-runtimes/out/features'
+import { InlineCompletionStates, Position } from '@aws/language-server-runtimes/server-interface'
 import { v4 as uuidv4 } from 'uuid'
 import { CodewhispererAutomatedTriggerType, CodewhispererTriggerType } from '../auto-trigger/autoTrigger'
 import { GenerateSuggestionsRequest, ResponseContext, Suggestion } from '../codeWhispererService'

--- a/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
@@ -1,6 +1,5 @@
-import { InlineCompletionStates } from '@aws/language-server-runtimes/out/features/lsp/inline-completions/protocolExtensions'
+import { InlineCompletionStates, Position } from '@aws/language-server-runtimes/out/protocol'
 import { v4 as uuidv4 } from 'uuid'
-import { Position } from 'vscode-languageserver'
 import { CodewhispererAutomatedTriggerType, CodewhispererTriggerType } from '../auto-trigger/autoTrigger'
 import { GenerateSuggestionsRequest, ResponseContext, Suggestion } from '../codeWhispererService'
 import { CodewhispererLanguage } from '../languageDetection'

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
@@ -1,8 +1,11 @@
 import { Server } from '@aws/language-server-runtimes'
-import { InlineCompletionListWithReferences } from '@aws/language-server-runtimes/out/features/lsp/inline-completions/protocolExtensions'
+import {
+    InlineCompletionListWithReferences,
+    CancellationToken,
+    InlineCompletionTriggerKind,
+} from '@aws/language-server-runtimes/out/protocol'
 import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
-import { CancellationToken, InlineCompletionTriggerKind } from 'vscode-languageserver'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { CodewhispererServerFactory } from './codeWhispererServer'
 import { CodeWhispererServiceBase, ResponseContext, Suggestion } from './codeWhispererService'

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
@@ -3,8 +3,8 @@ import {
     InlineCompletionListWithReferences,
     CancellationToken,
     InlineCompletionTriggerKind,
-} from '@aws/language-server-runtimes/out/features'
-import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
+} from '@aws/language-server-runtimes/server-interface'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { CodewhispererServerFactory } from './codeWhispererServer'

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
@@ -1,9 +1,9 @@
-import { Server } from '@aws/language-server-runtimes'
 import {
+    Server,
     InlineCompletionListWithReferences,
     CancellationToken,
     InlineCompletionTriggerKind,
-} from '@aws/language-server-runtimes/out/protocol'
+} from '@aws/language-server-runtimes/out/features'
 import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
 import { TextDocument } from 'vscode-languageserver-textdocument'

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.test.ts
@@ -1,4 +1,4 @@
-import { Telemetry } from '@aws/language-server-runtimes/out/features'
+import { Telemetry } from '@aws/language-server-runtimes/server-interface'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
 import { CodePercentageTracker } from './codePercentage'
 import assert = require('assert')

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.ts
@@ -1,4 +1,4 @@
-import { Telemetry } from '@aws/language-server-runtimes/out/features'
+import { Telemetry } from '@aws/language-server-runtimes/server-interface'
 import { CodeWhispererCodePercentageEvent } from './types'
 
 const CODE_PERCENTAGE_INTERVAL = 5 * 60 * 1000

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/userTriggerDecision.test.ts
@@ -1,9 +1,9 @@
-import { Server } from '@aws/language-server-runtimes'
 import {
+    Server,
     InlineCompletionListWithReferences,
     CancellationToken,
     InlineCompletionTriggerKind,
-} from '@aws/language-server-runtimes/out/protocol'
+} from '@aws/language-server-runtimes/out/features'
 import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
 import * as assert from 'assert'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/userTriggerDecision.test.ts
@@ -1,9 +1,12 @@
 import { Server } from '@aws/language-server-runtimes'
-import { InlineCompletionListWithReferences } from '@aws/language-server-runtimes/out/features/lsp/inline-completions/protocolExtensions'
+import {
+    InlineCompletionListWithReferences,
+    CancellationToken,
+    InlineCompletionTriggerKind,
+} from '@aws/language-server-runtimes/out/protocol'
 import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
 import * as assert from 'assert'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
-import { CancellationToken, InlineCompletionTriggerKind } from 'vscode-languageserver'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { CodewhispererServerFactory } from '../codeWhispererServer'
 import { CodeWhispererServiceBase, ResponseContext, Suggestion } from '../codeWhispererService'

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/userTriggerDecision.test.ts
@@ -3,8 +3,8 @@ import {
     InlineCompletionListWithReferences,
     CancellationToken,
     InlineCompletionTriggerKind,
-} from '@aws/language-server-runtimes/out/features'
-import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
+} from '@aws/language-server-runtimes/server-interface'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as assert from 'assert'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
 import { TextDocument } from 'vscode-languageserver-textdocument'

--- a/server/aws-lsp-yaml-json/package.json
+++ b/server/aws-lsp-yaml-json/package.json
@@ -8,7 +8,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.1.1",
+        "@aws/language-server-runtimes": "^0.2.0",
         "@aws/lsp-core": "^0.0.1",
         "@aws/lsp-json-common": "^0.0.1",
         "@aws/lsp-yaml-common": "^0.0.1",

--- a/server/aws-lsp-yaml-json/src/language-server/yamlJsonServer.test.ts
+++ b/server/aws-lsp-yaml-json/src/language-server/yamlJsonServer.test.ts
@@ -1,5 +1,5 @@
-import { Server } from '@aws/language-server-runtimes'
-import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
+import { Server } from '@aws/language-server-runtimes/server-interface'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import { AwsLanguageService } from '@aws/lsp-core/out/base'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
 import { CancellationToken } from 'vscode-languageserver'

--- a/server/aws-lsp-yaml-json/src/language-server/yamlJsonServer.ts
+++ b/server/aws-lsp-yaml-json/src/language-server/yamlJsonServer.ts
@@ -1,11 +1,11 @@
-import { Server } from '@aws/language-server-runtimes'
+import { Server } from '@aws/language-server-runtimes/server-interface'
 import { AwsLanguageService } from '@aws/lsp-core/out/base'
 import {
     CancellationToken,
     CompletionList,
     CompletionParams,
     DidChangeTextDocumentParams,
-} from 'vscode-languageserver/node'
+} from '@aws/language-server-runtimes/server-interface'
 import { create } from './yamlJsonService'
 
 /**

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -8,7 +8,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.1.1",
+        "@aws/language-server-runtimes": "^0.2.0",
         "vscode-languageserver": "^9.0.1"
     }
 }

--- a/server/hello-world-lsp/src/language-server/helloWorldServer.test.ts
+++ b/server/hello-world-lsp/src/language-server/helloWorldServer.test.ts
@@ -1,5 +1,5 @@
-import { Server } from '@aws/language-server-runtimes'
-import { TestFeatures } from '@aws/language-server-runtimes/out/testing'
+import { Server } from '@aws/language-server-runtimes/server-interface'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
 import { CancellationToken, ExecuteCommandParams } from 'vscode-languageserver'
 import { TextDocument } from 'vscode-languageserver-textdocument'

--- a/server/hello-world-lsp/src/language-server/helloWorldServer.ts
+++ b/server/hello-world-lsp/src/language-server/helloWorldServer.ts
@@ -1,6 +1,11 @@
-import { Logging, Lsp, Telemetry, Workspace } from '@aws/language-server-runtimes/out/features'
-import { CredentialsProvider } from '@aws/language-server-runtimes/out/features/auth/auth'
-import { Server } from '@aws/language-server-runtimes/out/runtimes'
+import {
+    Server,
+    Logging,
+    Lsp,
+    Telemetry,
+    Workspace,
+    CredentialsProvider,
+} from '@aws/language-server-runtimes/server-interface'
 import {
     CancellationToken,
     CompletionItem,


### PR DESCRIPTION
## Problem

New version of @aws/language-server-runtimes package v0.2.0 was released, which introduces breaking change into package component imports https://github.com/aws/language-server-runtimes/pull/76.

We need to migrate this project to new version of runtimes to have access to latest additions to features available.

## Solution

* Upgrade packages dependant on runtimes package to version 0.2.0
* Upgrade imports structure to match new project import directories.

### Notable changes:
* All imports are flattened and do not contain `/out/` directory in imports path anymore.
* All language servers implementations should now take dependency on `/server-interface/` directory to get access to Server features of Runtimes project.
  * Change imports of `LSP, Workspace, CredentialsProvider, Telemetry, Logging` classes from `@aws/language-server-runtimes/out/features` to `@aws/language-server-runtimes/server-interface`
  * Change import of `Server` object from `@aws/language-server-runtimes` to `@aws/language-server-runtimes/server-interface`
  * Change import of `TestingFeatures` object from `@aws/language-server-runtimes/out/testing` to `@aws/language-server-runtimes/testing`
* `@aws/language-server-runtimes/server-interface` exports also now contain types and interfaces from `vscode-languageserver` project, supported by Runtimes LSP feature. Depending directly on `vscode-languageserver` to get access to types in server implementation is not necessary, they can be accessed from `@aws/language-server-runtimes/server-interface` now.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
