### PR TITLE
Ensure getConnectionMetadata is defined

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -43,7 +43,7 @@ export const SecurityScanServerToken =
                 result: 'Succeeded',
                 codewhispererCodeScanTotalIssues: 0,
                 codewhispererCodeScanIssuesWithFixes: 0,
-                credentialStartUrl: credentialsProvider.getConnectionMetadata()?.sso?.startUrl ?? undefined,
+                credentialStartUrl: credentialsProvider.getConnectionMetadata?.()?.sso?.startUrl ?? undefined,
             }
             try {
                 if (!credentialsProvider.hasCredentials('bearer')) {

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -359,7 +359,7 @@ export const CodewhispererServerFactory =
                     triggerCharacter: triggerCharacter,
                     classifierResult: autoTriggerResult?.classifierResult,
                     classifierThreshold: autoTriggerResult?.classifierThreshold,
-                    credentialStartUrl: credentialsProvider.getConnectionMetadata()?.sso?.startUrl ?? undefined,
+                    credentialStartUrl: credentialsProvider.getConnectionMetadata?.()?.sso?.startUrl ?? undefined,
                 })
 
                 codePercentageTracker.countInvocation(inferredLanguageId)


### PR DESCRIPTION
## Problem
getConnectionMetadata will be made optional when enabling the injection of credentialsProvider. Current code will break if the provider does not define the method.

https://github.com/aws/language-server-runtimes/pull/101

## Solution
Make the method optional since practically it is already optional
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
