### PR TITLE
Update latest chat-ui-types dependency

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -134,7 +134,7 @@
     },
     "devDependencies": {
         "@aws/language-server-runtimes": "^0.2.5",
-        "@aws/chat-client-ui-types": "0.0.3",
+        "@aws/chat-client-ui-types": "0.x.x",
         "@aws-sdk/credential-providers": "^3.540.0",
         "@aws-sdk/types": "^3.535.0",
         "@types/vscode": "^1.88.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -239,7 +239,7 @@
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.540.0",
                 "@aws-sdk/types": "^3.535.0",
-                "@aws/chat-client-ui-types": "0.0.3",
+                "@aws/chat-client-ui-types": "0.x.x",
                 "@aws/language-server-runtimes": "^0.2.5",
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",


### PR DESCRIPTION
## Problem
We want to use latest chat-client-ui-types version
## Solution
Consume latest version of the package
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
