### PR TITLE
Update `patchYamlJsonPackage.js` to handle paths with spaces in `applyPatch`

### DIFF
--- a/server/aws-lsp-yaml-json/patchYamlJsonPackage.js
+++ b/server/aws-lsp-yaml-json/patchYamlJsonPackage.js
@@ -1,4 +1,4 @@
-const execSync = require('child_process').execSync
+const execFileSync = require('child_process').execFileSync
 const fs = require('node:fs')
 
 const pathToYamlPackage = require.resolve('yaml-language-server')
@@ -35,9 +35,13 @@ const filePathToPatchPathUnsafeEval = {
 function applyPatch(filePathToPatchPath) {
     for (var filePath in filePathToPatchPath) {
         const pathToPatch = `${__dirname}/${filePathToPatchPath[filePath]}`
-        const script = `cd ${rootPackage} && patch ${filePath} ${pathToPatch}`
-        console.log(script)
-        const output = execSync(script, { encoding: 'utf-8', timeout: 2000 })
+        const patchProc = execFileSync('patch', [filePath, pathToPatch], { cwd: rootPackage, encoding: 'utf-8', timeout: 2000 })
+
+        console.log({
+            cmd: patchProc.spawnfile,
+            args: patchProc.spawnargs,
+            cwd: rootPackage,
+        });
     }
 }
 


### PR DESCRIPTION
## Problem

When `language-servers` is checked out under a directory that contains spaces in the full path, `npm install` will fail to complete due to `patchYamlJsonPackage.js`.

## Solution

This commit fixes this issue by ensuring file paths are quoted to support spaces in them.

### Testing

Ensured `npm install` succeeds in a directory with spaces in the full path (i.e. under a user's `Application Support` folder for Sublime Text on OS X).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
