### PR TITLE
Chat server skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6418,6 +6418,14 @@
                 "wbuf": "^1.1.0"
             }
         },
+        "node_modules/hpagent": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+            "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/html-entities": {
             "version": "2.5.2",
             "dev": true,
@@ -12277,9 +12285,12 @@
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.3",
                 "@aws/language-server-runtimes-types": "^0.0.1",
+                "@smithy/abort-controller": "^2.2.0",
+                "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
                 "aws-sdk": "^2.1403.0",
                 "got": "^11.8.5",
+                "hpagent": "^1.2.0",
                 "js-md5": "^0.8.3",
                 "proxy-http-agent": "^1.0.1",
                 "uuid": "^9.0.1",
@@ -13774,6 +13785,8 @@
             "requires": {
                 "@aws/language-server-runtimes": "^0.2.3",
                 "@aws/language-server-runtimes-types": "^0.0.1",
+                "@smithy/abort-controller": "^2.2.0",
+                "@smithy/node-http-handler": "^2.5.0",
                 "@types/adm-zip": "^0.5.5",
                 "@types/uuid": "^9.0.6",
                 "adm-zip": "^0.5.10",
@@ -13781,6 +13794,7 @@
                 "aws-sdk": "^2.1403.0",
                 "copyfiles": "^2.4.1",
                 "got": "^11.8.5",
+                "hpagent": "^1.2.0",
                 "js-md5": "^0.8.3",
                 "proxy-http-agent": "^1.0.1",
                 "ts-mocha": "^10.0.0",
@@ -17209,6 +17223,11 @@
                 "readable-stream": "^2.0.1",
                 "wbuf": "^1.1.0"
             }
+        },
+        "hpagent": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+            "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="
         },
         "html-entities": {
             "version": "2.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12284,7 +12284,6 @@
             ],
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.3",
-                "@aws/language-server-runtimes-types": "^0.0.1",
                 "@smithy/abort-controller": "^2.2.0",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
@@ -13784,7 +13783,6 @@
             "version": "file:server/aws-lsp-codewhisperer",
             "requires": {
                 "@aws/language-server-runtimes": "^0.2.3",
-                "@aws/language-server-runtimes-types": "^0.0.1",
                 "@smithy/abort-controller": "^2.2.0",
                 "@smithy/node-http-handler": "^2.5.0",
                 "@types/adm-zip": "^0.5.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12276,6 +12276,7 @@
             ],
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.3",
+                "@aws/language-server-runtimes-types": "^0.0.1",
                 "adm-zip": "^0.5.10",
                 "aws-sdk": "^2.1403.0",
                 "got": "^11.8.5",
@@ -13772,6 +13773,7 @@
             "version": "file:server/aws-lsp-codewhisperer",
             "requires": {
                 "@aws/language-server-runtimes": "^0.2.3",
+                "@aws/language-server-runtimes-types": "^0.0.1",
                 "@types/adm-zip": "^0.5.5",
                 "@types/uuid": "^9.0.6",
                 "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -28,7 +28,6 @@
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.3",
-        "@aws/language-server-runtimes-types": "^0.0.1",
         "@smithy/abort-controller": "^2.2.0",
         "@smithy/node-http-handler": "^2.5.0",
         "hpagent": "^1.2.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -28,6 +28,7 @@
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.3",
+        "@aws/language-server-runtimes-types": "^0.0.1",
         "adm-zip": "^0.5.10",
         "aws-sdk": "^2.1403.0",
         "got": "^11.8.5",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -29,6 +29,9 @@
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.3",
         "@aws/language-server-runtimes-types": "^0.0.1",
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "hpagent": "^1.2.0",
         "adm-zip": "^0.5.10",
         "aws-sdk": "^2.1403.0",
         "got": "^11.8.5",

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
@@ -1,0 +1,60 @@
+import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
+import * as assert from 'assert'
+import sinon from 'ts-sinon'
+import { ChatSessionManagementService } from './chatSessionManagementService'
+import { ChatSessionService } from './chatSessionService'
+
+describe('ChatSessionManagementService', () => {
+    const mockCredentialsProvider: CredentialsProvider = {
+        hasCredentials: sinon.stub().returns(true),
+        getCredentials: sinon.stub().returns(Promise.resolve({ token: 'mockToken' })),
+        getConnectionMetadata: sinon.stub(),
+    }
+
+    const mockSessionId = 'mockSessionId'
+    const mockSessionId2 = 'mockSessionId2'
+    let disposeStub: sinon.SinonStub
+    let chatSessionManagementService: ChatSessionManagementService
+
+    beforeEach(() => {
+        disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
+        chatSessionManagementService = new ChatSessionManagementService(mockCredentialsProvider)
+    })
+
+    afterEach(() => {
+        disposeStub.restore()
+    })
+
+    it('getSession should return an existing client if found or create a new client if not found', () => {
+        assert.ok(!chatSessionManagementService.hasSession(mockSessionId))
+        // getSession creates a new session if not found
+        const chatClient = chatSessionManagementService.getSession(mockSessionId)
+
+        assert.ok(chatClient instanceof ChatSessionService)
+        assert.ok(chatSessionManagementService.hasSession(mockSessionId))
+
+        // check if the object reference is the same to ensure we are only creating one client
+        assert.strictEqual(chatSessionManagementService.getSession(mockSessionId), chatClient)
+    })
+
+    it('deleting session should dispose the chat session service and delete from map', () => {
+        chatSessionManagementService.getSession(mockSessionId)
+
+        assert.ok(chatSessionManagementService.hasSession(mockSessionId))
+
+        chatSessionManagementService.deleteSession(mockSessionId)
+
+        assert.ok(!chatSessionManagementService.hasSession(mockSessionId))
+
+        sinon.assert.calledOnce(disposeStub)
+    })
+
+    it('disposing the chat session management should dispose all the chat session services', () => {
+        chatSessionManagementService.getSession(mockSessionId)
+        chatSessionManagementService.getSession(mockSessionId2)
+
+        chatSessionManagementService.dispose()
+
+        sinon.assert.calledTwice(disposeStub)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
@@ -5,56 +5,70 @@ import { ChatSessionManagementService } from './chatSessionManagementService'
 import { ChatSessionService } from './chatSessionService'
 
 describe('ChatSessionManagementService', () => {
-    const mockCredentialsProvider: CredentialsProvider = {
-        hasCredentials: sinon.stub().returns(true),
-        getCredentials: sinon.stub().returns(Promise.resolve({ token: 'mockToken' })),
-        getConnectionMetadata: sinon.stub(),
-    }
+    it('getInstance should return the same instance if initialized', () => {
+        const instance = ChatSessionManagementService.getInstance()
+        const instance2 = ChatSessionManagementService.getInstance()
 
-    const mockSessionId = 'mockSessionId'
-    const mockSessionId2 = 'mockSessionId2'
-    let disposeStub: sinon.SinonStub
-    let chatSessionManagementService: ChatSessionManagementService
-
-    beforeEach(() => {
-        disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
-        chatSessionManagementService = new ChatSessionManagementService(mockCredentialsProvider)
+        assert.strictEqual(instance, instance2)
     })
 
-    afterEach(() => {
-        disposeStub.restore()
+    it('creating a session without credentials provider should throw an error', () => {
+        assert.throws(() => ChatSessionManagementService.getInstance().getSession('mockSessionId'))
     })
 
-    it('getSession should return an existing client if found or create a new client if not found', () => {
-        assert.ok(!chatSessionManagementService.hasSession(mockSessionId))
-        // getSession creates a new session if not found
-        const chatClient = chatSessionManagementService.getSession(mockSessionId)
+    describe('Session interface', () => {
+        const mockCredentialsProvider: CredentialsProvider = {
+            hasCredentials: sinon.stub().returns(true),
+            getCredentials: sinon.stub().returns(Promise.resolve({ token: 'mockToken' })),
+            getConnectionMetadata: sinon.stub(),
+        }
 
-        assert.ok(chatClient instanceof ChatSessionService)
-        assert.ok(chatSessionManagementService.hasSession(mockSessionId))
+        const mockSessionId = 'mockSessionId'
+        const mockSessionId2 = 'mockSessionId2'
+        let disposeStub: sinon.SinonStub
+        let chatSessionManagementService: ChatSessionManagementService
 
-        // check if the object reference is the same to ensure we are only creating one client
-        assert.strictEqual(chatSessionManagementService.getSession(mockSessionId), chatClient)
-    })
+        beforeEach(() => {
+            disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
+            chatSessionManagementService =
+                ChatSessionManagementService.getInstance().withCredentialsProvider(mockCredentialsProvider)
+        })
 
-    it('deleting session should dispose the chat session service and delete from map', () => {
-        chatSessionManagementService.getSession(mockSessionId)
+        afterEach(() => {
+            disposeStub.restore()
+        })
 
-        assert.ok(chatSessionManagementService.hasSession(mockSessionId))
+        it('getSession should return an existing client if found or create a new client if not found', () => {
+            assert.ok(!chatSessionManagementService.hasSession(mockSessionId))
+            // getSession creates a new session if not found
+            const chatClient = chatSessionManagementService.getSession(mockSessionId)
 
-        chatSessionManagementService.deleteSession(mockSessionId)
+            assert.ok(chatClient instanceof ChatSessionService)
+            assert.ok(chatSessionManagementService.hasSession(mockSessionId))
 
-        assert.ok(!chatSessionManagementService.hasSession(mockSessionId))
+            // check if the object reference is the same to ensure we are only creating one client
+            assert.strictEqual(chatSessionManagementService.getSession(mockSessionId), chatClient)
+        })
 
-        sinon.assert.calledOnce(disposeStub)
-    })
+        it('deleting session should dispose the chat session service and delete from map', () => {
+            chatSessionManagementService.getSession(mockSessionId)
 
-    it('disposing the chat session management should dispose all the chat session services', () => {
-        chatSessionManagementService.getSession(mockSessionId)
-        chatSessionManagementService.getSession(mockSessionId2)
+            assert.ok(chatSessionManagementService.hasSession(mockSessionId))
 
-        chatSessionManagementService.dispose()
+            chatSessionManagementService.deleteSession(mockSessionId)
 
-        sinon.assert.calledTwice(disposeStub)
+            assert.ok(!chatSessionManagementService.hasSession(mockSessionId))
+
+            sinon.assert.calledOnce(disposeStub)
+        })
+
+        it('disposing the chat session management should dispose all the chat session services', () => {
+            chatSessionManagementService.getSession(mockSessionId)
+            chatSessionManagementService.getSession(mockSessionId2)
+
+            chatSessionManagementService.dispose()
+
+            sinon.assert.calledTwice(disposeStub)
+        })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
@@ -15,11 +15,11 @@ export class ChatSessionManagementService {
         this.#clientConfig = clientConfig
     }
 
-    hasSession(tabId: string): boolean {
+    public hasSession(tabId: string): boolean {
         return this.#sessionByTab.has(tabId)
     }
 
-    getSession(tabId: string): ChatSessionService {
+    public getSession(tabId: string): ChatSessionService {
         const maybeSession = this.#sessionByTab.get(tabId)
 
         if (!maybeSession) {
@@ -34,12 +34,12 @@ export class ChatSessionManagementService {
         return maybeSession
     }
 
-    deleteSession(tabId: string): void {
+    public deleteSession(tabId: string): void {
         this.#sessionByTab.get(tabId)?.dispose()
         this.#sessionByTab.delete(tabId)
     }
 
-    dispose(): void {
+    public dispose(): void {
         this.#sessionByTab.forEach(session => session.dispose())
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
@@ -1,0 +1,39 @@
+import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
+import { ChatSessionService } from './chatSessionService'
+
+export class ChatSessionManagementService {
+    #sessionByTab: Map<string, ChatSessionService>
+    #credentialsProvider: CredentialsProvider
+
+    constructor(credentialsProvider: CredentialsProvider) {
+        this.#credentialsProvider = credentialsProvider
+        this.#sessionByTab = new Map<string, any>()
+    }
+
+    hasSession(tabId: string): boolean {
+        return this.#sessionByTab.has(tabId)
+    }
+
+    getSession(tabId: string): ChatSessionService {
+        const maybeSession = this.#sessionByTab.get(tabId)
+
+        if (!maybeSession) {
+            const newSession = new ChatSessionService(this.#credentialsProvider)
+
+            this.#sessionByTab.set(tabId, newSession)
+
+            return newSession
+        }
+
+        return maybeSession
+    }
+
+    deleteSession(tabId: string): void {
+        this.#sessionByTab.get(tabId)?.dispose()
+        this.#sessionByTab.delete(tabId)
+    }
+
+    dispose(): void {
+        this.#sessionByTab.forEach(session => session.dispose())
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
@@ -2,17 +2,31 @@ import { CredentialsProvider } from '@aws/language-server-runtimes/server-interf
 import { ChatSessionService, ChatSessionServiceConfig } from './chatSessionService'
 
 export class ChatSessionManagementService {
-    #sessionByTab: Map<string, ChatSessionService>
-    #credentialsProvider: CredentialsProvider
+    static #instance?: ChatSessionManagementService
+    #sessionByTab: Map<string, ChatSessionService> = new Map<string, any>()
+    #credentialsProvider?: CredentialsProvider
     #clientConfig?: ChatSessionServiceConfig | (() => ChatSessionServiceConfig)
 
-    constructor(
-        credentialsProvider: CredentialsProvider,
-        clientConfig?: ChatSessionServiceConfig | (() => ChatSessionServiceConfig)
-    ) {
-        this.#credentialsProvider = credentialsProvider
-        this.#sessionByTab = new Map<string, any>()
+    public static getInstance() {
+        if (!ChatSessionManagementService.#instance) {
+            ChatSessionManagementService.#instance = new ChatSessionManagementService()
+        }
+
+        return ChatSessionManagementService.#instance
+    }
+
+    private constructor() {}
+
+    public withConfig(clientConfig?: ChatSessionServiceConfig | (() => ChatSessionServiceConfig)) {
         this.#clientConfig = clientConfig
+
+        return this
+    }
+
+    public withCredentialsProvider(credentialsProvider: CredentialsProvider) {
+        this.#credentialsProvider = credentialsProvider
+
+        return this
     }
 
     public hasSession(tabId: string): boolean {
@@ -24,6 +38,10 @@ export class ChatSessionManagementService {
 
         if (!maybeSession) {
             const clientConfig = typeof this.#clientConfig === 'function' ? this.#clientConfig() : this.#clientConfig
+
+            if (!this.#credentialsProvider) {
+                throw new Error('Credentials provider is not set')
+            }
             const newSession = new ChatSessionService(this.#credentialsProvider, clientConfig)
 
             this.#sessionByTab.set(tabId, newSession)

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
@@ -1,13 +1,18 @@
 import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
-import { ChatSessionService } from './chatSessionService'
+import { ChatSessionService, ChatSessionServiceConfig } from './chatSessionService'
 
 export class ChatSessionManagementService {
     #sessionByTab: Map<string, ChatSessionService>
     #credentialsProvider: CredentialsProvider
+    #clientConfig?: ChatSessionServiceConfig | (() => ChatSessionServiceConfig)
 
-    constructor(credentialsProvider: CredentialsProvider) {
+    constructor(
+        credentialsProvider: CredentialsProvider,
+        clientConfig?: ChatSessionServiceConfig | (() => ChatSessionServiceConfig)
+    ) {
         this.#credentialsProvider = credentialsProvider
         this.#sessionByTab = new Map<string, any>()
+        this.#clientConfig = clientConfig
     }
 
     hasSession(tabId: string): boolean {
@@ -18,7 +23,8 @@ export class ChatSessionManagementService {
         const maybeSession = this.#sessionByTab.get(tabId)
 
         if (!maybeSession) {
-            const newSession = new ChatSessionService(this.#credentialsProvider)
+            const clientConfig = typeof this.#clientConfig === 'function' ? this.#clientConfig() : this.#clientConfig
+            const newSession = new ChatSessionService(this.#credentialsProvider, clientConfig)
 
             this.#sessionByTab.set(tabId, newSession)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -1,5 +1,6 @@
 import {
     CodeWhispererStreaming,
+    CodeWhispererStreamingClientConfig,
     GenerateAssistantResponseCommandInput,
     GenerateAssistantResponseCommandOutput,
 } from '@amzn/codewhisperer-streaming'
@@ -8,6 +9,7 @@ import { CredentialsProvider } from '@aws/language-server-runtimes/server-interf
 import { AbortController } from '@smithy/abort-controller'
 import { getBearerTokenFromProvider } from '../utils'
 
+export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
     readonly #codeWhispererRegion = 'us-east-1'
@@ -24,12 +26,13 @@ export class ChatSessionService {
         this.#sessionId = value
     }
 
-    constructor(credentialsProvider: CredentialsProvider) {
+    constructor(credentialsProvider: CredentialsProvider, config?: CodeWhispererStreamingClientConfig) {
         this.#client = new CodeWhispererStreaming({
             region: this.#codeWhispererRegion,
             endpoint: this.#codeWhispererEndpoint,
             token: () => Promise.resolve({ token: getBearerTokenFromProvider(credentialsProvider) }),
             retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
+            ...config,
         })
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -51,12 +51,12 @@ export class ChatSessionService {
         return response
     }
 
-    public dispose() {
+    public dispose(): void {
         this.#abortController?.abort()
         this.#client.destroy()
     }
 
-    public abortRequest() {
+    public abortRequest(): void {
         this.#abortController?.abort()
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -53,12 +53,12 @@ export const QChatServerTokenProxy = QChatServerToken(credentialsProvider => {
          *
          * At the same time, hpagent is not compatible with v2 sdk
          */
-        const { HttpsHandler } = require('hpagent')
+        const { HttpsProxyAgent } = require('hpagent')
 
         // passing client options as a function so a new http handler can be created
         clientOptions = () => {
-            // this approach mimics aws-sdk-v3-js-proxy
-            const agent = new HttpsHandler({
+            // this mimics aws-sdk-v3-js-proxy
+            const agent = new HttpsProxyAgent({
                 proxy: proxyUrl,
             })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -3,7 +3,7 @@ import { ChatSessionServiceConfig } from './chat/chatSessionService'
 import { SecurityScanServerToken } from './codeWhispererSecurityScanServer'
 import { CodewhispererServerFactory } from './codeWhispererServer'
 import { CodeWhispererServiceToken } from './codeWhispererService'
-import { QChatServerToken } from './qChatServer'
+import { QChatServer } from './qChatServer'
 
 export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credentialsProvider => {
     let additionalAwsConfig = {}
@@ -37,7 +37,7 @@ export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken
     return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
 })
 
-export const QChatServerTokenProxy = QChatServerToken(credentialsProvider => {
+export const QChatServerProxy = QChatServer(credentialsProvider => {
     let clientOptions: ChatSessionServiceConfig | undefined
 
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
@@ -71,5 +71,7 @@ export const QChatServerTokenProxy = QChatServerToken(credentialsProvider => {
         }
     }
 
-    return new ChatSessionManagementService(credentialsProvider, clientOptions)
+    return ChatSessionManagementService.getInstance()
+        .withCredentialsProvider(credentialsProvider)
+        .withConfig(clientOptions)
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -1,0 +1,34 @@
+import { ChatParams, EndChatParams } from '@aws/language-server-runtimes-types'
+import { CancellationToken, CredentialsProvider, Server } from '@aws/language-server-runtimes/server-interface'
+import { ChatSessionManagementService } from './chat/chatSessionManagementService'
+
+export const QChatServerToken =
+    (service: (credentialsProvider: CredentialsProvider) => ChatSessionManagementService): Server =>
+    ({ chat, credentialsProvider, logging }) => {
+        const codewhispererclient: ChatSessionManagementService = service(credentialsProvider)
+
+        chat.onEndChat((params: EndChatParams, _token: CancellationToken) => {
+            logging.log('received end chat request')
+            codewhispererclient.deleteSession(params.tabId)
+
+            return true
+        })
+
+        chat.onChatPrompt(async (params: ChatParams, token: CancellationToken) => {
+            logging.log('received chat prompt')
+
+            const session = codewhispererclient.getSession(params.tabId)
+
+            token.onCancellationRequested(() => {
+                session.abortRequest()
+            })
+
+            return {}
+        })
+
+        logging.log('Chat server has been initialized')
+
+        return () => {
+            codewhispererclient.dispose()
+        }
+    }

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -1,5 +1,10 @@
-import { ChatParams, EndChatParams } from '@aws/language-server-runtimes-types'
-import { CancellationToken, CredentialsProvider, Server } from '@aws/language-server-runtimes/server-interface'
+import {
+    CancellationToken,
+    ChatParams,
+    CredentialsProvider,
+    EndChatParams,
+    Server,
+} from '@aws/language-server-runtimes/server-interface'
 import { ChatSessionManagementService } from './chat/chatSessionManagementService'
 
 export const QChatServerToken =

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -7,7 +7,7 @@ import {
 } from '@aws/language-server-runtimes/server-interface'
 import { ChatSessionManagementService } from './chat/chatSessionManagementService'
 
-export const QChatServerToken =
+export const QChatServer =
     (service: (credentialsProvider: CredentialsProvider) => ChatSessionManagementService): Server =>
     ({ chat, credentialsProvider, logging }) => {
         const codewhispererclient: ChatSessionManagementService = service(credentialsProvider)


### PR DESCRIPTION
## Description
- Create a chat server skeleton with a proxy variant
- Create session management service that manages the mapping between tabId and api client
  - Each tab can have an outgoing request at the same time (we will need to add a restriction there)
  - Each outgoing request can be cancelled separately

## Future Tasks
- Add more tests for the ChatServer as I work on the implementation
- Look into reducing the number of libraries needed for http proxy

## Testing
- Tested in vscode "Run and Debug" 
   - I can make a chat request  
   - I can make a request through a proxy 
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
