### PR TITLE
Remove @smithy/abort-controller to fix browser builds

### DIFF
--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -30,7 +30,6 @@
         "@amzn/codewhisperer-streaming": "file:./src.gen/@amzn/codewhisperer-streaming",
         "@aws/language-server-runtimes": "^0.2.3",
         "@aws/language-server-runtimes-types": "^0.0.2",
-        "@smithy/abort-controller": "^2.2.0",
         "@smithy/node-http-handler": "^2.5.0",
         "hpagent": "^1.2.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
@@ -4,7 +4,6 @@ import {
     GenerateAssistantResponseCommandOutput,
 } from '@amzn/codewhisperer-streaming'
 import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
-import { AbortController } from '@smithy/abort-controller'
 import * as assert from 'assert'
 import sinon from 'ts-sinon'
 import { ChatSessionService } from './chatSessionService'

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -6,7 +6,6 @@ import {
 } from '@amzn/codewhisperer-streaming'
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
-import { AbortController } from '@smithy/abort-controller'
 import { getBearerTokenFromProvider } from '../utils'
 
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig


### PR DESCRIPTION
## Problem

Browser build of qChatServer gets error in runtime in making Q api calls:  `TypeError: Failed to construct 'Request': Failed to read the 'signal' property from 'RequestInit': Failed to convert value to 'AbortSignal'.`  According to this issue, https://github.com/aws/aws-sdk-js-v3/issues/4582, we should use browser's native `AbortController`.

## Solution
Browsers have full support for `AbortController` for a while and `AbortController` has been part of Node since v15.0.0. So we shouldn't need to install this that package at all.  `aws-sdk-v3`, which the streaming client uses under the hood, does not support 14.x anymore so we can just to remove `@smithy/abort-controller`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
