### PR TITLE
Create session if sesison doesn't exist in getSession

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -110,34 +110,29 @@ describe('ChatController', () => {
 
         sinon.assert.calledOnce(disposeStub)
 
-        const sessionResult = chatSessionManagementService.getSession(mockTabId)
+        const hasSession = chatSessionManagementService.hasSession(mockTabId)
 
-        sinon.assert.match(sessionResult, {
-            success: false,
-            error: sinon.match.string,
-        })
+        assert.ok(!hasSession)
     })
 
-    it('deletes a session by tab id a end chat request is received', () => {
+    it('deletes a session by tab id an end chat request is received', () => {
         chatController.onTabAdd({ tabId: mockTabId })
 
         chatController.onEndChat({ tabId: mockTabId }, mockCancellationToken)
 
         sinon.assert.calledOnce(disposeStub)
 
-        const sessionResult = chatSessionManagementService.getSession(mockTabId)
+        const hasSession = chatSessionManagementService.hasSession(mockTabId)
 
-        sinon.assert.match(sessionResult, {
-            success: false,
-            error: sinon.match.string,
-        })
+        assert.ok(!hasSession)
     })
 
     describe('onChatPrompt', () => {
         beforeEach(() => {
             chatController.onTabAdd({ tabId: mockTabId })
         })
-        it('throw error if session is not found', async () => {
+        it("throws error if credentials provider doesn't exist", async () => {
+            ChatSessionManagementService.getInstance().withCredentialsProvider(undefined as any)
             const result = await chatController.onChatPrompt(
                 { tabId: 'XXXX', prompt: { prompt: 'Hello' } },
                 mockCancellationToken

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -37,7 +37,7 @@ export class ChatController implements ChatHandlers {
         const { data: session } = sessionResult
 
         if (!session) {
-            this.#log('Session not found for tabId', params.tabId)
+            this.#log('Get session error', params.tabId)
             return new ResponseError<ChatResult>(
                 ErrorCodes.InvalidParams,
                 'error' in sessionResult ? sessionResult.error : 'Unknown error'

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
@@ -42,25 +42,19 @@ describe('ChatSessionManagementService', () => {
             disposeStub.restore()
         })
 
-        it('getSession should return an existing client if found', () => {
+        it('getSession should create a client if not found and returns existing client if found', () => {
             assert.ok(!chatSessionManagementService.hasSession(mockSessionId))
 
-            sinon.assert.match(chatSessionManagementService.getSession(mockSessionId), {
-                success: false,
-                error: sinon.match.string,
-            })
+            const result = chatSessionManagementService.getSession(mockSessionId)
 
-            const chatClientData = chatSessionManagementService.createSession(mockSessionId)
-
-            sinon.assert.match(chatClientData, {
+            sinon.assert.match(result, {
                 success: true,
                 data: sinon.match.instanceOf(ChatSessionService),
             })
 
             assert.ok(chatSessionManagementService.hasSession(mockSessionId))
 
-            // asserting object reference
-            assert.strictEqual(chatSessionManagementService.getSession(mockSessionId).data, chatClientData.data)
+            assert.strictEqual(chatSessionManagementService.getSession(mockSessionId).data, result.data)
         })
 
         it('creating a session with an existing id should return an error', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
@@ -65,15 +65,8 @@ export class ChatSessionManagementService {
 
     public getSession(tabId: string): Result<ChatSessionService, string> {
         const session = this.#sessionByTab.get(tabId)
-        return session
-            ? {
-                  success: true,
-                  data: session,
-              }
-            : {
-                  success: false,
-                  error: 'Session does not exist',
-              }
+
+        return session ? { success: true, data: session } : this.createSession(tabId)
     }
 
     public deleteSession(tabId: string): Result<void, string> {


### PR DESCRIPTION
## Description
We want to be able to initialize chat UI with a tab already created. The validation in `getSession` is not a critical check so I think we can just relax it.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
