### PR TITLE
Fix @amzn/codewhisperer-streaming resolve issue in consumers

### DIFF
--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -27,6 +27,7 @@
         "fix:prettier": "prettier . --write"
     },
     "dependencies": {
+        "@amzn/codewhisperer-streaming": "file:./src.gen/@amzn/codewhisperer-streaming",
         "@aws/language-server-runtimes": "^0.2.3",
         "@aws/language-server-runtimes-types": "^0.0.2",
         "@smithy/abort-controller": "^2.2.0",


### PR DESCRIPTION
## Problem
When  `@aws/lsp-codewhisperer` is consumed as a module, we get this error at build time:
```
ERROR in ./node_modules/@aws/lsp-codewhisperer/out/language-server/chat/chatSessionService.js 16:34-74
Module not found: Error: Can't resolve '@amzn/codewhisperer-streaming' in '.../node_modules/@aws/lsp-codewhisperer/out/language-server/chat'
```

Even though `@amzn/codewhisperer-streaming` are packaged within the builds, build system is not able to resolve that path (e.g. not found in `node_modules` or aliases). Currently, our internal build system relies on manually releasing the streaming package, which is not possible for consumers.

## Solution
To make it work for consumers,  the most efficient way to solve this is to define a local dependency with a local path in `package.json`. During install command, package managers will detect the dependency and bring the package into `node_modules`. As a result, build systems (e.g. webpack, vite...) are able to resolve the module.

## Testing
I tested in our internal release process.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
