### PR TITLE
Escape backticks in user prompts

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -30,6 +30,16 @@ export interface InboundChatApi {
     showError(params: ErrorParams): void
 }
 
+function createMarkdownCodeBlock(input: string) {
+    // Determine the number of backticks in the input
+    const backtickCount = (input.match(/`+/g) || []).map(ticks => ticks.length).sort((a, b) => b - a)[0] || 0
+
+    // Use a backtick delimiter that is 3 greater than the maximum found in the input
+    const delimiter = '`'.repeat(backtickCount + 3)
+
+    return `\n${delimiter}\n${input}\n${delimiter}\n`
+}
+
 export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [MynahUI, InboundChatApi] => {
     const handleChatPrompt = (mynahUi: MynahUI, tabId: string, prompt: ChatPrompt, _eventId?: string) => {
         // Send chat prompt to server
@@ -273,7 +283,7 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
         const tabId = getOrCreateTabId()
         if (!tabId) return
 
-        const markdownSelection = ['\n```\n', params.selection, '\n```'].join('')
+        const markdownSelection = createMarkdownCodeBlock(params.selection)
 
         mynahUi.addToUserPrompt(tabId, markdownSelection)
         messager.onSendToPrompt(params, tabId)


### PR DESCRIPTION
## Problem

Right now the way we create markdown code blocks for `send to prompt` is a bit too naive and is prone to breaking when a user selection contains backticks. See for example:

<img width="977" alt="image" src="https://github.com/aws/language-servers/assets/28572423/c98f2253-0d93-408a-99b7-1dd97ae8e607">


## Solution

To overcome this, we can implement a function that finds the longest backtick sequence inside a provided user selection and then creates the markdown code block with more backticks than that amount

This has the small caveat that codeblocks with backticks will now consume more of the character limit 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
