### PR TITLE
Add script to enable bundleDependencies in monorepo workspaces

### DIFF
--- a/core/aws-lsp-core/.npmignore
+++ b/core/aws-lsp-core/.npmignore
@@ -1,0 +1,5 @@
+src/
+node_modules/
+package-lock.json
+.*
+tsconfig.*

--- a/script/link_bundled_dep.sh
+++ b/script/link_bundled_dep.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# This script is needed as a workaround for https://github.com/npm/cli/issues/3466
+
+root_dir=$(dirname "$0")/..
+target_package_dir=$(pwd)
+
+if [ -z target_package_dir/package.json ]; then
+    echo "package.json not found in the $target_package_dir directory."
+    exit 1
+fi
+
+# Get the bundleDependencies array from package.json
+bundle_dependencies=$(jq -r '.bundleDependencies[]' package.json)
+
+if [ -z "$bundle_dependencies" ]; then
+    echo "No bundleDependencies found in package.json."
+    exit 0
+fi
+
+
+# Loop through each bundleDependency
+for dependency in $bundle_dependencies; do
+    dependency_path="$root_dir/node_modules/$dependency"
+    
+     # Check if the dependency exists in the root node_modules directory
+    if [ -d "$dependency_path" ]; then
+        # Create a symlink for the dependency
+        link_location="node_modules/$dependency"
+        link_target=$(readlink -f "$dependency_path")
+
+        mkdir -p $link_location
+        # Clear contents or remove last folder in the path
+        rm -r $link_location
+
+        ln -s $link_target $link_location
+        echo "Symlink created for $dependency"
+    else
+        echo "ERROR: $dependency not found in the root node_modules directory."
+        exit 1
+    fi
+done

--- a/server/aws-lsp-json/.npmignore
+++ b/server/aws-lsp-json/.npmignore
@@ -1,0 +1,5 @@
+src/
+node_modules/
+package-lock.json
+.*
+tsconfig.*

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -3,9 +3,19 @@
     "version": "0.0.1",
     "description": "CodeBuild Language Server for JSON templates",
     "main": "out/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/aws/language-servers"
+    },
+    "author": "Amazon Web Services",
+    "license": "Apache-2.0",
+    "engines": {
+        "node": ">=18.0.0"
+    },
     "scripts": {
         "compile": "tsc --build",
-        "test": "ts-mocha -b 'src/**/*.test.ts'"
+        "test": "ts-mocha -b 'src/**/*.test.ts'",
+        "prepack": "../../script/link_bundled_dep.sh"
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.5",
@@ -22,5 +32,8 @@
         "bracketSpacing": true,
         "arrowParens": "avoid",
         "endOfLine": "lf"
-    }
+    },
+    "bundleDependencies": [
+        "@aws/lsp-core"
+    ]
 }

--- a/server/aws-lsp-yaml/.npmignore
+++ b/server/aws-lsp-yaml/.npmignore
@@ -1,0 +1,5 @@
+src/
+node_modules/
+package-lock.json
+.*
+tsconfig.*

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -3,9 +3,19 @@
     "version": "0.0.1",
     "description": "CodeBuild Language Server for YAML template",
     "main": "out/index.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/aws/language-servers"
+    },
+    "author": "Amazon Web Services",
+    "license": "Apache-2.0",
+    "engines": {
+        "node": ">=18.0.0"
+    },
     "scripts": {
         "compile": "tsc --build",
-        "postinstall": "node patchYamlPackage.js"
+        "postinstall": "node patchYamlPackage.js",
+        "prepack": "../../script/link_bundled_dep.sh"
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.5",
@@ -23,5 +33,8 @@
         "bracketSpacing": true,
         "arrowParens": "avoid",
         "endOfLine": "lf"
-    }
+    },
+    "bundleDependencies": [
+        "@aws/lsp-core"
+    ]
 }


### PR DESCRIPTION
## Problem
We want to publish JSON and YAML LSP servers to NPM. They depend on the core subpackage in the monorepo and to avoid publishing it we need to include the dependency in the published package. 

This is currently not possible due to https://github.com/npm/cli/issues/3466

## Solution
Create script that: 
- reads `bundleDependencies`
- Goes to root node_modules and finds the dependency
- Creates a symlink in subpackage node_modules pointing to the dependency folder
- Run this script as part `prepack` script 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
