### PR TITLE
Revert "Bump @aws-sdk/middleware-token from 3.425.0 to 3.564.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1190,304 +1190,168 @@
             }
         },
         "node_modules/@aws-sdk/middleware-token": {
-            "version": "3.564.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-token/-/middleware-token-3.564.0.tgz",
-            "integrity": "sha512-9YmCcMZBesCVF8WarFkb4PegGbPqGUJ/av/usd4DMjTMzz6qvLt5VQwIQL6qpTLz+WreZzNIWPTQ7ReID1uN3A==",
+            "version": "3.425.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/token-providers": "3.564.0",
-                "@aws-sdk/types": "3.535.0",
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "tslib": "^2.6.2"
+                "@aws-sdk/token-providers": "3.425.0",
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/types": "^2.3.4",
+                "@smithy/util-middleware": "^2.0.3",
+                "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/client-sso": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.556.0.tgz",
-            "integrity": "sha512-unXdWS7uvHqCcOyC1de+Fr8m3F2vMg2m24GPea0bg7rVGTYmiyn9mhUX11VCt+ozydrw+F50FQwL6OqoqPocmw==",
-            "peer": true,
+        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/middleware-host-header": "3.535.0",
-                "@aws-sdk/middleware-logger": "3.535.0",
-                "@aws-sdk/middleware-recursion-detection": "3.535.0",
-                "@aws-sdk/middleware-user-agent": "3.540.0",
-                "@aws-sdk/region-config-resolver": "3.535.0",
-                "@aws-sdk/types": "3.535.0",
-                "@aws-sdk/util-endpoints": "3.540.0",
-                "@aws-sdk/util-user-agent-browser": "3.535.0",
-                "@aws-sdk/util-user-agent-node": "3.535.0",
-                "@smithy/config-resolver": "^2.2.0",
-                "@smithy/core": "^1.4.2",
-                "@smithy/fetch-http-handler": "^2.5.0",
-                "@smithy/hash-node": "^2.2.0",
-                "@smithy/invalid-dependency": "^2.2.0",
-                "@smithy/middleware-content-length": "^2.2.0",
-                "@smithy/middleware-endpoint": "^2.5.1",
-                "@smithy/middleware-retry": "^2.3.1",
-                "@smithy/middleware-serde": "^2.3.0",
-                "@smithy/middleware-stack": "^2.2.0",
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/node-http-handler": "^2.5.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "@smithy/url-parser": "^2.2.0",
-                "@smithy/util-base64": "^2.3.0",
-                "@smithy/util-body-length-browser": "^2.2.0",
-                "@smithy/util-body-length-node": "^2.3.0",
-                "@smithy/util-defaults-mode-browser": "^2.2.1",
-                "@smithy/util-defaults-mode-node": "^2.3.1",
-                "@smithy/util-endpoints": "^1.2.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "@smithy/util-retry": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.564.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.564.0.tgz",
-            "integrity": "sha512-LWBXiwA0qlGhpJx3fbFQagVEyVPoecGtJh3+5hoc+CTVnT00J7T0jLe3kgemvEI9kjhIyDW+MFkq1jCttrGNJw==",
+        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/middleware-host-header": "3.535.0",
-                "@aws-sdk/middleware-logger": "3.535.0",
-                "@aws-sdk/middleware-recursion-detection": "3.535.0",
-                "@aws-sdk/middleware-user-agent": "3.540.0",
-                "@aws-sdk/region-config-resolver": "3.535.0",
-                "@aws-sdk/types": "3.535.0",
-                "@aws-sdk/util-endpoints": "3.540.0",
-                "@aws-sdk/util-user-agent-browser": "3.535.0",
-                "@aws-sdk/util-user-agent-node": "3.535.0",
-                "@smithy/config-resolver": "^2.2.0",
-                "@smithy/core": "^1.4.2",
-                "@smithy/fetch-http-handler": "^2.5.0",
-                "@smithy/hash-node": "^2.2.0",
-                "@smithy/invalid-dependency": "^2.2.0",
-                "@smithy/middleware-content-length": "^2.2.0",
-                "@smithy/middleware-endpoint": "^2.5.1",
-                "@smithy/middleware-retry": "^2.3.1",
-                "@smithy/middleware-serde": "^2.3.0",
-                "@smithy/middleware-stack": "^2.2.0",
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/node-http-handler": "^2.5.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "@smithy/url-parser": "^2.2.0",
-                "@smithy/util-base64": "^2.3.0",
-                "@smithy/util-body-length-browser": "^2.2.0",
-                "@smithy/util-body-length-node": "^2.3.0",
-                "@smithy/util-defaults-mode-browser": "^2.2.1",
-                "@smithy/util-defaults-mode-node": "^2.3.1",
-                "@smithy/util-endpoints": "^1.2.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "@smithy/util-retry": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/credential-provider-node": "^3.564.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/client-sts": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.556.0.tgz",
-            "integrity": "sha512-TsK3js7Suh9xEmC886aY+bv0KdLLYtzrcmVt6sJ/W6EnDXYQhBuKYFhp03NrN2+vSvMGpqJwR62DyfKe1G0QzQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/core": "3.556.0",
-                "@aws-sdk/middleware-host-header": "3.535.0",
-                "@aws-sdk/middleware-logger": "3.535.0",
-                "@aws-sdk/middleware-recursion-detection": "3.535.0",
-                "@aws-sdk/middleware-user-agent": "3.540.0",
-                "@aws-sdk/region-config-resolver": "3.535.0",
-                "@aws-sdk/types": "3.535.0",
-                "@aws-sdk/util-endpoints": "3.540.0",
-                "@aws-sdk/util-user-agent-browser": "3.535.0",
-                "@aws-sdk/util-user-agent-node": "3.535.0",
-                "@smithy/config-resolver": "^2.2.0",
-                "@smithy/core": "^1.4.2",
-                "@smithy/fetch-http-handler": "^2.5.0",
-                "@smithy/hash-node": "^2.2.0",
-                "@smithy/invalid-dependency": "^2.2.0",
-                "@smithy/middleware-content-length": "^2.2.0",
-                "@smithy/middleware-endpoint": "^2.5.1",
-                "@smithy/middleware-retry": "^2.3.1",
-                "@smithy/middleware-serde": "^2.3.0",
-                "@smithy/middleware-stack": "^2.2.0",
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/node-http-handler": "^2.5.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "@smithy/url-parser": "^2.2.0",
-                "@smithy/util-base64": "^2.3.0",
-                "@smithy/util-body-length-browser": "^2.2.0",
-                "@smithy/util-body-length-node": "^2.3.0",
-                "@smithy/util-defaults-mode-browser": "^2.2.1",
-                "@smithy/util-defaults-mode-node": "^2.3.1",
-                "@smithy/util-endpoints": "^1.2.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "@smithy/util-retry": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/credential-provider-node": "^3.556.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/core": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.556.0.tgz",
-            "integrity": "sha512-vJaSaHw2kPQlo11j/Rzuz0gk1tEaKdz+2ser0f0qZ5vwFlANjt08m/frU17ctnVKC1s58bxpctO/1P894fHLrA==",
-            "dependencies": {
-                "@smithy/core": "^1.4.2",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/signature-v4": "^2.3.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "fast-xml-parser": "4.2.5",
-                "tslib": "^2.6.2"
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.552.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.552.0.tgz",
-            "integrity": "sha512-vsmu7Cz1i45pFEqzVb4JcFmAmVnWFNLsGheZc8SCptlqCO5voETrZZILHYIl4cjKkSDk3pblBOf0PhyjqWW6WQ==",
-            "peer": true,
+        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.535.0",
-                "@smithy/fetch-http-handler": "^2.5.0",
-                "@smithy/node-http-handler": "^2.5.0",
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-stream": "^2.2.0",
-                "tslib": "^2.6.2"
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.564.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.564.0.tgz",
-            "integrity": "sha512-kiEfBoKRcbX7I/rjhVGJrTUQ0895ANhPu6KE1GRZW7wc1gIGgKGJ+0tvAqRtQjYX0U9pivEDb0dh16OF9PBFFw==",
-            "peer": true,
+        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sts": "3.556.0",
-                "@aws-sdk/credential-provider-env": "3.535.0",
-                "@aws-sdk/credential-provider-process": "3.535.0",
-                "@aws-sdk/credential-provider-sso": "3.564.0",
-                "@aws-sdk/credential-provider-web-identity": "3.556.0",
-                "@aws-sdk/types": "3.535.0",
-                "@smithy/credential-provider-imds": "^2.3.0",
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/shared-ini-file-loader": "^2.4.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.564.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.564.0.tgz",
-            "integrity": "sha512-HXD5ZCXzfcd6cJ/pW8frh8DuYlKaCd/JKmwzuCRUxgxZwbLEeNmyRYvF+D7osETJJZ4VIwgVbpEw1yLqRz1onw==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.535.0",
-                "@aws-sdk/credential-provider-http": "3.552.0",
-                "@aws-sdk/credential-provider-ini": "3.564.0",
-                "@aws-sdk/credential-provider-process": "3.535.0",
-                "@aws-sdk/credential-provider-sso": "3.564.0",
-                "@aws-sdk/credential-provider-web-identity": "3.556.0",
-                "@aws-sdk/types": "3.535.0",
-                "@smithy/credential-provider-imds": "^2.3.0",
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/shared-ini-file-loader": "^2.4.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.564.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.564.0.tgz",
-            "integrity": "sha512-Wv0NV8tDwtydEpsp/kVZ22Z+40bsSBDYgYZ1Uxx+KR8a1PvT6B5FnEtccWTJ371sQG/uqLum7dXSbJq1Qqze1w==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/client-sso": "3.556.0",
-                "@aws-sdk/token-providers": "3.564.0",
-                "@aws-sdk/types": "3.535.0",
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/shared-ini-file-loader": "^2.4.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.556.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.556.0.tgz",
-            "integrity": "sha512-R/YAL8Uh8i+dzVjzMnbcWLIGeeRi2mioHVGnVF+minmaIkCiQMZg2HPrdlKm49El+RljT28Nl5YHRuiqzEIwMA==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/client-sts": "3.556.0",
-                "@aws-sdk/types": "3.535.0",
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
+                "@aws-sdk/types": "3.425.0",
+                "@aws-sdk/util-endpoints": "3.425.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/token-providers": {
-            "version": "3.564.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.564.0.tgz",
-            "integrity": "sha512-Kk5ixcl9HjqwzfBJZGQAtsqwKa7Z8P7Mdug837BG8zCJbhf7wwNsmItzXTiAlpVrDZyT8P1yWIxsLOS1YUtmow==",
+            "version": "3.425.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.564.0",
-                "@aws-sdk/types": "3.535.0",
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/shared-ini-file-loader": "^2.4.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/middleware-host-header": "3.425.0",
+                "@aws-sdk/middleware-logger": "3.425.0",
+                "@aws-sdk/middleware-recursion-detection": "3.425.0",
+                "@aws-sdk/middleware-user-agent": "3.425.0",
+                "@aws-sdk/types": "3.425.0",
+                "@aws-sdk/util-endpoints": "3.425.0",
+                "@aws-sdk/util-user-agent-browser": "3.425.0",
+                "@aws-sdk/util-user-agent-node": "3.425.0",
+                "@smithy/config-resolver": "^2.0.11",
+                "@smithy/fetch-http-handler": "^2.2.1",
+                "@smithy/hash-node": "^2.0.10",
+                "@smithy/invalid-dependency": "^2.0.10",
+                "@smithy/middleware-content-length": "^2.0.12",
+                "@smithy/middleware-endpoint": "^2.0.10",
+                "@smithy/middleware-retry": "^2.0.13",
+                "@smithy/middleware-serde": "^2.0.10",
+                "@smithy/middleware-stack": "^2.0.4",
+                "@smithy/node-config-provider": "^2.0.13",
+                "@smithy/node-http-handler": "^2.1.6",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/smithy-client": "^2.1.9",
+                "@smithy/types": "^2.3.4",
+                "@smithy/url-parser": "^2.0.10",
+                "@smithy/util-base64": "^2.0.0",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.13",
+                "@smithy/util-defaults-mode-node": "^2.0.15",
+                "@smithy/util-retry": "^2.0.3",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.5.0"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/types": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.425.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/types": "^2.3.4",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/node-config-provider": "^2.0.13",
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
@@ -2612,10 +2476,10 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.3.0.tgz",
-            "integrity": "sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==",
+            "version": "2.2.0",
+            "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/eventstream-codec": "^2.2.0",
                 "@smithy/is-array-buffer": "^2.2.0",
                 "@smithy/types": "^2.12.0",
                 "@smithy/util-hex-encoding": "^2.2.0",
@@ -2713,12 +2577,11 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
-            "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+            "version": "2.2.0",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/property-provider": "^2.2.0",
-                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/smithy-client": "^2.5.0",
                 "@smithy/types": "^2.12.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
@@ -2728,15 +2591,14 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
-            "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+            "version": "2.3.0",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/credential-provider-imds": "^2.3.0",
                 "@smithy/node-config-provider": "^2.3.0",
                 "@smithy/property-provider": "^2.2.0",
-                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/smithy-client": "^2.5.0",
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
@@ -12879,7 +12741,7 @@
                 "@aws-sdk/middleware-host-header": "3.425.0",
                 "@aws-sdk/middleware-logger": "3.425.0",
                 "@aws-sdk/middleware-recursion-detection": "3.425.0",
-                "@aws-sdk/middleware-token": "3.564.0",
+                "@aws-sdk/middleware-token": "3.425.0",
                 "@aws-sdk/middleware-user-agent": "3.425.0",
                 "@aws-sdk/region-config-resolver": "3.425.0",
                 "@aws-sdk/types": "3.425.0",
@@ -12986,7 +12848,7 @@
                 "@aws-sdk/middleware-host-header": "3.425.0",
                 "@aws-sdk/middleware-logger": "3.425.0",
                 "@aws-sdk/middleware-recursion-detection": "3.425.0",
-                "@aws-sdk/middleware-token": "3.564.0",
+                "@aws-sdk/middleware-token": "3.425.0",
                 "@aws-sdk/middleware-user-agent": "3.425.0",
                 "@aws-sdk/region-config-resolver": "3.425.0",
                 "@aws-sdk/types": "3.425.0",
@@ -13843,265 +13705,123 @@
             }
         },
         "@aws-sdk/middleware-token": {
-            "version": "3.564.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-token/-/middleware-token-3.564.0.tgz",
-            "integrity": "sha512-9YmCcMZBesCVF8WarFkb4PegGbPqGUJ/av/usd4DMjTMzz6qvLt5VQwIQL6qpTLz+WreZzNIWPTQ7ReID1uN3A==",
+            "version": "3.425.0",
             "requires": {
-                "@aws-sdk/token-providers": "3.564.0",
-                "@aws-sdk/types": "3.535.0",
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "tslib": "^2.6.2"
+                "@aws-sdk/token-providers": "3.425.0",
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/types": "^2.3.4",
+                "@smithy/util-middleware": "^2.0.3",
+                "tslib": "^2.5.0"
             },
             "dependencies": {
-                "@aws-sdk/client-sso": {
-                    "version": "3.556.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.556.0.tgz",
-                    "integrity": "sha512-unXdWS7uvHqCcOyC1de+Fr8m3F2vMg2m24GPea0bg7rVGTYmiyn9mhUX11VCt+ozydrw+F50FQwL6OqoqPocmw==",
-                    "peer": true,
+                "@aws-sdk/middleware-host-header": {
+                    "version": "3.425.0",
                     "requires": {
-                        "@aws-crypto/sha256-browser": "3.0.0",
-                        "@aws-crypto/sha256-js": "3.0.0",
-                        "@aws-sdk/core": "3.556.0",
-                        "@aws-sdk/middleware-host-header": "3.535.0",
-                        "@aws-sdk/middleware-logger": "3.535.0",
-                        "@aws-sdk/middleware-recursion-detection": "3.535.0",
-                        "@aws-sdk/middleware-user-agent": "3.540.0",
-                        "@aws-sdk/region-config-resolver": "3.535.0",
-                        "@aws-sdk/types": "3.535.0",
-                        "@aws-sdk/util-endpoints": "3.540.0",
-                        "@aws-sdk/util-user-agent-browser": "3.535.0",
-                        "@aws-sdk/util-user-agent-node": "3.535.0",
-                        "@smithy/config-resolver": "^2.2.0",
-                        "@smithy/core": "^1.4.2",
-                        "@smithy/fetch-http-handler": "^2.5.0",
-                        "@smithy/hash-node": "^2.2.0",
-                        "@smithy/invalid-dependency": "^2.2.0",
-                        "@smithy/middleware-content-length": "^2.2.0",
-                        "@smithy/middleware-endpoint": "^2.5.1",
-                        "@smithy/middleware-retry": "^2.3.1",
-                        "@smithy/middleware-serde": "^2.3.0",
-                        "@smithy/middleware-stack": "^2.2.0",
-                        "@smithy/node-config-provider": "^2.3.0",
-                        "@smithy/node-http-handler": "^2.5.0",
-                        "@smithy/protocol-http": "^3.3.0",
-                        "@smithy/smithy-client": "^2.5.1",
-                        "@smithy/types": "^2.12.0",
-                        "@smithy/url-parser": "^2.2.0",
-                        "@smithy/util-base64": "^2.3.0",
-                        "@smithy/util-body-length-browser": "^2.2.0",
-                        "@smithy/util-body-length-node": "^2.3.0",
-                        "@smithy/util-defaults-mode-browser": "^2.2.1",
-                        "@smithy/util-defaults-mode-node": "^2.3.1",
-                        "@smithy/util-endpoints": "^1.2.0",
-                        "@smithy/util-middleware": "^2.2.0",
-                        "@smithy/util-retry": "^2.2.0",
-                        "@smithy/util-utf8": "^2.3.0",
-                        "tslib": "^2.6.2"
+                        "@aws-sdk/types": "3.425.0",
+                        "@smithy/protocol-http": "^3.0.6",
+                        "@smithy/types": "^2.3.4",
+                        "tslib": "^2.5.0"
                     }
                 },
-                "@aws-sdk/client-sso-oidc": {
-                    "version": "3.564.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.564.0.tgz",
-                    "integrity": "sha512-LWBXiwA0qlGhpJx3fbFQagVEyVPoecGtJh3+5hoc+CTVnT00J7T0jLe3kgemvEI9kjhIyDW+MFkq1jCttrGNJw==",
+                "@aws-sdk/middleware-logger": {
+                    "version": "3.425.0",
                     "requires": {
-                        "@aws-crypto/sha256-browser": "3.0.0",
-                        "@aws-crypto/sha256-js": "3.0.0",
-                        "@aws-sdk/core": "3.556.0",
-                        "@aws-sdk/middleware-host-header": "3.535.0",
-                        "@aws-sdk/middleware-logger": "3.535.0",
-                        "@aws-sdk/middleware-recursion-detection": "3.535.0",
-                        "@aws-sdk/middleware-user-agent": "3.540.0",
-                        "@aws-sdk/region-config-resolver": "3.535.0",
-                        "@aws-sdk/types": "3.535.0",
-                        "@aws-sdk/util-endpoints": "3.540.0",
-                        "@aws-sdk/util-user-agent-browser": "3.535.0",
-                        "@aws-sdk/util-user-agent-node": "3.535.0",
-                        "@smithy/config-resolver": "^2.2.0",
-                        "@smithy/core": "^1.4.2",
-                        "@smithy/fetch-http-handler": "^2.5.0",
-                        "@smithy/hash-node": "^2.2.0",
-                        "@smithy/invalid-dependency": "^2.2.0",
-                        "@smithy/middleware-content-length": "^2.2.0",
-                        "@smithy/middleware-endpoint": "^2.5.1",
-                        "@smithy/middleware-retry": "^2.3.1",
-                        "@smithy/middleware-serde": "^2.3.0",
-                        "@smithy/middleware-stack": "^2.2.0",
-                        "@smithy/node-config-provider": "^2.3.0",
-                        "@smithy/node-http-handler": "^2.5.0",
-                        "@smithy/protocol-http": "^3.3.0",
-                        "@smithy/smithy-client": "^2.5.1",
-                        "@smithy/types": "^2.12.0",
-                        "@smithy/url-parser": "^2.2.0",
-                        "@smithy/util-base64": "^2.3.0",
-                        "@smithy/util-body-length-browser": "^2.2.0",
-                        "@smithy/util-body-length-node": "^2.3.0",
-                        "@smithy/util-defaults-mode-browser": "^2.2.1",
-                        "@smithy/util-defaults-mode-node": "^2.3.1",
-                        "@smithy/util-endpoints": "^1.2.0",
-                        "@smithy/util-middleware": "^2.2.0",
-                        "@smithy/util-retry": "^2.2.0",
-                        "@smithy/util-utf8": "^2.3.0",
-                        "tslib": "^2.6.2"
+                        "@aws-sdk/types": "3.425.0",
+                        "@smithy/types": "^2.3.4",
+                        "tslib": "^2.5.0"
                     }
                 },
-                "@aws-sdk/client-sts": {
-                    "version": "3.556.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.556.0.tgz",
-                    "integrity": "sha512-TsK3js7Suh9xEmC886aY+bv0KdLLYtzrcmVt6sJ/W6EnDXYQhBuKYFhp03NrN2+vSvMGpqJwR62DyfKe1G0QzQ==",
-                    "peer": true,
+                "@aws-sdk/middleware-recursion-detection": {
+                    "version": "3.425.0",
                     "requires": {
-                        "@aws-crypto/sha256-browser": "3.0.0",
-                        "@aws-crypto/sha256-js": "3.0.0",
-                        "@aws-sdk/core": "3.556.0",
-                        "@aws-sdk/middleware-host-header": "3.535.0",
-                        "@aws-sdk/middleware-logger": "3.535.0",
-                        "@aws-sdk/middleware-recursion-detection": "3.535.0",
-                        "@aws-sdk/middleware-user-agent": "3.540.0",
-                        "@aws-sdk/region-config-resolver": "3.535.0",
-                        "@aws-sdk/types": "3.535.0",
-                        "@aws-sdk/util-endpoints": "3.540.0",
-                        "@aws-sdk/util-user-agent-browser": "3.535.0",
-                        "@aws-sdk/util-user-agent-node": "3.535.0",
-                        "@smithy/config-resolver": "^2.2.0",
-                        "@smithy/core": "^1.4.2",
-                        "@smithy/fetch-http-handler": "^2.5.0",
-                        "@smithy/hash-node": "^2.2.0",
-                        "@smithy/invalid-dependency": "^2.2.0",
-                        "@smithy/middleware-content-length": "^2.2.0",
-                        "@smithy/middleware-endpoint": "^2.5.1",
-                        "@smithy/middleware-retry": "^2.3.1",
-                        "@smithy/middleware-serde": "^2.3.0",
-                        "@smithy/middleware-stack": "^2.2.0",
-                        "@smithy/node-config-provider": "^2.3.0",
-                        "@smithy/node-http-handler": "^2.5.0",
-                        "@smithy/protocol-http": "^3.3.0",
-                        "@smithy/smithy-client": "^2.5.1",
-                        "@smithy/types": "^2.12.0",
-                        "@smithy/url-parser": "^2.2.0",
-                        "@smithy/util-base64": "^2.3.0",
-                        "@smithy/util-body-length-browser": "^2.2.0",
-                        "@smithy/util-body-length-node": "^2.3.0",
-                        "@smithy/util-defaults-mode-browser": "^2.2.1",
-                        "@smithy/util-defaults-mode-node": "^2.3.1",
-                        "@smithy/util-endpoints": "^1.2.0",
-                        "@smithy/util-middleware": "^2.2.0",
-                        "@smithy/util-retry": "^2.2.0",
-                        "@smithy/util-utf8": "^2.3.0",
-                        "tslib": "^2.6.2"
+                        "@aws-sdk/types": "3.425.0",
+                        "@smithy/protocol-http": "^3.0.6",
+                        "@smithy/types": "^2.3.4",
+                        "tslib": "^2.5.0"
                     }
                 },
-                "@aws-sdk/core": {
-                    "version": "3.556.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.556.0.tgz",
-                    "integrity": "sha512-vJaSaHw2kPQlo11j/Rzuz0gk1tEaKdz+2ser0f0qZ5vwFlANjt08m/frU17ctnVKC1s58bxpctO/1P894fHLrA==",
+                "@aws-sdk/middleware-user-agent": {
+                    "version": "3.425.0",
                     "requires": {
-                        "@smithy/core": "^1.4.2",
-                        "@smithy/protocol-http": "^3.3.0",
-                        "@smithy/signature-v4": "^2.3.0",
-                        "@smithy/smithy-client": "^2.5.1",
-                        "@smithy/types": "^2.12.0",
-                        "fast-xml-parser": "4.2.5",
-                        "tslib": "^2.6.2"
-                    }
-                },
-                "@aws-sdk/credential-provider-http": {
-                    "version": "3.552.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.552.0.tgz",
-                    "integrity": "sha512-vsmu7Cz1i45pFEqzVb4JcFmAmVnWFNLsGheZc8SCptlqCO5voETrZZILHYIl4cjKkSDk3pblBOf0PhyjqWW6WQ==",
-                    "peer": true,
-                    "requires": {
-                        "@aws-sdk/types": "3.535.0",
-                        "@smithy/fetch-http-handler": "^2.5.0",
-                        "@smithy/node-http-handler": "^2.5.0",
-                        "@smithy/property-provider": "^2.2.0",
-                        "@smithy/protocol-http": "^3.3.0",
-                        "@smithy/smithy-client": "^2.5.1",
-                        "@smithy/types": "^2.12.0",
-                        "@smithy/util-stream": "^2.2.0",
-                        "tslib": "^2.6.2"
-                    }
-                },
-                "@aws-sdk/credential-provider-ini": {
-                    "version": "3.564.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.564.0.tgz",
-                    "integrity": "sha512-kiEfBoKRcbX7I/rjhVGJrTUQ0895ANhPu6KE1GRZW7wc1gIGgKGJ+0tvAqRtQjYX0U9pivEDb0dh16OF9PBFFw==",
-                    "peer": true,
-                    "requires": {
-                        "@aws-sdk/client-sts": "3.556.0",
-                        "@aws-sdk/credential-provider-env": "3.535.0",
-                        "@aws-sdk/credential-provider-process": "3.535.0",
-                        "@aws-sdk/credential-provider-sso": "3.564.0",
-                        "@aws-sdk/credential-provider-web-identity": "3.556.0",
-                        "@aws-sdk/types": "3.535.0",
-                        "@smithy/credential-provider-imds": "^2.3.0",
-                        "@smithy/property-provider": "^2.2.0",
-                        "@smithy/shared-ini-file-loader": "^2.4.0",
-                        "@smithy/types": "^2.12.0",
-                        "tslib": "^2.6.2"
-                    }
-                },
-                "@aws-sdk/credential-provider-node": {
-                    "version": "3.564.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.564.0.tgz",
-                    "integrity": "sha512-HXD5ZCXzfcd6cJ/pW8frh8DuYlKaCd/JKmwzuCRUxgxZwbLEeNmyRYvF+D7osETJJZ4VIwgVbpEw1yLqRz1onw==",
-                    "peer": true,
-                    "requires": {
-                        "@aws-sdk/credential-provider-env": "3.535.0",
-                        "@aws-sdk/credential-provider-http": "3.552.0",
-                        "@aws-sdk/credential-provider-ini": "3.564.0",
-                        "@aws-sdk/credential-provider-process": "3.535.0",
-                        "@aws-sdk/credential-provider-sso": "3.564.0",
-                        "@aws-sdk/credential-provider-web-identity": "3.556.0",
-                        "@aws-sdk/types": "3.535.0",
-                        "@smithy/credential-provider-imds": "^2.3.0",
-                        "@smithy/property-provider": "^2.2.0",
-                        "@smithy/shared-ini-file-loader": "^2.4.0",
-                        "@smithy/types": "^2.12.0",
-                        "tslib": "^2.6.2"
-                    }
-                },
-                "@aws-sdk/credential-provider-sso": {
-                    "version": "3.564.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.564.0.tgz",
-                    "integrity": "sha512-Wv0NV8tDwtydEpsp/kVZ22Z+40bsSBDYgYZ1Uxx+KR8a1PvT6B5FnEtccWTJ371sQG/uqLum7dXSbJq1Qqze1w==",
-                    "peer": true,
-                    "requires": {
-                        "@aws-sdk/client-sso": "3.556.0",
-                        "@aws-sdk/token-providers": "3.564.0",
-                        "@aws-sdk/types": "3.535.0",
-                        "@smithy/property-provider": "^2.2.0",
-                        "@smithy/shared-ini-file-loader": "^2.4.0",
-                        "@smithy/types": "^2.12.0",
-                        "tslib": "^2.6.2"
-                    }
-                },
-                "@aws-sdk/credential-provider-web-identity": {
-                    "version": "3.556.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.556.0.tgz",
-                    "integrity": "sha512-R/YAL8Uh8i+dzVjzMnbcWLIGeeRi2mioHVGnVF+minmaIkCiQMZg2HPrdlKm49El+RljT28Nl5YHRuiqzEIwMA==",
-                    "peer": true,
-                    "requires": {
-                        "@aws-sdk/client-sts": "3.556.0",
-                        "@aws-sdk/types": "3.535.0",
-                        "@smithy/property-provider": "^2.2.0",
-                        "@smithy/types": "^2.12.0",
-                        "tslib": "^2.6.2"
+                        "@aws-sdk/types": "3.425.0",
+                        "@aws-sdk/util-endpoints": "3.425.0",
+                        "@smithy/protocol-http": "^3.0.6",
+                        "@smithy/types": "^2.3.4",
+                        "tslib": "^2.5.0"
                     }
                 },
                 "@aws-sdk/token-providers": {
-                    "version": "3.564.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.564.0.tgz",
-                    "integrity": "sha512-Kk5ixcl9HjqwzfBJZGQAtsqwKa7Z8P7Mdug837BG8zCJbhf7wwNsmItzXTiAlpVrDZyT8P1yWIxsLOS1YUtmow==",
+                    "version": "3.425.0",
                     "requires": {
-                        "@aws-sdk/client-sso-oidc": "3.564.0",
-                        "@aws-sdk/types": "3.535.0",
-                        "@smithy/property-provider": "^2.2.0",
-                        "@smithy/shared-ini-file-loader": "^2.4.0",
-                        "@smithy/types": "^2.12.0",
-                        "tslib": "^2.6.2"
+                        "@aws-crypto/sha256-browser": "3.0.0",
+                        "@aws-crypto/sha256-js": "3.0.0",
+                        "@aws-sdk/middleware-host-header": "3.425.0",
+                        "@aws-sdk/middleware-logger": "3.425.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+                        "@aws-sdk/middleware-user-agent": "3.425.0",
+                        "@aws-sdk/types": "3.425.0",
+                        "@aws-sdk/util-endpoints": "3.425.0",
+                        "@aws-sdk/util-user-agent-browser": "3.425.0",
+                        "@aws-sdk/util-user-agent-node": "3.425.0",
+                        "@smithy/config-resolver": "^2.0.11",
+                        "@smithy/fetch-http-handler": "^2.2.1",
+                        "@smithy/hash-node": "^2.0.10",
+                        "@smithy/invalid-dependency": "^2.0.10",
+                        "@smithy/middleware-content-length": "^2.0.12",
+                        "@smithy/middleware-endpoint": "^2.0.10",
+                        "@smithy/middleware-retry": "^2.0.13",
+                        "@smithy/middleware-serde": "^2.0.10",
+                        "@smithy/middleware-stack": "^2.0.4",
+                        "@smithy/node-config-provider": "^2.0.13",
+                        "@smithy/node-http-handler": "^2.1.6",
+                        "@smithy/property-provider": "^2.0.0",
+                        "@smithy/protocol-http": "^3.0.6",
+                        "@smithy/shared-ini-file-loader": "^2.0.6",
+                        "@smithy/smithy-client": "^2.1.9",
+                        "@smithy/types": "^2.3.4",
+                        "@smithy/url-parser": "^2.0.10",
+                        "@smithy/util-base64": "^2.0.0",
+                        "@smithy/util-body-length-browser": "^2.0.0",
+                        "@smithy/util-body-length-node": "^2.1.0",
+                        "@smithy/util-defaults-mode-browser": "^2.0.13",
+                        "@smithy/util-defaults-mode-node": "^2.0.15",
+                        "@smithy/util-retry": "^2.0.3",
+                        "@smithy/util-utf8": "^2.0.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/types": {
+                    "version": "3.425.0",
+                    "requires": {
+                        "@smithy/types": "^2.3.4",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-endpoints": {
+                    "version": "3.425.0",
+                    "requires": {
+                        "@aws-sdk/types": "3.425.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-user-agent-browser": {
+                    "version": "3.425.0",
+                    "requires": {
+                        "@aws-sdk/types": "3.425.0",
+                        "@smithy/types": "^2.3.4",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-user-agent-node": {
+                    "version": "3.425.0",
+                    "requires": {
+                        "@aws-sdk/types": "3.425.0",
+                        "@smithy/node-config-provider": "^2.0.13",
+                        "@smithy/types": "^2.3.4",
+                        "tslib": "^2.5.0"
                     }
                 }
             }
@@ -15149,10 +14869,9 @@
             }
         },
         "@smithy/signature-v4": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.3.0.tgz",
-            "integrity": "sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==",
+            "version": "2.2.0",
             "requires": {
+                "@smithy/eventstream-codec": "^2.2.0",
                 "@smithy/is-array-buffer": "^2.2.0",
                 "@smithy/types": "^2.12.0",
                 "@smithy/util-hex-encoding": "^2.2.0",
@@ -15221,27 +14940,23 @@
             }
         },
         "@smithy/util-defaults-mode-browser": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
-            "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
+            "version": "2.2.0",
             "requires": {
                 "@smithy/property-provider": "^2.2.0",
-                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/smithy-client": "^2.5.0",
                 "@smithy/types": "^2.12.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             }
         },
         "@smithy/util-defaults-mode-node": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
-            "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
+            "version": "2.3.0",
             "requires": {
                 "@smithy/config-resolver": "^2.2.0",
                 "@smithy/credential-provider-imds": "^2.3.0",
                 "@smithy/node-config-provider": "^2.3.0",
                 "@smithy/property-provider": "^2.2.0",
-                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/smithy-client": "^2.5.0",
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             }

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
@@ -21,7 +21,7 @@
         "@aws-sdk/middleware-host-header": "3.425.0",
         "@aws-sdk/middleware-logger": "3.425.0",
         "@aws-sdk/middleware-recursion-detection": "3.425.0",
-        "@aws-sdk/middleware-token": "3.564.0",
+        "@aws-sdk/middleware-token": "3.425.0",
         "@aws-sdk/middleware-user-agent": "3.425.0",
         "@aws-sdk/region-config-resolver": "3.425.0",
         "@aws-sdk/types": "3.425.0",


### PR DESCRIPTION
Pre-maturely merged, internal process not synced yet
Reverts aws/language-servers#218