### PR TITLE
Release 0.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7681,7 +7681,7 @@
         },
         "server/aws-lsp-codewhisperer": {
             "name": "@aws/lsp-codewhisperer",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7690,7 +7690,8 @@
                 "got": "^11.8.5",
                 "js-md5": "^0.8.3",
                 "proxy-http-agent": "^1.0.1",
-                "uuid": "^9.0.1"
+                "uuid": "^9.0.1",
+                "vscode-uri": "^3.0.8"
             },
             "devDependencies": {
                 "@types/adm-zip": "^0.4.34",

--- a/server/aws-lsp-codewhisperer/CHANGELOG.md
+++ b/server/aws-lsp-codewhisperer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.4] - 2024-03-28
+- Integrate dependency graph with RunSecurityScan function
+- Add server for transform feature
+- Add diagnostics, handle hover for security scan findings, handler for cancel scan, and security scan telemetry event
+- Migrate consumption of `@aws/language-server-runtimes` from local to NPMJS
+
 ## [0.0.3] - 2024-02-01
 - Add support for using AWS SDK through proxy
 

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -28,7 +28,8 @@
         "got": "^11.8.5",
         "js-md5": "^0.8.3",
         "proxy-http-agent": "^1.0.1",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "vscode-uri": "^3.0.8"
     },
     "devDependencies": {
         "@types/adm-zip": "^0.4.34",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/lsp-codewhisperer",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "CodeWhisperer Language Server",
     "main": "out/index.js",
     "repository": {


### PR DESCRIPTION
## Problem
Due to v0.0.3 not able to be installed because it was depending on local tarball that was not included in the registry, we need to publish a new version of the CodeWhisperer server

## Solution
Migrate the consumption of `@aws/language-server-runtimes` from local to npmjs, release new version and publish it to npm.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
