### PR TITLE
Upgrade typedoc version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3577,6 +3577,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ansi-sequence-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+            "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+            "dev": true
+        },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
             "dev": true,
@@ -10289,13 +10295,15 @@
             }
         },
         "node_modules/shiki": {
-            "version": "0.11.1",
+            "version": "0.14.7",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+            "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "jsonc-parser": "^3.0.0",
-                "vscode-oniguruma": "^1.6.1",
-                "vscode-textmate": "^6.0.0"
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
             }
         },
         "node_modules/side-channel": {
@@ -11405,6 +11413,39 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/typedoc": {
+            "version": "0.25.13",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+            "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
+            "dev": true,
+            "dependencies": {
+                "lunr": "^2.3.9",
+                "marked": "^4.3.0",
+                "minimatch": "^9.0.3",
+                "shiki": "^0.14.7"
+            },
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "peerDependencies": {
+                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+            }
+        },
+        "node_modules/typedoc/node_modules/marked": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+            "dev": true,
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/typescript": {
             "version": "5.4.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
@@ -11659,13 +11700,15 @@
         },
         "node_modules/vscode-oniguruma": {
             "version": "1.7.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+            "dev": true
         },
         "node_modules/vscode-textmate": {
-            "version": "6.0.0",
-            "dev": true,
-            "license": "MIT"
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+            "dev": true
         },
         "node_modules/vscode-uri": {
             "version": "3.0.8",
@@ -12695,50 +12738,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "server/aws-lsp-codewhisperer/node_modules/minimatch": {
-            "version": "5.1.6",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/typedoc": {
-            "version": "0.23.23",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "lunr": "^2.3.9",
-                "marked": "^4.2.4",
-                "minimatch": "^5.1.1",
-                "shiki": "^0.11.1"
-            },
-            "bin": {
-                "typedoc": "bin/typedoc"
-            },
-            "engines": {
-                "node": ">= 14.14"
-            },
-            "peerDependencies": {
-                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/typescript": {
-            "version": "4.9.5",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        },
         "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming": {
             "version": "0.0.1",
             "dependencies": {
@@ -12788,7 +12787,7 @@
                 "@types/uuid": "^9.0.8",
                 "concurrently": "7.0.0",
                 "rimraf": "^3.0.0",
-                "typedoc": "0.23.23",
+                "typedoc": "0.25.13",
                 "typescript": "~5.4.5"
             },
             "engines": {
@@ -12891,7 +12890,7 @@
                 "concurrently": "7.0.0",
                 "rimraf": "^3.0.0",
                 "tslib": "^2.5.0",
-                "typedoc": "0.23.23",
+                "typedoc": "0.25.13",
                 "typescript": "~5.4.5",
                 "uuid": "^9.0.1"
             },
@@ -14155,28 +14154,6 @@
                 "@types/node": {
                     "version": "14.18.63",
                     "dev": true
-                },
-                "minimatch": {
-                    "version": "5.1.6",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "^2.0.1"
-                    }
-                },
-                "typedoc": {
-                    "version": "0.23.23",
-                    "dev": true,
-                    "requires": {
-                        "lunr": "^2.3.9",
-                        "marked": "^4.2.4",
-                        "minimatch": "^5.1.1",
-                        "shiki": "^0.11.1"
-                    }
-                },
-                "typescript": {
-                    "version": "4.9.5",
-                    "dev": true,
-                    "peer": true
                 }
             }
         },
@@ -15652,6 +15629,12 @@
         },
         "ansi-regex": {
             "version": "5.0.1",
+            "dev": true
+        },
+        "ansi-sequence-parser": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+            "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
             "dev": true
         },
         "ansi-styles": {
@@ -20031,12 +20014,15 @@
             "dev": true
         },
         "shiki": {
-            "version": "0.11.1",
+            "version": "0.14.7",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+            "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
             "dev": true,
             "requires": {
-                "jsonc-parser": "^3.0.0",
-                "vscode-oniguruma": "^1.6.1",
-                "vscode-textmate": "^6.0.0"
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
             }
         },
         "side-channel": {
@@ -20787,6 +20773,26 @@
                 "mime-types": "~2.1.24"
             }
         },
+        "typedoc": {
+            "version": "0.25.13",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+            "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
+            "dev": true,
+            "requires": {
+                "lunr": "^2.3.9",
+                "marked": "^4.3.0",
+                "minimatch": "^9.0.3",
+                "shiki": "^0.14.7"
+            },
+            "dependencies": {
+                "marked": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+                    "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+                    "dev": true
+                }
+            }
+        },
         "typescript": {
             "version": "5.4.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
@@ -20959,10 +20965,14 @@
         },
         "vscode-oniguruma": {
             "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
             "dev": true
         },
         "vscode-textmate": {
-            "version": "6.0.0",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
             "dev": true
         },
         "vscode-uri": {

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
@@ -62,7 +62,7 @@
         "@types/uuid": "^9.0.8",
         "concurrently": "7.0.0",
         "rimraf": "^3.0.0",
-        "typedoc": "0.23.23",
+        "typedoc": "0.25.13",
         "typescript": "~5.4.5"
     },
     "engines": {


### PR DESCRIPTION
## Problem
Dependabot upgraded the typescript version and the build passed for some reason. It should trigger a version conflict instead due to `typedoc` dependency requiring typescript version 4.x 

## Solution
Upgrade typedoc to latest version

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
