### PR TITLE
Emits basic chat metrics

### DIFF
--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -2,6 +2,7 @@ import {
     ChatResult,
     chatRequestType,
     tabAddNotificationType,
+    tabChangeNotificationType,
     tabRemoveNotificationType,
     telemetryNotificationType,
 } from '@aws/language-server-runtimes/protocol'
@@ -53,6 +54,9 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri) 
                 break
             case tabRemoveNotificationType.method:
                 languageClient.sendNotification(tabRemoveNotificationType, message.params)
+                break
+            case tabChangeNotificationType.method:
+                languageClient.sendNotification(tabChangeNotificationType, message.params)
                 break
             case telemetryNotificationType.method:
                 languageClient.sendNotification(telemetryNotificationType, message.params)

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -147,7 +147,7 @@ describe('ChatController', () => {
         chatController.onTabChange({ tabId: mockTabId })
 
         sinon.assert.calledWithExactly(activeTabSpy.set, mockTabId)
-        sinon.assert.calledOnce(emitConversationMetricStub)
+        sinon.assert.calledTwice(emitConversationMetricStub)
     })
 
     it('onTabRemove unsets tab id if current tab is removed and emits metrics', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -11,6 +11,7 @@ import { createIterableResponse } from '../testUtils'
 import { ChatController } from './chatController'
 import { ChatSessionManagementService } from './chatSessionManagementService'
 import { ChatSessionService } from './chatSessionService'
+import { ChatTelemetryController } from './chatTelemetryController'
 import { DocumentContextExtractor } from './contexts/documentContext'
 
 describe('ChatController', () => {
@@ -52,6 +53,12 @@ describe('ChatController', () => {
 
     let generateAssistantResponseStub: sinon.SinonStub
     let disposeStub: sinon.SinonStub
+    let activeTabSpy: {
+        get: sinon.SinonSpy<[], string | undefined>
+        set: sinon.SinonSpy<[string | undefined], void>
+    }
+    let removeConversationIdSpy: sinon.SinonSpy
+    let emitConversationMetricStub: sinon.SinonStub
 
     let testFeatures: TestFeatures
     let chatSessionManagementService: ChatSessionManagementService
@@ -76,6 +83,10 @@ describe('ChatController', () => {
 
         testFeatures = new TestFeatures()
 
+        activeTabSpy = sinon.spy(ChatTelemetryController.prototype, 'activeTabId', ['get', 'set'])
+        removeConversationIdSpy = sinon.spy(ChatTelemetryController.prototype, 'removeConversationId')
+        emitConversationMetricStub = sinon.stub(ChatTelemetryController.prototype, 'emitConversationMetric')
+
         disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
 
         chatSessionManagementService = ChatSessionManagementService.getInstance().withCredentialsProvider(
@@ -86,8 +97,7 @@ describe('ChatController', () => {
     })
 
     afterEach(() => {
-        generateAssistantResponseStub.restore()
-        disposeStub.restore()
+        sinon.restore()
         ChatSessionManagementService.reset()
     })
 
@@ -125,6 +135,45 @@ describe('ChatController', () => {
         const hasSession = chatSessionManagementService.hasSession(mockTabId)
 
         assert.ok(!hasSession)
+    })
+
+    it('onTabAdd sets active tab id in telemetryController', () => {
+        chatController.onTabAdd({ tabId: mockTabId })
+
+        sinon.assert.calledWithExactly(activeTabSpy.set, mockTabId)
+    })
+
+    it('onTabChange sets active tab id in telemetryController and emits metrics', () => {
+        chatController.onTabChange({ tabId: mockTabId })
+
+        sinon.assert.calledWithExactly(activeTabSpy.set, mockTabId)
+        sinon.assert.calledOnce(emitConversationMetricStub)
+    })
+
+    it('onTabRemove unsets tab id if current tab is removed and emits metrics', () => {
+        chatController.onTabAdd({ tabId: mockTabId })
+
+        emitConversationMetricStub.resetHistory()
+        activeTabSpy.set.resetHistory()
+
+        chatController.onTabRemove({ tabId: mockTabId })
+
+        sinon.assert.calledWithExactly(removeConversationIdSpy, mockTabId)
+        sinon.assert.calledOnce(emitConversationMetricStub)
+    })
+
+    it('onTabRemove does not unset tabId if current tab is not being removed', () => {
+        chatController.onTabAdd({ tabId: mockTabId })
+        chatController.onTabAdd({ tabId: 'mockTabId-2' })
+
+        testFeatures.telemetry.emitMetric.resetHistory()
+        activeTabSpy.set.resetHistory()
+
+        chatController.onTabRemove({ tabId: mockTabId })
+
+        sinon.assert.notCalled(activeTabSpy.set)
+        sinon.assert.calledWithExactly(removeConversationIdSpy, mockTabId)
+        sinon.assert.notCalled(emitConversationMetricStub)
     })
 
     describe('onChatPrompt', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -144,6 +144,11 @@ export class ChatController implements ChatHandlers {
     }
 
     onTabChange(params: TabChangeParams) {
+        this.#telemetryController.emitConversationMetric({
+            name: ChatTelemetryEventName.ExitFocusConversation,
+            data: {},
+        })
+
         this.#telemetryController.activeTabId = params.tabId
 
         this.#telemetryController.emitConversationMetric({

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -159,11 +159,11 @@ export class ChatController implements ChatHandlers {
 
     onTabRemove(params: TabRemoveParams) {
         if (this.#telemetryController.activeTabId === params.tabId) {
-            this.#telemetryController.activeTabId = undefined
             this.#telemetryController.emitConversationMetric({
                 name: ChatTelemetryEventName.ExitFocusConversation,
                 data: {},
             })
+            this.#telemetryController.activeTabId = undefined
         }
 
         this.#chatSessionManagementService.deleteSession(params.tabId)

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -2,7 +2,7 @@ import {
     GenerateAssistantResponseCommandInput,
     GenerateAssistantResponseCommandOutput,
 } from '@amzn/codewhisperer-streaming'
-import { chatRequestType } from '@aws/language-server-runtimes/protocol'
+import { TabChangeParams, chatRequestType } from '@aws/language-server-runtimes/protocol'
 import {
     CancellationToken,
     Chat,
@@ -15,9 +15,11 @@ import {
     TabAddParams,
     TabRemoveParams,
 } from '@aws/language-server-runtimes/server-interface'
+import { ChatTelemetryEventName } from '../telemetry/types'
 import { Features, LspHandlers, Result } from '../types'
 import { ChatEventParser } from './chatEventParser'
 import { ChatSessionManagementService } from './chatSessionManagementService'
+import { ChatTelemetryController } from './chatTelemetryController'
 import { QAPIInputConverter } from './qAPIInputConverter'
 
 type ChatHandlers = LspHandlers<Chat>
@@ -26,11 +28,13 @@ export class ChatController implements ChatHandlers {
     #features: Features
     #chatSessionManagementService: ChatSessionManagementService
     #qAPIInputConverter: QAPIInputConverter
+    #telemetryController: ChatTelemetryController
 
     constructor(chatSessionManagementService: ChatSessionManagementService, features: Features) {
         this.#features = features
         this.#chatSessionManagementService = chatSessionManagementService
         this.#qAPIInputConverter = new QAPIInputConverter(features.workspace, features.logging)
+        this.#telemetryController = new ChatTelemetryController(features.telemetry)
     }
 
     dispose() {
@@ -83,7 +87,6 @@ export class ChatController implements ChatHandlers {
             )
 
             response = await session.generateAssistantResponse(requestInput)
-            this.#log('Response to tab:', params.tabId, JSON.stringify(response.$metadata))
         } catch (err) {
             this.#log(`Q api request error ${err instanceof Error ? err.message : 'unknown'}`)
 
@@ -91,6 +94,10 @@ export class ChatController implements ChatHandlers {
                 ErrorCodes.InternalError,
                 err instanceof Error ? err.message : 'Internal Server Error'
             )
+        }
+
+        if (response.conversationId) {
+            this.#telemetryController.setConversationId(params.tabId, response.conversationId)
         }
 
         try {
@@ -130,13 +137,36 @@ export class ChatController implements ChatHandlers {
     onSourceLinkClick() {}
 
     onTabAdd(params: TabAddParams) {
+        this.#telemetryController.activeTabId = params.tabId
+
+        this.#telemetryController.emitConversationMetric({
+            name: ChatTelemetryEventName.EnterFocusConversation,
+            data: {},
+        })
+
         this.#chatSessionManagementService.createSession(params.tabId)
     }
 
-    onTabChange() {}
+    onTabChange(params: TabChangeParams) {
+        this.#telemetryController.activeTabId = params.tabId
+
+        this.#telemetryController.emitConversationMetric({
+            name: ChatTelemetryEventName.EnterFocusConversation,
+            data: {},
+        })
+    }
 
     onTabRemove(params: TabRemoveParams) {
+        if (this.#telemetryController.activeTabId === params.tabId) {
+            this.#telemetryController.activeTabId = undefined
+            this.#telemetryController.emitConversationMetric({
+                name: ChatTelemetryEventName.ExitFocusChat,
+                data: {},
+            })
+        }
+
         this.#chatSessionManagementService.deleteSession(params.tabId)
+        this.#telemetryController.removeConversationId(params.tabId)
     }
 
     onQuickAction(_params: QuickActionParams, _cancellationToken: CancellationToken): never {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -87,6 +87,7 @@ export class ChatController implements ChatHandlers {
             )
 
             response = await session.generateAssistantResponse(requestInput)
+            this.#log('Response to tab:', params.tabId, JSON.stringify(response.$metadata))
         } catch (err) {
             this.#log(`Q api request error ${err instanceof Error ? err.message : 'unknown'}`)
 
@@ -139,11 +140,6 @@ export class ChatController implements ChatHandlers {
     onTabAdd(params: TabAddParams) {
         this.#telemetryController.activeTabId = params.tabId
 
-        this.#telemetryController.emitConversationMetric({
-            name: ChatTelemetryEventName.EnterFocusConversation,
-            data: {},
-        })
-
         this.#chatSessionManagementService.createSession(params.tabId)
     }
 
@@ -160,7 +156,7 @@ export class ChatController implements ChatHandlers {
         if (this.#telemetryController.activeTabId === params.tabId) {
             this.#telemetryController.activeTabId = undefined
             this.#telemetryController.emitConversationMetric({
-                name: ChatTelemetryEventName.ExitFocusChat,
+                name: ChatTelemetryEventName.ExitFocusConversation,
                 data: {},
             })
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatTelemetryController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatTelemetryController.test.ts
@@ -46,7 +46,7 @@ describe('TelemetryController', () => {
         const telemetryHandler = testFeatures.telemetry.onClientTelemetry.firstCall.firstArg
 
         telemetryHandler({
-            name: ChatUIEventName.EnterFocus,
+            name: ChatUIEventName.EnterUIFocus,
         })
 
         sinon.assert.calledOnceWithExactly(testFeatures.telemetry.emitMetric, {
@@ -59,7 +59,7 @@ describe('TelemetryController', () => {
         const telemetryHandler = testFeatures.telemetry.onClientTelemetry.firstCall.firstArg
 
         telemetryHandler({
-            name: ChatUIEventName.ExitFocus,
+            name: ChatUIEventName.ExitUIFocus,
         })
 
         sinon.assert.calledOnceWithExactly(testFeatures.telemetry.emitMetric, {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatTelemetryController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatTelemetryController.test.ts
@@ -1,0 +1,106 @@
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import sinon from 'ts-sinon'
+import { ChatTelemetryEventName } from '../telemetry/types'
+import { CONVERSATION_ID_METRIC_KEY, ChatTelemetryController, ChatUIEventName } from './chatTelemetryController'
+import assert = require('assert')
+
+describe('TelemetryController', () => {
+    const mockTabId = 'mockTabId'
+    const mockConversationId = 'mockConversationId'
+
+    let testFeatures: TestFeatures
+    let telemetryController: ChatTelemetryController
+
+    beforeEach(() => {
+        testFeatures = new TestFeatures()
+        telemetryController = new ChatTelemetryController(testFeatures.telemetry)
+    })
+
+    it('able to set and get activeTabId', () => {
+        assert.strictEqual(telemetryController.activeTabId, undefined)
+
+        telemetryController.activeTabId = mockTabId
+
+        assert.strictEqual(telemetryController.activeTabId, mockTabId)
+    })
+
+    it('able to set and get conversationId for a tab id', () => {
+        assert.strictEqual(telemetryController.getConversationId(mockTabId), undefined)
+
+        telemetryController.setConversationId(mockTabId, mockConversationId)
+
+        assert.strictEqual(telemetryController.getConversationId(mockTabId), mockConversationId)
+    })
+
+    it('able to remove conversation id by tab id from the map', () => {
+        telemetryController.setConversationId(mockTabId, mockConversationId)
+
+        assert.strictEqual(telemetryController.getConversationId(mockTabId), mockConversationId)
+
+        telemetryController.removeConversationId(mockTabId)
+
+        assert.strictEqual(telemetryController.getConversationId(mockTabId), undefined)
+    })
+
+    it('handles enter focus client telemetry', () => {
+        const telemetryHandler = testFeatures.telemetry.onClientTelemetry.firstCall.firstArg
+
+        telemetryHandler({
+            name: ChatUIEventName.EnterFocus,
+        })
+
+        sinon.assert.calledOnceWithExactly(testFeatures.telemetry.emitMetric, {
+            name: ChatTelemetryEventName.EnterFocusChat,
+            data: {},
+        })
+    })
+
+    it('handles exit focus client telemetry', () => {
+        const telemetryHandler = testFeatures.telemetry.onClientTelemetry.firstCall.firstArg
+
+        telemetryHandler({
+            name: ChatUIEventName.ExitFocus,
+        })
+
+        sinon.assert.calledOnceWithExactly(testFeatures.telemetry.emitMetric, {
+            name: ChatTelemetryEventName.ExitFocusChat,
+            data: {},
+        })
+    })
+
+    it('does not handle unknown client telemetry', () => {
+        const telemetryHandler = testFeatures.telemetry.onClientTelemetry.firstCall.firstArg
+
+        telemetryHandler({
+            params: { name: 'Unknown event' },
+        })
+
+        sinon.assert.notCalled(testFeatures.telemetry.emitMetric)
+    })
+
+    it('does not emit metrics if conversation id is not present', () => {
+        telemetryController.emitConversationMetric({
+            name: ChatTelemetryEventName.EnterFocusConversation,
+            data: {},
+        })
+
+        sinon.assert.notCalled(testFeatures.telemetry.emitMetric)
+    })
+
+    it('emits metrics only if conversation id for active tab is present', () => {
+        telemetryController.setConversationId(mockTabId, mockConversationId)
+        telemetryController.activeTabId = mockTabId
+
+        telemetryController.emitConversationMetric({
+            name: ChatTelemetryEventName.EnterFocusConversation,
+            data: {},
+        })
+
+        sinon.assert.calledOnceWithExactly(testFeatures.telemetry.emitMetric, {
+            name: ChatTelemetryEventName.EnterFocusConversation,
+            data: {
+                [CONVERSATION_ID_METRIC_KEY]: mockConversationId,
+            },
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatTelemetryController.ts
@@ -1,0 +1,90 @@
+import { MetricEvent } from '@aws/language-server-runtimes/server-interface'
+
+import { ChatTelemetryEventMap, ChatTelemetryEventName } from '../telemetry/types'
+import { Features } from '../types'
+import { isObject } from '../utils'
+
+const CONVERSATION_ID_METRIC_KEY = 'CWSPRChatConversationId'
+
+enum MynahUIEventName {
+    EnterFocus = 'enterFocus',
+    ExitFocus = 'exitFocus',
+}
+
+interface ChatMetricEvent<TName extends ChatTelemetryEventName> extends MetricEvent {
+    name: TName
+    data: ChatTelemetryEventMap[TName]
+}
+
+export class ChatTelemetryController {
+    #activeTabId?: string
+    #conversationIdByTabId: { [tabId: string]: string }
+    #telemetry: Features['telemetry']
+
+    constructor(telemetry: Features['telemetry']) {
+        this.#conversationIdByTabId = {}
+        this.#telemetry = telemetry
+
+        this.#telemetry.onClientTelemetry(params => this.#handleClientTelemetry(params))
+    }
+
+    public set activeTabId(tabId: string | undefined) {
+        this.#activeTabId = tabId
+    }
+
+    public get activeTabId(): string | undefined {
+        return this.#activeTabId
+    }
+
+    public getConversationId(tabId?: string) {
+        return tabId && this.#conversationIdByTabId[tabId]
+    }
+
+    public removeConversationId(tabId: string) {
+        delete this.#conversationIdByTabId[tabId]
+    }
+
+    public setConversationId(tabId: string, conversationId: string) {
+        this.#conversationIdByTabId[tabId] = conversationId
+    }
+
+    public emitChatMetric<TName extends ChatTelemetryEventName>(metric: ChatMetricEvent<TName>) {
+        this.#telemetry.emitMetric(metric)
+    }
+
+    public emitConversationMetric<TName extends ChatTelemetryEventName>(
+        metric: Omit<ChatMetricEvent<TName>, 'data'> & {
+            data: Omit<ChatMetricEvent<TName>['data'], typeof CONVERSATION_ID_METRIC_KEY>
+        }
+    ) {
+        const conversationId = this.getConversationId(this.activeTabId)
+        if (conversationId) {
+            this.emitChatMetric({
+                ...metric,
+                data: {
+                    ...metric.data,
+                    [CONVERSATION_ID_METRIC_KEY]: conversationId,
+                },
+            })
+        }
+    }
+
+    #handleClientTelemetry(params: unknown) {
+        if (isObject(params) && 'name' in params && typeof params.name === 'string') {
+            switch (params.name) {
+                case MynahUIEventName.EnterFocus:
+                    this.emitChatMetric({
+                        name: ChatTelemetryEventName.EnterFocusChat,
+                        data: {},
+                    })
+                    break
+                case MynahUIEventName.ExitFocus:
+                    this.emitChatMetric({
+                        name: ChatTelemetryEventName.ExitFocusChat,
+                        data: {},
+                    })
+                    break
+            }
+        }
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatTelemetryController.ts
@@ -4,9 +4,9 @@ import { ChatTelemetryEventMap, ChatTelemetryEventName } from '../telemetry/type
 import { Features } from '../types'
 import { isObject } from '../utils'
 
-const CONVERSATION_ID_METRIC_KEY = 'CWSPRChatConversationId'
+export const CONVERSATION_ID_METRIC_KEY = 'CWSPRChatConversationId'
 
-enum MynahUIEventName {
+export enum ChatUIEventName {
     EnterFocus = 'enterFocus',
     ExitFocus = 'exitFocus',
 }
@@ -72,13 +72,13 @@ export class ChatTelemetryController {
     #handleClientTelemetry(params: unknown) {
         if (isObject(params) && 'name' in params && typeof params.name === 'string') {
             switch (params.name) {
-                case MynahUIEventName.EnterFocus:
+                case ChatUIEventName.EnterFocus:
                     this.emitChatMetric({
                         name: ChatTelemetryEventName.EnterFocusChat,
                         data: {},
                     })
                     break
-                case MynahUIEventName.ExitFocus:
+                case ChatUIEventName.ExitFocus:
                     this.emitChatMetric({
                         name: ChatTelemetryEventName.ExitFocusChat,
                         data: {},

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatTelemetryController.ts
@@ -7,8 +7,8 @@ import { isObject } from '../utils'
 export const CONVERSATION_ID_METRIC_KEY = 'CWSPRChatConversationId'
 
 export enum ChatUIEventName {
-    EnterFocus = 'enterFocus',
-    ExitFocus = 'exitFocus',
+    EnterUIFocus = 'enterFocus',
+    ExitUIFocus = 'exitFocus',
 }
 
 interface ChatMetricEvent<TName extends ChatTelemetryEventName> extends MetricEvent {
@@ -72,13 +72,13 @@ export class ChatTelemetryController {
     #handleClientTelemetry(params: unknown) {
         if (isObject(params) && 'name' in params && typeof params.name === 'string') {
             switch (params.name) {
-                case ChatUIEventName.EnterFocus:
+                case ChatUIEventName.EnterUIFocus:
                     this.emitChatMetric({
                         name: ChatTelemetryEventName.EnterFocusChat,
                         data: {},
                     })
                     break
-                case ChatUIEventName.ExitFocus:
+                case ChatUIEventName.ExitUIFocus:
                     this.emitChatMetric({
                         name: ChatTelemetryEventName.ExitFocusChat,
                         data: {},

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -11,22 +11,22 @@ export const QChatServer =
 
         const chatController = new ChatController(chatSessionManagementService, features)
 
-        chat.onTabAdd((...params) => {
-            logging.log(`Adding tab: ${params[0].tabId}`)
+        chat.onTabAdd(params => {
+            logging.log(`Adding tab: ${params.tabId}`)
 
-            return chatController.onTabAdd(...params)
+            return chatController.onTabAdd(params)
         })
 
-        chat.onTabChange((...params) => {
-            logging.log(`Changing to tab: ${params[0].tabId}`)
+        chat.onTabChange(params => {
+            logging.log(`Changing to tab: ${params.tabId}`)
 
-            return chatController.onTabChange(...params)
+            return chatController.onTabChange(params)
         })
 
-        chat.onTabRemove((...params) => {
-            logging.log(`Removing tab: ${params[0].tabId}`)
+        chat.onTabRemove(params => {
+            logging.log(`Removing tab: ${params.tabId}`)
 
-            return chatController.onTabRemove(...params)
+            return chatController.onTabRemove(params)
         })
 
         chat.onEndChat((...params) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -12,12 +12,20 @@ export const QChatServer =
         const chatController = new ChatController(chatSessionManagementService, features)
 
         chat.onTabAdd((...params) => {
-            logging.log('Received tab add request')
+            logging.log(`Adding tab: ${params[0].tabId}`)
+
             return chatController.onTabAdd(...params)
         })
 
+        chat.onTabChange((...params) => {
+            logging.log(`Changing to tab: ${params[0].tabId}`)
+
+            return chatController.onTabChange(...params)
+        })
+
         chat.onTabRemove((...params) => {
-            logging.log('Received tab remove request')
+            logging.log(`Removing tab: ${params[0].tabId}`)
+
             return chatController.onTabRemove(...params)
         })
 
@@ -29,6 +37,10 @@ export const QChatServer =
         chat.onChatPrompt((...params) => {
             logging.log('Received chat prompt')
             return chatController.onChatPrompt(...params)
+        })
+
+        chat.onQuickAction((...params) => {
+            return chatController.onQuickAction(...params)
         })
 
         logging.log('Q Chat server has been initialized')

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
@@ -96,3 +96,29 @@ export interface SecurityScanEvent {
     codewhispererCodeScanIssuesWithFixes: number
     credentialStartUrl: string | undefined
 }
+
+export enum ChatTelemetryEventName {
+    EnterFocusChat = 'EnterFocusChat',
+    ExitFocusChat = 'ExitFocusChat',
+    EnterFocusConversation = 'EnterFocusConversation',
+    ExitFocusConversation = 'ExitFocusConversation',
+}
+
+export interface ChatTelemetryEventMap {
+    [ChatTelemetryEventName.EnterFocusChat]: EnterFocusChatEvent
+    [ChatTelemetryEventName.ExitFocusChat]: ExitFocusChatEvent
+    [ChatTelemetryEventName.EnterFocusConversation]: EnterFocusConversationEvent
+    [ChatTelemetryEventName.ExitFocusConversation]: ExitFocusConversationEvent
+}
+
+export interface EnterFocusChatEvent {}
+
+export interface ExitFocusChatEvent {}
+
+export interface EnterFocusConversationEvent {
+    CWSPRChatConversationId: string
+}
+
+export interface ExitFocusConversationEvent {
+    CWSPRChatConversationId: string
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -19,6 +19,10 @@ function hasTime(error: Error): error is typeof error & { time: Date } {
     return (error as { time?: unknown }).time instanceof Date
 }
 
+export function isObject(value: unknown): value is { [key: number | string | symbol]: any } {
+    return Boolean(value) && typeof value === 'object'
+}
+
 export function getCompletionType(suggestion: Suggestion): CodewhispererCompletionType {
     const nonBlankLines = suggestion.content.split('\n').filter(line => line.trim() !== '').length
 


### PR DESCRIPTION
## Description
Emits metrics for `tabAdd`, `tabChange`, `tabRemove` notifications, as well as `enterFocus` and `exitFocus` telemetry events received from client. 

- Add `chatTelemetryController` which does the following:
   - listens to `enterFocus` and `exitFocus` telemetry events from client
   - keeps track of tab id to conversation id mapping
   - auto append conversation id to related metrics
- Add tests

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
