### PR TITLE
Update runtimes to 0.2.2

### DIFF
--- a/app/aws-lsp-codewhisperer-binary/package.json
+++ b/app/aws-lsp-codewhisperer-binary/package.json
@@ -11,7 +11,7 @@
         "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --out-path bin --compress GZip ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.1",
+        "@aws/language-server-runtimes": "^0.2.2",
         "@aws/lsp-codewhisperer": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-binary/package.json
+++ b/app/aws-lsp-yaml-json-binary/package.json
@@ -14,16 +14,16 @@
     },
     "dependencies": {
         "@aws/aws-lsp-yaml-json": "*",
-        "@aws/language-server-runtimes": "^0.2.1"
+        "@aws/language-server-runtimes": "^0.2.2"
     },
     "devDependencies": {
-        "pkg": "^5.8.1",
         "@types/chai": "^4.3.5",
         "@types/chai-as-promised": "^7.1.5",
         "@types/mocha": "^10.0.1",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "mocha": "^10.2.0",
+        "pkg": "^5.8.1",
         "ts-lsp-client": "^1.0.1"
     }
 }

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -12,26 +12,26 @@
     },
     "dependencies": {
         "@aws/aws-lsp-yaml-json": "*",
-        "@aws/language-server-runtimes": "^0.2.1"
+        "@aws/language-server-runtimes": "^0.2.2"
     },
     "devDependencies": {
         "@types/node": "^20.11.30",
+        "assert": "^2.1.0",
+        "crypto-browserify": "^3.12.0",
         "fs": "^0.0.1-security",
         "license-checker": "^25.0.1",
+        "os-browserify": "^0.3.0",
+        "oss-attribution-generator": "^1.7.1",
         "path": "^0.12.7",
+        "path-browserify": "^1.0.1",
         "pkg": "^5.8.1",
+        "stream-browserify": "^3.0.0",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.3",
+        "umd-compat-loader": "^2.1.2",
         "webpack": "^5.91.0",
         "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.0.4",
-        "assert": "^2.1.0",
-        "crypto-browserify": "^3.12.0",
-        "os-browserify": "^0.3.0",
-        "oss-attribution-generator": "^1.7.1",
-        "path-browserify": "^1.0.1",
-        "stream-browserify": "^3.0.0",
-        "umd-compat-loader": "^2.1.2"
+        "webpack-dev-server": "^5.0.4"
     }
 }

--- a/app/hello-world-lsp-binary/package.json
+++ b/app/hello-world-lsp-binary/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.1"
+        "@aws/language-server-runtimes": "^0.2.2"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
             "name": "@aws/lsp-codewhisperer-binary",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.1",
+                "@aws/language-server-runtimes": "^0.2.2",
                 "@aws/lsp-codewhisperer": "*"
             },
             "bin": {
@@ -87,7 +87,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/aws-lsp-yaml-json": "*",
-                "@aws/language-server-runtimes": "^0.2.1"
+                "@aws/language-server-runtimes": "^0.2.2"
             },
             "bin": {
                 "aws-lsp-yaml-json-binary": "out/index.js"
@@ -108,7 +108,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/aws-lsp-yaml-json": "*",
-                "@aws/language-server-runtimes": "^0.2.1"
+                "@aws/language-server-runtimes": "^0.2.2"
             },
             "devDependencies": {
                 "@types/node": "^20.11.30",
@@ -136,7 +136,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.1"
+                "@aws/language-server-runtimes": "^0.2.2"
             },
             "bin": {
                 "hello-world-lsp-binary": "out/index.js"
@@ -1552,9 +1552,7 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.1.tgz",
-            "integrity": "sha512-4OnlIPRB02GXUD1Wh52MV0gfU50SPau8sTgW0PfMIv5B49EmAZiZiOyXYiUBxG6Yt1tIm+ncjhG+j8Tw8VbBtA==",
+            "version": "0.2.2",
             "dependencies": {
                 "jose": "^5.2.3",
                 "rxjs": "^7.8.1",
@@ -2880,9 +2878,7 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.12.6",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.6.tgz",
-            "integrity": "sha512-3KurE8taB8GCvZBPngVbp0lk5CKi8M9f9k1rsADh0Evdz5SzJ+Q+Hx9uHoFGsLnLnd1xmkDQr2hVhlA0Mn0lKQ==",
+            "version": "20.12.5",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -5047,9 +5043,7 @@
             }
         },
         "node_modules/downlevel-dts/node_modules/typescript": {
-            "version": "5.5.0-dev.20240415",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.0-dev.20240415.tgz",
-            "integrity": "sha512-2FlWR0afPLL3qaO+AcMp6rWmV6nrLoRhwDYAgGn7/Kw1/K8hcW83bZnn+gzGNWfXozx/EdJuG0KfN7V/RGysjg==",
+            "version": "5.5.0-dev.20240408",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -12048,7 +12042,7 @@
                 "src.gen/@amzn/codewhisperer-streaming"
             ],
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.1",
+                "@aws/language-server-runtimes": "^0.2.2",
                 "adm-zip": "^0.5.10",
                 "aws-sdk": "^2.1403.0",
                 "got": "^11.8.5",
@@ -12336,7 +12330,7 @@
             "name": "@aws/aws-lsp-yaml-json",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.1",
+                "@aws/language-server-runtimes": "^0.2.2",
                 "@aws/lsp-core": "^0.0.1",
                 "@aws/lsp-json-common": "^0.0.1",
                 "@aws/lsp-yaml-common": "^0.0.1",
@@ -12348,7 +12342,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.1",
+                "@aws/language-server-runtimes": "^0.2.2",
                 "vscode-languageserver": "^9.0.1"
             }
         }

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -26,7 +26,7 @@
         "fix:prettier": "prettier . --write"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.1",
+        "@aws/language-server-runtimes": "^0.2.2",
         "adm-zip": "^0.5.10",
         "aws-sdk": "^2.1403.0",
         "got": "^11.8.5",

--- a/server/aws-lsp-yaml-json/package.json
+++ b/server/aws-lsp-yaml-json/package.json
@@ -8,7 +8,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.1",
+        "@aws/language-server-runtimes": "^0.2.2",
         "@aws/lsp-core": "^0.0.1",
         "@aws/lsp-json-common": "^0.0.1",
         "@aws/lsp-yaml-common": "^0.0.1",

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -8,7 +8,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.1",
+        "@aws/language-server-runtimes": "^0.2.2",
         "vscode-languageserver": "^9.0.1"
     }
 }


### PR DESCRIPTION
## Description 

Updating runtimes to [0.2.2](https://www.npmjs.com/package/@aws/language-server-runtimes/v/0.2.2)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
