### PR TITLE
Added customizable LSP server

### DIFF
--- a/app/aws-lsp-yaml-json-binary/src/index.ts
+++ b/app/aws-lsp-yaml-json-binary/src/index.ts
@@ -1,6 +1,12 @@
 import { standalone } from '@aws/language-server-runtimes/runtimes'
 import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
-import { YamlLanguageServer } from '@aws/aws-lsp-yaml-json'
+import { CreateYamlJsonLanguageServer } from '@aws/aws-lsp-yaml-json'
+
+const jsonSchemaUrl =
+    'https://raw.githubusercontent.com/aws/serverless-application-model/main/samtranslator/schema/schema.json'
+const displayName = 'aws-lsp-yaml-json'
+
+const YamlJsonLanguageServer = CreateYamlJsonLanguageServer(displayName, jsonSchemaUrl)
 
 const MAJOR = 0
 const MINOR = 1
@@ -9,7 +15,7 @@ const VERSION = `${MAJOR}.${MINOR}.${PATCH}`
 
 const props: RuntimeProps = {
     version: VERSION,
-    servers: [YamlLanguageServer],
+    servers: [YamlJsonLanguageServer],
     name: 'AWS YAML/JSON server',
 }
 standalone(props)

--- a/app/aws-lsp-yaml-json-webworker/src/yamlJsonWebWorkerRuntimeServer.ts
+++ b/app/aws-lsp-yaml-json-webworker/src/yamlJsonWebWorkerRuntimeServer.ts
@@ -1,6 +1,12 @@
 import { webworker } from '@aws/language-server-runtimes/runtimes/webworker'
 import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
-import { YamlLanguageServer } from '@aws/aws-lsp-yaml-json'
+import { CreateYamlJsonLanguageServer } from '@aws/aws-lsp-yaml-json'
+
+const jsonSchemaUrl =
+    'https://raw.githubusercontent.com/aws/serverless-application-model/main/samtranslator/schema/schema.json'
+const displayName = 'aws-lsp-yaml-json'
+
+const YamlJsonLanguageServer = CreateYamlJsonLanguageServer(displayName, jsonSchemaUrl)
 
 const MAJOR = 0
 const MINOR = 1
@@ -9,7 +15,7 @@ const VERSION = `${MAJOR}.${MINOR}.${PATCH}`
 
 const props: RuntimeProps = {
     version: VERSION,
-    servers: [YamlLanguageServer],
+    servers: [YamlJsonLanguageServer],
     name: 'AWS YAML/JSON server',
 }
 webworker(props)

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,7 @@
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.540.0",
                 "@aws-sdk/types": "^3.535.0",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",
                 "typescript": "^5.1.3",
@@ -15831,6 +15832,7 @@
             "requires": {
                 "@aws-sdk/credential-providers": "^3.540.0",
                 "@aws-sdk/types": "^3.535.0",
+                "@aws/language-server-runtimes": "^0.2.3",
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",
                 "typescript": "^5.1.3",

--- a/server/aws-lsp-yaml-json/src/index.ts
+++ b/server/aws-lsp-yaml-json/src/index.ts
@@ -1,1 +1,1 @@
-export { YamlLanguageServer } from './language-server/yamlJsonServer'
+export { CreateYamlJsonLanguageServer } from './language-server/yamlJsonServer'

--- a/server/aws-lsp-yaml-json/src/language-server/yamlJsonServer.ts
+++ b/server/aws-lsp-yaml-json/src/language-server/yamlJsonServer.ts
@@ -133,9 +133,6 @@ export const YamlJsonServerFactory =
         }
     }
 
-const jsonSchemaUrl =
-    'https://raw.githubusercontent.com/aws/serverless-application-model/main/samtranslator/schema/schema.json'
-
 async function getSchema(url: string) {
     const response = await fetch(url)
     const schema = await (await response.blob()).text()
@@ -143,12 +140,17 @@ async function getSchema(url: string) {
     return schema
 }
 
-const yamlJsonServerProps = {
-    displayName: 'aws-lsp-yaml-json',
-    defaultSchemaUri: jsonSchemaUrl,
-    uriResolver: getSchema,
-    allowComments: true,
-}
-
-const service = create(yamlJsonServerProps)
-export const YamlLanguageServer = YamlJsonServerFactory(service)
+export const CreateYamlJsonLanguageServer = (
+    displayName: string,
+    defaultSchemaUri: string,
+    allowComments: boolean = true,
+    uriResolver: (url: string) => Promise<string> = getSchema
+) =>
+    YamlJsonServerFactory(
+        create({
+            displayName: displayName,
+            defaultSchemaUri: defaultSchemaUri,
+            allowComments: allowComments,
+            uriResolver: uriResolver,
+        })
+    )


### PR DESCRIPTION
## Problem
LSP server should be customizable and get any json-schema.

## Solution
Added function to create LSP Server using any json-schema. Added options to customize display name, uri Resolver and allow Comments for JSON files.

## Testing
ran `npm install && npm run test`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
