### PR TITLE
Update runtimes to 0.2.3 and install types

### DIFF
--- a/app/aws-lsp-codewhisperer-binary/package.json
+++ b/app/aws-lsp-codewhisperer-binary/package.json
@@ -11,7 +11,7 @@
         "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --out-path bin --compress GZip ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.2",
+        "@aws/language-server-runtimes": "^0.2.3",
         "@aws/lsp-codewhisperer": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-binary/package.json
+++ b/app/aws-lsp-yaml-json-binary/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@aws/aws-lsp-yaml-json": "*",
-        "@aws/language-server-runtimes": "^0.2.2"
+        "@aws/language-server-runtimes": "^0.2.3"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@aws/aws-lsp-yaml-json": "*",
-        "@aws/language-server-runtimes": "^0.2.2"
+        "@aws/language-server-runtimes": "^0.2.3"
     },
     "devDependencies": {
         "@types/node": "^20.11.30",

--- a/app/hello-world-lsp-binary/package.json
+++ b/app/hello-world-lsp-binary/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.2"
+        "@aws/language-server-runtimes": "^0.2.3"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -17,8 +17,9 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/mynah-ui": "^4.5.4",
-        "@aws/language-server-runtimes": "^0.2.1"
+        "@aws/language-server-runtimes": "^0.2.3",
+        "@aws/language-server-runtimes-types": "^0.0.1",
+        "@aws/mynah-ui": "^4.5.4"
     },
     "devDependencies": {
         "webpack": "^5.38.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
             "name": "@aws/lsp-codewhisperer-binary",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.2",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "@aws/lsp-codewhisperer": "*"
             },
             "bin": {
@@ -88,7 +88,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/aws-lsp-yaml-json": "*",
-                "@aws/language-server-runtimes": "^0.2.2"
+                "@aws/language-server-runtimes": "^0.2.3"
             },
             "bin": {
                 "aws-lsp-yaml-json-binary": "out/index.js"
@@ -109,7 +109,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/aws-lsp-yaml-json": "*",
-                "@aws/language-server-runtimes": "^0.2.2"
+                "@aws/language-server-runtimes": "^0.2.3"
             },
             "devDependencies": {
                 "@types/node": "^20.11.30",
@@ -137,7 +137,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.2"
+                "@aws/language-server-runtimes": "^0.2.3"
             },
             "bin": {
                 "hello-world-lsp-binary": "out/index.js"
@@ -158,6 +158,8 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
+                "@aws/language-server-runtimes": "^0.2.3",
+                "@aws/language-server-runtimes-types": "^0.0.1",
                 "@aws/mynah-ui": "^4.5.4"
             },
             "devDependencies": {
@@ -1654,19 +1656,27 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.2.tgz",
-            "integrity": "sha512-wFNXX1aTW+/jiHCPp1pRXkBgbKgdKnMwWV0XCVKPaw2olRri67UTCA3x+mqhrcaDWsPflAsRlpGddLFEjMamZA==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.3.tgz",
+            "integrity": "sha512-CehNMCdlaGHr8RkckhvTZsdcM/eRYoQA9hVNsQ+f5NNyNcyjzcPiLX9AUN5oZt3Eb6IG6ZSpLBivP3OChMkjFQ==",
             "dependencies": {
+                "@aws/language-server-runtimes-types": "0.0.1",
                 "jose": "^5.2.3",
                 "rxjs": "^7.8.1",
                 "vscode-languageserver": "^9.0.1",
-                "vscode-languageserver-protocol": "^3.17.5",
-                "vscode-languageserver-textdocument": "^1.0.11",
-                "vscode-languageserver-types": "^3.17.5"
+                "vscode-languageserver-protocol": "^3.17.5"
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes-types": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.1.tgz",
+            "integrity": "sha512-Y6v1pt6F70cd7Yu14BJr2GQuHzzje8xNY3PcmWXqsGUJHOUJmOucdGxKThQ6LTU6B8v80P66jfGnhqkIMwEAFg==",
+            "dependencies": {
+                "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-languageserver-types": "^3.17.5"
             }
         },
         "node_modules/@aws/lsp-buildspec": {
@@ -12259,12 +12269,13 @@
         "server/aws-lsp-codewhisperer": {
             "name": "@aws/lsp-codewhisperer",
             "version": "0.0.4",
+            "hasInstallScript": true,
             "license": "Apache-2.0",
             "workspaces": [
                 "src.gen/@amzn/codewhisperer-streaming"
             ],
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.2",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "adm-zip": "^0.5.10",
                 "aws-sdk": "^2.1403.0",
                 "got": "^11.8.5",
@@ -12539,7 +12550,7 @@
             "name": "@aws/aws-lsp-yaml-json",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.2",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "@aws/lsp-core": "^0.0.1",
                 "@aws/lsp-json-common": "^0.0.1",
                 "@aws/lsp-yaml-common": "^0.0.1",
@@ -12551,7 +12562,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.2",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "vscode-languageserver": "^9.0.1"
             }
         }
@@ -13673,7 +13684,7 @@
         "@aws/aws-lsp-yaml-json": {
             "version": "file:server/aws-lsp-yaml-json",
             "requires": {
-                "@aws/language-server-runtimes": "^0.2.2",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "@aws/lsp-core": "^0.0.1",
                 "@aws/lsp-json-common": "^0.0.1",
                 "@aws/lsp-yaml-common": "^0.0.1",
@@ -13684,7 +13695,7 @@
         "@aws/hello-world-lsp": {
             "version": "file:server/hello-world-lsp",
             "requires": {
-                "@aws/language-server-runtimes": "^0.2.2",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "vscode-languageserver": "^9.0.1"
             }
         },
@@ -13692,7 +13703,7 @@
             "version": "file:app/hello-world-lsp-binary",
             "requires": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.2",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "@types/chai": "^4.3.5",
                 "@types/chai-as-promised": "^7.1.5",
                 "@types/mocha": "^10.0.1",
@@ -13700,18 +13711,26 @@
                 "chai-as-promised": "^7.1.1",
                 "mocha": "^10.2.0",
                 "pkg": "^5.8.1",
-                "ts-lsp-client": "^1.0.1"
+                "ts-lsp-client": "^1.0.3"
             }
         },
         "@aws/language-server-runtimes": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.2.tgz",
-            "integrity": "sha512-wFNXX1aTW+/jiHCPp1pRXkBgbKgdKnMwWV0XCVKPaw2olRri67UTCA3x+mqhrcaDWsPflAsRlpGddLFEjMamZA==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.3.tgz",
+            "integrity": "sha512-CehNMCdlaGHr8RkckhvTZsdcM/eRYoQA9hVNsQ+f5NNyNcyjzcPiLX9AUN5oZt3Eb6IG6ZSpLBivP3OChMkjFQ==",
             "requires": {
+                "@aws/language-server-runtimes-types": "0.0.1",
                 "jose": "^5.2.3",
                 "rxjs": "^7.8.1",
                 "vscode-languageserver": "^9.0.1",
-                "vscode-languageserver-protocol": "^3.17.5",
+                "vscode-languageserver-protocol": "^3.17.5"
+            }
+        },
+        "@aws/language-server-runtimes-types": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.1.tgz",
+            "integrity": "sha512-Y6v1pt6F70cd7Yu14BJr2GQuHzzje8xNY3PcmWXqsGUJHOUJmOucdGxKThQ6LTU6B8v80P66jfGnhqkIMwEAFg==",
+            "requires": {
                 "vscode-languageserver-textdocument": "^1.0.11",
                 "vscode-languageserver-types": "^3.17.5"
             }
@@ -13752,8 +13771,8 @@
         "@aws/lsp-codewhisperer": {
             "version": "file:server/aws-lsp-codewhisperer",
             "requires": {
-                "@aws/language-server-runtimes": "^0.2.2",
-                "@types/adm-zip": "^0.4.34",
+                "@aws/language-server-runtimes": "^0.2.3",
+                "@types/adm-zip": "^0.5.5",
                 "@types/uuid": "^9.0.6",
                 "adm-zip": "^0.5.10",
                 "assert": "^2.1.0",
@@ -13877,7 +13896,7 @@
         "@aws/lsp-codewhisperer-binary": {
             "version": "file:app/aws-lsp-codewhisperer-binary",
             "requires": {
-                "@aws/language-server-runtimes": "^0.2.2",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "@aws/lsp-codewhisperer": "*",
                 "pkg": "^5.8.1"
             }
@@ -13940,7 +13959,7 @@
             "version": "file:app/aws-lsp-yaml-json-binary",
             "requires": {
                 "@aws/aws-lsp-yaml-json": "*",
-                "@aws/language-server-runtimes": "^0.2.2",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "@types/chai": "^4.3.5",
                 "@types/chai-as-promised": "^7.1.5",
                 "@types/mocha": "^10.0.1",
@@ -13948,14 +13967,14 @@
                 "chai-as-promised": "^7.1.1",
                 "mocha": "^10.2.0",
                 "pkg": "^5.8.1",
-                "ts-lsp-client": "^1.0.1"
+                "ts-lsp-client": "^1.0.3"
             }
         },
         "@aws/lsp-yaml-json-webworker": {
             "version": "file:app/aws-lsp-yaml-json-webworker",
             "requires": {
                 "@aws/aws-lsp-yaml-json": "*",
-                "@aws/language-server-runtimes": "^0.2.2",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "@types/node": "^20.11.30",
                 "assert": "^2.1.0",
                 "crypto-browserify": "^3.12.0",
@@ -13989,6 +14008,8 @@
         "@aws/q-chat-client": {
             "version": "file:chat-client",
             "requires": {
+                "@aws/language-server-runtimes": "^0.2.3",
+                "@aws/language-server-runtimes-types": "^0.0.1",
                 "@aws/mynah-ui": "^4.5.4",
                 "webpack": "^5.38.1",
                 "webpack-cli": "^4.7.2"
@@ -14814,7 +14835,9 @@
             "dev": true
         },
         "@types/adm-zip": {
-            "version": "0.4.34",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.5.tgz",
+            "integrity": "sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -15558,7 +15581,7 @@
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",
                 "typescript": "^5.1.3",
-                "vscode-languageclient": "^8.1.0"
+                "vscode-languageclient": "^9.0.1"
             }
         },
         "balanced-match": {
@@ -20087,19 +20110,15 @@
             }
         },
         "ts-lsp-client": {
-            "version": "1.0.1",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/ts-lsp-client/-/ts-lsp-client-1.0.3.tgz",
+            "integrity": "sha512-0ItrsqvNUM9KNFGbeT1N8jSi9gvasGOvxJUXjGf4P2TX0w250AUWLeRStaSrQbYcFDshDtE5d4BshUmYwodDgw==",
             "dev": true,
             "requires": {
-                "json-rpc-2.0": "^1.6.0",
+                "json-rpc-2.0": "^1.7.0",
                 "pino": "^7.0.5",
                 "pino-pretty": "^5.1.3",
-                "tslib": "~2.4.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.4.1",
-                    "dev": true
-                }
+                "tslib": "~2.6.2"
             }
         },
         "ts-mocha": {
@@ -20399,12 +20418,14 @@
             "version": "8.2.0"
         },
         "vscode-languageclient": {
-            "version": "8.1.0",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+            "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
             "dev": true,
             "requires": {
                 "minimatch": "^5.1.0",
                 "semver": "^7.3.7",
-                "vscode-languageserver-protocol": "3.17.3"
+                "vscode-languageserver-protocol": "3.17.5"
             },
             "dependencies": {
                 "minimatch": {
@@ -20413,22 +20434,6 @@
                     "requires": {
                         "brace-expansion": "^2.0.1"
                     }
-                },
-                "vscode-jsonrpc": {
-                    "version": "8.1.0",
-                    "dev": true
-                },
-                "vscode-languageserver-protocol": {
-                    "version": "3.17.3",
-                    "dev": true,
-                    "requires": {
-                        "vscode-jsonrpc": "8.1.0",
-                        "vscode-languageserver-types": "3.17.3"
-                    }
-                },
-                "vscode-languageserver-types": {
-                    "version": "3.17.3",
-                    "dev": true
                 }
             }
         },

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -27,7 +27,7 @@
         "fix:prettier": "prettier . --write"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.2",
+        "@aws/language-server-runtimes": "^0.2.3",
         "adm-zip": "^0.5.10",
         "aws-sdk": "^2.1403.0",
         "got": "^11.8.5",

--- a/server/aws-lsp-yaml-json/package.json
+++ b/server/aws-lsp-yaml-json/package.json
@@ -8,7 +8,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.2",
+        "@aws/language-server-runtimes": "^0.2.3",
         "@aws/lsp-core": "^0.0.1",
         "@aws/lsp-json-common": "^0.0.1",
         "@aws/lsp-yaml-common": "^0.0.1",

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -8,7 +8,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.2",
+        "@aws/language-server-runtimes": "^0.2.3",
         "vscode-languageserver": "^9.0.1"
     }
 }


### PR DESCRIPTION
## Problem
Update latest runtimes in all packages, and use types packages in Chat Client.

## Solution
Bump versions of dependencies

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
