### PR TITLE
Fix CodeWhisperer IAM "optout" header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/dist*
 **/.vscode-test
 !/bin
 *.tsbuildinfo
+app/aws-lsp-partiql-binary

--- a/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperer.ts
+++ b/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperer.ts
@@ -3,6 +3,8 @@ import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 const apiConfig = require('./service.json')
 import CodeWhispererClient = require('./codewhisperersigv4client')
 
+export type CodeWhispererSigv4ClientConfigurationOptions = ServiceConfigurationOptions
+
 export function createCodeWhispererSigv4Client(options: ServiceConfigurationOptions): CodeWhispererClient {
     return createService(options) as CodeWhispererClient
 }


### PR DESCRIPTION
## Problem

The CodeWhisperer IAM Server was creating its client using the options type from the CodeWhisperer Token Client. This led to a bug wherein the IAM Server was using `onRequestSetup`, which is not a recognized option for its client. Instead, the proper way to modify HTTP requests in its client is to use `setupRequestListeners`.

This discrepancy is due to the fact that the Service Client's options passed via the factory method for the Token Client [have been modified](https://github.com/andredcoliveira/language-servers/blob/6ba221873b824d611c731230dab91cc3caeda318/server/aws-lsp-codewhisperer/src/client/token/codewhisperer.ts). I think this is unnecessary and might be what led to this bug, which is why I did not modify the IAM Client module to match the Token Client. I would suggest modifying the Token Client instead to use the official `aws-sdk` types/options if possible, without changing them—I don't have a strong opinion here, but I err on the side of this being beyond the scope of this PR.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

Use the correct options type when creating the client and set up the http request header using valid options/methods.

### Testing

As far as I can tell, adding a test is not trivial because this repository currently has no testing setup that includes the service clients. See https://github.com/andredcoliveira/language-servers/blob/6ba221873b824d611c731230dab91cc3caeda318/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts#L470-L473.

Tested by verifying CodeWhisperer requests made using the Browser Developer Tools:

#### Before

Header is missing:

![header_before_missing](https://github.com/aws/language-servers/assets/24967743/641e0c28-48f9-47fc-838e-150eedcd5a82)

#### After

Header is showing:

![header_after_showing](https://github.com/aws/language-servers/assets/24967743/fcbbe23c-0545-4779-a87c-c28ea2d9c26e)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
