### PR TITLE
Add configuration to create standalone nodejs bundle for Amazon Q server

### DIFF
--- a/app/aws-lsp-codewhisperer-binary/README.md
+++ b/app/aws-lsp-codewhisperer-binary/README.md
@@ -1,0 +1,18 @@
+## Amazon Q Language Server Bundle Configuration
+
+This package provides example configuration to produce Amazon Q server implementation bundled with [Language Server Runtimes for AS](https://github.com/aws/language-server-runtimes).
+
+To create bundle run:
+```bash
+npm run bundle
+```
+
+This command will compile package and produce bundled Javascript program at `./out/aws-lsp-codewhisperer-binary.js` path.
+
+To test server you can use sample IDEs client in [`./client`](../../client) subpackages. In VSCode, you can use "Run and Debug" functionality with [sample client extension](../../CONTRIBUTING.md#with-minimal-vscode-client) and update `launch.json` configuration to point to [compiled bundle file](../../.vscode/launch.json#L60). Change value for `LSP_SERVER` valiable from `${workspaceFolder}/app/aws-lsp-codewhisperer-binary/out/index.js` to `${workspaceFolder}/app/aws-lsp-codewhisperer-binary/out/aws-lsp-codewhisperer-binary.js`.
+
+To verify compiled bundle can run, you can start it in your shell with NodeJS:
+
+```bash
+node ./out/aws-lsp-codewhisperer-binary.js --stdio
+```

--- a/app/aws-lsp-codewhisperer-binary/package.json
+++ b/app/aws-lsp-codewhisperer-binary/package.json
@@ -7,14 +7,20 @@
         "aws-lsp-codewhisperer-binary": "./out/index.js"
     },
     "scripts": {
+        "bundle": "npm run compile && npm run webpack && npm run package-x64",
+        "clean": "rm -rf out/ bin/ tsconfig.tsbuildinfo",
         "compile": "tsc --build",
-        "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --out-path bin --compress GZip ."
+        "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --out-path bin --compress GZip .",
+        "webpack": "webpack"
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.3",
         "@aws/lsp-codewhisperer": "*"
     },
     "devDependencies": {
-        "pkg": "^5.8.1"
+        "pkg": "^5.8.1",
+        "ts-loader": "^9.4.4",
+        "webpack": "^5.88.2",
+        "webpack-cli": "^5.1.4"
     }
 }

--- a/app/aws-lsp-codewhisperer-binary/webpack.config.js
+++ b/app/aws-lsp-codewhisperer-binary/webpack.config.js
@@ -1,0 +1,36 @@
+var path = require('path')
+// var webpack = require('webpack')
+
+const baseConfig = {
+    mode: 'development',
+    output: {
+        path: __dirname,
+        filename: 'out/[name].js',
+        globalObject: 'this',
+        library: {
+            type: 'umd',
+        },
+    },
+    resolve: {
+        extensions: ['.ts', '.tsx', '.js'],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                use: 'ts-loader',
+                exclude: /node_modules/,
+            },
+        ],
+    },
+}
+
+const nodeJsBundleConfig = {
+    ...baseConfig,
+    entry: {
+        'aws-lsp-codewhisperer-binary': path.join(__dirname, 'src/index.ts'),
+    },
+    target: 'node',
+}
+
+module.exports = [nodeJsBundleConfig]

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,10 @@
                 "aws-lsp-codewhisperer-binary": "out/index.js"
             },
             "devDependencies": {
-                "pkg": "^5.8.1"
+                "pkg": "^5.8.1",
+                "ts-loader": "^9.4.4",
+                "webpack": "^5.88.2",
+                "webpack-cli": "^5.1.4"
             }
         },
         "app/aws-lsp-s3-binary": {
@@ -13826,7 +13829,6 @@
                 "@amzn/codewhisperer-streaming": "file:./src.gen/@amzn/codewhisperer-streaming",
                 "@aws/language-server-runtimes": "^0.2.3",
                 "@aws/language-server-runtimes-types": "^0.0.2",
-                "@smithy/abort-controller": "^2.2.0",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
                 "aws-sdk": "^2.1403.0",


### PR DESCRIPTION
## Problem
Packaging Amazon Q server into single executable with `vercel/pkg` is outdated. For testing purposes, we need to be able to produce standalone Javascript bundle, not bundled with NodeJS.

## Solution

Add configuration to create NodeJS bundle for Amazon Q server bundled with [standalone](https://github.com/aws/language-server-runtimes/tree/main/runtimes/runtimes) Language Server Runtime using Webpack.

Added README with documentation on how to produce and test bundle.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
