### PR TITLE
Remove downlevel command and dependency from CodeWhisperer streaming client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5201,31 +5201,6 @@
                 "url": "https://github.com/fb55/domutils?sponsor=1"
             }
         },
-        "node_modules/downlevel-dts": {
-            "version": "0.10.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^7.3.2",
-                "shelljs": "^0.8.3",
-                "typescript": "next"
-            },
-            "bin": {
-                "downlevel-dts": "index.js"
-            }
-        },
-        "node_modules/downlevel-dts/node_modules/typescript": {
-            "version": "5.5.0-dev.20240416",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
-        },
         "node_modules/duplexify": {
             "version": "4.1.3",
             "dev": true,
@@ -10085,40 +10060,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/shelljs": {
-            "version": "0.8.5",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "bin": {
-                "shjs": "bin/shjs"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/shelljs/node_modules/interpret": {
-            "version": "1.4.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/shelljs/node_modules/rechoir": {
-            "version": "0.6.2",
-            "dev": true,
-            "dependencies": {
-                "resolve": "^1.1.6"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
         "node_modules/shiki": {
             "version": "0.11.1",
             "dev": true,
@@ -12512,7 +12453,6 @@
                 "@types/node": "^14.14.31",
                 "@types/uuid": "^8.3.0",
                 "concurrently": "7.0.0",
-                "downlevel-dts": "0.10.1",
                 "rimraf": "^3.0.0",
                 "typedoc": "0.23.23",
                 "typescript": "~4.9.5"
@@ -12616,7 +12556,6 @@
                 "@types/node": "^14.14.31",
                 "@types/uuid": "^8.3.0",
                 "concurrently": "7.0.0",
-                "downlevel-dts": "0.10.1",
                 "rimraf": "^3.0.0",
                 "tslib": "^2.5.0",
                 "typedoc": "0.23.23",
@@ -16414,21 +16353,6 @@
                 "domhandler": "^5.0.3"
             }
         },
-        "downlevel-dts": {
-            "version": "0.10.1",
-            "dev": true,
-            "requires": {
-                "semver": "^7.3.2",
-                "shelljs": "^0.8.3",
-                "typescript": "next"
-            },
-            "dependencies": {
-                "typescript": {
-                    "version": "5.5.0-dev.20240416",
-                    "dev": true
-                }
-            }
-        },
         "duplexify": {
             "version": "4.1.3",
             "dev": true,
@@ -19549,28 +19473,6 @@
         "shell-quote": {
             "version": "1.8.1",
             "dev": true
-        },
-        "shelljs": {
-            "version": "0.8.5",
-            "dev": true,
-            "requires": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
-            },
-            "dependencies": {
-                "interpret": {
-                    "version": "1.4.0",
-                    "dev": true
-                },
-                "rechoir": {
-                    "version": "0.6.2",
-                    "dev": true,
-                    "requires": {
-                        "resolve": "^1.1.6"
-                    }
-                }
-            }
         },
         "shiki": {
             "version": "0.11.1",

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
@@ -8,7 +8,6 @@
         "build:docs": "typedoc",
         "build:es": "tsc -p tsconfig.es.json",
         "build:types": "tsc -p tsconfig.types.json",
-        "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
         "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
         "prepack": "npm run clean && npm run build"
     },
@@ -62,7 +61,6 @@
         "@types/node": "^14.14.31",
         "@types/uuid": "^8.3.0",
         "concurrently": "7.0.0",
-        "downlevel-dts": "0.10.1",
         "rimraf": "^3.0.0",
         "typedoc": "0.23.23",
         "typescript": "~4.9.5"


### PR DESCRIPTION
## Problem
CodeWhisperer streaming client has unused dependency, which messes with our internal workflow.

## Solution

Script that uses dependency seem to be unused during build process. Remove it and problematic dependency from the project.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
