### PR TITLE
Fix security scan duplicate hover message

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -207,7 +207,6 @@ export const SecurityScanServerToken =
                 },
             }
         }
-        diagnosticsProvider.handleHover()
 
         lsp.onExecuteCommand(onExecuteCommandHandler)
         lsp.addInitializer(onInitializeHandler)

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
@@ -47,15 +47,13 @@ class SecurityScanDiagnosticsProvider {
     }
 
     mapScanIssueToDiagnostics(issue: CodeScanIssue): Diagnostic {
-        const diagnostic: Diagnostic = {
-            range: this.createDiagnosticsRange(issue.startLine, issue.endLine),
-            message: `${issue.detectorName} - ${issue.description.text}`,
-            severity: DiagnosticSeverity.Warning,
-            code: issue.relatedVulnerabilities.join(','),
-            source: 'CodeWhisperer',
-        }
-
-        return diagnostic
+        return Diagnostic.create(
+            this.createDiagnosticsRange(issue.startLine, issue.endLine),
+            `${issue.detectorName} - ${issue.description.text}`,
+            DiagnosticSeverity.Warning,
+            issue.relatedVulnerabilities.join(','),
+            'CodeWhisperer'
+        )
     }
 
     async validateDiagnostics(uri: string, e: TextDocumentContentChangeEvent) {

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanDiagnosticsProvider.ts
@@ -112,19 +112,6 @@ class SecurityScanDiagnosticsProvider {
         return true
     }
 
-    /**
-     * A default hover element for diagnostics is surfaced in the IDE
-     * that displays as `${diagnostic.Code}: ${diagnostic.Description}`
-     *
-     * Creating a custom lsp hover will add content to the IDE's existing hover,
-     * but will not replace the above default display text.
-     */
-    handleHover = () => {
-        this.lsp.onHover(({ position, textDocument }) => {
-            return null
-        })
-    }
-
     getLineOffset(range: Range, text: string) {
         const originLines = range.end.line - range.start.line + 1
         const changedLines = text.split('\n').length


### PR DESCRIPTION
## Problem
Security Scan diagnostic error messages were displayed twice in the IDE hover.

## Solution

Removes the LSP hover message since the default hover displays the relevant information. 
- Future work to add additional content to this hover can redefine a hover handler - this will add, but not replace, content in the IDE's existing diagnostic hover.

Also changes the Diagnostic's Description to be constructed with the `DetectorName` rather than the `Title`. The `Title` field is a combination of the error code and the `DetectorName`, which was resulting in duplication of the error code

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
