### PR TITLE
Increment aws-lsp-codewhisperer version to 0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13820,7 +13820,7 @@
         },
         "server/aws-lsp-codewhisperer": {
             "name": "@aws/lsp-codewhisperer",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "Apache-2.0",
             "workspaces": [
                 "src.gen/@amzn/codewhisperer-streaming"

--- a/server/aws-lsp-codewhisperer/CHANGELOG.md
+++ b/server/aws-lsp-codewhisperer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.6] - 2024-05-23
+- Send telemetry for vote, copyCodeToClipboard and authFollowUpClicked events
+- Rename CodeWhisperer to Amazon Q
+
 ## [0.0.5] - 2024-05-15
 - Create Chat server export it for consumption
 - Fix duplicate hover message in security scan

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/lsp-codewhisperer",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "CodeWhisperer Language Server",
     "main": "out/index.js",
     "repository": {


### PR DESCRIPTION
## Problem
We need to bump a version of CodeWhisperer server for release
## Solution
Version is bumped to 0.0.6


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
