### PR TITLE
added patches for markdown and unsafe-eval

### DIFF
--- a/app/aws-lsp-yaml-json-binary/src/tests/testUtilsCF.ts
+++ b/app/aws-lsp-yaml-json-binary/src/tests/testUtilsCF.ts
@@ -420,7 +420,7 @@ Globals:
 export const HOVER_YAML = {
     contents: {
         kind: 'markdown',
-        value: '#### Resources\n\nSource: [schema.json](https://raw.githubusercontent.com/aws/serverless-application-model/main/samtranslator/schema/schema.json)',
+        value: '',
     },
     range: {
         start: { line: 0, character: 0 },

--- a/app/aws-lsp-yaml-json-binary/src/tests/yamlJsonServerCFInteg.test.ts
+++ b/app/aws-lsp-yaml-json-binary/src/tests/yamlJsonServerCFInteg.test.ts
@@ -192,7 +192,7 @@ describe('Test YamlJsonServer with CloudFormation schema', () => {
         expect(result).to.deep.equal(COMPLETIONS_EMPTY_OBJECT_YAML)
     })
 
-    it('should return hover items, YAML', async () => {
+    it('should return hover item without header and footer, YAML', async () => {
         const docUri = 'hover.yml'
         client.didOpen({
             textDocument: {

--- a/core/aws-lsp-yaml-common/README.md
+++ b/core/aws-lsp-yaml-common/README.md
@@ -1,0 +1,12 @@
+## Temporary Patch for yaml-language-server Dependency
+
+In the current state of this package, we need to apply a temporary patch to the yaml-language-server dependency.
+
+The script applies 2 patches:
+- `patches/markdown`: adds hover setting to enable/disable Title and Source from hover tooltip. [PR](https://github.com/redhat-developer/yaml-language-server/pull/892)
+- `patches/unsafe-eval`: adds skipSchemaValidation settings to enable/disable json schema validation. [PR draft](https://github.com/redhat-developer/yaml-language-server/pull/965).
+
+
+The patch file is applied during the installation process using the `postinstall` script in the `package.json` file. This script runs the `patchYamlJsonPackage.js` script, which searches path to the `yaml-language-server` package and applies the patches once.
+
+### Note: This is a temporary solution, and we plan to remove the custom patching once the yaml-language-server package is updated. The features from PRs above should be merged to yaml-language-server package. After features are merged we need to update the version and enable skipSchemaValidation setting.

--- a/core/aws-lsp-yaml-common/package.json
+++ b/core/aws-lsp-yaml-common/package.json
@@ -4,7 +4,8 @@
     "description": "YAML Language Server common code library",
     "main": "out/index.js",
     "scripts": {
-        "compile": "tsc --build"
+        "compile": "tsc --build",
+        "postinstall": "node patchYamlJsonPackage.js"
     },
     "dependencies": {
         "@aws/lsp-core": "^0.0.1",

--- a/core/aws-lsp-yaml-common/patchYamlJsonPackage.js
+++ b/core/aws-lsp-yaml-common/patchYamlJsonPackage.js
@@ -1,0 +1,52 @@
+const execSync = require('child_process').execSync
+const fs = require('node:fs')
+
+const pathToYamlPackage = require.resolve('yaml-language-server')
+const rootPackage = pathToYamlPackage.substring(
+    0,
+    pathToYamlPackage.indexOf('node_modules/yaml-language-server/out/server/src/index.js')
+)
+const pathToFileHover = rootPackage + 'node_modules/yaml-language-server/lib/esm/languageservice/services/yamlHover.js'
+
+const filePathToPatchPathMarkdown = {
+    'node_modules/yaml-language-server/lib/esm/languageservice/services/yamlHover.js':
+        'patches/markdown/yamlHover.esm.patch',
+    'node_modules/yaml-language-server/lib/umd/languageservice/services/yamlHover.js':
+        'patches/markdown/yamlHover.umd.patch',
+    'node_modules/yaml-language-server/out/server/src/languageservice/services/yamlHover.js':
+        'patches/markdown/yamlHover.src.patch',
+    'node_modules/yaml-language-server/lib/esm/languageservice/yamlLanguageService.d.ts':
+        'patches/markdown/yamlLanguageService.esm.patch',
+    'node_modules/yaml-language-server/lib/umd/languageservice/yamlLanguageService.d.ts':
+        'patches/markdown/yamlLanguageService.umd.patch',
+    'node_modules/yaml-language-server/out/server/src/languageservice/yamlLanguageService.d.ts':
+        'patches/markdown/yamlLanguageService.src.patch',
+}
+
+const filePathToPatchPathUnsafeEval = {
+    'node_modules/yaml-language-server/lib/esm/languageservice/services/yamlSchemaService.js':
+        'patches/unsafe-eval/yamlSchemaService.esm.patch',
+    'node_modules/yaml-language-server/lib/umd/languageservice/services/yamlSchemaService.js':
+        'patches/unsafe-eval/yamlSchemaService.umd.patch',
+    'node_modules/yaml-language-server/out/server/src/languageservice/services/yamlSchemaService.js':
+        'patches/unsafe-eval/yamlSchemaService.src.patch',
+}
+
+function applyPatch(filePathToPatchPath) {
+    for (var filePath in filePathToPatchPath) {
+        const pathToPatch = `${__dirname}/${filePathToPatchPath[filePath]}`
+        const script = `cd ${rootPackage} && patch ${filePath} ${pathToPatch}`
+        console.log(script)
+        const output = execSync(script, { encoding: 'utf-8', timeout: 2000 })
+    }
+}
+
+fs.readFile(pathToFileHover, function (err, data) {
+    if (err) throw err
+    if (data.indexOf('this.hoverSettings = {showSource: true, showTitle: true};') >= 0) {
+        console.log('Patch is already applied')
+    } else {
+        applyPatch(filePathToPatchPathMarkdown)
+        applyPatch(filePathToPatchPathUnsafeEval)
+    }
+})

--- a/core/aws-lsp-yaml-common/patches/markdown/yamlHover.esm.patch
+++ b/core/aws-lsp-yaml-common/patches/markdown/yamlHover.esm.patch
@@ -1,0 +1,47 @@
+--- a/node_modules/yaml-language-server/lib/esm/languageservice/services/yamlHover.js	2024-04-28 20:38:52
++++ b/node_modules/yaml-language-server/lib/esm/languageservice/services/yamlHover.js	2024-04-28 20:55:28
+@@ -16,11 +16,13 @@
+     constructor(schemaService, telemetry) {
+         this.telemetry = telemetry;
+         this.shouldHover = true;
++        this.hoverSettings = {showSource: true, showTitle: true};
+         this.schemaService = schemaService;
+     }
+     configure(languageSettings) {
+         if (languageSettings) {
+             this.shouldHover = languageSettings.hover;
++            this.hoverSettings = languageSettings.hoverSettings;
+             this.indentation = languageSettings.indentation;
+         }
+     }
+\ No newline at end of file
+@@ -82,6 +84,8 @@
+         const removePipe = (value) => {
+             return value.replace(/\|\|\s*$/, '');
+         };
++        const showSource = this.hoverSettings?.showSource ?? true;
++        const showTitle = this.hoverSettings?.showTitle ?? true;
+         return this.schemaService.getSchemaForResource(document.uri, doc).then((schema) => {
+             if (schema && node && !schema.errors.length) {
+                 const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset);
+\ No newline at end of file
+@@ -133,7 +137,7 @@
+                     return true;
+                 });
+                 let result = '';
+-                if (title) {
++                if (showTitle && title) {
+                     result = '#### ' + toMarkdown(title);
+                 }
+                 if (markdownDescription) {
+\ No newline at end of file
+@@ -157,7 +161,7 @@
+                         result += `\n\n\`\`\`${example}\`\`\``;
+                     });
+                 }
+-                if (result.length > 0 && schema.schema.url) {
++                if (showSource && result.length > 0 && schema.schema.url) {
+                     result += `\n\nSource: [${getSchemaName(schema.schema)}](${schema.schema.url})`;
+                 }
+                 return createHover(result);
+\ No newline at end of file

--- a/core/aws-lsp-yaml-common/patches/markdown/yamlHover.src.patch
+++ b/core/aws-lsp-yaml-common/patches/markdown/yamlHover.src.patch
@@ -1,0 +1,47 @@
+--- a/node_modules/yaml-language-server/out/server/src/languageservice/services/yamlHover.js	2024-05-02 15:13:13
++++ b/node_modules/yaml-language-server/out/server/src/languageservice/services/yamlHover.js	2024-05-02 15:28:53
+@@ -18,11 +18,13 @@
+     constructor(schemaService, telemetry) {
+         this.telemetry = telemetry;
+         this.shouldHover = true;
++        this.hoverSettings = {showSource: true, showTitle: true};
+         this.schemaService = schemaService;
+     }
+     configure(languageSettings) {
+         if (languageSettings) {
+             this.shouldHover = languageSettings.hover;
++            this.hoverSettings = languageSettings.hoverSettings;
+             this.indentation = languageSettings.indentation;
+         }
+     }
+\ No newline at end of file
+@@ -84,6 +86,8 @@
+         const removePipe = (value) => {
+             return value.replace(/\|\|\s*$/, '');
+         };
++        const showSource = this.hoverSettings?.showSource ?? true;
++        const showTitle = this.hoverSettings?.showTitle ?? true;
+         return this.schemaService.getSchemaForResource(document.uri, doc).then((schema) => {
+             if (schema && node && !schema.errors.length) {
+                 const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset);
+\ No newline at end of file
+@@ -135,7 +139,7 @@
+                     return true;
+                 });
+                 let result = '';
+-                if (title) {
++                if (showTitle && title) {
+                     result = '#### ' + toMarkdown(title);
+                 }
+                 if (markdownDescription) {
+\ No newline at end of file
+@@ -159,7 +163,7 @@
+                         result += `\n\n\`\`\`${example}\`\`\``;
+                     });
+                 }
+-                if (result.length > 0 && schema.schema.url) {
++                if (showSource && result.length > 0 && schema.schema.url) {
+                     result += `\n\nSource: [${getSchemaName(schema.schema)}](${schema.schema.url})`;
+                 }
+                 return createHover(result);
+\ No newline at end of file

--- a/core/aws-lsp-yaml-common/patches/markdown/yamlHover.umd.patch
+++ b/core/aws-lsp-yaml-common/patches/markdown/yamlHover.umd.patch
@@ -1,0 +1,47 @@
+--- a/node_modules/yaml-language-server/lib/umd/languageservice/services/yamlHover.js	2024-05-02 15:13:13
++++ b/node_modules/yaml-language-server/lib/umd/languageservice/services/yamlHover.js	2024-05-02 15:20:47
+@@ -27,11 +27,13 @@
+         constructor(schemaService, telemetry) {
+             this.telemetry = telemetry;
+             this.shouldHover = true;
++            this.hoverSettings = {showSource: true, showTitle: true};
+             this.schemaService = schemaService;
+         }
+         configure(languageSettings) {
+             if (languageSettings) {
+                 this.shouldHover = languageSettings.hover;
++                this.hoverSettings = languageSettings.hoverSettings;
+                 this.indentation = languageSettings.indentation;
+             }
+         }
+\ No newline at end of file
+@@ -93,6 +95,8 @@
+             const removePipe = (value) => {
+                 return value.replace(/\|\|\s*$/, '');
+             };
++            const showSource = this.hoverSettings?.showSource ?? true;
++            const showTitle = this.hoverSettings?.showTitle ?? true;
+             return this.schemaService.getSchemaForResource(document.uri, doc).then((schema) => {
+                 if (schema && node && !schema.errors.length) {
+                     const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset);
+\ No newline at end of file
+@@ -144,7 +148,7 @@
+                         return true;
+                     });
+                     let result = '';
+-                    if (title) {
++                    if (showTitle && title) {
+                         result = '#### ' + toMarkdown(title);
+                     }
+                     if (markdownDescription) {
+\ No newline at end of file
+@@ -168,7 +172,7 @@
+                             result += `\n\n\`\`\`${example}\`\`\``;
+                         });
+                     }
+-                    if (result.length > 0 && schema.schema.url) {
++                    if (showSource && result.length > 0 && schema.schema.url) {
+                         result += `\n\nSource: [${getSchemaName(schema.schema)}](${schema.schema.url})`;
+                     }
+                     return createHover(result);
+\ No newline at end of file

--- a/core/aws-lsp-yaml-common/patches/markdown/yamlLanguageService.esm.patch
+++ b/core/aws-lsp-yaml-common/patches/markdown/yamlLanguageService.esm.patch
@@ -1,0 +1,10 @@
+--- a/node_modules/yaml-language-server/lib/esm/languageservice/yamlLanguageService.d.ts	2024-05-02 15:36:28
++++ b/node_modules/yaml-language-server/lib/esm/languageservice/yamlLanguageService.d.ts	2024-05-02 15:36:32
+@@ -25,6 +25,7 @@
+ export interface LanguageSettings {
+     validate?: boolean;
+     hover?: boolean;
++    hoverSettings?: {showSource?: boolean; showTitle?: boolean;};
+     completion?: boolean;
+     format?: boolean;
+     isKubernetes?: boolean;

--- a/core/aws-lsp-yaml-common/patches/markdown/yamlLanguageService.src.patch
+++ b/core/aws-lsp-yaml-common/patches/markdown/yamlLanguageService.src.patch
@@ -1,0 +1,10 @@
+--- a/node_modules/yaml-language-server/out/server/src/languageservice/yamlLanguageService.d.ts	2024-05-02 15:33:31
++++ b/node_modules/yaml-language-server/out/server/src/languageservice/yamlLanguageService.d.ts	2024-05-02 15:34:03
+@@ -25,6 +25,7 @@
+ export interface LanguageSettings {
+     validate?: boolean;
+     hover?: boolean;
++    hoverSettings?: {showSource?: boolean; showTitle?: boolean;};
+     completion?: boolean;
+     format?: boolean;
+     isKubernetes?: boolean;

--- a/core/aws-lsp-yaml-common/patches/markdown/yamlLanguageService.umd.patch
+++ b/core/aws-lsp-yaml-common/patches/markdown/yamlLanguageService.umd.patch
@@ -1,0 +1,10 @@
+--- a/node_modules/yaml-language-server/lib/umd/languageservice/yamlLanguageService.d.ts	2024-05-02 15:13:12
++++ b/node_modules/yaml-language-server/lib/umd/languageservice/yamlLanguageService.d.ts	2024-05-02 15:38:22
+@@ -25,6 +25,7 @@
+ export interface LanguageSettings {
+     validate?: boolean;
+     hover?: boolean;
++    hoverSettings?: {showSource?: boolean; showTitle?: boolean;};
+     completion?: boolean;
+     format?: boolean;
+     isKubernetes?: boolean;

--- a/core/aws-lsp-yaml-common/patches/unsafe-eval/yamlSchemaService.esm.patch
+++ b/core/aws-lsp-yaml-common/patches/unsafe-eval/yamlSchemaService.esm.patch
@@ -1,0 +1,34 @@
+--- a/node_modules/yaml-language-server/lib/esm/languageservice/services/yamlSchemaService.js	2024-05-02 15:43:07
++++ b/node_modules/yaml-language-server/lib/esm/languageservice/services/yamlSchemaService.js	2024-05-02 15:42:46
+@@ -12,14 +12,8 @@
+ import { parse } from 'yaml';
+ import * as path from 'path';
+ import { getSchemaFromModeline } from './modelineUtil';
+-import Ajv from 'ajv';
+ import { getSchemaTitle } from '../utils/schemaUtils';
+ const localize = nls.loadMessageBundle();
+-const ajv = new Ajv();
+-// load JSON Schema 07 def to validate loaded schemas
+-// eslint-disable-next-line @typescript-eslint/no-var-requires
+-const jsonSchema07 = require('ajv/dist/refs/json-schema-draft-07.json');
+-const schema07Validator = ajv.compile(jsonSchema07);
+ export var MODIFICATION_ACTIONS;
+ (function (MODIFICATION_ACTIONS) {
+     MODIFICATION_ACTIONS[MODIFICATION_ACTIONS["delete"] = 0] = "delete";
+\ No newline at end of file
+@@ -87,13 +81,7 @@
+         const resolveErrors = schemaToResolve.errors.slice(0);
+         let schema = schemaToResolve.schema;
+         const contextService = this.contextService;
+-        if (!schema07Validator(schema)) {
+-            const errs = [];
+-            for (const err of schema07Validator.errors) {
+-                errs.push(`${err.instancePath} : ${err.message}`);
+-            }
+-            resolveErrors.push(`Schema '${getSchemaTitle(schemaToResolve.schema, schemaURL)}' is not valid:\n${errs.join('\n')}`);
+-        }
++
+         const findSection = (schema, path) => {
+             if (!path) {
+                 return schema;
+\ No newline at end of file

--- a/core/aws-lsp-yaml-common/patches/unsafe-eval/yamlSchemaService.src.patch
+++ b/core/aws-lsp-yaml-common/patches/unsafe-eval/yamlSchemaService.src.patch
@@ -1,0 +1,33 @@
+--- ./node_modules/yaml-language-server/out/server/src/languageservice/services/yamlSchemaService.js	2024-05-02 15:47:54
++++ ./node_modules/yaml-language-server/out/server/src/languageservice/services/yamlSchemaService.js	2024-05-02 15:47:40
+@@ -14,14 +14,8 @@
+ const yaml_1 = require("yaml");
+ const path = require("path");
+ const modelineUtil_1 = require("./modelineUtil");
+-const ajv_1 = require("ajv");
+ const schemaUtils_1 = require("../utils/schemaUtils");
+ const localize = nls.loadMessageBundle();
+-const ajv = new ajv_1.default();
+-// load JSON Schema 07 def to validate loaded schemas
+-// eslint-disable-next-line @typescript-eslint/no-var-requires
+-const jsonSchema07 = require('ajv/dist/refs/json-schema-draft-07.json');
+-const schema07Validator = ajv.compile(jsonSchema07);
+ var MODIFICATION_ACTIONS;
+ (function (MODIFICATION_ACTIONS) {
+     MODIFICATION_ACTIONS[MODIFICATION_ACTIONS["delete"] = 0] = "delete";
+\ No newline at end of file
+@@ -90,13 +84,6 @@
+         const resolveErrors = schemaToResolve.errors.slice(0);
+         let schema = schemaToResolve.schema;
+         const contextService = this.contextService;
+-        if (!schema07Validator(schema)) {
+-            const errs = [];
+-            for (const err of schema07Validator.errors) {
+-                errs.push(`${err.instancePath} : ${err.message}`);
+-            }
+-            resolveErrors.push(`Schema '${(0, schemaUtils_1.getSchemaTitle)(schemaToResolve.schema, schemaURL)}' is not valid:\n${errs.join('\n')}`);
+-        }
+         const findSection = (schema, path) => {
+             if (!path) {
+                 return schema;
+\ No newline at end of file

--- a/core/aws-lsp-yaml-common/patches/unsafe-eval/yamlSchemaService.umd.patch
+++ b/core/aws-lsp-yaml-common/patches/unsafe-eval/yamlSchemaService.umd.patch
@@ -1,0 +1,33 @@
+--- a/node_modules/yaml-language-server/lib/umd/languageservice/services/yamlSchemaService.js	2024-05-02 15:45:09
++++ b/node_modules/yaml-language-server/lib/umd/languageservice/services/yamlSchemaService.js	2024-05-02 15:44:54
+@@ -23,14 +23,8 @@
+     const yaml_1 = require("yaml");
+     const path = require("path");
+     const modelineUtil_1 = require("./modelineUtil");
+-    const ajv_1 = require("ajv");
+     const schemaUtils_1 = require("../utils/schemaUtils");
+     const localize = nls.loadMessageBundle();
+-    const ajv = new ajv_1.default();
+-    // load JSON Schema 07 def to validate loaded schemas
+-    // eslint-disable-next-line @typescript-eslint/no-var-requires
+-    const jsonSchema07 = require('ajv/dist/refs/json-schema-draft-07.json');
+-    const schema07Validator = ajv.compile(jsonSchema07);
+     var MODIFICATION_ACTIONS;
+     (function (MODIFICATION_ACTIONS) {
+         MODIFICATION_ACTIONS[MODIFICATION_ACTIONS["delete"] = 0] = "delete";
+\ No newline at end of file
+@@ -99,13 +93,6 @@
+             const resolveErrors = schemaToResolve.errors.slice(0);
+             let schema = schemaToResolve.schema;
+             const contextService = this.contextService;
+-            if (!schema07Validator(schema)) {
+-                const errs = [];
+-                for (const err of schema07Validator.errors) {
+-                    errs.push(`${err.instancePath} : ${err.message}`);
+-                }
+-                resolveErrors.push(`Schema '${(0, schemaUtils_1.getSchemaTitle)(schemaToResolve.schema, schemaURL)}' is not valid:\n${errs.join('\n')}`);
+-            }
+             const findSection = (schema, path) => {
+                 if (!path) {
+                     return schema;
+\ No newline at end of file

--- a/core/aws-lsp-yaml-common/src/language-server/yamlLanguageService.ts
+++ b/core/aws-lsp-yaml-common/src/language-server/yamlLanguageService.ts
@@ -59,6 +59,7 @@ export class YamlLanguageService implements AwsLanguageService {
     private updateSchemaMapping(documentUri: string): void {
         this.yamlService.configure({
             hover: true,
+            hoverSettings: { showSource: false, showTitle: false },
             completion: true,
             format: true,
             validate: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -226,6 +226,7 @@
         "core/aws-lsp-yaml-common": {
             "name": "@aws/lsp-yaml-common",
             "version": "0.0.1",
+            "hasInstallScript": true,
             "dependencies": {
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "9.0.1",


### PR DESCRIPTION
## Problem
- we do not want to show footer and header in hover content
- ajv compile require `unsafe-eval` rule to be enabled. We can't enable this rule.

## Solution
Added patches for markdown hover result and removed ajv usage.

## Testing
ran `npm install && npm run test`
checked in browser that unsafe-eval is not required after applying the patch

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
