### PR TITLE
Update SecurityScanResponse to include relevant details when security scan is performed

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -164,7 +164,7 @@ export const SecurityScanServerToken =
                 }
                 logging.log(`Security scan failed. ${error}`)
                 securityScanTelemetryEntry.result = 'Failed'
-                var err = getErrorMessage(error)
+                const err = getErrorMessage(error)
                 return {
                     status: 'Failed',
                     error: err,

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -1,8 +1,8 @@
 import {
-    Server,
-    CredentialsProvider,
     CancellationToken,
+    CredentialsProvider,
     ExecuteCommandParams,
+    Server,
 } from '@aws/language-server-runtimes/server-interface'
 import { pathToFileURL } from 'url'
 import { ArtifactMap } from '../client/token/codewhispererbearertokenclient'
@@ -11,9 +11,9 @@ import { DependencyGraphFactory } from './dependencyGraph/dependencyGraphFactory
 import { getSupportedLanguageId, supportedSecurityScanLanguages } from './languageDetection'
 import SecurityScanDiagnosticsProvider from './securityScan/securityScanDiagnosticsProvider'
 import { SecurityScanCancelledError, SecurityScanHandler } from './securityScan/securityScanHandler'
-import { SecurityScanRequestParams, SecurityScanResponseParams } from './securityScan/types'
+import { SecurityScanRequestParams, SecurityScanResponse } from './securityScan/types'
 import { SecurityScanEvent } from './telemetry/types'
-import { parseJson } from './utils'
+import { getErrorMessage, parseJson } from './utils'
 
 export const SecurityScanServerToken =
     (service: (credentialsProvider: CredentialsProvider) => CodeWhispererServiceToken): Server =>
@@ -43,7 +43,7 @@ export const SecurityScanServerToken =
             }
             try {
                 if (!credentialsProvider.hasCredentials('bearer')) {
-                    throw new Error('credentialsrProvider does not have bearer token credentials')
+                    throw new Error('credentialsProvider does not have bearer token credentials')
                 }
                 if (!params.arguments || params.arguments.length === 0) {
                     throw new Error(`Incorrect params provided. Params: ${params}`)
@@ -133,7 +133,7 @@ export const SecurityScanServerToken =
                     }),
                     { total: 0, withFixes: 0 }
                 )
-                logging.log(`Security scan totally found ${total} issues. ${withFixes} of them have fixes.`)
+                logging.log(`Security scan found ${total} issues, ${withFixes} have suggested fixes.`)
                 securityScanTelemetryEntry.codewhispererCodeScanTotalIssues = total
                 securityScanTelemetryEntry.codewhispererCodeScanIssuesWithFixes = withFixes
                 scanHandler.throwIfCancelled(token)
@@ -145,30 +145,30 @@ export const SecurityScanServerToken =
 
                 logging.log(`Security scan completed.`)
                 truncation.scannedFiles.forEach(file => logging.log(`Scanned file: ${file}`))
+
                 return {
-                    result: {
-                        status: jobStatus,
+                    status: 'Succeeded',
+                    findings: {
+                        totalFindings: total,
+                        findingsWithFixes: withFixes,
                         scannedFiles: Array.from(truncation.scannedFiles.values()).join(','),
                     },
-                } as SecurityScanResponseParams
+                } as SecurityScanResponse
             } catch (error) {
                 if (error instanceof SecurityScanCancelledError) {
                     logging.log(`Security scan has been cancelled. ${error}`)
                     securityScanTelemetryEntry.result = 'Cancelled'
                     return {
-                        result: {
-                            status: 'Cancelled',
-                        },
-                    } as SecurityScanResponseParams
+                        status: 'Cancelled',
+                    } as SecurityScanResponse
                 }
                 logging.log(`Security scan failed. ${error}`)
                 securityScanTelemetryEntry.result = 'Failed'
+                var err = getErrorMessage(error)
                 return {
-                    result: {
-                        status: 'Failed',
-                    },
-                    error,
-                } as SecurityScanResponseParams
+                    status: 'Failed',
+                    error: err,
+                } as SecurityScanResponse
             } finally {
                 securityScanTelemetryEntry.duration = performance.now() - securityScanStartTime
                 securityScanTelemetryEntry.codeScanServiceInvocationsDuration =

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
@@ -50,7 +50,7 @@ class SecurityScanDiagnosticsProvider {
             `${issue.title} - ${issue.description.text}`,
             2,
             issue.relatedVulnerabilities.join(','),
-            'CodeWhisperer Security Scan'
+            'CodeWhisperer'
         )
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
@@ -1,8 +1,8 @@
 import {
-    Logging,
-    Lsp,
     Diagnostic,
     Hover,
+    Logging,
+    Lsp,
     Position,
     Range,
     TextDocumentContentChangeEvent,
@@ -50,7 +50,7 @@ class SecurityScanDiagnosticsProvider {
             `${issue.title} - ${issue.description.text}`,
             2,
             issue.relatedVulnerabilities.join(','),
-            'Detected by CodeWhisperer'
+            'CodeWhisperer Security Scan'
         )
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/types.ts
@@ -52,15 +52,19 @@ export interface AggregatedCodeScanIssue {
     issues: CodeScanIssue[]
 }
 
-export type SecurityScanStatus = 'Succeeded' | 'Failed' | 'InProgress' | 'Cancelled'
+export type SecurityScanStatus = 'Succeeded' | 'Failed' | 'Cancelled'
 export interface SecurityScanRequestParams extends ExecuteCommandParams {
     command: 'aws/codewhisperer/runSecurityScan'
 }
-export interface SecurityScanResponseParams {
-    result: SecurityScanResult
+
+export interface SecurityScanResponse {
+    status: SecurityScanStatus
+    findings?: SecurityScanFindings
     error?: string
 }
-export interface SecurityScanResult {
-    status: SecurityScanStatus
-    scannedFiles?: string
+
+export interface SecurityScanFindings {
+    totalFindings: number
+    findingsWithFixes: number
+    scannedFiles: string
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -31,3 +31,10 @@ export function parseJson(jsonString: string) {
         throw new Error(`error while parsing string: ${jsonString}`)
     }
 }
+
+export function getErrorMessage(error: any): string {
+    if (error instanceof Error) {
+        return error.message
+    }
+    return String(error)
+}


### PR DESCRIPTION
## Description
This change updates the `SecurityScanResponse` that is sent to client when RunSecurityScan is invoked.
Changes include:
* `SecurityScanFindings` data object is created that represents the total findings, findings with fixes and files scanned.
* `SecurityScanResponse` now contains `SecurityScanFindings` and the status of the operation
* Error records the error message when a failure occurs instead of passing it as an object
* Tool name for the security scan is updated to be more concise as `CodeWhisperer`
*  Security scan final output message is refactored to be a bit more clear


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
