### PR TITLE
Refactor chat handlers

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -89,7 +89,7 @@ describe('ChatController', () => {
         clock.restore()
     })
 
-    it('chatController creates a session when a tab add notifcation is received', () => {
+    it('creates a session when a tab add notifcation is received', () => {
         chatController.onTabAdd({ tabId: mockTabId })
 
         const sessionResult = chatSessionManagementService.getSession(mockTabId)
@@ -99,7 +99,7 @@ describe('ChatController', () => {
         })
     })
 
-    it('chatController deletes a session by tab id when a tab remove notifcation is received', () => {
+    it('deletes a session by tab id when a tab remove notifcation is received', () => {
         chatController.onTabAdd({ tabId: mockTabId })
 
         assert.ok(chatSessionManagementService.getSession(mockTabId).data instanceof ChatSessionService)
@@ -116,7 +116,7 @@ describe('ChatController', () => {
         })
     })
 
-    it('chatController deletes a session by tab id a end chat request is received', () => {
+    it('deletes a session by tab id a end chat request is received', () => {
         chatController.onTabAdd({ tabId: mockTabId })
 
         chatController.onEndChat({ tabId: mockTabId }, mockCancellationToken)

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -1,0 +1,253 @@
+import { ChatResponseStream, CodeWhispererStreaming } from '@amzn/codewhisperer-streaming'
+import { ChatResult, ErrorCodes, ResponseError } from '@aws/language-server-runtimes/server-interface'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import * as assert from 'assert'
+import sinon from 'ts-sinon'
+import { createIterableResponse } from '../testUtils'
+import { ChatController } from './chatController'
+import { ChatSessionManagementService } from './chatSessionManagementService'
+import { ChatSessionService } from './chatSessionService'
+
+describe('ChatController', () => {
+    const mockTabId = 'tab-1'
+    const mockConversationId = 'mock-conversation-id'
+    const mockMessageId = 'mock-message-id'
+
+    const mockAssistantResponseList: ChatResponseStream[] = [
+        {
+            assistantResponseEvent: {
+                content: 'Hello ',
+            },
+        },
+        {
+            assistantResponseEvent: {
+                content: 'World',
+            },
+        },
+        {
+            assistantResponseEvent: {
+                content: '!',
+            },
+        },
+    ]
+
+    const expectedCompleteChatResult: ChatResult = {
+        messageId: mockMessageId,
+        body: 'Hello World!',
+        canBeVoted: undefined,
+        codeReference: undefined,
+        followUp: undefined,
+        relatedContent: undefined,
+    }
+
+    const mockCancellationToken = {
+        isCancellationRequested: false,
+        onCancellationRequested: () => ({ dispose: () => null }),
+    }
+
+    let generateAssistantResponseStub: sinon.SinonStub
+    let disposeStub: sinon.SinonStub
+    let clock: sinon.SinonFakeTimers
+
+    let testFeatures: TestFeatures
+    let chatSessionManagementService: ChatSessionManagementService
+    let chatController: ChatController
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers()
+        generateAssistantResponseStub = sinon
+            .stub(CodeWhispererStreaming.prototype, 'generateAssistantResponse')
+            .callsFake(() => {
+                return new Promise(resolve =>
+                    setTimeout(() => {
+                        resolve({
+                            conversationId: mockConversationId,
+                            $metadata: {
+                                requestId: mockMessageId,
+                            },
+                            generateAssistantResponseResponse: createIterableResponse(mockAssistantResponseList),
+                        })
+                    }, 100)
+                )
+            })
+
+        testFeatures = new TestFeatures()
+
+        disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
+
+        chatSessionManagementService = ChatSessionManagementService.getInstance().withCredentialsProvider(
+            testFeatures.credentialsProvider
+        )
+
+        chatController = new ChatController(chatSessionManagementService, testFeatures)
+    })
+
+    afterEach(() => {
+        generateAssistantResponseStub.restore()
+        disposeStub.restore()
+        ChatSessionManagementService.reset()
+        clock.restore()
+    })
+
+    it('chatController creates a session when a tab add notifcation is received', () => {
+        chatController.onTabAdd({ tabId: mockTabId })
+
+        const sessionResult = chatSessionManagementService.getSession(mockTabId)
+        sinon.assert.match(sessionResult, {
+            success: true,
+            data: sinon.match.instanceOf(ChatSessionService),
+        })
+    })
+
+    it('chatController deletes a session by tab id when a tab remove notifcation is received', () => {
+        chatController.onTabAdd({ tabId: mockTabId })
+
+        assert.ok(chatSessionManagementService.getSession(mockTabId).data instanceof ChatSessionService)
+
+        chatController.onTabRemove({ tabId: mockTabId })
+
+        sinon.assert.calledOnce(disposeStub)
+
+        const sessionResult = chatSessionManagementService.getSession(mockTabId)
+
+        sinon.assert.match(sessionResult, {
+            success: false,
+            error: sinon.match.string,
+        })
+    })
+
+    it('chatController deletes a session by tab id a end chat request is received', () => {
+        chatController.onTabAdd({ tabId: mockTabId })
+
+        chatController.onEndChat({ tabId: mockTabId }, mockCancellationToken)
+
+        sinon.assert.calledOnce(disposeStub)
+
+        const sessionResult = chatSessionManagementService.getSession(mockTabId)
+
+        sinon.assert.match(sessionResult, {
+            success: false,
+            error: sinon.match.string,
+        })
+    })
+
+    describe('onChatPrompt', () => {
+        it('throw error if session is not found', async () => {
+            const result = await chatController.onChatPrompt(
+                { tabId: 'XXXX', prompt: { prompt: 'Hello' } },
+                mockCancellationToken
+            )
+
+            assert.ok(result instanceof ResponseError)
+        })
+
+        it('read all the response streams and return compiled results', async () => {
+            chatController.onTabAdd({ tabId: mockTabId })
+
+            const chatResultPromise = chatController.onChatPrompt(
+                { tabId: mockTabId, prompt: { prompt: 'Hello' } },
+                mockCancellationToken
+            )
+
+            clock.next()
+
+            const chatResult = await chatResultPromise
+
+            assert.deepStrictEqual(chatResult, expectedCompleteChatResult)
+        })
+
+        it('returns a ResponseError if request input is not valid', async () => {
+            chatController.onTabAdd({ tabId: mockTabId })
+
+            const chatResultPromise = chatController.onChatPrompt(
+                { tabId: mockTabId, prompt: {} },
+                mockCancellationToken
+            )
+
+            clock.next()
+            const chatResult = await chatResultPromise
+            assert.ok(chatResult instanceof ResponseError)
+        })
+
+        it('returns a ResponseError if generateAssistantResponse returns an error', async () => {
+            generateAssistantResponseStub.callsFake(() => {
+                throw new Error('Error')
+            })
+
+            chatController.onTabAdd({ tabId: mockTabId })
+
+            const chatResult = await chatController.onChatPrompt(
+                { tabId: mockTabId, prompt: { prompt: 'Hello' } },
+                mockCancellationToken
+            )
+
+            assert.ok(chatResult instanceof ResponseError)
+        })
+
+        it('returns a ResponseError if response streams return an error event', async () => {
+            generateAssistantResponseStub.callsFake(() => {
+                return Promise.resolve({
+                    conversationId: mockConversationId,
+                    $metadata: {
+                        requestId: mockMessageId,
+                    },
+                    generateAssistantResponseResponse: createIterableResponse([
+                        // ["Hello ", "World"]
+                        ...mockAssistantResponseList.slice(0, 2),
+                        { error: { message: 'some error' } },
+                        // ["!"]
+                        ...mockAssistantResponseList.slice(2),
+                    ]),
+                })
+            })
+
+            chatController.onTabAdd({ tabId: mockTabId })
+
+            const chatResult = await chatController.onChatPrompt(
+                { tabId: mockTabId, prompt: { prompt: 'Hello' } },
+                mockCancellationToken
+            )
+
+            assert.deepStrictEqual(
+                chatResult,
+                new ResponseError(ErrorCodes.InternalError, 'some error', {
+                    ...expectedCompleteChatResult,
+                    body: 'Hello World',
+                })
+            )
+        })
+
+        it('returns a ResponseError if response streams return an invalid state event', async () => {
+            generateAssistantResponseStub.callsFake(() => {
+                return Promise.resolve({
+                    conversationId: mockConversationId,
+                    $metadata: {
+                        requestId: mockMessageId,
+                    },
+                    generateAssistantResponseResponse: createIterableResponse([
+                        // ["Hello ", "World"]
+                        ...mockAssistantResponseList.slice(0, 2),
+                        { invalidStateEvent: { message: 'invalid state' } },
+                        // ["!"]
+                        ...mockAssistantResponseList.slice(2),
+                    ]),
+                })
+            })
+
+            chatController.onTabAdd({ tabId: mockTabId })
+
+            const chatResult = await chatController.onChatPrompt(
+                { tabId: mockTabId, prompt: { prompt: 'Hello' } },
+                mockCancellationToken
+            )
+
+            assert.deepStrictEqual(
+                chatResult,
+                new ResponseError(ErrorCodes.InternalError, 'invalid state', {
+                    ...expectedCompleteChatResult,
+                    body: 'Hello World',
+                })
+            )
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -1,0 +1,118 @@
+import { GenerateAssistantResponseCommandOutput } from '@amzn/codewhisperer-streaming'
+import { TabRemoveParams, chatRequestType } from '@aws/language-server-runtimes/protocol'
+import {
+    CancellationToken,
+    Chat,
+    ChatParams,
+    ChatResult,
+    EndChatParams,
+    ErrorCodes,
+    ResponseError,
+    TabAddParams,
+} from '@aws/language-server-runtimes/server-interface'
+import { EnsurePromise, Features, HandlerReturnType, LspHandlers, Result } from '../types'
+import { ChatEventParser } from './chatEventParser'
+import { ChatSessionManagementService } from './chatSessionManagementService'
+import { convertChatParamsToRequestInput } from './utils'
+
+type ChatHandlers = LspHandlers<Pick<Chat, 'onTabAdd' | 'onTabRemove' | 'onChatPrompt' | 'onEndChat'>>
+
+export class ChatController implements ChatHandlers {
+    #features: Features
+    #chatSessionManagementService: ChatSessionManagementService
+
+    constructor(chatSessionManagementService: ChatSessionManagementService, features: Features) {
+        this.#features = features
+        this.#chatSessionManagementService = chatSessionManagementService
+    }
+
+    #log(message: string) {
+        this.#features.logging.log(message)
+    }
+
+    onTabAdd(params: TabAddParams) {
+        this.#chatSessionManagementService.createSession(params.tabId)
+    }
+
+    onTabRemove(params: TabRemoveParams) {
+        this.#chatSessionManagementService.deleteSession(params.tabId)
+    }
+
+    onEndChat(params: EndChatParams, _token: CancellationToken): HandlerReturnType<ChatHandlers, 'onEndChat'> {
+        const { success } = this.#chatSessionManagementService.deleteSession(params.tabId)
+
+        return success
+    }
+
+    async onChatPrompt(
+        params: ChatParams,
+        token: CancellationToken
+    ): EnsurePromise<HandlerReturnType<ChatHandlers, 'onChatPrompt'>> {
+        const sessionResult = this.#chatSessionManagementService.getSession(params.tabId)
+
+        const { data: session } = sessionResult
+
+        if (!session) {
+            this.#log(`Session not found for tabId: ${params.tabId}`)
+            return new ResponseError<ChatResult>(
+                ErrorCodes.InvalidParams,
+                'error' in sessionResult ? sessionResult.error : 'Unknown error'
+            )
+        }
+
+        token.onCancellationRequested(() => {
+            this.#log('cancellation requested')
+            session.abortRequest()
+        })
+
+        const requestInput = convertChatParamsToRequestInput(params)
+
+        if (!requestInput.success) {
+            this.#log(requestInput.error)
+            return new ResponseError<ChatResult>(ErrorCodes.InvalidParams, requestInput.error)
+        }
+
+        let response: GenerateAssistantResponseCommandOutput
+
+        try {
+            response = await session.generateAssistantResponse(requestInput.data)
+        } catch (err) {
+            this.#log(`Q api request error ${err instanceof Error ? err.message : 'unknown'}`)
+
+            return new ResponseError<ChatResult>(
+                ErrorCodes.InternalError,
+                err instanceof Error ? err.message : 'Internal Server Error'
+            )
+        }
+
+        const result = await this.#processAssistantResponse(response, (params as any).partialResultToken)
+
+        return result.success
+            ? result.data
+            : new ResponseError<ChatResult>(ErrorCodes.InternalError, result.error, result.data)
+    }
+
+    async #processAssistantResponse(
+        response: GenerateAssistantResponseCommandOutput,
+        partialResultToken?: string
+    ): Promise<Result<ChatResult, string>> {
+        const chatEventParser = new ChatEventParser(response.$metadata.requestId!)
+
+        for await (const chatEvent of response.generateAssistantResponseResponse!) {
+            this.#log('Streaming partial chat event')
+
+            const chatResult = chatEventParser.processPartialEvent(chatEvent)
+
+            // terminate early when there is an error
+            if (!chatResult.success) {
+                return chatResult
+            }
+
+            if (partialResultToken) {
+                this.#features.lsp.sendProgress(chatRequestType, partialResultToken, chatResult.data)
+            }
+        }
+
+        return chatEventParser.getChatResult()
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.test.ts
@@ -1,5 +1,7 @@
 import { ChatResult } from '@aws/language-server-runtimes/protocol'
 import * as assert from 'assert'
+import sinon from 'ts-sinon'
+
 import { ChatEventParser } from './chatEventParser'
 
 describe('ChatEventParser', () => {
@@ -8,7 +10,7 @@ describe('ChatEventParser', () => {
     it('set error if invalidState event is received', () => {
         const chatEventParser = new ChatEventParser(mockMessageId)
 
-        assert.deepStrictEqual(
+        sinon.assert.match(
             chatEventParser.processPartialEvent({
                 invalidStateEvent: {
                     message: 'Invalid state!',
@@ -16,22 +18,24 @@ describe('ChatEventParser', () => {
                 },
             }),
             {
-                messageId: mockMessageId,
-                body: undefined,
-                canBeVoted: undefined,
-                codeReference: undefined,
-                followUp: undefined,
-                relatedContent: undefined,
+                success: false,
+                data: {
+                    messageId: mockMessageId,
+                    body: undefined,
+                    canBeVoted: undefined,
+                    codeReference: undefined,
+                    followUp: undefined,
+                    relatedContent: undefined,
+                },
+                error: sinon.match.string,
             }
         )
-
-        assert.strictEqual(chatEventParser.error, 'Invalid state!')
     })
 
     it('set error if error event is received', () => {
         const chatEventParser = new ChatEventParser(mockMessageId)
 
-        assert.deepStrictEqual(
+        sinon.assert.match(
             chatEventParser.processPartialEvent({
                 error: {
                     name: 'InternalServerException',
@@ -42,12 +46,16 @@ describe('ChatEventParser', () => {
                 },
             }),
             {
-                messageId: mockMessageId,
-                body: undefined,
-                canBeVoted: undefined,
-                codeReference: undefined,
-                followUp: undefined,
-                relatedContent: undefined,
+                success: false,
+                data: {
+                    messageId: mockMessageId,
+                    body: undefined,
+                    canBeVoted: undefined,
+                    codeReference: undefined,
+                    followUp: undefined,
+                    relatedContent: undefined,
+                },
+                error: sinon.match.string,
             }
         )
 
@@ -64,12 +72,15 @@ describe('ChatEventParser', () => {
                 },
             }),
             {
-                messageId: mockMessageId,
-                body: 'This is an ',
-                canBeVoted: undefined,
-                codeReference: undefined,
-                followUp: undefined,
-                relatedContent: undefined,
+                success: true,
+                data: {
+                    messageId: mockMessageId,
+                    body: 'This is an ',
+                    canBeVoted: undefined,
+                    codeReference: undefined,
+                    followUp: undefined,
+                    relatedContent: undefined,
+                },
             }
         )
 
@@ -80,12 +91,15 @@ describe('ChatEventParser', () => {
                 },
             }),
             {
-                messageId: mockMessageId,
-                body: 'This is an assistant response.',
-                canBeVoted: undefined,
-                codeReference: undefined,
-                followUp: undefined,
-                relatedContent: undefined,
+                success: true,
+                data: {
+                    messageId: mockMessageId,
+                    body: 'This is an assistant response.',
+                    canBeVoted: undefined,
+                    codeReference: undefined,
+                    followUp: undefined,
+                    relatedContent: undefined,
+                },
             }
         )
     })
@@ -108,19 +122,22 @@ describe('ChatEventParser', () => {
         })
 
         assert.deepStrictEqual(chatEventParser.getChatResult(), {
-            messageId: mockMessageId,
-            body: 'This is an ',
-            followUp: {
-                options: [
-                    {
-                        pillText: 'follow up 1',
-                        prompt: 'follow up 1',
-                    },
-                ],
+            success: true,
+            data: {
+                messageId: mockMessageId,
+                body: 'This is an ',
+                followUp: {
+                    options: [
+                        {
+                            pillText: 'follow up 1',
+                            prompt: 'follow up 1',
+                        },
+                    ],
+                },
+                canBeVoted: undefined,
+                codeReference: undefined,
+                relatedContent: undefined,
             },
-            canBeVoted: undefined,
-            codeReference: undefined,
-            relatedContent: undefined,
         })
 
         chatEventParser.processPartialEvent({
@@ -196,6 +213,6 @@ describe('ChatEventParser', () => {
             },
         }
 
-        assert.deepStrictEqual(chatEventParser.getChatResult(), expectedData)
+        assert.deepStrictEqual(chatEventParser.getChatResult(), { success: true, data: expectedData })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.ts
@@ -5,6 +5,7 @@ import {
     ReferenceTrackerInformation,
     SourceLink,
 } from '@aws/language-server-runtimes/protocol'
+import { Result } from '../types'
 
 export class ChatEventParser implements ChatResult {
     error?: string
@@ -37,7 +38,7 @@ export class ChatEventParser implements ChatResult {
         this.messageId = messageId
     }
 
-    public processPartialEvent(chatEvent: ChatResponseStream): ChatResult {
+    public processPartialEvent(chatEvent: ChatResponseStream): Result<ChatResult, string> {
         const {
             followupPromptEvent,
             supplementaryWebLinksEvent,
@@ -84,8 +85,8 @@ export class ChatEventParser implements ChatResult {
         return this.getChatResult()
     }
 
-    public getChatResult(): ChatResult {
-        return {
+    public getChatResult(): Result<ChatResult, string> {
+        const chatResult: ChatResult = {
             messageId: this.messageId,
             body: this.body,
             canBeVoted: this.canBeVoted,
@@ -93,5 +94,16 @@ export class ChatEventParser implements ChatResult {
             followUp: this.followUp,
             codeReference: this.codeReference,
         }
+
+        return this.error
+            ? {
+                  success: false,
+                  data: chatResult,
+                  error: this.error,
+              }
+            : {
+                  success: true,
+                  data: chatResult,
+              }
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.test.ts
@@ -1,251 +1,70 @@
-import { ChatResponseStream, CodeWhispererStreaming } from '@amzn/codewhisperer-streaming'
-import {
-    ChatResult,
-    CredentialsProvider,
-    ErrorCodes,
-    ResponseError,
-    Server,
-} from '@aws/language-server-runtimes/server-interface'
+import { Server } from '@aws/language-server-runtimes/server-interface'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
-import * as assert from 'assert'
 import sinon from 'ts-sinon'
+import { ChatController } from './chat/chatController'
 import { ChatSessionManagementService } from './chat/chatSessionManagementService'
-import { ChatSessionService } from './chat/chatSessionService'
 import { QChatServer } from './qChatServer'
-import { createIterableResponse } from './testUtils'
 
 describe('QChatServer', () => {
-    const mockTabId = 'tab-1'
-    const mockConversationId = 'mock-conversation-id'
-    const mockMessageId = 'mock-message-id'
-
-    const mockAssistantResponseList: ChatResponseStream[] = [
-        {
-            assistantResponseEvent: {
-                content: 'Hello ',
-            },
-        },
-        {
-            assistantResponseEvent: {
-                content: 'World',
-            },
-        },
-        {
-            assistantResponseEvent: {
-                content: '!',
-            },
-        },
-    ]
-
-    const expectedCompleteChatResult: ChatResult = {
-        messageId: mockMessageId,
-        body: 'Hello World!',
-        canBeVoted: undefined,
-        codeReference: undefined,
-        followUp: undefined,
-        relatedContent: undefined,
-    }
-
-    const mockCancellationToken = {
-        isCancellationRequested: false,
-        onCancellationRequested: () => ({ dispose: () => null }),
-    }
-
-    let generateAssistantResponseStub: sinon.SinonStub
+    const mockTabId = 'mockTabId'
     let disposeStub: sinon.SinonStub
-    let clock: sinon.SinonFakeTimers
-
     let testFeatures: TestFeatures
-    let chatSessionManagementService: ChatSessionManagementService
     let disposeServer: () => void
+    let chatSessionManagementService: ChatSessionManagementService
 
     beforeEach(() => {
-        clock = sinon.useFakeTimers()
-        generateAssistantResponseStub = sinon
-            .stub(CodeWhispererStreaming.prototype, 'generateAssistantResponse')
-            .callsFake(() => {
-                return new Promise(resolve =>
-                    setTimeout(() => {
-                        resolve({
-                            conversationId: mockConversationId,
-                            $metadata: {
-                                requestId: mockMessageId,
-                            },
-                            generateAssistantResponseResponse: createIterableResponse(mockAssistantResponseList),
-                        })
-                    }, 100)
-                )
-            })
-
-        disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
-
-        chatSessionManagementService = ChatSessionManagementService.getInstance()
-
-        const chatServerFactory: Server = QChatServer((credentialProvider: CredentialsProvider) => {
-            return chatSessionManagementService.withCredentialsProvider(credentialProvider)
-        })
-
         testFeatures = new TestFeatures()
+        disposeStub = sinon.stub(ChatSessionManagementService.prototype, 'dispose')
+
+        chatSessionManagementService = ChatSessionManagementService.getInstance().withCredentialsProvider(
+            testFeatures.credentialsProvider
+        )
+        const chatServerFactory: Server = QChatServer(() => chatSessionManagementService)
+
         disposeServer = chatServerFactory(testFeatures)
     })
 
     afterEach(() => {
-        generateAssistantResponseStub.restore()
-        disposeStub.restore()
+        sinon.restore()
         ChatSessionManagementService.reset()
-        clock.restore()
+        testFeatures.dispose()
     })
 
     it('dispose should dispose all chat session services', () => {
-        testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: mockTabId })
-        testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: 'tab-2' })
-
         disposeServer()
 
-        sinon.assert.calledTwice(disposeStub)
+        sinon.assert.calledOnce(disposeStub)
     })
 
-    it('server creates a session when a tab add notifcation is received', () => {
+    it('calls the corresponding controller when tabAdd notification is received', () => {
+        const tabAddStub = sinon.stub(ChatController.prototype, 'onTabAdd')
+
         testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: mockTabId })
 
-        assert.ok(chatSessionManagementService.getSession(mockTabId) instanceof ChatSessionService)
+        sinon.assert.calledOnce(tabAddStub)
     })
 
-    it('server deletes a session by tab id when a tab remove notifcation is received', () => {
-        testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: mockTabId })
-
-        assert.ok(chatSessionManagementService.getSession(mockTabId) instanceof ChatSessionService)
+    it('calls the corresponding controller when tabRemove notification is received', () => {
+        const tabRemoveStub = sinon.stub(ChatController.prototype, 'onTabRemove')
 
         testFeatures.chat.onTabRemove.firstCall.firstArg({ tabId: mockTabId })
 
-        sinon.assert.calledOnce(disposeStub)
-        assert.strictEqual(chatSessionManagementService.getSession(mockTabId), undefined)
+        sinon.assert.calledOnce(tabRemoveStub)
     })
 
-    it('server deletes a session by tab id a end chat request is received', () => {
-        testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: mockTabId })
+    it('calls the corresponding controller when endChat request is received', () => {
+        const endChatStub = sinon.stub(ChatController.prototype, 'onEndChat')
 
-        assert.ok(chatSessionManagementService.getSession(mockTabId) instanceof ChatSessionService)
+        testFeatures.chat.onEndChat.firstCall.firstArg({ tabId: mockTabId })
 
-        testFeatures.chat.onEndChat.firstCall.firstArg({ tabId: mockTabId }, mockCancellationToken)
-
-        sinon.assert.calledOnce(disposeStub)
-        assert.strictEqual(chatSessionManagementService.getSession(mockTabId), undefined)
+        sinon.assert.calledOnce(endChatStub)
     })
 
-    describe('onChatPrompt', () => {
-        it('throw error if session is not found', async () => {
-            const result = await testFeatures.chat.onChatPrompt.firstCall.firstArg(
-                { tabId: 'XXXX', prompt: { prompt: 'Hello' } },
-                mockCancellationToken
-            )
+    it('calls the corresponding controller when chatPrompt request is received', () => {
+        const chatPromptStub = sinon.stub(ChatController.prototype, 'onChatPrompt')
 
-            assert.ok(result instanceof ResponseError)
-        })
+        testFeatures.chat.onChatPrompt.firstCall.firstArg({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, {})
 
-        // TODO: partialResultToken is missing from the types so tests need to be added later
-        it('read all the response streams and return compiled results', async () => {
-            testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: mockTabId })
-
-            const chatResultPromise = testFeatures.chat.onChatPrompt
-                .getCall(0)
-                .firstArg({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, mockCancellationToken)
-
-            clock.next()
-
-            const chatResult = await chatResultPromise
-
-            assert.deepStrictEqual(chatResult, expectedCompleteChatResult)
-        })
-
-        it('returns a ResponseError if request input is not valid', async () => {
-            testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: mockTabId })
-
-            const chatResultPromise = testFeatures.chat.onChatPrompt
-                .getCall(0)
-                .firstArg({ tabId: mockTabId, prompt: {} }, mockCancellationToken)
-
-            clock.next()
-            const chatResult = await chatResultPromise
-            assert.ok(chatResult instanceof ResponseError)
-        })
-
-        it('returns a ResponseError if generateAssistantResponse returns an error', async () => {
-            generateAssistantResponseStub.callsFake(() => {
-                throw new Error('Error')
-            })
-
-            testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: mockTabId })
-
-            const chatResult = await testFeatures.chat.onChatPrompt
-                .getCall(0)
-                .firstArg({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, mockCancellationToken)
-
-            assert.ok(chatResult instanceof ResponseError)
-        })
-
-        it('returns a ResponseError if response streams return an error event', async () => {
-            generateAssistantResponseStub.callsFake(() => {
-                return Promise.resolve({
-                    conversationId: mockConversationId,
-                    $metadata: {
-                        requestId: mockMessageId,
-                    },
-                    generateAssistantResponseResponse: createIterableResponse([
-                        // ["Hello ", "World"]
-                        ...mockAssistantResponseList.slice(0, 2),
-                        { error: { message: 'some error' } },
-                        // ["!"]
-                        ...mockAssistantResponseList.slice(2),
-                    ]),
-                })
-            })
-
-            testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: mockTabId })
-
-            const chatResult = await testFeatures.chat.onChatPrompt
-                .getCall(0)
-                .firstArg({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, mockCancellationToken)
-
-            assert.deepStrictEqual(
-                chatResult,
-                new ResponseError(ErrorCodes.InternalError, 'some error', {
-                    ...expectedCompleteChatResult,
-                    body: 'Hello World',
-                })
-            )
-        })
-
-        it('returns a ResponseError if response streams return an invalid state event', async () => {
-            generateAssistantResponseStub.callsFake(() => {
-                return Promise.resolve({
-                    conversationId: mockConversationId,
-                    $metadata: {
-                        requestId: mockMessageId,
-                    },
-                    generateAssistantResponseResponse: createIterableResponse([
-                        // ["Hello ", "World"]
-                        ...mockAssistantResponseList.slice(0, 2),
-                        { invalidStateEvent: { message: 'invalid state' } },
-                        // ["!"]
-                        ...mockAssistantResponseList.slice(2),
-                    ]),
-                })
-            })
-
-            testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: mockTabId })
-
-            const chatResult = await testFeatures.chat.onChatPrompt
-                .getCall(0)
-                .firstArg({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, mockCancellationToken)
-
-            assert.deepStrictEqual(
-                chatResult,
-                new ResponseError(ErrorCodes.InternalError, 'invalid state', {
-                    ...expectedCompleteChatResult,
-                    body: 'Hello World',
-                })
-            )
-        })
+        sinon.assert.calledOnce(chatPromptStub)
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -1,102 +1,34 @@
-import { GenerateAssistantResponseCommandOutput } from '@amzn/codewhisperer-streaming'
-import {
-    CancellationToken,
-    ChatParams,
-    CredentialsProvider,
-    EndChatParams,
-    ErrorCodes,
-    ResponseError,
-    Server,
-    TabAddParams,
-    TabRemoveParams,
-} from '@aws/language-server-runtimes/server-interface'
-import { ChatEventParser } from './chat/chatEventParser'
+import { CredentialsProvider, Server } from '@aws/language-server-runtimes/server-interface'
+import { ChatController } from './chat/chatController'
 import { ChatSessionManagementService } from './chat/chatSessionManagementService'
-import { convertChatParamsToRequestInput } from './chat/utils'
 
 export const QChatServer =
     (service: (credentialsProvider: CredentialsProvider) => ChatSessionManagementService): Server =>
-    ({ chat, credentialsProvider, logging }) => {
+    features => {
+        const { chat, credentialsProvider, logging } = features
+
         const chatSessionManagementService: ChatSessionManagementService = service(credentialsProvider)
 
-        chat.onTabAdd((params: TabAddParams) => {
+        const chatController = new ChatController(chatSessionManagementService, features)
+
+        chat.onTabAdd((...params) => {
             logging.log('Received tab add request')
-
-            // while createSession should throw an error when we are trying to
-            // create a duplicate session, but this handler doesn't need to care
-            if (chatSessionManagementService.getSession(params.tabId)) {
-                logging.log('Session already exists')
-            } else {
-                chatSessionManagementService.createSession(params.tabId)
-            }
+            return chatController.onTabAdd(...params)
         })
 
-        chat.onTabRemove((params: TabRemoveParams) => {
+        chat.onTabRemove((...params) => {
             logging.log('Received tab remove request')
-            chatSessionManagementService.deleteSession(params.tabId)
+            return chatController.onTabRemove(...params)
         })
 
-        chat.onEndChat((params: EndChatParams, _token: CancellationToken) => {
+        chat.onEndChat((...params) => {
             logging.log('Received end chat request')
-
-            chatSessionManagementService.deleteSession(params.tabId)
-
-            return true
+            return chatController.onEndChat(...params)
         })
 
-        chat.onChatPrompt(async (params: ChatParams, token: CancellationToken) => {
+        chat.onChatPrompt((...params) => {
             logging.log('Received chat prompt')
-
-            const session = chatSessionManagementService.getSession(params.tabId)
-
-            if (!session) {
-                logging.log(`Session not found for tabId: ${params.tabId}`)
-                return new ResponseError(ErrorCodes.InvalidParams, 'Session not found')
-            }
-
-            token.onCancellationRequested(() => {
-                logging.log('cancellation requested')
-                session.abortRequest()
-            })
-
-            let response: GenerateAssistantResponseCommandOutput
-
-            const requestInput = convertChatParamsToRequestInput(params)
-
-            if (!requestInput.success) {
-                logging.log(requestInput.error)
-                return new ResponseError(ErrorCodes.InvalidParams, requestInput.error)
-            }
-
-            try {
-                response = await session.generateAssistantResponse(requestInput.data)
-            } catch (err) {
-                logging.log('Q api request error')
-
-                return new ResponseError(
-                    ErrorCodes.InternalError,
-                    err instanceof Error ? err.message : 'Internal Server Error'
-                )
-            }
-
-            const chatEventParser = new ChatEventParser(response.$metadata.requestId!)
-
-            for await (const chatEvent of response.generateAssistantResponseResponse!) {
-                logging.log('Streaming partial chat event')
-
-                const chatResult = chatEventParser.processPartialEvent(chatEvent)
-
-                if (chatEventParser.error) {
-                    return new ResponseError(ErrorCodes.InternalError, chatEventParser.error, chatResult)
-                }
-
-                // TODO: partialResultToken is missing from the type
-                // if (params.partialResultToken) {
-                //     lsp.sendProgress(chatRequestType, params.partialResultToken, chatResult)
-                // }
-            }
-
-            return chatEventParser.getChatResult()
+            return chatController.onChatPrompt(...params)
         })
 
         logging.log('Q Chat server has been initialized')

--- a/server/aws-lsp-codewhisperer/src/language-server/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/types.ts
@@ -12,14 +12,7 @@ export type Result<TData, TError> =
           data?: TData
           error: TError
       }
-export type EnsurePromise<T> = T extends Promise<any> ? T : Promise<any>
 
 export type LspHandlers<THandlerMap> = {
     [K in keyof THandlerMap]: THandlerMap[K] extends (...args: any[]) => any ? Parameters<THandlerMap[K]>[0] : never
 }
-
-export type HandlerReturnType<THandlerMap, TKey extends keyof THandlerMap> = THandlerMap[TKey] extends (
-    ...args: any[]
-) => any
-    ? ReturnType<THandlerMap[TKey]>
-    : never

--- a/server/aws-lsp-codewhisperer/src/language-server/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/types.ts
@@ -1,3 +1,7 @@
+import { Server } from '@aws/language-server-runtimes/server-interface'
+
+export type Features = Parameters<Server>[0]
+
 export type Result<TData, TError> =
     | {
           success: true
@@ -5,5 +9,17 @@ export type Result<TData, TError> =
       }
     | {
           success: false
+          data?: TData
           error: TError
       }
+export type EnsurePromise<T> = T extends Promise<any> ? T : Promise<any>
+
+export type LspHandlers<THandlerMap> = {
+    [K in keyof THandlerMap]: THandlerMap[K] extends (...args: any[]) => any ? Parameters<THandlerMap[K]>[0] : never
+}
+
+export type HandlerReturnType<THandlerMap, TKey extends keyof THandlerMap> = THandlerMap[TKey] extends (
+    ...args: any[]
+) => any
+    ? ReturnType<THandlerMap[TKey]>
+    : never


### PR DESCRIPTION
## Description
- Create a controller logic to centralize the handler functions so it's more maintainable/readable
- Convert many of the code to use the Result pattern so we can have a more unified error handling pattern
 
## Note
- Tests in `chatController.test.ts` are moved from `QChatServer.test.ts` and are modified accordingly

## License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
