### PR TITLE
Release @aws/lsp-partiql v0.0.1 to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20806,8 +20806,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.4",
-                "@aws/lsp-core": "^0.0.1"
+                "@aws/language-server-runtimes": "^0.2.4"
             },
             "devDependencies": {
                 "@babel/plugin-transform-modules-commonjs": "^7.24.1",

--- a/server/aws-lsp-partiql/.npmignore
+++ b/server/aws-lsp-partiql/.npmignore
@@ -1,0 +1,5 @@
+src/
+node_modules/
+package-lock.json
+.*
+tsconfig.*

--- a/server/aws-lsp-partiql/CHANGELOG.md
+++ b/server/aws-lsp-partiql/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [0.0.1] - 2024-05-31
+- Initial release of PArtiQL Language Server implementation

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -4,6 +4,10 @@
     "license": "Apache-2.0",
     "description": "PartiQL language server",
     "version": "0.0.1",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/aws/language-servers"
+    },
     "main": "out/index.js",
     "types": "out/index.d.ts",
     "scripts": {
@@ -17,8 +21,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.4",
-        "@aws/lsp-core": "^0.0.1"
+        "@aws/language-server-runtimes": "^0.2.4"
     },
     "devDependencies": {
         "babel-plugin-transform-import-meta": "^2.2.1",


### PR DESCRIPTION
## Problem
We want to release existing PartiQL server as npm package.

## Solution

Prepared `server/aws-lsp-partiql` project for npm release

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
