### PR TITLE
[DO NOT MERGE] Example for execute commands with routing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,7 +59,8 @@
             "env": {
                 "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-codewhisperer-binary/out/index.js",
                 "ENABLE_INLINE_COMPLETION": "true",
-                "ENABLE_TOKEN_PROVIDER": "true"
+                "ENABLE_TOKEN_PROVIDER": "true",
+                "ENABLE_CUSTOM_COMMANDS": "true"
                 // "HTTPS_PROXY": "http://127.0.0.1:8888",
             },
             "preLaunchTask": "npm: compile"

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -40,6 +40,14 @@
             {
                 "command": "helloWorld.log",
                 "title": "Hello World LSP - Log Command"
+            },
+            {
+                "command": "aws.codewhisperer.runSecurityScan",
+                "title": "Security Code Scan - Run"
+            },
+            {
+                "command": "aws.codewhisperer.cancelSecurityScan",
+                "title": "Security Code Scan - Cancel"
             }
         ],
         "configuration": {

--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -16,7 +16,7 @@ import {
     writeEncryptionInit,
 } from './credentialsActivation'
 import { registerInlineCompletion } from './inlineCompletionActivation'
-import { registerLogCommand } from './sampleCommandActivation'
+import { registerLogCommand, registerSecurityScanCommands } from './sampleCommandActivation'
 
 export async function activateDocumentsLanguageServer(extensionContext: ExtensionContext) {
     /**
@@ -117,6 +117,7 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
     const enableCustomCommands = process.env.ENABLE_CUSTOM_COMMANDS === 'true'
     if (enableCustomCommands) {
         await registerLogCommand(client, extensionContext)
+        await registerSecurityScanCommands(client, extensionContext)
     }
 
     client.start()

--- a/client/vscode/src/sampleCommandActivation.ts
+++ b/client/vscode/src/sampleCommandActivation.ts
@@ -5,12 +5,41 @@ export function registerLogCommand(languageClient: LanguageClient, extensionCont
     extensionContext.subscriptions.push(commands.registerCommand('helloWorld.log', logCommand(languageClient)))
 }
 
-export function logCommand(languageClient: LanguageClient) {
+export function registerSecurityScanCommands(languageClient: LanguageClient, extensionContext: ExtensionContext) {
+    extensionContext.subscriptions.push(
+        commands.registerCommand('aws.codewhisperer.runSecurityScan', runSecurityScanCommand(languageClient))
+    )
+    extensionContext.subscriptions.push(
+        commands.registerCommand('aws.codewhisperer.cancelSecurityScan', cancelSecurityScanCommand(languageClient))
+    )
+}
+
+function logCommand(languageClient: LanguageClient) {
     return async () => {
         const request: ExecuteCommandParams = {
             command: '/helloWorld/log',
         }
         await languageClient.sendRequest(ExecuteCommandRequest.method, request)
         languageClient.info(`Client: The log command has been executed`)
+    }
+}
+
+function runSecurityScanCommand(languageClient: LanguageClient) {
+    return async () => {
+        const request: ExecuteCommandParams = {
+            command: 'aws/codewhisperer/runSecurityScan',
+        }
+        await languageClient.sendRequest(ExecuteCommandRequest.method, request)
+        languageClient.info(`Client: The run security scan command has been executed`)
+    }
+}
+
+function cancelSecurityScanCommand(languageClient: LanguageClient) {
+    return async () => {
+        const request: ExecuteCommandParams = {
+            command: 'aws/codewhisperer/cancelSecurityScan',
+        }
+        await languageClient.sendRequest(ExecuteCommandRequest.method, request)
+        languageClient.info(`Client: The cancel security scan command has been executed`)
     }
 }


### PR DESCRIPTION
## Problem

Shows how to configure LSP servers for execute commands support on example of CodeWhispererCodeScan server.
Related to [PR](https://github.com/aws/language-server-runtimes/pull/81).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
