### PR TITLE
Clear security scan findings on workspace/didChangeWorkspaceFolders event

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -28,7 +28,7 @@ export const SecurityScanServerToken =
 
         const runSecurityScan = async (params: SecurityScanRequestParams, token: CancellationToken) => {
             logging.log(`Starting security scan`)
-            diagnosticsProvider.resetDiagnostics()
+            await diagnosticsProvider.resetDiagnostics()
             let jobStatus: string
             const securityScanStartTime = performance.now()
             let serviceInvocationStartTime = 0
@@ -223,6 +223,12 @@ export const SecurityScanServerToken =
                 await diagnosticsProvider.validateDiagnostics(p.textDocument.uri, change)
             })
         })
+
+        lsp.workspace.onDidChangeWorkspaceFolders(async event => {
+            // clear security scan diagnostics for previous run when a workspace change event occurs
+            await diagnosticsProvider.resetDiagnostics()
+        })
+
         logging.log('SecurityScan server has been initialized')
 
         return () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
@@ -23,10 +23,10 @@ class SecurityScanDiagnosticsProvider {
         this.findings = []
     }
 
-    resetDiagnostics() {
-        this.findings.forEach(finding => {
-            this.logging.log(finding.filePath)
-            this.publishDiagnostics(finding.filePath, [])
+    async resetDiagnostics() {
+        this.findings.forEach(async finding => {
+            this.logging.log(`reset diagnostics for: ${finding.filePath}`)
+            await this.publishDiagnostics(finding.filePath, [])
         })
         this.diagnostics = new Map()
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
@@ -24,10 +24,12 @@ class SecurityScanDiagnosticsProvider {
     }
 
     async resetDiagnostics() {
-        this.findings.forEach(async finding => {
-            this.logging.log(`reset diagnostics for: ${finding.filePath}`)
-            await this.publishDiagnostics(finding.filePath, [])
-        })
+        await Promise.all(
+            this.findings.map(finding => {
+                this.logging.log(`reset diagnostics for: ${finding.filePath}`)
+                this.publishDiagnostics(finding.filePath, [])
+            })
+        )
         this.diagnostics = new Map()
     }
 


### PR DESCRIPTION
## Description
This change fixes a bug where when a project was unloaded in the IDE and a new one opened, the security scan findings(diagnostics) associated with the previous project did not get cleared.
This change adds handling for the `workspace/didChangeWorkspaceFolders` [lsp notification ](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWorkspaceFolders) sent by the client. The handler clears diagnostics associated with the previous security scan run(project).

Bonus: This change also converts the `resetDiagnostic` method to operate asynchronously.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
