### PR TITLE
feat: add PartiQL language aserver

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,6 +50,18 @@
             "preLaunchTask": "npm: compile"
         },
         {
+            "name": "PartiQL Server",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}/client/vscode"],
+            "outFiles": ["${workspaceFolder}/client/vscode/out/**/*.js"],
+            "env": {
+                "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-partiql-binary/out/aws-lsp-partiql-binary.js"
+            },
+            "preLaunchTask": "npm: compile"
+        },
+        {
             "name": "CodeWhisperer Server",
             "type": "extensionHost",
             "request": "launch",

--- a/app/aws-lsp-partiql-binary/package.json
+++ b/app/aws-lsp-partiql-binary/package.json
@@ -9,9 +9,10 @@
     "scripts": {
         "bundle": "npm run compile && npm run webpack && npm run package-x64",
         "clean": "rm -rf out/ bin/ tsconfig.tsbuildinfo",
-        "compile": "tsc --build",
-        "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --output bin/aws-lsp-partiql-binary --compress GZip .",
-        "webpack": "webpack"
+        "compile": "npm run compile:tsc && npm run compile:webpack",
+        "compile:tsc": "tsc --build",
+        "compile:webpack": "webpack",
+        "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --output bin/aws-lsp-partiql-binary --compress GZip ."
     },
     "dependencies": {
         "@aws/aws-lsp-partiql": "^0.0.1",

--- a/app/aws-lsp-partiql-binary/package.json
+++ b/app/aws-lsp-partiql-binary/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "@aws/aws-lsp-partiql-binary",
+    "version": "0.0.1",
+    "description": "PartiQL Language Server Runtimes",
+    "main": "out/index.js",
+    "bin": {
+        "aws-lsp-partiql-binary": "./out/aws-lsp-partiql-binary.js"
+    },
+    "scripts": {
+        "bundle": "npm run compile && npm run webpack && npm run package-x64",
+        "clean": "rm -rf out/ bin/ tsconfig.tsbuildinfo",
+        "compile": "tsc --build",
+        "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --output bin/aws-lsp-partiql-binary --compress GZip .",
+        "webpack": "webpack"
+    },
+    "dependencies": {
+        "@aws/aws-lsp-partiql": "^0.0.1",
+        "@aws/language-server-runtimes": "^0.2.5"
+    },
+    "devDependencies": {
+        "pkg": "^5.8.1",
+        "ts-lsp-client": "^1.0.3",
+        "ts-loader": "^9.4.4",
+        "webpack": "^5.88.2",
+        "webpack-cli": "^5.1.4"
+    }
+}

--- a/app/aws-lsp-partiql-binary/package.json
+++ b/app/aws-lsp-partiql-binary/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@aws/aws-lsp-partiql-binary",
+    "name": "@aws/lsp-partiql-binary",
     "version": "0.0.1",
     "description": "PartiQL Language Server Runtimes",
     "main": "out/index.js",
@@ -15,7 +15,7 @@
         "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --output bin/aws-lsp-partiql-binary --compress GZip ."
     },
     "dependencies": {
-        "@aws/aws-lsp-partiql": "^0.0.1",
+        "@aws/lsp-partiql": "^0.0.1",
         "@aws/language-server-runtimes": "^0.2.5"
     },
     "devDependencies": {

--- a/app/aws-lsp-partiql-binary/src/index.ts
+++ b/app/aws-lsp-partiql-binary/src/index.ts
@@ -1,6 +1,6 @@
-import { PartiQLLanguageServer } from '@aws/aws-lsp-partiql'
 import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
 import { standalone } from '@aws/language-server-runtimes/runtimes/standalone'
+import { PartiQLLanguageServer } from '@aws/lsp-partiql'
 
 const props: RuntimeProps = {
     servers: [PartiQLLanguageServer],

--- a/app/aws-lsp-partiql-binary/src/index.ts
+++ b/app/aws-lsp-partiql-binary/src/index.ts
@@ -1,0 +1,9 @@
+import { PartiQLLanguageServer } from '@aws/aws-lsp-partiql'
+import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
+import { standalone } from '@aws/language-server-runtimes/runtimes/standalone'
+
+const props: RuntimeProps = {
+    servers: [PartiQLLanguageServer],
+    name: 'AWS PartiQL',
+}
+standalone(props)

--- a/app/aws-lsp-partiql-binary/tsconfig.json
+++ b/app/aws-lsp-partiql-binary/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./out"
+    },
+    "include": ["src"]
+}

--- a/app/aws-lsp-partiql-binary/webpack.config.js
+++ b/app/aws-lsp-partiql-binary/webpack.config.js
@@ -1,0 +1,35 @@
+var path = require('path')
+
+const baseConfig = {
+    mode: 'development',
+    output: {
+        path: __dirname,
+        filename: 'out/[name].js',
+        globalObject: 'this',
+        library: {
+            type: 'umd',
+        },
+    },
+    resolve: {
+        extensions: ['.ts', '.js'],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                use: 'ts-loader',
+                exclude: [/node_modules/],
+            },
+        ],
+    },
+}
+
+const nodeJsBundleConfig = {
+    ...baseConfig,
+    entry: {
+        'aws-lsp-partiql-binary': path.join(__dirname, 'src/index.ts'),
+    },
+    target: 'node',
+}
+
+module.exports = [nodeJsBundleConfig]

--- a/package-lock.json
+++ b/package-lock.json
@@ -240,6 +240,29 @@
                 "yaml-language-server": "^1.13.0"
             }
         },
+        "node_modules/@ampproject/remapping": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@ampproject/remapping/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
         "node_modules/@amzn/codewhisperer-streaming": {
             "resolved": "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming",
             "link": true
@@ -1667,6 +1690,10 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws/aws-lsp-partiql": {
+            "resolved": "server/aws-lsp-partiql",
+            "link": true
+        },
         "node_modules/@aws/aws-lsp-yaml-json": {
             "resolved": "server/aws-lsp-yaml-json",
             "link": true
@@ -1789,6 +1816,130 @@
                 "unescape-html": "^1.1.0"
             }
         },
+        "node_modules/@babel/code-frame": {
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/highlight": "^7.24.2",
+                "picocolors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/compat-data": {
+            "version": "7.24.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
+            "integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
+            "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
+            "dev": true,
+            "dependencies": {
+                "@ampproject/remapping": "^2.2.0",
+                "@babel/code-frame": "^7.24.2",
+                "@babel/generator": "^7.24.5",
+                "@babel/helper-compilation-targets": "^7.23.6",
+                "@babel/helper-module-transforms": "^7.24.5",
+                "@babel/helpers": "^7.24.5",
+                "@babel/parser": "^7.24.5",
+                "@babel/template": "^7.24.0",
+                "@babel/traverse": "^7.24.5",
+                "@babel/types": "^7.24.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@babel/generator": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+            "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.5",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^2.5.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@babel/parser": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@babel/core/node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/generator": {
             "version": "7.18.2",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
@@ -1798,6 +1949,208 @@
                 "@babel/types": "^7.18.2",
                 "@jridgewell/gen-mapping": "^0.3.0",
                 "jsesc": "^2.5.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+            "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/compat-data": "^7.23.5",
+                "@babel/helper-validator-option": "^7.23.5",
+                "browserslist": "^4.22.2",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/helper-environment-visitor": {
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-function-name": {
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-hoist-variables": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.22.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.24.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+            "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
+            "integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-module-imports": "^7.24.3",
+                "@babel/helper-simple-access": "^7.24.5",
+                "@babel/helper-split-export-declaration": "^7.24.5",
+                "@babel/helper-validator-identifier": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-plugin-utils": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+            "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-simple-access": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
+            "integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-split-export-declaration": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+            "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1821,6 +2174,129 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+            "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
+            "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/template": "^7.24.0",
+                "@babel/traverse": "^7.24.5",
+                "@babel/types": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/highlight": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
+            "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "chalk": "^2.4.2",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
+        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/@babel/parser": {
             "version": "7.18.4",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
@@ -1833,6 +2309,200 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-bigint": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-class-properties": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.12.13"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-import-meta": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-jsx": {
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.1.tgz",
+            "integrity": "sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.24.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-top-level-await": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+            "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-typescript": {
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.1.tgz",
+            "integrity": "sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.24.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-modules-commonjs": {
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.1.tgz",
+            "integrity": "sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.23.3",
+                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-simple-access": "^7.22.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/runtime": {
             "version": "7.24.5",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
@@ -1843,6 +2513,127 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+            "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.23.5",
+                "@babel/parser": "^7.24.0",
+                "@babel/types": "^7.24.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template/node_modules/@babel/parser": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/template/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
+            "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.24.2",
+                "@babel/generator": "^7.24.5",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.24.5",
+                "@babel/parser": "^7.24.5",
+                "@babel/types": "^7.24.5",
+                "debug": "^4.3.1",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/generator": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+            "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.5",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^2.5.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/parser": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/@babel/types": {
@@ -1858,6 +2649,12 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+            "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+            "dev": true
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -1878,6 +2675,374 @@
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+            "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+            "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+            "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+            "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+            "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+            "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+            "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+            "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+            "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+            "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+            "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+            "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+            "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+            "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+            "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+            "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+            "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+            "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+            "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+            "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+            "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -2115,6 +3280,483 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/@istanbuljs/load-nyc-config": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+            "dev": true,
+            "dependencies": {
+                "camelcase": "^5.3.1",
+                "find-up": "^4.1.0",
+                "get-package-type": "^0.1.0",
+                "js-yaml": "^3.13.1",
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/schema": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@jest/console": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+            "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/core": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+            "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+            "dev": true,
+            "dependencies": {
+                "@jest/console": "^29.7.0",
+                "@jest/reporters": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "ci-info": "^3.2.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.9",
+                "jest-changed-files": "^29.7.0",
+                "jest-config": "^29.7.0",
+                "jest-haste-map": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-resolve-dependencies": "^29.7.0",
+                "jest-runner": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "jest-watcher": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "pretty-format": "^29.7.0",
+                "slash": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@jest/environment": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+            "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/fake-timers": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "jest-mock": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/expect": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+            "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+            "dev": true,
+            "dependencies": {
+                "expect": "^29.7.0",
+                "jest-snapshot": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/expect-utils": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+            "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+            "dev": true,
+            "dependencies": {
+                "jest-get-type": "^29.6.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/fake-timers": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+            "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@sinonjs/fake-timers": "^10.0.2",
+                "@types/node": "*",
+                "jest-message-util": "^29.7.0",
+                "jest-mock": "^29.7.0",
+                "jest-util": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/fake-timers/node_modules/@sinonjs/fake-timers": {
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+            "dev": true,
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.0"
+            }
+        },
+        "node_modules/@jest/globals": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+            "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/expect": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "jest-mock": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/reporters": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+            "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+            "dev": true,
+            "dependencies": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.9",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^6.0.0",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.1.3",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-worker": "^29.7.0",
+                "slash": "^3.0.0",
+                "string-length": "^4.0.1",
+                "strip-ansi": "^6.0.0",
+                "v8-to-istanbul": "^9.0.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@jest/reporters/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@jest/reporters/node_modules/jest-worker": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+            "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "jest-util": "^29.7.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/reporters/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/@jest/schemas": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+            "dev": true,
+            "dependencies": {
+                "@sinclair/typebox": "^0.27.8"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/source-map": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+            "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.2.9"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/source-map/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@jest/test-result": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+            "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+            "dev": true,
+            "dependencies": {
+                "@jest/console": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "collect-v8-coverage": "^1.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/test-sequencer": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+            "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/test-result": "^29.7.0",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/transform": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+            "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.11.6",
+                "@jest/types": "^29.6.3",
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "babel-plugin-istanbul": "^6.1.1",
+                "chalk": "^4.0.0",
+                "convert-source-map": "^2.0.0",
+                "fast-json-stable-stringify": "^2.1.0",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-util": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "pirates": "^4.0.4",
+                "slash": "^3.0.0",
+                "write-file-atomic": "^4.0.2"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/transform/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@jest/types": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/schemas": "^29.6.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -2297,6 +3939,12 @@
             "engines": {
                 "node": ">=14"
             }
+        },
+        "node_modules/@sinclair/typebox": {
+            "version": "0.27.8",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+            "dev": true
         },
         "node_modules/@sindresorhus/is": {
             "version": "4.6.0",
@@ -3043,6 +4691,87 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/babel__core": {
+            "version": "7.20.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "node_modules/@types/babel__core/node_modules/@babel/parser": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@types/babel__core/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@types/babel__generator": {
+            "version": "7.6.8",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+            "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__template": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__traverse": {
+            "version": "7.20.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+            "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.20.7"
+            }
+        },
+        "node_modules/@types/babel__traverse/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+            "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@types/body-parser": {
             "version": "1.19.5",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -3157,6 +4886,26 @@
                 "@types/send": "*"
             }
         },
+        "node_modules/@types/fs-extra": {
+            "version": "11.0.4",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+            "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@types/jsonfile": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/graceful-fs": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+            "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/http-cache-semantics": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -3175,6 +4924,40 @@
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/istanbul-lib-coverage": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+            "dev": true
+        },
+        "node_modules/@types/istanbul-lib-report": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+            "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+            "dev": true,
+            "dependencies": {
+                "@types/istanbul-lib-coverage": "*"
+            }
+        },
+        "node_modules/@types/istanbul-reports": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+            "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/istanbul-lib-report": "*"
+            }
+        },
+        "node_modules/@types/jest": {
+            "version": "29.5.12",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+            "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+            "dev": true,
+            "dependencies": {
+                "expect": "^29.0.0",
+                "pretty-format": "^29.0.0"
             }
         },
         "node_modules/@types/jsdom": {
@@ -3200,6 +4983,16 @@
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true,
             "optional": true
+        },
+        "node_modules/@types/jsonfile": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+            "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/keyv": {
             "version": "3.1.4",
@@ -3343,6 +5136,12 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/stack-utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+            "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+            "dev": true
+        },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -3377,6 +5176,21 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/yargs": {
+            "version": "17.0.32",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+            "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+            "dev": true,
+            "dependencies": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "node_modules/@types/yargs-parser": {
+            "version": "21.0.3",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+            "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "7.8.0",
@@ -3932,6 +5746,33 @@
                 "node": ">=6"
             }
         },
+        "node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ansi-escapes/node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ansi-html-community": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -4251,6 +6092,135 @@
         "node_modules/awsdocuments-ls-client": {
             "resolved": "client/vscode",
             "link": true
+        },
+        "node_modules/babel-jest": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+            "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+            "dev": true,
+            "dependencies": {
+                "@jest/transform": "^29.7.0",
+                "@types/babel__core": "^7.1.14",
+                "babel-plugin-istanbul": "^6.1.1",
+                "babel-preset-jest": "^29.6.3",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.9",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.8.0"
+            }
+        },
+        "node_modules/babel-plugin-istanbul": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+            "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-instrument": "^5.0.4",
+                "test-exclude": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+            "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.12.3",
+                "@babel/parser": "^7.14.7",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.2.0",
+                "semver": "^6.3.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/babel-plugin-istanbul/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/babel-plugin-jest-hoist": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+            "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/template": "^7.3.3",
+                "@babel/types": "^7.3.3",
+                "@types/babel__core": "^7.1.14",
+                "@types/babel__traverse": "^7.0.6"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/babel-plugin-transform-import-meta": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-import-meta/-/babel-plugin-transform-import-meta-2.2.1.tgz",
+            "integrity": "sha512-AxNh27Pcg8Kt112RGa3Vod2QS2YXKKJ6+nSvRtv7qQTJAdx0MZa4UHZ4lnxHUWA2MNbLuZQv5FVab4P1CoLOWw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/template": "^7.4.4",
+                "tslib": "^2.4.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.10.0"
+            }
+        },
+        "node_modules/babel-preset-current-node-syntax": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+            "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.8.3",
+                "@babel/plugin-syntax-import-meta": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+                "@babel/plugin-syntax-top-level-await": "^7.8.3"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/babel-preset-jest": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+            "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+            "dev": true,
+            "dependencies": {
+                "babel-plugin-jest-hoist": "^29.6.3",
+                "babel-preset-current-node-syntax": "^1.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -4655,6 +6625,27 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
+        "node_modules/bs-logger": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+            "dev": true,
+            "dependencies": {
+                "fast-json-stable-stringify": "2.x"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/bser": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+            "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+            "dev": true,
+            "dependencies": {
+                "node-int64": "^0.4.0"
+            }
+        },
         "node_modules/buffer": {
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -4842,6 +6833,15 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/char-regex": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/check-error": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -4908,6 +6908,21 @@
                 "node": ">=6.0"
             }
         },
+        "node_modules/ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/cipher-base": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -4917,6 +6932,12 @@
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
             }
+        },
+        "node_modules/cjs-module-lexer": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+            "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
+            "dev": true
         },
         "node_modules/cliui": {
             "version": "7.0.4",
@@ -4966,6 +6987,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+            "dev": true,
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
         "node_modules/code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -4974,6 +7005,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/collect-v8-coverage": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+            "dev": true
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -5159,6 +7196,12 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true
+        },
         "node_modules/cookie": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -5262,6 +7305,27 @@
                 "ripemd160": "^2.0.0",
                 "safe-buffer": "^5.0.1",
                 "sha.js": "^2.4.8"
+            }
+        },
+        "node_modules/create-jest": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+            "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.9",
+                "jest-config": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "prompts": "^2.0.1"
+            },
+            "bin": {
+                "create-jest": "bin/create-jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/create-require": {
@@ -5424,6 +7488,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dedent": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
+            "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+            "dev": true,
+            "peerDependencies": {
+                "babel-plugin-macros": "^3.1.0"
+            },
+            "peerDependenciesMeta": {
+                "babel-plugin-macros": {
+                    "optional": true
+                }
             }
         },
         "node_modules/deep-eql": {
@@ -5602,6 +7680,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/detect-newline": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+            "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/detect-node": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -5625,6 +7712,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/diff-sequences": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+            "dev": true,
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/diffie-hellman": {
@@ -5796,6 +7892,18 @@
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
             "dev": true
         },
+        "node_modules/emittery": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+            "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+            }
+        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5906,6 +8014,44 @@
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.2.tgz",
             "integrity": "sha512-l60ETUTmLqbVbVHv1J4/qj+M8nq7AwMzEcg3kmJDt9dCNrTk+yHcYFf/Kw75pMDwd9mPcIGCG5LcS20SxYRzFA==",
             "dev": true
+        },
+        "node_modules/esbuild": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+            "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.20.2",
+                "@esbuild/android-arm": "0.20.2",
+                "@esbuild/android-arm64": "0.20.2",
+                "@esbuild/android-x64": "0.20.2",
+                "@esbuild/darwin-arm64": "0.20.2",
+                "@esbuild/darwin-x64": "0.20.2",
+                "@esbuild/freebsd-arm64": "0.20.2",
+                "@esbuild/freebsd-x64": "0.20.2",
+                "@esbuild/linux-arm": "0.20.2",
+                "@esbuild/linux-arm64": "0.20.2",
+                "@esbuild/linux-ia32": "0.20.2",
+                "@esbuild/linux-loong64": "0.20.2",
+                "@esbuild/linux-mips64el": "0.20.2",
+                "@esbuild/linux-ppc64": "0.20.2",
+                "@esbuild/linux-riscv64": "0.20.2",
+                "@esbuild/linux-s390x": "0.20.2",
+                "@esbuild/linux-x64": "0.20.2",
+                "@esbuild/netbsd-x64": "0.20.2",
+                "@esbuild/openbsd-x64": "0.20.2",
+                "@esbuild/sunos-x64": "0.20.2",
+                "@esbuild/win32-arm64": "0.20.2",
+                "@esbuild/win32-ia32": "0.20.2",
+                "@esbuild/win32-x64": "0.20.2"
+            }
         },
         "node_modules/escalade": {
             "version": "3.1.2",
@@ -6196,6 +8342,15 @@
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
+        "node_modules/exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/expand-template": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -6203,6 +8358,22 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/expect": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+            "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/expect-utils": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/express": {
@@ -6389,6 +8560,15 @@
             },
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/fb-watchman": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+            "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+            "dev": true,
+            "dependencies": {
+                "bser": "2.1.1"
             }
         },
         "node_modules/file-entry-cache": {
@@ -6704,6 +8884,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -6740,6 +8929,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-package-type": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/get-stream": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -6750,6 +8948,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.7.5",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
+            "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
+            "dev": true,
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/github-from-package": {
@@ -7102,6 +9312,12 @@
                     "url": "https://patreon.com/mdevils"
                 }
             ]
+        },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true
         },
         "node_modules/htmlparser2": {
             "version": "8.0.2",
@@ -7504,6 +9720,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-generator-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+            "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/is-generator-function": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
@@ -7714,6 +9939,93 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-instrument": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
+            "integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.23.9",
+                "@babel/parser": "^7.23.9",
+                "@istanbuljs/schema": "^0.1.3",
+                "istanbul-lib-coverage": "^3.2.0",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-instrument/node_modules/@babel/parser": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+            "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+            "dev": true,
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-source-maps": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+            "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+            "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+            "dev": true,
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/jackspeak": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
@@ -7730,6 +10042,687 @@
             },
             "optionalDependencies": {
                 "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/jest": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+            "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/core": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "import-local": "^3.0.2",
+                "jest-cli": "^29.7.0"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-changed-files": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+            "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+            "dev": true,
+            "dependencies": {
+                "execa": "^5.0.0",
+                "jest-util": "^29.7.0",
+                "p-limit": "^3.1.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-circus": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+            "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/expect": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "co": "^4.6.0",
+                "dedent": "^1.0.0",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^29.7.0",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "p-limit": "^3.1.0",
+                "pretty-format": "^29.7.0",
+                "pure-rand": "^6.0.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-cli": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+            "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+            "dev": true,
+            "dependencies": {
+                "@jest/core": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "create-jest": "^29.7.0",
+                "exit": "^0.1.2",
+                "import-local": "^3.0.2",
+                "jest-config": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "yargs": "^17.3.1"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-cli/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/jest-cli/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/jest-cli/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/jest-config": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+            "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.11.6",
+                "@jest/test-sequencer": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "babel-jest": "^29.7.0",
+                "chalk": "^4.0.0",
+                "ci-info": "^3.2.0",
+                "deepmerge": "^4.2.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.9",
+                "jest-circus": "^29.7.0",
+                "jest-environment-node": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-runner": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "parse-json": "^5.2.0",
+                "pretty-format": "^29.7.0",
+                "slash": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "@types/node": "*",
+                "ts-node": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "ts-node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-config/node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-diff": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+            "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^29.6.3",
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-docblock": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+            "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+            "dev": true,
+            "dependencies": {
+                "detect-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-each": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+            "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^29.6.3",
+                "jest-util": "^29.7.0",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-environment-node": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+            "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/fake-timers": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "jest-mock": "^29.7.0",
+                "jest-util": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-get-type": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+            "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+            "dev": true,
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-haste-map": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+            "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@types/graceful-fs": "^4.1.3",
+                "@types/node": "*",
+                "anymatch": "^3.0.3",
+                "fb-watchman": "^2.0.0",
+                "graceful-fs": "^4.2.9",
+                "jest-regex-util": "^29.6.3",
+                "jest-util": "^29.7.0",
+                "jest-worker": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "walker": "^1.0.8"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "^2.3.2"
+            }
+        },
+        "node_modules/jest-haste-map/node_modules/jest-worker": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+            "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "jest-util": "^29.7.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-haste-map/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/jest-leak-detector": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+            "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+            "dev": true,
+            "dependencies": {
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-matcher-utils": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+            "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "jest-diff": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-message-util": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+            "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.12.13",
+                "@jest/types": "^29.6.3",
+                "@types/stack-utils": "^2.0.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.9",
+                "micromatch": "^4.0.4",
+                "pretty-format": "^29.7.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-mock": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+            "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "jest-util": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-pnp-resolver": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "peerDependencies": {
+                "jest-resolve": "*"
+            },
+            "peerDependenciesMeta": {
+                "jest-resolve": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-regex-util": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+            "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+            "dev": true,
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-resolve": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+            "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "jest-pnp-resolver": "^1.2.2",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "resolve": "^1.20.0",
+                "resolve.exports": "^2.0.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-resolve-dependencies": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+            "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+            "dev": true,
+            "dependencies": {
+                "jest-regex-util": "^29.6.3",
+                "jest-snapshot": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-runner": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+            "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/console": "^29.7.0",
+                "@jest/environment": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "emittery": "^0.13.1",
+                "graceful-fs": "^4.2.9",
+                "jest-docblock": "^29.7.0",
+                "jest-environment-node": "^29.7.0",
+                "jest-haste-map": "^29.7.0",
+                "jest-leak-detector": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-resolve": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-watcher": "^29.7.0",
+                "jest-worker": "^29.7.0",
+                "p-limit": "^3.1.0",
+                "source-map-support": "0.5.13"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-runner/node_modules/jest-worker": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+            "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "jest-util": "^29.7.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-runner/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/jest-runner/node_modules/source-map-support": {
+            "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+            "dev": true,
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/jest-runner/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/jest-runtime": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+            "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/fake-timers": "^29.7.0",
+                "@jest/globals": "^29.7.0",
+                "@jest/source-map": "^29.6.3",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "cjs-module-lexer": "^1.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-mock": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-runtime/node_modules/strip-bom": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-snapshot": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+            "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.11.6",
+                "@babel/generator": "^7.7.2",
+                "@babel/plugin-syntax-jsx": "^7.7.2",
+                "@babel/plugin-syntax-typescript": "^7.7.2",
+                "@babel/types": "^7.3.3",
+                "@jest/expect-utils": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "babel-preset-current-node-syntax": "^1.0.0",
+                "chalk": "^4.0.0",
+                "expect": "^29.7.0",
+                "graceful-fs": "^4.2.9",
+                "jest-diff": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^29.7.0",
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-util": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+            "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "ci-info": "^3.2.0",
+                "graceful-fs": "^4.2.9",
+                "picomatch": "^2.2.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-validate": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+            "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "camelcase": "^6.2.0",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^29.6.3",
+                "leven": "^3.1.0",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-validate/node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-validate/node_modules/leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/jest-watcher": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+            "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+            "dev": true,
+            "dependencies": {
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "emittery": "^0.13.1",
+                "jest-util": "^29.7.0",
+                "string-length": "^4.0.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-worker": {
@@ -7790,6 +10783,12 @@
             "version": "0.8.3",
             "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
             "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ=="
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
@@ -7939,6 +10938,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/kleur": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/launch-editor": {
@@ -8107,6 +11115,12 @@
                 "node": ">=4"
             }
         },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true
+        },
         "node_modules/load-json-file": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -8184,6 +11198,12 @@
             "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
             "dev": true
         },
+        "node_modules/lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+            "dev": true
+        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -8238,11 +11258,35 @@
             "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
             "dev": true
         },
+        "node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dev": true,
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
+        },
+        "node_modules/makeerror": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+            "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+            "dev": true,
+            "dependencies": {
+                "tmpl": "1.0.5"
+            }
         },
         "node_modules/marked": {
             "version": "12.0.2",
@@ -8759,6 +11803,12 @@
             "engines": {
                 "node": ">= 6.13.0"
             }
+        },
+        "node_modules/node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+            "dev": true
         },
         "node_modules/node-releases": {
             "version": "2.0.14",
@@ -9939,6 +12989,15 @@
             "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
             "dev": true
         },
+        "node_modules/pirates": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+            "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/pkg": {
             "version": "5.8.1",
             "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.8.1.tgz",
@@ -10174,6 +13233,32 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/pretty-format": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/schemas": "^29.6.3",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^18.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -10266,6 +13351,19 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/prompts": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+            "dev": true,
+            "dependencies": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -10339,6 +13437,22 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/pure-rand": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+            "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ]
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -10513,6 +13627,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/react-is": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true
         },
         "node_modules/read-installed": {
             "version": "4.0.3",
@@ -10808,6 +13928,24 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
+        "node_modules/resolve.exports": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+            "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/resolve/node_modules/is-core-module": {
@@ -11384,6 +14522,12 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/sisteransi": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "dev": true
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11671,6 +14815,33 @@
                 "node": ">= 10.x"
             }
         },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true
+        },
+        "node_modules/stack-utils": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/stack-utils/node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/statuses": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -11733,6 +14904,19 @@
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
+        },
+        "node_modules/string-length": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+            "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+            "dev": true,
+            "dependencies": {
+                "char-regex": "^1.0.2",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/string-width": {
             "version": "4.2.3",
@@ -12063,6 +15247,42 @@
                 "randombytes": "^2.1.0"
             }
         },
+        "node_modules/test-exclude": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+            "dev": true,
+            "dependencies": {
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/test-exclude/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/test-exclude/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -12104,6 +15324,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+            "dev": true
+        },
+        "node_modules/tmpl": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
         "node_modules/to-fast-properties": {
@@ -12216,6 +15442,70 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.2.0"
+            }
+        },
+        "node_modules/ts-jest": {
+            "version": "29.1.2",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
+            "integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
+            "dev": true,
+            "dependencies": {
+                "bs-logger": "0.x",
+                "fast-json-stable-stringify": "2.x",
+                "jest-util": "^29.0.0",
+                "json5": "^2.2.3",
+                "lodash.memoize": "4.x",
+                "make-error": "1.x",
+                "semver": "^7.5.3",
+                "yargs-parser": "^21.0.1"
+            },
+            "bin": {
+                "ts-jest": "cli.js"
+            },
+            "engines": {
+                "node": "^16.10.0 || ^18.0.0 || >=20.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": ">=7.0.0-beta.0 <8",
+                "@jest/types": "^29.0.0",
+                "babel-jest": "^29.0.0",
+                "jest": "^29.0.0",
+                "typescript": ">=4.3 <6"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                },
+                "@jest/types": {
+                    "optional": true
+                },
+                "babel-jest": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ts-jest/node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ts-jest/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/ts-loader": {
@@ -12487,6 +15777,25 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/tsx": {
+            "version": "4.10.4",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.10.4.tgz",
+            "integrity": "sha512-Gtg9qnZWNqC/OtcgiXfoAUdAKx3/cgKOYvEocAsv+m21MV/eKpV/WUjRXe6/sDCaGBl2/v8S6v29BpUnGMCX5A==",
+            "dev": true,
+            "dependencies": {
+                "esbuild": "~0.20.2",
+                "get-tsconfig": "^4.7.5"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
@@ -12766,6 +16075,30 @@
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true
         },
+        "node_modules/v8-to-istanbul": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+            "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.12",
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.12.0"
+            }
+        },
+        "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -12893,6 +16226,15 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/walker": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+            "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+            "dev": true,
+            "dependencies": {
+                "makeerror": "1.0.12"
             }
         },
         "node_modules/watchpack": {
@@ -13520,6 +16862,19 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
+        "node_modules/write-file-atomic": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+            "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+            "dev": true,
+            "dependencies": {
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.7"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/ws": {
             "version": "8.17.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
@@ -13593,6 +16948,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true
         },
         "node_modules/yaml": {
             "version": "2.2.2",
@@ -13795,6 +17156,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zx": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/zx/-/zx-8.1.0.tgz",
+            "integrity": "sha512-2BCoOK6JTWikAkwPCV2dFr+1ou29WoY+6XltLu+Ou9dvxrqm/p+HuHCgBtMRMIVFexQzUSGfB5VbYeY8XmGBPQ==",
+            "dev": true,
+            "bin": {
+                "zx": "build/cli.js"
+            },
+            "engines": {
+                "node": ">= 12.17.0"
+            },
+            "optionalDependencies": {
+                "@types/fs-extra": "^11.0.4",
+                "@types/node": ">=20.12.11"
             }
         },
         "server/aws-lsp-buildspec": {
@@ -14039,6 +17416,25 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "server/aws-lsp-partiql": {
+            "version": "0.0.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws/language-server-runtimes": "^0.2.4",
+                "@aws/lsp-core": "^0.0.1",
+                "vscode-languageserver": "^9.0.1",
+                "vscode-languageserver-textdocument": "^1.0.8"
+            },
+            "devDependencies": {
+                "@babel/plugin-transform-modules-commonjs": "^7.24.1",
+                "@types/jest": "29.5.12",
+                "babel-plugin-transform-import-meta": "^2.2.1",
+                "jest": "^29.7.0",
+                "ts-jest": "^29.1.2",
+                "tsx": "^4.7.2",
+                "zx": "^8.1.0"
             }
         },
         "server/aws-lsp-s3": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,24 @@
                 "webpack-cli": "^5.1.4"
             }
         },
+        "app/aws-lsp-partiql-binary": {
+            "name": "@aws/aws-lsp-partiql-binary",
+            "version": "0.0.1",
+            "dependencies": {
+                "@aws/aws-lsp-partiql": "^0.0.1",
+                "@aws/language-server-runtimes": "^0.2.5"
+            },
+            "bin": {
+                "aws-lsp-partiql-binary": "out/aws-lsp-partiql-binary.js"
+            },
+            "devDependencies": {
+                "pkg": "^5.8.1",
+                "ts-loader": "^9.4.4",
+                "ts-lsp-client": "^1.0.3",
+                "webpack": "^5.88.2",
+                "webpack-cli": "^5.1.4"
+            }
+        },
         "app/aws-lsp-s3-binary": {
             "name": "@aws/lsp-s3-binary",
             "version": "0.0.1",
@@ -1692,6 +1710,10 @@
         },
         "node_modules/@aws/aws-lsp-partiql": {
             "resolved": "server/aws-lsp-partiql",
+            "link": true
+        },
+        "node_modules/@aws/aws-lsp-partiql-binary": {
+            "resolved": "app/aws-lsp-partiql-binary",
             "link": true
         },
         "node_modules/@aws/aws-lsp-yaml-json": {
@@ -17419,6 +17441,7 @@
             }
         },
         "server/aws-lsp-partiql": {
+            "name": "@aws/aws-lsp-partiql",
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {

--- a/server/aws-lsp-partiql/.gitignore
+++ b/server/aws-lsp-partiql/.gitignore
@@ -1,3 +1,0 @@
-# development files
-/docker-output
-/coverage

--- a/server/aws-lsp-partiql/.gitignore
+++ b/server/aws-lsp-partiql/.gitignore
@@ -1,0 +1,3 @@
+# development files
+/docker-output
+/coverage

--- a/server/aws-lsp-partiql/.prettierignore
+++ b/server/aws-lsp-partiql/.prettierignore
@@ -1,0 +1,2 @@
+# automatically generated files from wasm-pack
+/src/partiql-parser-wasm/**/*.*

--- a/server/aws-lsp-partiql/README.md
+++ b/server/aws-lsp-partiql/README.md
@@ -18,5 +18,5 @@ Tests for this package are run using [Jest](https://jestjs.io/), to run the test
 
 This package currently has a couple of potential points-of-improvement:
 
-- In the bindings for the parser WASM binary, there is a [code path](https://code.amazon.com/packages/CloudEditor/blobs/c7d056f39bdf48379395516cdf49e5c5b18f047a/--/packages/partiql-language-server/src/partiql-parser-wasm/partiql_playground.js#L367) which imports the `partiql_playground_bg.wasm` file. We don't use this file and code path at runtime due to the inlining of the WASM binary. When doing import checks however, Webpack fails building because it cannot find this binary. To work around this, we include a no-op file with the expected name.
+- In the bindings for the parser WASM binary, there is a code path which imports the `partiql_playground_bg.wasm` file. We don't use this file and code path at runtime due to the inlining of the WASM binary. When doing import checks however, Webpack fails building because it cannot find this binary. To work around this, we include a no-op file with the expected name.
 - In the tests for the language service, there are a couple of untested happy paths. Input couldn't be found to trigger these happy paths.

--- a/server/aws-lsp-partiql/README.md
+++ b/server/aws-lsp-partiql/README.md
@@ -1,0 +1,22 @@
+# PartiQL LSP server
+
+LSP server for the [PartiQL language](https://partiql.org/). This server offers diagnostics for PartiQL files by parsing the file using the [Rust parser maintained by the PartiQL team](https://github.com/partiql/partiql-lang-rust).
+
+This parser is compiled to a WebAssembly binary using the bindings maintained by the PartiQL team in the [PartiQL playground package](https://github.com/partiql/partiql-rust-playground). This binary is further encoded as a base64 string in a Javascript file to make it easy to be bundled together with the other assets of the server.
+
+### Updating the binary
+
+_Updating the binary requires the Docker CLI to be in your PATH_
+
+To update the binary used by the server, run `npm run update-parser-binary`. This will, inside a Docker container, pull the PartiQL playground repository from GitHub and run the `build` command to create a new binary. It is then encoded into base64 in a Typescript file and copied to the `src` folder. Running `npm run build` will then transpile the binary file to Javascript and place it in the `lib` folder.
+
+### Tests
+
+Tests for this package are run using [Jest](https://jestjs.io/), to run the tests in this package run `-npm run test`. 
+
+### Potential improvements
+
+This package currently has a couple of potential points-of-improvement:
+
+- In the bindings for the parser WASM binary, there is a [code path](https://code.amazon.com/packages/CloudEditor/blobs/c7d056f39bdf48379395516cdf49e5c5b18f047a/--/packages/partiql-language-server/src/partiql-parser-wasm/partiql_playground.js#L367) which imports the `partiql_playground_bg.wasm` file. We don't use this file and code path at runtime due to the inlining of the WASM binary. When doing import checks however, Webpack fails building because it cannot find this binary. To work around this, we include a no-op file with the expected name.
+- In the tests for the language service, there are a couple of untested happy paths. Input couldn't be found to trigger these happy paths.

--- a/server/aws-lsp-partiql/build-scripts/compile-inline-partiql-wasm.mts
+++ b/server/aws-lsp-partiql/build-scripts/compile-inline-partiql-wasm.mts
@@ -1,7 +1,7 @@
 import { $ } from 'zx'
 
 // Build/run docker container to build and encode binary.
-await $`docker build scripts/compile-partiql-wasm-docker --file scripts/compile-partiql-wasm-docker/compile-base64-partiql-wasm-binary.dockerfile -t partiql-wasm`
+await $`docker build build-scripts/compile-partiql-wasm-docker --file build-scripts/compile-partiql-wasm-docker/compile-base64-partiql-wasm-binary.dockerfile -t partiql-wasm`
 await $`docker run --name partiql-wasm -d partiql-wasm:latest`
 
 // Copy binary and bindings out of docker to host.

--- a/server/aws-lsp-partiql/build-scripts/compile-inline-partiql-wasm.mts
+++ b/server/aws-lsp-partiql/build-scripts/compile-inline-partiql-wasm.mts
@@ -1,0 +1,23 @@
+import { $ } from 'zx'
+
+// Build/run docker container to build and encode binary.
+await $`docker build scripts/compile-partiql-wasm-docker --file scripts/compile-partiql-wasm-docker/compile-base64-partiql-wasm-binary.dockerfile -t partiql-wasm`
+await $`docker run --name partiql-wasm -d partiql-wasm:latest`
+
+// Copy binary and bindings out of docker to host.
+await $`docker cp partiql-wasm:/dir/partiql-rust-playground/pkg-web/. ./docker-output`
+
+// Clean-up docker.
+await $`docker stop partiql-wasm`
+await $`docker rm partiql-wasm`
+
+// Copy relevant files from docker-output folder to src folder.
+const filesToMove = [
+    'docker-output/partiql_playground.js',
+    'docker-output/partiql_playground.d.ts',
+    'docker-output/partiql-wasm-parser-inline.ts',
+]
+await $`mv ${filesToMove} src/partiql-parser-wasm`
+
+// Clean-up generated files.
+await $`rm -rf docker-output`

--- a/server/aws-lsp-partiql/build-scripts/compile-partiql-wasm-docker/base64-encode-partiql-binary.mts
+++ b/server/aws-lsp-partiql/build-scripts/compile-partiql-wasm-docker/base64-encode-partiql-binary.mts
@@ -1,0 +1,12 @@
+import { fs } from 'zx'
+
+// Read .wasm binary file, NOTICE and LICENSE file and add description of our modifications.
+const base64EncodedBinary = fs.readFileSync('/dir/partiql-rust-playground/pkg-web/partiql_playground_bg.wasm', 'base64')
+const license = fs.readFileSync('/dir/partiql-rust-playground/pkg-web/LICENSE', 'utf-8')
+const notice = fs.readFileSync('/dir/partiql-rust-playground/NOTICE', 'utf-8')
+const modifications =
+    '`base64EncodedBinary` contains a base64 encoding of the Rust PartiQL parser compiled to WebAssembly.\n\tModifications around it are to import it from a JS/TS file and instantiate it using `WebAssembly.instantiate.`'
+
+// Copy the encoded binary, notice and license into a .ts file.
+const encodedPartiQLServer = `/*\n${license}\n\n\t${notice}\n\n\t${modifications}\n*/\n\nconst base64String = atob(\"${base64EncodedBinary}\");\nconst base64Buffer = new Uint8Array(base64String.length);\nfor (var i = 0; i < base64String.length; i++) base64Buffer[i] = base64String.charCodeAt(i);\nexport default base64Buffer;`
+fs.writeFileSync('/dir/partiql-rust-playground/pkg-web/partiql-wasm-parser-inline.ts', encodedPartiQLServer)

--- a/server/aws-lsp-partiql/build-scripts/compile-partiql-wasm-docker/compile-base64-partiql-wasm-binary.dockerfile
+++ b/server/aws-lsp-partiql/build-scripts/compile-partiql-wasm-docker/compile-base64-partiql-wasm-binary.dockerfile
@@ -1,0 +1,18 @@
+FROM amazonlinux:2023
+WORKDIR /dir
+### Add Rust bin path to PATH var.
+ENV PATH="${PATH}:/root/.cargo/bin"
+### Install system dependencies & node
+RUN yum update -y && \
+    yum install tar gzip -y && \
+    yum install git -y && \
+    yum install gcc gcc-c++ make -y && \
+    yum install nodejs -y
+### Install node dependencies required to run the scripts
+RUN npm install zx && \
+    npm -g install tsx
+### Copy the scripts from the host to the container
+COPY . /dir
+### Run the scripts
+RUN tsx compile-partiql-wasm-binary.mts && \
+    tsx base64-encode-partiql-binary.mts

--- a/server/aws-lsp-partiql/build-scripts/compile-partiql-wasm-docker/compile-partiql-wasm-binary.mts
+++ b/server/aws-lsp-partiql/build-scripts/compile-partiql-wasm-docker/compile-partiql-wasm-binary.mts
@@ -1,0 +1,10 @@
+import { $, cd } from 'zx'
+
+// Install Rust using Rustup and WASM dependencies.
+await $`npm install -g wasm-pack`
+await $`curl https://sh.rustup.rs -sSf | sh -s -- -y`
+
+// Clone partiql rust playground and run build script.
+await $`git clone https://github.com/partiql/partiql-rust-playground`
+cd('partiql-rust-playground')
+await $`make build`

--- a/server/aws-lsp-partiql/build-scripts/create-empty-wasm-file.mts
+++ b/server/aws-lsp-partiql/build-scripts/create-empty-wasm-file.mts
@@ -1,0 +1,7 @@
+import { fs } from 'zx'
+
+// Create empty .wasm binary file and move it to lib folder to have a file called `partiql_playground_bg.wasm` when webpack is checking import URLs
+// during webpack build. Creating an empty file because we don't actually use the .wasm file but have the binary encoded into a string.
+const noOpWasmContent =
+    'Empty no-op file to have a file called `partiql_playground_bg.wasm` when doing import checks. This file is not used by the PartiQL LSP server, the WASM binary is used from a base64 string in the js bundle.'
+fs.writeFileSync('out/partiql-parser-wasm/partiql_playground_bg.wasm', noOpWasmContent)

--- a/server/aws-lsp-partiql/jest.config.js
+++ b/server/aws-lsp-partiql/jest.config.js
@@ -7,44 +7,10 @@ module.exports = {
         [`/src/partiql-parser-wasm/partiql_playground.js`]: require.resolve('./test-utils/esm-transformer'),
     },
     transformIgnorePatterns: [...(tsPreset.transformIgnorePatterns || [])],
-    // Stop running tests after N failures
-    bail: 0,
-
-    // Automatically clear mock calls, instances and results before every test
-    clearMocks: true,
-
-    // Indicates whether the coverage information should be collected while executing the test
-    collectCoverage: true,
-
-    // The directory where Jest should output its coverage files
-    coverageDirectory: 'coverage',
-
-    // An array of regexp pattern strings used to skip coverage collection
-    coveragePathIgnorePatterns: ['src/partiql-parser-wasm'],
-
-    // Indicates which provider should be used to instrument code for coverage
-    // Options are the default 'babel' or the experimental 'v8'.
-    coverageProvider: 'babel',
-
-    // A list of reporter names that Jest uses when writing coverage reports
-    coverageReporters: ['json', 'text', 'lcov', 'clover'],
-
-    // Make calling deprecated APIs throw helpful error messages
-    errorOnDeprecated: true,
-
-    // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-    maxWorkers: '60%',
-
-    // The number of seconds after which a test is considered as slow and reported as such in the results.
-    slowTestThreshold: 5,
 
     // The test environment that will be used for testing
-    // Runs tests in 'node' mode by default, add override to top of files that need JSDOM.
     testEnvironment: 'node',
 
     // The glob patterns Jest uses to detect test files
     testMatch: ['**/*.test.ts?(x)'],
-
-    // Indicates whether each individual test should be reported during the run
-    verbose: false,
 }

--- a/server/aws-lsp-partiql/jest.config.js
+++ b/server/aws-lsp-partiql/jest.config.js
@@ -1,0 +1,50 @@
+const tsPreset = require('ts-jest/jest-preset')
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+    transform: {
+        ...tsPreset.transform,
+        [`/src/partiql-parser-wasm/partiql_playground.js`]: require.resolve('./test-utils/esm-transformer'),
+    },
+    transformIgnorePatterns: [...(tsPreset.transformIgnorePatterns || [])],
+    // Stop running tests after N failures
+    bail: 0,
+
+    // Automatically clear mock calls, instances and results before every test
+    clearMocks: true,
+
+    // Indicates whether the coverage information should be collected while executing the test
+    collectCoverage: true,
+
+    // The directory where Jest should output its coverage files
+    coverageDirectory: 'coverage',
+
+    // An array of regexp pattern strings used to skip coverage collection
+    coveragePathIgnorePatterns: ['src/partiql-parser-wasm'],
+
+    // Indicates which provider should be used to instrument code for coverage
+    // Options are the default 'babel' or the experimental 'v8'.
+    coverageProvider: 'babel',
+
+    // A list of reporter names that Jest uses when writing coverage reports
+    coverageReporters: ['json', 'text', 'lcov', 'clover'],
+
+    // Make calling deprecated APIs throw helpful error messages
+    errorOnDeprecated: true,
+
+    // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+    maxWorkers: '60%',
+
+    // The number of seconds after which a test is considered as slow and reported as such in the results.
+    slowTestThreshold: 5,
+
+    // The test environment that will be used for testing
+    // Runs tests in 'node' mode by default, add override to top of files that need JSDOM.
+    testEnvironment: 'node',
+
+    // The glob patterns Jest uses to detect test files
+    testMatch: ['**/*.test.ts?(x)'],
+
+    // Indicates whether each individual test should be reported during the run
+    verbose: false,
+}

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@aws/aws-lsp-partiql",
+    "name": "@aws/lsp-partiql",
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
     "description": "PartiQL language server",

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -18,9 +18,7 @@
     ],
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.4",
-        "@aws/lsp-core": "^0.0.1",
-        "vscode-languageserver": "^9.0.1",
-        "vscode-languageserver-textdocument": "^1.0.8"
+        "@aws/lsp-core": "^0.0.1"
     },
     "devDependencies": {
         "babel-plugin-transform-import-meta": "^2.2.1",

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -1,0 +1,44 @@
+{
+    "name": "@aws/aws-lsp-partiql",
+    "author": "Amazon Web Services",
+    "license": "Apache-2.0",
+    "description": "PartiQL language server",
+    "version": "0.0.1",
+    "main": "out/index.js",
+    "types": "out/index.d.ts",
+    "scripts": {
+        "compile": "tsc --build",
+        "test": "jest",
+        "postcompile": "npm run copy-empty-binary",
+        "copy-empty-binary": "tsx build-scripts/create-empty-wasm-file.mts",
+        "update-parser-binary": "tsx build-scripts/compile-inline-partiql-wasm.mts"
+    },
+    "files": [
+        "out"
+    ],
+    "dependencies": {
+        "@aws/language-server-runtimes": "^0.2.4",
+        "@aws/lsp-core": "^0.0.1",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.8"
+    },
+    "devDependencies": {
+        "babel-plugin-transform-import-meta": "^2.2.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.1",
+        "jest": "^29.7.0",
+        "@types/jest": "29.5.12",
+        "ts-jest": "^29.1.2",
+        "tsx": "^4.7.2",
+        "zx": "^8.1.0"
+    },
+    "prettier": {
+        "printWidth": 120,
+        "trailingComma": "es5",
+        "tabWidth": 4,
+        "singleQuote": true,
+        "semi": false,
+        "bracketSpacing": true,
+        "arrowParens": "avoid",
+        "endOfLine": "lf"
+    }
+}

--- a/server/aws-lsp-partiql/src/index.tsx
+++ b/server/aws-lsp-partiql/src/index.tsx
@@ -1,0 +1,2 @@
+import { PartiQLLanguageServer } from './server/language-server'
+export { PartiQLLanguageServer }

--- a/server/aws-lsp-partiql/src/partiql-parser-wasm/README.md
+++ b/server/aws-lsp-partiql/src/partiql-parser-wasm/README.md
@@ -1,0 +1,7 @@
+# PartiQL Parser WASM
+
+This folder contains the binary encoded as a base64 string, and bindings for the WASM compiled verion of the Rust PartiQL parser: https://github.com/partiql/partiql-lang-rust
+
+Bindings and binary are generated from: https://github.com/partiql/partiql-rust-playground 
+
+Binary and bindings can be update from the source on GitHub by running `npm run update-parser-binary`.

--- a/server/aws-lsp-partiql/src/partiql-parser-wasm/partiql_playground.d.ts
+++ b/server/aws-lsp-partiql/src/partiql-parser-wasm/partiql_playground.d.ts
@@ -1,0 +1,83 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * @param {string} query
+ * @param {string} env
+ * @returns {string}
+ */
+export function generate_session(query: string, env: string): string
+/**
+ * @param {string} session
+ * @returns {Array<any>}
+ */
+export function decode_session_as_array(session: string): Array<any>
+/**
+ * Parses the given query and returns the json serialized string.
+ * @param {string} query
+ * @returns {string}
+ */
+export function parse_as_json(query: string): string
+/**
+ * Evaluates the given query using the given environment and returns the json serialized string.
+ * @param {string} statement
+ * @param {string} env
+ * @returns {string}
+ */
+export function eval_as_json(statement: string, env: string): string
+/**
+ * Evaluates the given query using the given environment and returns the output string.
+ * @param {string} statement
+ * @param {string} env
+ * @returns {string}
+ */
+export function eval_as_string(statement: string, env: string): string
+/**
+ * Creates a logical plan for the given query and returns the json serialized string.
+ * @param {string} statement
+ * @returns {string}
+ */
+export function explain_as_json(statement: string): string
+/**
+ * Creates a logical plan for the given query and returns the output string.
+ * @param {string} statement
+ * @returns {string}
+ */
+export function explain_as_string(statement: string): string
+
+export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module
+
+export interface InitOutput {
+    readonly memory: WebAssembly.Memory
+    readonly generate_session: (a: number, b: number, c: number, d: number, e: number) => void
+    readonly decode_session_as_array: (a: number, b: number) => number
+    readonly parse_as_json: (a: number, b: number, c: number) => void
+    readonly eval_as_json: (a: number, b: number, c: number, d: number, e: number) => void
+    readonly eval_as_string: (a: number, b: number, c: number, d: number, e: number) => void
+    readonly explain_as_json: (a: number, b: number, c: number) => void
+    readonly explain_as_string: (a: number, b: number, c: number) => void
+    readonly __wbindgen_add_to_stack_pointer: (a: number) => number
+    readonly __wbindgen_malloc: (a: number, b: number) => number
+    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number
+    readonly __wbindgen_free: (a: number, b: number, c: number) => void
+}
+
+export type SyncInitInput = BufferSource | WebAssembly.Module
+/**
+ * Instantiates the given `module`, which can either be bytes or
+ * a precompiled `WebAssembly.Module`.
+ *
+ * @param {SyncInitInput} module
+ *
+ * @returns {InitOutput}
+ */
+export function initSync(module: SyncInitInput): InitOutput
+
+/**
+ * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+ * for everything else, calls `WebAssembly.instantiate` directly.
+ *
+ * @param {InitInput | Promise<InitInput>} module_or_path
+ *
+ * @returns {Promise<InitOutput>}
+ */
+export default function __wbg_init(module_or_path?: InitInput | Promise<InitInput>): Promise<InitOutput>

--- a/server/aws-lsp-partiql/src/partiql-parser-wasm/partiql_playground.js
+++ b/server/aws-lsp-partiql/src/partiql-parser-wasm/partiql_playground.js
@@ -1,0 +1,403 @@
+let wasm
+
+const cachedTextDecoder =
+    typeof TextDecoder !== 'undefined'
+        ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true })
+        : {
+              decode: () => {
+                  throw Error('TextDecoder not available')
+              },
+          }
+
+if (typeof TextDecoder !== 'undefined') {
+    cachedTextDecoder.decode()
+}
+
+let cachedUint8Memory0 = null
+
+function getUint8Memory0() {
+    if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
+        cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer)
+    }
+    return cachedUint8Memory0
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0
+    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len))
+}
+
+const heap = new Array(128).fill(undefined)
+
+heap.push(undefined, null, true, false)
+
+let heap_next = heap.length
+
+function addHeapObject(obj) {
+    if (heap_next === heap.length) heap.push(heap.length + 1)
+    const idx = heap_next
+    heap_next = heap[idx]
+
+    heap[idx] = obj
+    return idx
+}
+
+function getObject(idx) {
+    return heap[idx]
+}
+
+function dropObject(idx) {
+    if (idx < 132) return
+    heap[idx] = heap_next
+    heap_next = idx
+}
+
+function takeObject(idx) {
+    const ret = getObject(idx)
+    dropObject(idx)
+    return ret
+}
+
+let WASM_VECTOR_LEN = 0
+
+const cachedTextEncoder =
+    typeof TextEncoder !== 'undefined'
+        ? new TextEncoder('utf-8')
+        : {
+              encode: () => {
+                  throw Error('TextEncoder not available')
+              },
+          }
+
+const encodeString =
+    typeof cachedTextEncoder.encodeInto === 'function'
+        ? function (arg, view) {
+              return cachedTextEncoder.encodeInto(arg, view)
+          }
+        : function (arg, view) {
+              const buf = cachedTextEncoder.encode(arg)
+              view.set(buf)
+              return {
+                  read: arg.length,
+                  written: buf.length,
+              }
+          }
+
+function passStringToWasm0(arg, malloc, realloc) {
+    if (realloc === undefined) {
+        const buf = cachedTextEncoder.encode(arg)
+        const ptr = malloc(buf.length, 1) >>> 0
+        getUint8Memory0()
+            .subarray(ptr, ptr + buf.length)
+            .set(buf)
+        WASM_VECTOR_LEN = buf.length
+        return ptr
+    }
+
+    let len = arg.length
+    let ptr = malloc(len, 1) >>> 0
+
+    const mem = getUint8Memory0()
+
+    let offset = 0
+
+    for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset)
+        if (code > 0x7f) break
+        mem[ptr + offset] = code
+    }
+
+    if (offset !== len) {
+        if (offset !== 0) {
+            arg = arg.slice(offset)
+        }
+        ptr = realloc(ptr, len, (len = offset + arg.length * 3), 1) >>> 0
+        const view = getUint8Memory0().subarray(ptr + offset, ptr + len)
+        const ret = encodeString(arg, view)
+
+        offset += ret.written
+        ptr = realloc(ptr, len, offset, 1) >>> 0
+    }
+
+    WASM_VECTOR_LEN = offset
+    return ptr
+}
+
+let cachedInt32Memory0 = null
+
+function getInt32Memory0() {
+    if (cachedInt32Memory0 === null || cachedInt32Memory0.byteLength === 0) {
+        cachedInt32Memory0 = new Int32Array(wasm.memory.buffer)
+    }
+    return cachedInt32Memory0
+}
+/**
+ * @param {string} query
+ * @param {string} env
+ * @returns {string}
+ */
+export function generate_session(query, env) {
+    let deferred3_0
+    let deferred3_1
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16)
+        const ptr0 = passStringToWasm0(query, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc)
+        const len0 = WASM_VECTOR_LEN
+        const ptr1 = passStringToWasm0(env, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc)
+        const len1 = WASM_VECTOR_LEN
+        wasm.generate_session(retptr, ptr0, len0, ptr1, len1)
+        var r0 = getInt32Memory0()[retptr / 4 + 0]
+        var r1 = getInt32Memory0()[retptr / 4 + 1]
+        deferred3_0 = r0
+        deferred3_1 = r1
+        return getStringFromWasm0(r0, r1)
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16)
+        wasm.__wbindgen_free(deferred3_0, deferred3_1, 1)
+    }
+}
+
+/**
+ * @param {string} session
+ * @returns {Array<any>}
+ */
+export function decode_session_as_array(session) {
+    const ptr0 = passStringToWasm0(session, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc)
+    const len0 = WASM_VECTOR_LEN
+    const ret = wasm.decode_session_as_array(ptr0, len0)
+    return takeObject(ret)
+}
+
+/**
+ * Parses the given query and returns the json serialized string.
+ * @param {string} query
+ * @returns {string}
+ */
+export function parse_as_json(query) {
+    let deferred2_0
+    let deferred2_1
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16)
+        const ptr0 = passStringToWasm0(query, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc)
+        const len0 = WASM_VECTOR_LEN
+        wasm.parse_as_json(retptr, ptr0, len0)
+        var r0 = getInt32Memory0()[retptr / 4 + 0]
+        var r1 = getInt32Memory0()[retptr / 4 + 1]
+        deferred2_0 = r0
+        deferred2_1 = r1
+        return getStringFromWasm0(r0, r1)
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16)
+        wasm.__wbindgen_free(deferred2_0, deferred2_1, 1)
+    }
+}
+
+/**
+ * Evaluates the given query using the given environment and returns the json serialized string.
+ * @param {string} statement
+ * @param {string} env
+ * @returns {string}
+ */
+export function eval_as_json(statement, env) {
+    let deferred3_0
+    let deferred3_1
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16)
+        const ptr0 = passStringToWasm0(statement, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc)
+        const len0 = WASM_VECTOR_LEN
+        const ptr1 = passStringToWasm0(env, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc)
+        const len1 = WASM_VECTOR_LEN
+        wasm.eval_as_json(retptr, ptr0, len0, ptr1, len1)
+        var r0 = getInt32Memory0()[retptr / 4 + 0]
+        var r1 = getInt32Memory0()[retptr / 4 + 1]
+        deferred3_0 = r0
+        deferred3_1 = r1
+        return getStringFromWasm0(r0, r1)
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16)
+        wasm.__wbindgen_free(deferred3_0, deferred3_1, 1)
+    }
+}
+
+/**
+ * Evaluates the given query using the given environment and returns the output string.
+ * @param {string} statement
+ * @param {string} env
+ * @returns {string}
+ */
+export function eval_as_string(statement, env) {
+    let deferred3_0
+    let deferred3_1
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16)
+        const ptr0 = passStringToWasm0(statement, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc)
+        const len0 = WASM_VECTOR_LEN
+        const ptr1 = passStringToWasm0(env, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc)
+        const len1 = WASM_VECTOR_LEN
+        wasm.eval_as_string(retptr, ptr0, len0, ptr1, len1)
+        var r0 = getInt32Memory0()[retptr / 4 + 0]
+        var r1 = getInt32Memory0()[retptr / 4 + 1]
+        deferred3_0 = r0
+        deferred3_1 = r1
+        return getStringFromWasm0(r0, r1)
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16)
+        wasm.__wbindgen_free(deferred3_0, deferred3_1, 1)
+    }
+}
+
+/**
+ * Creates a logical plan for the given query and returns the json serialized string.
+ * @param {string} statement
+ * @returns {string}
+ */
+export function explain_as_json(statement) {
+    let deferred2_0
+    let deferred2_1
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16)
+        const ptr0 = passStringToWasm0(statement, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc)
+        const len0 = WASM_VECTOR_LEN
+        wasm.explain_as_json(retptr, ptr0, len0)
+        var r0 = getInt32Memory0()[retptr / 4 + 0]
+        var r1 = getInt32Memory0()[retptr / 4 + 1]
+        deferred2_0 = r0
+        deferred2_1 = r1
+        return getStringFromWasm0(r0, r1)
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16)
+        wasm.__wbindgen_free(deferred2_0, deferred2_1, 1)
+    }
+}
+
+/**
+ * Creates a logical plan for the given query and returns the output string.
+ * @param {string} statement
+ * @returns {string}
+ */
+export function explain_as_string(statement) {
+    let deferred2_0
+    let deferred2_1
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16)
+        const ptr0 = passStringToWasm0(statement, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc)
+        const len0 = WASM_VECTOR_LEN
+        wasm.explain_as_string(retptr, ptr0, len0)
+        var r0 = getInt32Memory0()[retptr / 4 + 0]
+        var r1 = getInt32Memory0()[retptr / 4 + 1]
+        deferred2_0 = r0
+        deferred2_1 = r1
+        return getStringFromWasm0(r0, r1)
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16)
+        wasm.__wbindgen_free(deferred2_0, deferred2_1, 1)
+    }
+}
+
+async function __wbg_load(module, imports) {
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports)
+            } catch (e) {
+                if (module.headers.get('Content-Type') != 'application/wasm') {
+                    console.warn(
+                        '`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n',
+                        e
+                    )
+                } else {
+                    throw e
+                }
+            }
+        }
+
+        const bytes = await module.arrayBuffer()
+        return await WebAssembly.instantiate(bytes, imports)
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports)
+
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module }
+        } else {
+            return instance
+        }
+    }
+}
+
+function __wbg_get_imports() {
+    const imports = {}
+    imports.wbg = {}
+    imports.wbg.__wbindgen_string_new = function (arg0, arg1) {
+        const ret = getStringFromWasm0(arg0, arg1)
+        return addHeapObject(ret)
+    }
+    imports.wbg.__wbindgen_object_drop_ref = function (arg0) {
+        takeObject(arg0)
+    }
+    imports.wbg.__wbg_new_16b304a2cfa7ff4a = function () {
+        const ret = new Array()
+        return addHeapObject(ret)
+    }
+    imports.wbg.__wbg_push_a5b05aedc7234f9f = function (arg0, arg1) {
+        const ret = getObject(arg0).push(getObject(arg1))
+        return ret
+    }
+    imports.wbg.__wbindgen_throw = function (arg0, arg1) {
+        throw new Error(getStringFromWasm0(arg0, arg1))
+    }
+
+    return imports
+}
+
+function __wbg_init_memory(imports, maybe_memory) {}
+
+function __wbg_finalize_init(instance, module) {
+    wasm = instance.exports
+    __wbg_init.__wbindgen_wasm_module = module
+    cachedInt32Memory0 = null
+    cachedUint8Memory0 = null
+
+    return wasm
+}
+
+function initSync(module) {
+    if (wasm !== undefined) return wasm
+
+    const imports = __wbg_get_imports()
+
+    __wbg_init_memory(imports)
+
+    if (!(module instanceof WebAssembly.Module)) {
+        module = new WebAssembly.Module(module)
+    }
+
+    const instance = new WebAssembly.Instance(module, imports)
+
+    return __wbg_finalize_init(instance, module)
+}
+
+async function __wbg_init(input) {
+    if (wasm !== undefined) return wasm
+
+    if (typeof input === 'undefined') {
+        input = new URL('partiql_playground_bg.wasm', import.meta.url)
+    }
+    const imports = __wbg_get_imports()
+
+    if (
+        typeof input === 'string' ||
+        (typeof Request === 'function' && input instanceof Request) ||
+        (typeof URL === 'function' && input instanceof URL)
+    ) {
+        input = fetch(input)
+    }
+
+    __wbg_init_memory(imports)
+
+    const { instance, module } = await __wbg_load(await input, imports)
+
+    return __wbg_finalize_init(instance, module)
+}
+
+export { initSync }
+export default __wbg_init

--- a/server/aws-lsp-partiql/src/server/error-parsing/lexer-errors.ts
+++ b/server/aws-lsp-partiql/src/server/error-parsing/lexer-errors.ts
@@ -1,0 +1,50 @@
+export type InvalidInputErrorInfo = string
+
+const expectedLexerErrorTypes = ['InvalidInput', 'UnterminatedIonLiteral', 'UnterminatedComment', 'Unknown']
+
+// The parser can return lexer errors as part of it's output. Lexer errors can be an object or a string
+// in the same way as for the parser errors.
+export function convertObjectToLexerError(error: any) {
+    if (typeof error === 'object') {
+        const [lexErrorType, lexErrorInfo] = Object.entries(error)[0] as [string, InvalidInputErrorInfo]
+        if (!expectedLexerErrorTypes.includes(lexErrorType))
+            throw new Error('partiql error parsing error: unexpected lexer error type')
+        return createStringFromLexerError(lexErrorType, lexErrorInfo)
+    } else if (typeof error === 'string') {
+        if (!expectedLexerErrorTypes.includes(error))
+            throw new Error('partiql error parsing error: unexpected lexer error type')
+        return createStringFromLexerError(error)
+    } else {
+        throw new Error('partiql error parsing error: lexer error not object or string')
+    }
+}
+
+// Convert the errors reported by the lexer to a human-readable string following
+// the errors found in https://github.com/partiql/partiql-lang-rust/blob/5dc7c6e33666978654d3e4ed519209c2f8fc3038/partiql-parser/src/error.rs.
+export function createStringFromLexerError(errorType: string, errorInfo?: InvalidInputErrorInfo) {
+    switch (errorType) {
+        case 'InvalidInput':
+            if (!isInvalidInputErrorInfo(errorInfo))
+                throw Error('partiql error parsing error: InvalidInput unexpected format')
+            return `Lexing error: invalid input: ${errorInfo}.`
+
+        case 'UnterminatedIonLiteral':
+            return 'Lexing error: unterminated ion literal.'
+
+        case 'UnterminatedComment':
+            return 'Lexing error: unterminated comment.'
+
+        case 'Unknown':
+            return 'Lexing error: unknown error.'
+
+        default:
+            // This code path is only reached when error type doesn't match any of the expected error types which
+            // should never happen when triggered by the error parsing process.
+            throw new Error('partiql error parsing error: unexpected lexer error type')
+    }
+}
+
+function isInvalidInputErrorInfo(errorInfo: InvalidInputErrorInfo | undefined): errorInfo is InvalidInputErrorInfo {
+    const invalidInputErrorInfo = errorInfo as InvalidInputErrorInfo
+    return !!invalidInputErrorInfo && typeof invalidInputErrorInfo === 'string'
+}

--- a/server/aws-lsp-partiql/src/server/error-parsing/parser-errors.ts
+++ b/server/aws-lsp-partiql/src/server/error-parsing/parser-errors.ts
@@ -1,0 +1,131 @@
+import { convertObjectToLexerError } from './lexer-errors'
+
+type LocationInfo = {
+    start: number
+    end: number
+}
+type SyntaxErrorInfo = {
+    inner: string
+    location: LocationInfo
+}
+type UnexpectedTokenErrorInfo = {
+    inner: { token: string }
+    location: LocationInfo
+}
+type LexicalErrorInfo = {
+    inner: object | string
+    location: LocationInfo
+}
+type IllegalStateErrorInfo = {
+    location: LocationInfo
+}
+type ParserErrorInfo = SyntaxErrorInfo | UnexpectedTokenErrorInfo | IllegalStateErrorInfo | LexicalErrorInfo
+
+const expectedParserErrorTypes = [
+    'SyntaxError',
+    'UnexpectedEndOfInput',
+    'UnexpectedToken',
+    'LexicalError',
+    'IllegalState',
+    'Unknown',
+]
+
+export function convertObjectToParserError(error: any): { message: string; location: LocationInfo } {
+    let errorType: string
+    let errorInfo: ParserErrorInfo | undefined
+    let location: LocationInfo
+
+    // The error the parser returns should either be an object where the key is the error type and the
+    // value for that key is the error details, or a string denothing the error type for the general file.
+    // We place errors for the entire file at the first line/column of the doc. If something else we
+    // throw an error.
+    try {
+        if (typeof error === 'object') {
+            ;[errorType, errorInfo] = Object.entries(error)[0] as [string, ParserErrorInfo]
+            // Check whether the error type is one of the correctly handled types.
+            if (!expectedParserErrorTypes.includes(errorType))
+                throw new Error('partiql error parsing error: unexpected parser error type')
+            location = { start: errorInfo.location.start, end: errorInfo.location.end }
+        } else if (typeof error === 'string') {
+            // Check whether the error type is one of the correctly handled types.
+            if (!expectedParserErrorTypes.includes(error))
+                throw new Error('partiql error parsing error: unexpected parser error type')
+            errorType = error
+            location = { start: 0, end: 0 }
+        } else {
+            throw new Error('partiql error parsing error: parser error not object or string')
+        }
+        // If no error was thrown at this point, we know the error type matches our expectation,
+        // try to construct the error string corresponding to the type from the info provided.
+        return { message: createStringFromParserError(errorType, errorInfo), location: location }
+    } catch (e) {
+        if (e instanceof Error && e.message.startsWith('partiql error parsing error:')) {
+            const specificError = e.message.split(':')[1]
+            throw new Error(`Output from PartiQL parser does not have the expected format: ${specificError}.`)
+        } else throw e
+    }
+}
+
+// Convert the errors reported by the parser to a human-readable string following
+// the errors found in https://github.com/partiql/partiql-lang-rust/blob/5dc7c6e33666978654d3e4ed519209c2f8fc3038/partiql-parser/src/error.rs.
+export function createStringFromParserError(errorType: string, errorInfo?: ParserErrorInfo) {
+    switch (errorType) {
+        case 'SyntaxError':
+            if (!isSyntaxErrorInfo(errorInfo))
+                throw new Error('partiql error parsing error: SyntaxError unexpected format')
+            return `Syntax Error: ${errorInfo.inner}.`
+
+        case 'UnexpectedEndOfInput':
+            return 'Unexpected end of input.'
+
+        case 'UnexpectedToken':
+            if (!isUnexptedTokenErrorInfo(errorInfo))
+                throw new Error('partiql error parsing error: UnexpectedToken unexpected format')
+            return `Unexpected token '${errorInfo.inner.token}'.`
+
+        case 'LexicalError':
+            if (!isLexicalErrorInfo(errorInfo))
+                throw new Error('partiql error parsing error: LexicalError unexpected format')
+            return convertObjectToLexerError(errorInfo.inner)
+
+        case 'IllegalState':
+            if (!isIllegalStateErrorInfo(errorInfo))
+                throw new Error('partiql error parsing error: IllegalState unexpected format')
+            return `Illegal State: ${errorInfo}.`
+
+        case 'Unknown':
+            'Unknown parse error.'
+
+        default:
+            // This code path is only reached when error type doesn't match any of the expected error types which
+            // should never happen when triggered by the error parsing process.
+            throw new Error('partiql error parsing error: unexpected parser error type')
+    }
+}
+
+function isSyntaxErrorInfo(errorInfo: ParserErrorInfo | undefined): errorInfo is SyntaxErrorInfo {
+    const syntaxErrorInfo = errorInfo as SyntaxErrorInfo
+    return !!syntaxErrorInfo && syntaxErrorInfo.inner !== undefined && typeof syntaxErrorInfo.inner === 'string'
+}
+function isUnexptedTokenErrorInfo(errorInfo: ParserErrorInfo | undefined): errorInfo is UnexpectedTokenErrorInfo {
+    const unexpectedTokenErrorInfo = errorInfo as UnexpectedTokenErrorInfo
+    return (
+        !!unexpectedTokenErrorInfo &&
+        unexpectedTokenErrorInfo.inner !== undefined &&
+        typeof unexpectedTokenErrorInfo.inner === 'object' &&
+        unexpectedTokenErrorInfo.inner.token !== undefined &&
+        typeof unexpectedTokenErrorInfo.inner.token === 'string'
+    )
+}
+function isIllegalStateErrorInfo(errorInfo: ParserErrorInfo | undefined): errorInfo is IllegalStateErrorInfo {
+    const illegalStateErrorInfo = errorInfo as IllegalStateErrorInfo
+    return !!illegalStateErrorInfo && typeof illegalStateErrorInfo === 'string'
+}
+function isLexicalErrorInfo(errorInfo: ParserErrorInfo | undefined): errorInfo is LexicalErrorInfo {
+    const lexicalErrorInfo = errorInfo as LexicalErrorInfo
+    return (
+        !!lexicalErrorInfo &&
+        !!lexicalErrorInfo.inner &&
+        (typeof lexicalErrorInfo.inner === 'string' || typeof lexicalErrorInfo.inner === 'object')
+    )
+}

--- a/server/aws-lsp-partiql/src/server/language-server.test.ts
+++ b/server/aws-lsp-partiql/src/server/language-server.test.ts
@@ -1,0 +1,82 @@
+import { Server } from '@aws/language-server-runtimes/server-interface'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { TextDocumentItem } from 'vscode-languageserver-types'
+import { PartiQLServerFactory } from './language-server'
+import { createPartiQLLanguageService } from './language-service'
+
+// Here we test that the language service doValidation handler gets called at
+// the expected events. Tests that the service does what is expected can be found
+// in the service test file.
+describe('PartiQL Server', () => {
+    let features: TestFeatures
+    let server: Server
+
+    let service: ReturnType<typeof createPartiQLLanguageService>
+    let validationSpy: jest.SpyInstance
+    let loggingSpy: jest.SpyInstance
+
+    beforeEach(async () => {
+        service = createPartiQLLanguageService()
+
+        // Spy on the doValidation handler of the lanaguage service
+        validationSpy = jest.spyOn(service, 'doValidation')
+
+        server = PartiQLServerFactory(service)
+
+        // Initialize the features, but don't start server yet
+        features = new TestFeatures()
+
+        // Spy on the log handler of the logging feature
+        loggingSpy = jest.spyOn(features.logging, 'log')
+
+        // Start the server and open a document
+        await features.start(server)
+        features.openDocument(validationFile)
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+        features.dispose()
+    })
+
+    it('should validate when change document', async () => {
+        expect(validationSpy).toHaveBeenCalledTimes(0)
+        await features.doChangeTextDocument({
+            textDocument: validationFile,
+            contentChanges: [],
+        })
+        expect(validationSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should validate when open document', async () => {
+        expect(validationSpy).toHaveBeenCalledTimes(0)
+        await features.doOpenTextDocument({
+            textDocument: validationOpenFileItem,
+        })
+        expect(validationSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should log when receiving change notification for unknown file', async () => {
+        await features.doChangeTextDocument({
+            textDocument: unknownValidationFile,
+            contentChanges: [],
+        })
+        expect(loggingSpy).toHaveBeenCalledWith('textDocument [file:///testUnknownPartiQLvalidation.json] not found')
+    })
+})
+
+const validationContent = `SELECT FROM env`
+const validationFile = TextDocument.create('file:///testPartiQLvalidation.json', 'partiql', 1, validationContent)
+const validationOpenFileItem = TextDocumentItem.create(
+    'file:///testPartiQLnewfilevalidation.json',
+    'partiql',
+    1,
+    validationContent
+)
+const unknownValidationFile = TextDocument.create(
+    'file:///testUnknownPartiQLvalidation.json',
+    'partiql',
+    1,
+    validationContent
+)

--- a/server/aws-lsp-partiql/src/server/language-server.ts
+++ b/server/aws-lsp-partiql/src/server/language-server.ts
@@ -1,6 +1,10 @@
-import { type DidChangeTextDocumentParams, type Server } from '@aws/language-server-runtimes/server-interface'
-import { TextDocumentSyncKind, type DidOpenTextDocumentParams } from 'vscode-languageserver'
-import { TextDocument } from 'vscode-languageserver-textdocument'
+import {
+    TextDocument,
+    TextDocumentSyncKind,
+    type DidChangeTextDocumentParams,
+    type DidOpenTextDocumentParams,
+    type Server,
+} from '@aws/language-server-runtimes/server-interface'
 import { createPartiQLLanguageService } from './language-service'
 
 export const PartiQLServerFactory =

--- a/server/aws-lsp-partiql/src/server/language-server.ts
+++ b/server/aws-lsp-partiql/src/server/language-server.ts
@@ -1,0 +1,72 @@
+import { type DidChangeTextDocumentParams, type Server } from '@aws/language-server-runtimes/server-interface'
+import { TextDocumentSyncKind, type DidOpenTextDocumentParams } from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { createPartiQLLanguageService } from './language-service'
+
+export const PartiQLServerFactory =
+    (service: any): Server =>
+    ({ lsp, workspace, telemetry, logging }) => {
+        const onInitializeHandler = () => {
+            return {
+                capabilities: {
+                    hoverProvider: false,
+                    textDocumentSync: {
+                        openClose: true,
+                        change: TextDocumentSyncKind.Incremental,
+                    },
+                },
+            }
+        }
+
+        const onInitializedHandler = async () => {}
+
+        const onDidChangeTextDocumentHandler = async (params: DidChangeTextDocumentParams): Promise<any> => {
+            const textDocument = await workspace.getTextDocument(params.textDocument.uri)
+            if (!textDocument) {
+                logging.log(`textDocument [${params.textDocument.uri}] not found`)
+                return
+            }
+
+            const diagnostics = await service.doValidation(textDocument)
+
+            await lsp.publishDiagnostics({
+                uri: params.textDocument.uri,
+                diagnostics: diagnostics,
+                version: textDocument.version,
+            })
+        }
+
+        const onDidOpenTextDocumentHandler = async (params: DidOpenTextDocumentParams): Promise<any> => {
+            let textDocument = await workspace.getTextDocument(params.textDocument.uri)
+            if (!textDocument) {
+                textDocument = TextDocument.create(
+                    params.textDocument.uri,
+                    params.textDocument.languageId,
+                    params.textDocument.version,
+                    params.textDocument.text
+                )
+            }
+
+            const diagnostics = await service.doValidation(textDocument)
+
+            await lsp.publishDiagnostics({
+                uri: params.textDocument.uri,
+                diagnostics: diagnostics,
+                version: textDocument.version,
+            })
+        }
+
+        lsp.onInitialized(onInitializedHandler)
+        lsp.onDidChangeTextDocument(onDidChangeTextDocumentHandler)
+        lsp.onDidOpenTextDocument(onDidOpenTextDocumentHandler)
+        lsp.addInitializer(onInitializeHandler)
+
+        logging.log('The PartiQL LSP Language Server has been initialised')
+
+        // disposable
+        return () => {
+            // Do nothing
+        }
+    }
+
+export const PartiQLLanguageServer = PartiQLServerFactory(createPartiQLLanguageService())

--- a/server/aws-lsp-partiql/src/server/language-service.test.ts
+++ b/server/aws-lsp-partiql/src/server/language-service.test.ts
@@ -1,0 +1,184 @@
+import partiQlServerBinary from '../partiql-parser-wasm/partiql-wasm-parser-inline'
+import { initSync, parse_as_json } from '../partiql-parser-wasm/partiql_playground'
+import { convertObjectToLexerError, createStringFromLexerError } from './error-parsing/lexer-errors'
+import { convertObjectToParserError, createStringFromParserError } from './error-parsing/parser-errors'
+import { normalizeQuery } from './language-service'
+
+type parserTestDataType = { input: string; expectedOutput: string; errorType: string }
+
+const parserTestData: parserTestDataType[] = [
+    // Parser errors
+    // SyntaxError - Couldn't find input to trigger these errors.
+    { input: 'SELECT', expectedOutput: 'Unexpected end of input.', errorType: 'UnexpectedEndOfInput' },
+    { input: 'SELECT FROM', expectedOutput: "Unexpected token 'FROM'.", errorType: 'UnexpectedToken' },
+    // IllegalState - Couldn't find input to trigger these errors.
+
+    // Lexer errors
+    { input: '🥝', expectedOutput: 'Lexing error: invalid input: 🥝.', errorType: 'InvalidInput' },
+    { input: '`', expectedOutput: 'Lexing error: unterminated ion literal.', errorType: 'UnterminatedIonLiteral' },
+    { input: '/*', expectedOutput: 'Lexing error: unterminated comment.', errorType: 'UnterminatedComment' },
+]
+
+describe('PartiQL validation parsing', () => {
+    // Instantiate the PartiQL parser.
+    initSync(partiQlServerBinary)
+
+    parserTestData.forEach(testData => {
+        it(`should correctly parse errors for ${testData.errorType}.`, async () => {
+            const parsedQuery = JSON.parse(parse_as_json(normalizeQuery(testData.input)))
+            const error = parsedQuery.errors[0]
+            const diagnosticsMessage = convertObjectToParserError(error).message
+            expect(diagnosticsMessage).toBe(testData.expectedOutput)
+        })
+    })
+})
+
+type edgeCaseParserDataType = { input: any; name: string; specificErrorString: string }
+
+// These inputs should all throw errors.
+const edgeCaseParserTestData: edgeCaseParserDataType[] = [
+    // SyntaxErrror
+    {
+        name: 'syntax error has no token',
+        input: 'SyntaxError',
+        specificErrorString: 'SyntaxError unexpected format',
+    },
+    {
+        name: "syntax error doesn't have inner",
+        input: { SyntaxError: { outer: 'yay', location: { start: 0, end: 0 } } },
+        specificErrorString: 'SyntaxError unexpected format',
+    },
+    {
+        name: 'syntax error inner not a string',
+        input: { SyntaxError: { inner: () => {}, location: { start: 0, end: 0 } } },
+        specificErrorString: 'SyntaxError unexpected format',
+    },
+    // UnexpectedToken
+    {
+        name: 'unexpected token error has no token',
+        input: 'UnexpectedToken',
+        specificErrorString: 'UnexpectedToken unexpected format',
+    },
+    {
+        name: "unexpected token error doesn't have inner",
+        input: { UnexpectedToken: { outer: 'yay', location: { start: 0, end: 0 } } },
+        specificErrorString: 'UnexpectedToken unexpected format',
+    },
+    {
+        name: 'unexpected token error inner not a string',
+        input: { UnexpectedToken: { inner: () => {}, location: { start: 0, end: 0 } } },
+        specificErrorString: 'UnexpectedToken unexpected format',
+    },
+    // LexicalError
+    {
+        name: 'lexical error is not an object or string',
+        input: { LexicalError: { inner: () => {}, location: { start: 0, end: 0 } } },
+        specificErrorString: 'LexicalError unexpected format',
+    },
+    {
+        name: 'lexical error has no details',
+        input: 'LexicalError',
+        specificErrorString: 'LexicalError unexpected format',
+    },
+    {
+        name: 'invalid input lexical error has no token',
+        input: { LexicalError: { inner: 'InvalidInput', location: { start: 0, end: 0 } } },
+        specificErrorString: 'InvalidInput unexpected format',
+    },
+    {
+        name: "invalid input lexical error doesn't have inner",
+        input: { LexicalError: { inner: { InvalidInput: { outer: 'yay' } }, location: { start: 0, end: 0 } } },
+        specificErrorString: 'InvalidInput unexpected format',
+    },
+    {
+        name: 'invalid input lexical error inner not a string',
+        input: { LexicalError: { inner: { InvalidInput: { inner: () => {} } }, location: { start: 0, end: 0 } } },
+        specificErrorString: 'InvalidInput unexpected format',
+    },
+    {
+        name: 'lexical error has unexpected error type',
+        input: { LexicalError: { inner: 'WeirdUnexpectedError', location: { start: 0, end: 0 } } },
+        specificErrorString: 'unexpected lexer error type',
+    },
+    // IllegalState
+    {
+        name: 'illegal state error has details',
+        input: { IllegalState: { inner: 'yay', location: { start: 0, end: 0 } } },
+        specificErrorString: 'IllegalState unexpected format',
+    },
+    // Other
+    {
+        name: 'error is not an object or string',
+        input: () => {},
+        specificErrorString: 'parser error not object or string',
+    },
+    {
+        name: 'given unexpected error type',
+        input: 'WeirdUnexpectedError',
+        specificErrorString: 'unexpected parser error type',
+    },
+    {
+        name: 'given object with unexpected error type',
+        input: { WeirdUnexpectedError: { inner: '' } },
+        specificErrorString: 'unexpected parser error type',
+    },
+]
+
+describe('error parsing edge-cases', () => {
+    // These inputs should throw errors.
+    edgeCaseParserTestData.forEach(testData => {
+        it(`should throw when ${testData.name}.`, async () => {
+            expect(() => {
+                convertObjectToParserError(testData.input)
+            }).toThrowError(
+                `Output from PartiQL parser does not have the expected format:  ${testData.specificErrorString}.`
+            )
+        })
+    })
+
+    it('should throw error when parser string builder is called with unknown error type', () => {
+        expect(() => {
+            createStringFromParserError('WeirdUnexpectedError')
+        }).toThrowError('partiql error parsing error: unexpected parser error type')
+    })
+})
+
+it('should pass error on transparently if not partiql parser format error', () => {
+    expect(() => {
+        convertObjectToParserError({
+            SyntaxError: { inner: { token: 'cool token' }, noLocation: { noStart: 0, noEnd: 0 } },
+        })
+    }).toThrowError("Cannot read properties of undefined (reading 'start')")
+})
+
+// These inputs should all throw errors.
+const edgeCaseLexerTestData: edgeCaseParserDataType[] = [
+    {
+        name: 'lexical error is not an object or string',
+        input: () => {},
+        specificErrorString: 'partiql error parsing error: lexer error not object or string',
+    },
+    {
+        name: 'lexical error as object has unexpected type',
+        input: { WeirdUnexpectedError: { inner: '' } },
+        specificErrorString: 'partiql error parsing error: unexpected lexer error type',
+    },
+]
+
+describe('lexer error parsing edge-cases', () => {
+    // These inputs should throw errors. These tests are to handle specific cases which will normally be caught
+    // by the parsing before it reaches the lexer error parsing.
+    edgeCaseLexerTestData.forEach(testData => {
+        it(`should throw when ${testData.name}.`, async () => {
+            expect(() => {
+                convertObjectToLexerError(testData.input)
+            }).toThrowError(`${testData.specificErrorString}`)
+        })
+    })
+
+    it('should throw error when lexer string builder is called with unknown error type', () => {
+        expect(() => {
+            createStringFromLexerError('WeirdUnexpectedError')
+        }).toThrowError('partiql error parsing error: unexpected lexer error type')
+    })
+})

--- a/server/aws-lsp-partiql/src/server/language-service.ts
+++ b/server/aws-lsp-partiql/src/server/language-service.ts
@@ -1,8 +1,7 @@
-import type { Diagnostic } from 'vscode-languageserver-protocol'
-import { DiagnosticSeverity } from 'vscode-languageserver-protocol'
-import { TextDocument } from 'vscode-json-languageservice'
-import { parse_as_json, initSync } from '../partiql-parser-wasm/partiql_playground'
+import type { Diagnostic } from '@aws/language-server-runtimes/server-interface'
+import { DiagnosticSeverity, TextDocument } from '@aws/language-server-runtimes/server-interface'
 import partiQlServerBinary from '../partiql-parser-wasm/partiql-wasm-parser-inline'
+import { initSync, parse_as_json } from '../partiql-parser-wasm/partiql_playground'
 import { convertObjectToParserError } from './error-parsing/parser-errors'
 
 export function normalizeQuery(data: string): string {

--- a/server/aws-lsp-partiql/src/server/language-service.ts
+++ b/server/aws-lsp-partiql/src/server/language-service.ts
@@ -1,0 +1,39 @@
+import type { Diagnostic } from 'vscode-languageserver-protocol'
+import { DiagnosticSeverity } from 'vscode-languageserver-protocol'
+import { TextDocument } from 'vscode-json-languageservice'
+import { parse_as_json, initSync } from '../partiql-parser-wasm/partiql_playground'
+import partiQlServerBinary from '../partiql-parser-wasm/partiql-wasm-parser-inline'
+import { convertObjectToParserError } from './error-parsing/parser-errors'
+
+export function normalizeQuery(data: string): string {
+    return data != null ? data.replace(/\"/g, '\\"') : ''
+}
+
+export function createPartiQLLanguageService() {
+    return new PartiQLLanguageService()
+}
+
+class PartiQLLanguageService {
+    constructor() {
+        initSync(partiQlServerBinary)
+    }
+
+    public doValidation(textDocument: TextDocument): Diagnostic[] {
+        const parsedQuery = JSON.parse(parse_as_json(normalizeQuery(textDocument.getText())))
+
+        const diagnostics: Diagnostic[] = []
+        for (const error of parsedQuery.errors || []) {
+            const { message, location } = convertObjectToParserError(error)
+
+            diagnostics.push({
+                severity: DiagnosticSeverity.Error,
+                range: {
+                    start: textDocument.positionAt(location.start),
+                    end: textDocument.positionAt(location.end),
+                },
+                message: message,
+            })
+        }
+        return diagnostics
+    }
+}

--- a/server/aws-lsp-partiql/test-utils/esm-transformer.js
+++ b/server/aws-lsp-partiql/test-utils/esm-transformer.js
@@ -1,0 +1,9 @@
+const babelJestModule = require('babel-jest')
+const babelJest = babelJestModule.default
+
+module.exports = babelJest.createTransformer({
+    plugins: [
+        require.resolve('@babel/plugin-transform-modules-commonjs'),
+        require.resolve('babel-plugin-transform-import-meta'),
+    ],
+})

--- a/server/aws-lsp-partiql/tsconfig.json
+++ b/server/aws-lsp-partiql/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./out"
+    },
+    "include": ["src"]
+}

--- a/server/aws-lsp-partiql/tsconfig.json
+++ b/server/aws-lsp-partiql/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../tsconfig.packages.json",
     "compilerOptions": {
         "rootDir": "./src",
-        "outDir": "./out"
+        "outDir": "./out",
+        "allowJs": true
     },
     "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -68,6 +68,9 @@
         },
         {
             "path": "./app/aws-lsp-yaml-json-webworker"
+        },
+        {
+            "path": "./app/aws-lsp-partiql-binary"
         }
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,6 +46,9 @@
             "path": "./server/aws-lsp-yaml-json"
         },
         {
+            "path": "./server/aws-lsp-partiql"
+        },
+        {
             "path": "./app/aws-lsp-buildspec-binary"
         },
         {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,7 +46,7 @@
             "path": "./server/aws-lsp-yaml-json"
         },
         {
-            "path": "./server/aws-lsp-partiql"
+            "path": "./server/lsp-partiql"
         },
         {
             "path": "./app/aws-lsp-buildspec-binary"
@@ -70,7 +70,7 @@
             "path": "./app/aws-lsp-yaml-json-webworker"
         },
         {
-            "path": "./app/aws-lsp-partiql-binary"
+            "path": "./app/lsp-partiql-binary"
         }
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,7 +46,7 @@
             "path": "./server/aws-lsp-yaml-json"
         },
         {
-            "path": "./server/lsp-partiql"
+            "path": "./server/aws-lsp-partiql"
         },
         {
             "path": "./app/aws-lsp-buildspec-binary"
@@ -70,7 +70,7 @@
             "path": "./app/aws-lsp-yaml-json-webworker"
         },
         {
-            "path": "./app/lsp-partiql-binary"
+            "path": "./app/aws-lsp-partiql-binary"
         }
     ]
 }


### PR DESCRIPTION
## Problem

Adds an LSP server for the [PartiQL language](https://partiql.org/). This server offers diagnostics for PartiQL files by parsing the file using the [Rust parser maintained by the PartiQL team](https://github.com/partiql/partiql-lang-rust).

This parser is compiled to a WebAssembly binary using the bindings maintained by the PartiQL team in the [PartiQL playground package](https://github.com/partiql/partiql-rust-playground). This binary is further encoded as a base64 string in a Javascript file to make it easy to be bundled together with the other assets of the server. See the README for instructions on how to update the binary.

## Solution

- Tested the server wrapped in the standalone runtime in VS Code:

<img width="536" alt="Screenshot 2024-05-20 at 23 54 32" src="https://github.com/aws/language-servers/assets/34573235/ede3ee89-e809-43b4-a7dc-b30f5a116728">

- Tested the server wrapped in the webworker runtime a web-based LSP client.
- Added unit tests covering both the server and the service.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
