### PR TITLE
Added Quick Actions support to Chat Client

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+    "printWidth": 120,
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "singleQuote": true,
+    "semi": false,
+    "bracketSpacing": true,
+    "arrowParens": "avoid",
+    "endOfLine": "lf"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -116,8 +116,8 @@
                 "LSP_SERVER": "${workspaceFolder}/app/hello-world-lsp-runtimes/out/standalone.js",
                 "ENABLE_CUSTOM_COMMANDS": "true",
                 "ENABLE_CHAT": "true"
-            }
-            // "preLaunchTask": "npm: compile"
+            },
+            "preLaunchTask": "npm: compile"
         },
         {
             "type": "node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -114,9 +114,10 @@
             "outFiles": ["${workspaceFolder}/client/vscode/out/**/*.js"],
             "env": {
                 "LSP_SERVER": "${workspaceFolder}/app/hello-world-lsp-runtimes/out/standalone.js",
-                "ENABLE_CUSTOM_COMMANDS": "true"
-            },
-            "preLaunchTask": "npm: compile"
+                "ENABLE_CUSTOM_COMMANDS": "true",
+                "ENABLE_CHAT": "true"
+            }
+            // "preLaunchTask": "npm: compile"
         },
         {
             "type": "node",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,8 @@
         "editor.insertSpaces": true,
         "editor.codeActionsOnSave": {
             "source.fixAll.eslint": "explicit",
-            "source.organizeImports": "explicit",
-            "source.sortMembers": "explicit"
+            "source.organizeImports": "never",
+            "source.sortMembers": "never"
         },
         "editor.formatOnSave": true
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,9 @@
     "[typescript]": {
         "editor.insertSpaces": true,
         "editor.codeActionsOnSave": {
-            "source.fixAll.eslint": true,
-            "source.organizeImports": true,
-            "source.sortMembers": true
+            "source.fixAll.eslint": "explicit",
+            "source.organizeImports": "explicit",
+            "source.sortMembers": "explicit"
         },
         "editor.formatOnSave": true
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "typescript.preferences.quoteStyle": "single",
+    "typescript.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false,
     "[typescript]": {
         "editor.insertSpaces": true,
         "editor.codeActionsOnSave": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -7,7 +7,7 @@
         "hello-world-lsp-binary": "./out/standalone.js"
     },
     "scripts": {
-        "bundle": "npm run compile && npm run webpack && npm run package-x64",
+        "bundle": "npm run compile && npm run webpack # && npm run package-x64",
         "clean": "rm -rf out/ bin/ tsconfig.tsbuildinfo",
         "compile": "tsc --build",
         "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --output bin/hello-world-lsp-binary --compress GZip .",

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -7,7 +7,7 @@
         "hello-world-lsp-binary": "./out/standalone.js"
     },
     "scripts": {
-        "bundle": "npm run compile && npm run webpack # && npm run package-x64",
+        "bundle": "npm run compile && npm run webpack && npm run package-x64",
         "clean": "rm -rf out/ bin/ tsconfig.tsbuildinfo",
         "compile": "tsc --build",
         "package-x64": "pkg --targets node18-linux-x64,node18-win-x64,node18-macos-x64 --output bin/hello-world-lsp-binary --compress GZip .",

--- a/app/hello-world-lsp-runtimes/webpack.config.js
+++ b/app/hello-world-lsp-runtimes/webpack.config.js
@@ -50,4 +50,4 @@ const webConfig = {
     ],
 }
 
-module.exports = [nodeConfig, webConfig]
+module.exports = [nodeConfig]

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -10,39 +10,33 @@ import {
     InsertToCursorPositionParams,
     SEND_TO_PROMPT,
     SendToPromptMessage,
-    TAB_ID_RECEIVED,
-    TabIdReceivedParams,
     UiMessage,
 } from '@aws/chat-client-ui-types'
 import {
+    CHAT_REQUEST_METHOD,
     ChatParams,
+    FEEDBACK_NOTIFICATION_METHOD,
+    FOLLOW_UP_CLICK_NOTIFICATION_METHOD,
     FeedbackParams,
     FollowUpClickParams,
+    INFO_LINK_CLICK_NOTIFICATION_METHOD,
     InfoLinkClickParams,
+    LINK_CLICK_NOTIFICATION_METHOD,
     LinkClickParams,
+    QUICK_ACTION_REQUEST_METHOD,
     QuickActionParams,
+    READY_NOTIFICATION_METHOD,
+    SOURCE_LINK_CLICK_NOTIFICATION_METHOD,
     SourceLinkClickParams,
+    TAB_ADD_NOTIFICATION_METHOD,
+    TAB_CHANGE_NOTIFICATION_METHOD,
+    TAB_REMOVE_NOTIFICATION_METHOD,
     TabAddParams,
     TabChangeParams,
     TabRemoveParams,
 } from '@aws/language-server-runtimes-types'
 import { MynahUIDataModel } from '@aws/mynah-ui'
-import {
-    CHAT_PROMPT,
-    FEEDBACK,
-    FOLLOW_UP_CLICKED,
-    INFO_LINK_CLICK,
-    LINK_CLICK,
-    NEW_TAB_CREATED,
-    QUICK_ACTION_COMMAND,
-    SOURCE_LINK_CLICK,
-    ServerMessage,
-    TAB_CHANGED,
-    TAB_REMOVED,
-    TELEMETRY,
-    TelemetryParams,
-    UI_IS_READY,
-} from '../contracts/serverContracts'
+import { ServerMessage, TELEMETRY, TelemetryParams } from '../contracts/serverContracts'
 import { ENTER_FOCUS, EXIT_FOCUS } from '../contracts/telemetry'
 import { Messager, OutboundChatApi } from './messager'
 import { InboundChatApi, createMynahUi } from './mynahUi'
@@ -75,7 +69,7 @@ export const createChat = (
         const message = event.data
 
         switch (message?.command) {
-            case CHAT_PROMPT:
+            case CHAT_REQUEST_METHOD:
                 mynahApi.addChatResponse(message.params, message.tabId, message.isPartialResult)
                 break
             case SEND_TO_PROMPT:
@@ -100,25 +94,22 @@ export const createChat = (
 
     const chatApi: OutboundChatApi = {
         sendChatPrompt: (params: ChatParams) => {
-            sendMessageToClient({ command: CHAT_PROMPT, params })
+            sendMessageToClient({ command: CHAT_REQUEST_METHOD, params })
         },
         sendQuickActionCommand: (params: QuickActionParams) => {
-            sendMessageToClient({ command: QUICK_ACTION_COMMAND, params })
-        },
-        tabIdReceived: (params: TabIdReceivedParams) => {
-            sendMessageToClient({ command: TAB_ID_RECEIVED, params })
+            sendMessageToClient({ command: QUICK_ACTION_REQUEST_METHOD, params })
         },
         telemetry: (params: TelemetryParams) => {
             sendMessageToClient({ command: TELEMETRY, params })
         },
         tabAdded: (params: TabAddParams) => {
-            sendMessageToClient({ command: NEW_TAB_CREATED, params })
+            sendMessageToClient({ command: TAB_ADD_NOTIFICATION_METHOD, params })
         },
         tabChanged: (params: TabChangeParams) => {
-            sendMessageToClient({ command: TAB_CHANGED, params })
+            sendMessageToClient({ command: TAB_CHANGE_NOTIFICATION_METHOD, params })
         },
         tabRemoved: (params: TabRemoveParams) => {
-            sendMessageToClient({ command: TAB_REMOVED, params })
+            sendMessageToClient({ command: TAB_REMOVE_NOTIFICATION_METHOD, params })
         },
         insertToCursorPosition: (params: InsertToCursorPositionParams) => {
             sendMessageToClient({ command: INSERT_TO_CURSOR_POSITION, params })
@@ -127,23 +118,23 @@ export const createChat = (
             sendMessageToClient({ command: AUTH_FOLLOW_UP_CLICKED, params })
         },
         followUpClicked: (params: FollowUpClickParams) => {
-            sendMessageToClient({ command: FOLLOW_UP_CLICKED, params })
+            sendMessageToClient({ command: FOLLOW_UP_CLICK_NOTIFICATION_METHOD, params })
         },
         sendFeedback: (params: FeedbackParams) => {
-            sendMessageToClient({ command: FEEDBACK, params })
+            sendMessageToClient({ command: FEEDBACK_NOTIFICATION_METHOD, params })
         },
         linkClick: (params: LinkClickParams) => {
-            sendMessageToClient({ command: LINK_CLICK, params })
+            sendMessageToClient({ command: LINK_CLICK_NOTIFICATION_METHOD, params })
         },
         sourceLinkClick: (params: SourceLinkClickParams) => {
-            sendMessageToClient({ command: SOURCE_LINK_CLICK, params })
+            sendMessageToClient({ command: SOURCE_LINK_CLICK_NOTIFICATION_METHOD, params })
         },
         infoLinkClick: (params: InfoLinkClickParams) => {
-            sendMessageToClient({ command: INFO_LINK_CLICK, params })
+            sendMessageToClient({ command: INFO_LINK_CLICK_NOTIFICATION_METHOD, params })
         },
         uiReady: () => {
             sendMessageToClient({
-                command: UI_IS_READY,
+                command: READY_NOTIFICATION_METHOD,
             })
 
             window.addEventListener('message', handleMessage)

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -49,11 +49,11 @@ const DEFAULT_TAB_DATA = {
     promptInputPlaceholder: 'Ask a question or enter "/" for quick actions',
 }
 
-type chatClientConfig = Pick<MynahUIDataModel, 'quickActionCommands'>
+type ChatClientConfig = Pick<MynahUIDataModel, 'quickActionCommands'>
 
 export const createChat = (
     clientApi: { postMessage: (msg: UiMessage | ServerMessage) => void },
-    config?: chatClientConfig
+    config?: ChatClientConfig
 ) => {
     // eslint-disable-next-line semi
     let mynahApi: InboundChatApi

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -61,10 +61,7 @@ export class Messager {
     }
 
     onSendToPrompt = (params: SendToPromptParams, tabId: string): void => {
-        // this.chatApi.tabIdReceived({
-        //     eventId: params.eventId,
-        //     tabId: tabId,
-        // })
+        this.chatApi.telemetry({ ...params, tabId })
     }
 
     onChatPrompt = (params: ChatParams): void => {
@@ -113,9 +110,6 @@ export class Messager {
     }
 
     onError = (params: ErrorParams): void => {
-        // this.chatApi.tabIdReceived({
-        //     eventId: params.eventId || '',
-        //     tabId: params.tabId,
-        // })
+        this.chatApi.telemetry(params)
     }
 }

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -8,7 +8,6 @@ import {
     ErrorParams,
     InsertToCursorPositionParams,
     SendToPromptParams,
-    TabIdReceivedParams,
 } from '@aws/chat-client-ui-types'
 import {
     ChatParams,
@@ -31,7 +30,6 @@ export interface OutboundChatApi {
     tabAdded(params: TabAddParams): void
     tabChanged(params: TabChangeParams): void
     tabRemoved(params: TabRemoveParams): void
-    tabIdReceived(params: TabIdReceivedParams): void
     telemetry(params: TelemetryParams): void
     insertToCursorPosition(params: InsertToCursorPositionParams): void
     authFollowUpClicked(params: AuthFollowUpClickedParams): void
@@ -63,10 +61,10 @@ export class Messager {
     }
 
     onSendToPrompt = (params: SendToPromptParams, tabId: string): void => {
-        this.chatApi.tabIdReceived({
-            eventId: params.eventId,
-            tabId: tabId,
-        })
+        // this.chatApi.tabIdReceived({
+        //     eventId: params.eventId,
+        //     tabId: tabId,
+        // })
     }
 
     onChatPrompt = (params: ChatParams): void => {
@@ -115,9 +113,9 @@ export class Messager {
     }
 
     onError = (params: ErrorParams): void => {
-        this.chatApi.tabIdReceived({
-            eventId: params.eventId || '',
-            tabId: params.tabId,
-        })
+        // this.chatApi.tabIdReceived({
+        //     eventId: params.eventId || '',
+        //     tabId: params.tabId,
+        // })
     }
 }

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -16,6 +16,7 @@ import {
     FollowUpClickParams,
     InfoLinkClickParams,
     LinkClickParams,
+    QuickActionParams,
     SourceLinkClickParams,
     TabAddParams,
     TabChangeParams,
@@ -26,6 +27,7 @@ import { CopyCodeToClipboardParams, VoteParams } from '../contracts/telemetry'
 
 export interface OutboundChatApi {
     sendChatPrompt(params: ChatParams): void
+    sendQuickActionCommand(params: QuickActionParams): void
     tabAdded(params: TabAddParams): void
     tabChanged(params: TabChangeParams): void
     tabRemoved(params: TabRemoveParams): void
@@ -69,6 +71,10 @@ export class Messager {
 
     onChatPrompt = (params: ChatParams): void => {
         this.chatApi.sendChatPrompt(params)
+    }
+
+    onQuickActionCommand = (params: QuickActionParams): void => {
+        this.chatApi.sendQuickActionCommand(params)
     }
 
     onInsertToCursorPosition = (params: InsertToCursorPositionParams): void => {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -32,8 +32,17 @@ export interface InboundChatApi {
 
 export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [MynahUI, InboundChatApi] => {
     const handleChatPrompt = (mynahUi: MynahUI, tabId: string, prompt: ChatPrompt, _eventId?: string) => {
-        // Send chat prompt to server
-        messager.onChatPrompt({ prompt, tabId })
+        if (prompt.command) {
+            // Send prompt when quick action command attached
+            messager.onQuickActionCommand({
+                quickAction: prompt.command,
+                prompt: prompt.prompt,
+                tabId,
+            })
+        } else {
+            // Send chat prompt to server
+            messager.onChatPrompt({ prompt, tabId })
+        }
 
         // Add user prompt to UI
         mynahUi.addChatItem(tabId, {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -236,21 +236,20 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
 
     const addChatResponse = (chatResult: ChatResult, tabId: string, isPartialResult: boolean) => {
         if (!chatResult.body) {
+            // No chat body on response means the /clear quick action
+            mynahUi.updateStore(tabId, {
+                chatItems: [],
+            })
+
+            mynahUi.updateStore(tabId, {
+                loadingChat: false,
+                promptInputDisabledState: false,
+            })
             return
         }
 
         if (isPartialResult) {
-            mynahUi.updateLastChatAnswer(tabId, {
-                body: chatResult.body,
-                messageId: chatResult.messageId,
-                followUp: chatResult.followUp,
-                relatedContent: chatResult.relatedContent,
-                canBeVoted: chatResult.canBeVoted,
-                // Currently there is a typo in the codeReference field in runtimes package leading to incompatibility between mynah and runtimes
-                // TODO, use spread syntax when https://github.com/aws/language-server-runtimes/pull/120 is released into a new version
-                // ...chatResult
-            })
-
+            mynahUi.updateLastChatAnswer(tabId, { ...chatResult })
             return
         }
 
@@ -294,9 +293,9 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
         const body = [
             params.genericCommand,
             ' the following part of my code:',
-            '\n```\n',
+            '\n~~~~\n',
             params.selection,
-            '\n```',
+            '\n~~~~',
         ].join('')
         const chatPrompt: ChatPrompt = { prompt: body, escapedPrompt: body }
 

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -33,6 +33,17 @@ export interface InboundChatApi {
 export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [MynahUI, InboundChatApi] => {
     const handleChatPrompt = (mynahUi: MynahUI, tabId: string, prompt: ChatPrompt, _eventId?: string) => {
         if (prompt.command) {
+            // Temporary solution to handle clear quick actions on the client side
+            if (prompt.command === '/clear') {
+                mynahUi.updateStore(tabId, {
+                    chatItems: [],
+                })
+
+                mynahUi.updateStore(tabId, {
+                    loadingChat: false,
+                    promptInputDisabledState: false,
+                })
+            }
             // Send prompt when quick action command attached
             messager.onQuickActionCommand({
                 quickAction: prompt.command,
@@ -235,19 +246,6 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
     }
 
     const addChatResponse = (chatResult: ChatResult, tabId: string, isPartialResult: boolean) => {
-        if (!chatResult.body) {
-            // No chat body on response means the /clear quick action
-            mynahUi.updateStore(tabId, {
-                chatItems: [],
-            })
-
-            mynahUi.updateStore(tabId, {
-                loadingChat: false,
-                promptInputDisabledState: false,
-            })
-            return
-        }
-
         if (isPartialResult) {
             mynahUi.updateLastChatAnswer(tabId, { ...chatResult })
             return

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -90,7 +90,6 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
                 const payload: AuthFollowUpClickedParams = {
                     tabId,
                     messageId,
-                    eventId,
                     authFollowupType: followUp.type,
                 }
                 messager.onAuthFollowUpClicked(payload)

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -24,7 +24,7 @@ import { Messager } from './messager'
 import { TabFactory } from './tabs/tabFactory'
 
 export interface InboundChatApi {
-    addChatResponse(params: ChatResult, tabId: string, isFinalResult: boolean): void
+    addChatResponse(params: ChatResult, tabId: string, isPartialResult: boolean): void
     sendToPrompt(params: SendToPromptParams): void
     sendGenericCommand(params: GenericCommandParams): void
     showError(params: ErrorParams): void

--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -1,12 +1,13 @@
 import { ChatItemType, MynahUIDataModel } from '@aws/mynah-ui'
 
+export type DefaultTabData = Partial<MynahUIDataModel>
+
 export class TabFactory {
+    constructor(private defaultTabData: DefaultTabData) {}
+
     public createTab(needWelcomeMessages: boolean): MynahUIDataModel {
         const tabData: MynahUIDataModel = {
-            tabTitle: 'Chat',
-            promptInputInfo:
-                'Use of Amazon Q is subject to the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
-            promptInputPlaceholder: 'Ask a question or enter "/" for quick actions',
+            ...this.defaultTabData,
             chatItems: needWelcomeMessages
                 ? [
                       {

--- a/chat-client/src/contracts/serverContracts.ts
+++ b/chat-client/src/contracts/serverContracts.ts
@@ -8,35 +8,34 @@ import {
     TabAddParams,
     TabChangeParams,
     TabRemoveParams,
+    CHAT_REQUEST_METHOD,
+    TAB_ADD_NOTIFICATION_METHOD,
+    TAB_CHANGE_NOTIFICATION_METHOD,
+    TAB_REMOVE_NOTIFICATION_METHOD,
+    READY_NOTIFICATION_METHOD,
+    FOLLOW_UP_CLICK_NOTIFICATION_METHOD,
+    FEEDBACK_NOTIFICATION_METHOD,
+    LINK_CLICK_NOTIFICATION_METHOD,
+    SOURCE_LINK_CLICK_NOTIFICATION_METHOD,
+    INFO_LINK_CLICK_NOTIFICATION_METHOD,
+    QUICK_ACTION_REQUEST_METHOD,
 } from '@aws/language-server-runtimes-types'
-
-export const CHAT_PROMPT = 'aws/chat/sendChatPrompt'
-export const NEW_TAB_CREATED = 'aws/chat/tabAdd'
-export const TAB_CHANGED = 'aws/chat/tabChange'
-export const TAB_REMOVED = 'aws/chat/tabRemove'
-export const UI_IS_READY = 'aws/chat/ready'
-export const FOLLOW_UP_CLICKED = 'aws/chat/followUpClick'
-export const FEEDBACK = 'aws/chat/feedback'
-export const LINK_CLICK = 'aws/chat/linkClick'
-export const SOURCE_LINK_CLICK = 'aws/chat/sourceLinkClick'
-export const INFO_LINK_CLICK = 'aws/chat/infoLinkClick'
-export const QUICK_ACTION_COMMAND = 'aws/chat/sendChatQuickAction'
 
 export const TELEMETRY = 'telemetry/event'
 
 export type ServerMessageCommand =
-    | typeof CHAT_PROMPT
-    | typeof NEW_TAB_CREATED
-    | typeof TAB_REMOVED
-    | typeof TAB_CHANGED
-    | typeof UI_IS_READY
+    | typeof CHAT_REQUEST_METHOD
+    | typeof TAB_ADD_NOTIFICATION_METHOD
+    | typeof TAB_REMOVE_NOTIFICATION_METHOD
+    | typeof TAB_CHANGE_NOTIFICATION_METHOD
+    | typeof READY_NOTIFICATION_METHOD
     | typeof TELEMETRY
-    | typeof FOLLOW_UP_CLICKED
-    | typeof FEEDBACK
-    | typeof LINK_CLICK
-    | typeof SOURCE_LINK_CLICK
-    | typeof INFO_LINK_CLICK
-    | typeof QUICK_ACTION_COMMAND
+    | typeof FOLLOW_UP_CLICK_NOTIFICATION_METHOD
+    | typeof FEEDBACK_NOTIFICATION_METHOD
+    | typeof LINK_CLICK_NOTIFICATION_METHOD
+    | typeof SOURCE_LINK_CLICK_NOTIFICATION_METHOD
+    | typeof INFO_LINK_CLICK_NOTIFICATION_METHOD
+    | typeof QUICK_ACTION_REQUEST_METHOD
 
 export interface Message {
     command: ServerMessageCommand

--- a/chat-client/src/contracts/serverContracts.ts
+++ b/chat-client/src/contracts/serverContracts.ts
@@ -20,6 +20,7 @@ export const FEEDBACK = 'aws/chat/feedback'
 export const LINK_CLICK = 'aws/chat/linkClick'
 export const SOURCE_LINK_CLICK = 'aws/chat/sourceLinkClick'
 export const INFO_LINK_CLICK = 'aws/chat/infoLinkClick'
+export const QUICK_ACTION_COMMAND = 'aws/chat/sendChatQuickAction'
 
 export const TELEMETRY = 'telemetry/event'
 
@@ -35,6 +36,7 @@ export type ServerMessageCommand =
     | typeof LINK_CLICK
     | typeof SOURCE_LINK_CLICK
     | typeof INFO_LINK_CLICK
+    | typeof QUICK_ACTION_COMMAND
 
 export interface Message {
     command: ServerMessageCommand

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -133,7 +133,7 @@
         "compile:chat-client": "npm run compile --prefix ../../chat-client && cp -R ../../chat-client/build ."
     },
     "devDependencies": {
-        "@aws/language-server-runtimes": "^0.2.5",
+        "@aws/language-server-runtimes": "^0.2.6",
         "@aws/chat-client-ui-types": "0.x.x",
         "@aws-sdk/credential-providers": "^3.540.0",
         "@aws-sdk/types": "^3.535.0",

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -56,9 +56,9 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri) 
                     })
                 break
             case quickActionRequestType.method:
-                const quickaActionPartialResultToken = uuidv4()
+                const quickActionPartialResultToken = uuidv4()
 
-                languageClient.onProgress(quickActionRequestType, quickaActionPartialResultToken, partialResult => {
+                languageClient.onProgress(quickActionRequestType, quickActionPartialResultToken, partialResult => {
                     if (partialResult.body) {
                         panel.webview.postMessage({
                             command: 'aws/chat/sendChatPrompt',
@@ -72,7 +72,7 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri) 
                 languageClient
                     .sendRequest(
                         quickActionRequestType,
-                        Object.assign(message.params, { partialResultToken: quickaActionPartialResultToken })
+                        Object.assign(message.params, { partialResultToken: quickActionPartialResultToken })
                     )
                     .then((chatResult: ChatResult) => {
                         panel.webview.postMessage({

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -35,10 +35,10 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri) 
             case chatRequestType.method:
                 const partialResultToken = uuidv4()
 
-                languageClient.onProgress(chatRequestType, partialResultToken, partialResult => {
+                const chatDisposable = languageClient.onProgress(chatRequestType, partialResultToken, partialResult => {
                     if (partialResult.body) {
                         panel.webview.postMessage({
-                            command: 'aws/chat/sendChatPrompt',
+                            command: chatRequestType.method,
                             params: partialResult,
                             isPartialResult: true,
                             tabId: message.params.tabId,
@@ -50,25 +50,30 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri) 
                     .sendRequest(chatRequestType, Object.assign(message.params, { partialResultToken }))
                     .then((chatResult: ChatResult) => {
                         panel.webview.postMessage({
-                            command: 'aws/chat/sendChatPrompt',
+                            command: chatRequestType.method,
                             params: chatResult,
                             tabId: message.params.tabId,
                         })
+                        chatDisposable.dispose()
                     })
                 break
             case quickActionRequestType.method:
                 const quickActionPartialResultToken = uuidv4()
 
-                languageClient.onProgress(quickActionRequestType, quickActionPartialResultToken, partialResult => {
-                    if (partialResult.body) {
-                        panel.webview.postMessage({
-                            command: 'aws/chat/sendChatPrompt',
-                            params: partialResult,
-                            isPartialResult: true,
-                            tabId: message.params.tabId,
-                        })
+                const quickActionDisposable = languageClient.onProgress(
+                    quickActionRequestType,
+                    quickActionPartialResultToken,
+                    partialResult => {
+                        if (partialResult.body) {
+                            panel.webview.postMessage({
+                                command: chatRequestType.method,
+                                params: partialResult,
+                                isPartialResult: true,
+                                tabId: message.params.tabId,
+                            })
+                        }
                     }
-                })
+                )
 
                 languageClient
                     .sendRequest(
@@ -77,10 +82,11 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri) 
                     )
                     .then((chatResult: ChatResult) => {
                         panel.webview.postMessage({
-                            command: 'aws/chat/sendChatPrompt',
+                            command: chatRequestType.method,
                             params: chatResult,
                             tabId: message.params.tabId,
                         })
+                        quickActionDisposable.dispose()
                     })
                 break
             case feedbackNotificationType.method:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1705,10 +1705,11 @@
         },
         "node_modules/@aws/language-server-runtimes": {
             "version": "0.2.5",
-            "license": "Apache-2.0",
+            "resolved": "file:../language-server-runtimes/runtimes/out/aws-language-server-runtimes-0.2.5.tgz",
+            "integrity": "sha512-+Pls5uGiNl6Mr73q+ISaxOJ6KC0c6FHCUp5zz/i7iA6upilEI1cxyNfL2tpIrBCsG7UJSN+0NFFvcMNJs1ENZA==",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "0.x.x",
-                "jose": "^5.2.3",
+                "jose": "^5.3.0",
                 "rxjs": "^7.8.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-protocol": "^3.17.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -224,14 +224,6 @@
                 "webpack-cli": "^5.1.4"
             }
         },
-        "chat-client/node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.0.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "vscode-languageserver-textdocument": "^1.0.11",
-                "vscode-languageserver-types": "^3.17.5"
-            }
-        },
         "client/vscode": {
             "name": "awsdocuments-ls-client",
             "version": "0.1.0",
@@ -240,7 +232,7 @@
                 "@aws-sdk/credential-providers": "^3.540.0",
                 "@aws-sdk/types": "^3.535.0",
                 "@aws/chat-client-ui-types": "0.x.x",
-                "@aws/language-server-runtimes": "^0.2.5",
+                "@aws/language-server-runtimes": "^0.2.6",
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",
                 "typescript": "^5.4.5",
@@ -1682,10 +1674,11 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.0.3",
-            "license": "Apache-2.0",
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.0.5.tgz",
+            "integrity": "sha512-s6HjH7DsBBBCxJ4ldO2o0AMzjQ6fyDf+GxJOrNAJQHxJBqN58kv3VeRDOmMjnmj8d+0j5NJfcnEl8AoMjy4O9A==",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.0.3"
+                "@aws/language-server-runtimes-types": "0.x.x"
             }
         },
         "node_modules/@aws/fully-qualified-names": {
@@ -1704,9 +1697,9 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.5",
-            "resolved": "file:../language-server-runtimes/runtimes/out/aws-language-server-runtimes-0.2.5.tgz",
-            "integrity": "sha512-+Pls5uGiNl6Mr73q+ISaxOJ6KC0c6FHCUp5zz/i7iA6upilEI1cxyNfL2tpIrBCsG7UJSN+0NFFvcMNJs1ENZA==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.6.tgz",
+            "integrity": "sha512-SOwOKr+fqG3uQtnAV0mAZw2MdrPDQsZkyWjFes5H0eLjMl5OdwuQpX94zYDqnNnHdb46ZTjA8yM0ZnUdepQ1GA==",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "0.x.x",
                 "jose": "^5.3.0",
@@ -1719,8 +1712,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.0.3",
-            "license": "Apache-2.0",
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.5.tgz",
+            "integrity": "sha512-qGC3zRqLwTfJKLbCqX0z0iLhkoS2XOnU8MBhrk1utvCNiBYzujhLp+3uz02SsI7vJfz/w7GAM2bd5ex6IK9MUg==",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.11",
                 "vscode-languageserver-types": "^3.17.5"
@@ -15781,7 +15775,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.5",
+                "@aws/language-server-runtimes": "^0.2.6",
                 "vscode-languageserver": "^9.0.1"
             }
         }

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -8,7 +8,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.5",
+        "@aws/language-server-runtimes": "^0.2.6",
         "vscode-languageserver": "^9.0.1"
     }
 }

--- a/server/hello-world-lsp/src/language-server/helloWorldServer.ts
+++ b/server/hello-world-lsp/src/language-server/helloWorldServer.ts
@@ -132,7 +132,15 @@ export const HelloWorldServerFactory =
                     }
                 case 'world':
                     return {
-                        body: 'World of Actions response',
+                        body: 'World Quick Action response',
+                    }
+                case 'clear':
+                    return {
+                        body: 'Clear Quick Action response',
+                    }
+                case 'help':
+                    return {
+                        body: 'Help Quick Action response',
                     }
                 default:
                     logging.log(`[Hello world server] Unhandled quick action: ${params.quickAction}`)

--- a/server/hello-world-lsp/src/language-server/helloWorldServer.ts
+++ b/server/hello-world-lsp/src/language-server/helloWorldServer.ts
@@ -1,5 +1,6 @@
 import {
     Chat,
+    ChatParams,
     CredentialsProvider,
     Logging,
     Lsp,
@@ -71,12 +72,6 @@ export const HelloWorldServerFactory =
             return
         }
 
-        const onQuickAction = async (params: QuickActionParams): Promise<QuickActionResult> => {
-            return {
-                body: `${params.quickAction} Quick Action response`,
-            }
-        }
-
         lsp.addInitializer(() => {
             logging.log('The Hello World Capability has been initialised')
 
@@ -122,6 +117,30 @@ export const HelloWorldServerFactory =
         lsp.onInitialized(onInitializedHandler)
         lsp.onCompletion(onCompletionHandler)
         lsp.onExecuteCommand(onExecuteCommandHandler)
+
+        chat.onChatPrompt((params: ChatParams) => {
+            return {
+                body: `User said: "${params.prompt.prompt}"`,
+            }
+        })
+
+        const onQuickAction = (params: QuickActionParams): QuickActionResult => {
+            switch (params.quickAction) {
+                case 'hello':
+                    return {
+                        body: 'Hello Quick Action response',
+                    }
+                case 'world':
+                    return {
+                        body: 'World of Actions response',
+                    }
+                default:
+                    logging.log(`[Hello world server] Unhandled quick action: ${params.quickAction}`)
+                    return {
+                        body: "I'm sorry, Dave. I'm afraid I can't do that",
+                    }
+            }
+        }
         chat.onQuickAction(onQuickAction)
 
         logging.log('The Hello World Capability has been initialised')


### PR DESCRIPTION
## Problem
We need to implement Quick Actions support for Chat Client package.

## Solution

* Registered Quick Actions handlers in Chat Client package.
* Created sample Quick Actions and Chat message handlers in HelloWorld server. Added registration of custom AWS Language server `chatQuickActionsProvider` capability introduced in https://github.com/aws/language-server-runtimes/pull/131.
* Updated sample VSCode client extension to register Chat client synchronously and use `chatQuickActionsProvider` from LSP server InitializeResult handshake to configure Quick Actions in Chat Client.
* Extended Chat Client init function to allow passing configuration from integrating IDE Extension client. This allows to configure chat at start time.

## Note
Check on this PR are failing, until runtimes and types are not updated with https://github.com/aws/language-server-runtimes/pull/131.

### Follow-up
It it possible to implement feature to update chat client configuration at runtime after it was initialized. It is not implemented in this PR, but sample message is showed in VsCode extension activation https://github.com/aws/language-servers/pull/282/files#diff-baefbe4699d8511ee6a9fca7274c8c141c0bb1c22b8ab3f5863584b5e58b5af6R137-R142.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
