### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aws/aws-ides-team @kmile @ege0zcan @viktorsaws @rtarcr @rahmaniaam @imykhai @volodkevych
+* @aws/aws-ides-team @aws/dexp


### PR DESCRIPTION
## Problem
We had individual users set as code owners for project.

## Solution

Set @aws/dexp team as a code owner, instead of individual users.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
