### PR TITLE
Remove postinstall script to build dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12210,7 +12210,6 @@
         "server/aws-lsp-codewhisperer": {
             "name": "@aws/lsp-codewhisperer",
             "version": "0.0.4",
-            "hasInstallScript": true,
             "license": "Apache-2.0",
             "workspaces": [
                 "src.gen/@amzn/codewhisperer-streaming"

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
         "format": "prettier --write .",
         "format-staged": "npx pretty-quick --staged",
         "clean": "ts-node ./script/clean.ts",
-        "compile": "tsc --build --verbose && npm run postcompile --workspaces --if-present",
+        "precompile": "npm run precompile --workspaces --if-present",
+        "compile": "tsc --build --verbose && npm run compile:servers && npm run compile:apps",
+        "compile:apps": "npm run compile --workspace=app --if-present",
+        "compile:servers": "npm run compile --workspace=server --if-present",
         "watch": "tsc --build --watch",
         "test": "npm run compile && npm run test --workspaces --if-present",
         "test-integ": "npm run compile && npm run test-integ --workspaces --if-present",
         "test-unit": "npm run compile && npm run test-unit --workspaces --if-present",
-        "update-runtimes": "cp ../language-server-runtimes/aws-*.tgz bin/ && npm update @aws/language-server-runtimes",
         "package": "npm install && npm run compile && npm run package-x64 --workspaces --if-present && npm run package --workspaces --if-present"
     },
     "dependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -18,7 +18,6 @@
     "scripts": {
         "compile-streamingClient": "npm run build -w src.gen/@amzn/codewhisperer-streaming",
         "compile": "npm run compile-streamingClient && tsc --build",
-        "postinstall": "npm run compile-streamingClient",
         "postcompile": "npm run copyServiceClient",
         "copyServiceClient": "copyfiles -u 1 --error ./src/client/sigv4/*.json out && copyfiles -u 1 --error ./src/client/token/*.json out",
         "test:unit": "ts-mocha -b 'src/**/*.test.ts'",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -17,7 +17,8 @@
     ],
     "scripts": {
         "compile-streamingClient": "npm run build -w src.gen/@amzn/codewhisperer-streaming",
-        "compile": "npm run compile-streamingClient && tsc --build",
+        "precompile": "npm run compile-streamingClient",
+        "compile": "tsc --build",
         "postcompile": "npm run copyServiceClient",
         "copyServiceClient": "copyfiles -u 1 --error ./src/client/sigv4/*.json out && copyfiles -u 1 --error ./src/client/token/*.json out",
         "test:unit": "ts-mocha -b 'src/**/*.test.ts'",


### PR DESCRIPTION
## Problem
Postinstall script in CodeWhisperer LSP runs build script of streaming client dependency package. This script fails when `@aws/lsp-codewhisperer` client is installed as a dependency due to missing transient dependencies at installation time.

This breaks workflows, that use `@aws/lsp-codewhisperer` as a direct dependency.

## Solution

Remove `postinstall` script from `server/aws-lsp-codewhisperer`. Compiling streaming client dependency is triggered in `compile` command still.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
