### PR TITLE
Allow upgrading runtime packages within 0.x.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,11 +74,11 @@
             }
         },
         "app/aws-lsp-partiql-binary": {
-            "name": "@aws/aws-lsp-partiql-binary",
+            "name": "@aws/lsp-partiql-binary",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/aws-lsp-partiql": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.5"
+                "@aws/language-server-runtimes": "^0.2.5",
+                "@aws/lsp-partiql": "^0.0.1"
             },
             "bin": {
                 "aws-lsp-partiql-binary": "out/aws-lsp-partiql-binary.js"
@@ -1708,14 +1708,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws/aws-lsp-partiql": {
-            "resolved": "server/aws-lsp-partiql",
-            "link": true
-        },
-        "node_modules/@aws/aws-lsp-partiql-binary": {
-            "resolved": "app/aws-lsp-partiql-binary",
-            "link": true
-        },
         "node_modules/@aws/aws-lsp-yaml-json": {
             "resolved": "server/aws-lsp-yaml-json",
             "link": true
@@ -1803,6 +1795,14 @@
         },
         "node_modules/@aws/lsp-json-common": {
             "resolved": "core/aws-lsp-json-common",
+            "link": true
+        },
+        "node_modules/@aws/lsp-partiql": {
+            "resolved": "server/aws-lsp-partiql",
+            "link": true
+        },
+        "node_modules/@aws/lsp-partiql-binary": {
+            "resolved": "app/aws-lsp-partiql-binary",
             "link": true
         },
         "node_modules/@aws/lsp-s3": {
@@ -17226,8 +17226,8 @@
             ],
             "dependencies": {
                 "@amzn/codewhisperer-streaming": "file:./src.gen/@amzn/codewhisperer-streaming",
-                "@aws/language-server-runtimes": "^0.2.5",
-                "@aws/language-server-runtimes-types": "^0.0.2",
+                "@aws/language-server-runtimes": "0.x.x",
+                "@aws/language-server-runtimes-types": "0.x.x",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
                 "aws-sdk": "^2.1403.0",
@@ -17441,14 +17441,12 @@
             }
         },
         "server/aws-lsp-partiql": {
-            "name": "@aws/aws-lsp-partiql",
+            "name": "@aws/lsp-partiql",
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.4",
-                "@aws/lsp-core": "^0.0.1",
-                "vscode-languageserver": "^9.0.1",
-                "vscode-languageserver-textdocument": "^1.0.8"
+                "@aws/lsp-core": "^0.0.1"
             },
             "devDependencies": {
                 "@babel/plugin-transform-modules-commonjs": "^7.24.1",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -28,8 +28,8 @@
     },
     "dependencies": {
         "@amzn/codewhisperer-streaming": "file:./src.gen/@amzn/codewhisperer-streaming",
-        "@aws/language-server-runtimes": "^0.2.5",
-        "@aws/language-server-runtimes-types": "^0.0.2",
+        "@aws/language-server-runtimes": "0.x.x",
+        "@aws/language-server-runtimes-types": "0.x.x",
         "@smithy/node-http-handler": "^2.5.0",
         "hpagent": "^1.2.0",
         "adm-zip": "^0.5.10",


### PR DESCRIPTION
## Problem
In npm “^0.0.1” can be resolved only to “0.0.1", not “0.0.2” or “0.1.1".
 This is because npm considers a major version “the leftmost non zero digit”. So, “0.0.2" is a major version change.
https://docs.npmjs.com/cli/v6/using-npm/semver#caret-ranges-123-025-004
## Solution
Changed dependency to 0.x.x
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
