### PR TITLE
Add Chat Quick Action support

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -15,6 +15,7 @@ import {
     TabAddParams,
     TabRemoveParams,
 } from '@aws/language-server-runtimes/server-interface'
+import { v4 as uuid } from 'uuid'
 import { ChatTelemetryEventName } from '../telemetry/types'
 import { Features, LspHandlers, Result } from '../types'
 import { ChatEventParser } from './chatEventParser'
@@ -183,6 +184,7 @@ export class ChatController implements ChatHandlers {
 
             case QuickAction.Help:
                 return {
+                    messageId: uuid(),
                     body: HELP_MESSAGE,
                 }
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -21,6 +21,7 @@ import { ChatEventParser } from './chatEventParser'
 import { ChatSessionManagementService } from './chatSessionManagementService'
 import { ChatTelemetryController } from './chatTelemetryController'
 import { QAPIInputConverter } from './qAPIInputConverter'
+import { HELP_MESSAGE, QuickAction } from './quickActions'
 
 type ChatHandlers = LspHandlers<Chat>
 
@@ -170,8 +171,23 @@ export class ChatController implements ChatHandlers {
         this.#telemetryController.removeConversationId(params.tabId)
     }
 
-    onQuickAction(_params: QuickActionParams, _cancellationToken: CancellationToken): never {
-        throw new Error('Not implemented')
+    onQuickAction(params: QuickActionParams, _cancellationToken: CancellationToken) {
+        switch (params.quickAction) {
+            case QuickAction.Clear: {
+                const sessionResult = this.#chatSessionManagementService.getSession(params.tabId)
+
+                sessionResult.data?.clear()
+
+                return {}
+            }
+
+            case QuickAction.Help:
+                return {
+                    body: HELP_MESSAGE,
+                }
+        }
+
+        return {}
     }
 
     async #processAssistantResponse(

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
@@ -86,7 +86,7 @@ describe('Chat Session Service', () => {
         })
     })
 
-    it('calling .abortRequest() aborts request with AbortController', async () => {
+    it('abortRequest() aborts request with AbortController', async () => {
         await chatSessionService.generateAssistantResponse(mockRequestParams)
 
         chatSessionService.abortRequest()
@@ -94,12 +94,23 @@ describe('Chat Session Service', () => {
         sinon.assert.calledOnce(abortStub)
     })
 
-    it('calling .dispose() calls client.destroy and aborts outgoing requests', async () => {
+    it('dispose() calls client.destroy and aborts outgoing requests', async () => {
         await chatSessionService.generateAssistantResponse(mockRequestParams)
 
         chatSessionService.dispose()
 
         sinon.assert.calledOnce(abortStub)
         sinon.assert.calledOnce(destroyClientStub)
+    })
+
+    it('clear() reset session id and aborts outgoing request', async () => {
+        await chatSessionService.generateAssistantResponse(mockRequestParams)
+
+        assert.strictEqual(chatSessionService.sessionId, mockConversationId)
+
+        chatSessionService.clear()
+
+        sinon.assert.calledOnce(abortStub)
+        assert.strictEqual(chatSessionService.sessionId, undefined)
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -53,6 +53,11 @@ export class ChatSessionService {
         return response
     }
 
+    public clear(): void {
+        this.#abortController?.abort()
+        this.#sessionId = undefined
+    }
+
     public dispose(): void {
         this.#abortController?.abort()
         this.#client.destroy()

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/quickActions.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/quickActions.ts
@@ -1,0 +1,45 @@
+export enum QuickAction {
+    Clear = 'clear',
+    Help = 'help',
+}
+
+export const HELP_QUICK_ACTION = {
+    command: QuickAction.Help,
+    description: 'Learn more about Amazon Q',
+}
+
+export const CLEAR_QUICK_ACTION = {
+    command: QuickAction.Clear,
+    description: 'Clear this session',
+}
+
+const userGuideURL = 'https://docs.aws.amazon.com/amazonq/latest/aws-builder-use-ug/getting-started.html'
+
+export const HELP_MESSAGE = `I'm Amazon Q, a generative AI assistant. Learn more about me below. Your feedback will help me improve.
+\n\n### What I can do:
+\n\n- Answer questions about AWS
+\n\n- Answer questions about general programming concepts
+\n\n- Explain what a line of code or code function does
+\n\n- Write unit tests and code
+\n\n- Debug and fix code
+\n\n- Refactor code
+\n\n### What I don't do right now:
+\n\n- Answer questions in languages other than English
+\n\n- Remember conversations from your previous sessions
+\n\n- Have information about your AWS account or your specific AWS resources
+\n\n### Examples of questions I can answer:
+\n\n- When should I use ElastiCache?
+\n\n- How do I create an Application Load Balancer?
+\n\n- Explain the <selected code> and ask clarifying questions about it.
+\n\n- What is the syntax of declaring a variable in TypeScript?
+\n\n### Special Commands
+\n\n- /clear - Clear the conversation.
+\n\n- /dev - Get code suggestions across files in your current project. Provide a brief prompt, such as "Implement a GET API."
+\n\n- /transform - Transform your code. Use to upgrade Java code versions.
+\n\n- /help - View chat topics and commands.
+\n\n### Things to note:
+\n\n- I may not always provide completely accurate or current information.
+\n\n- Provide feedback by choosing the like or dislike buttons that appear below answers.
+\n\n- When you use Amazon Q, AWS may, for service improvement purposes, store data about your usage and content. You can opt-out of sharing this data by following the steps in AI services opt-out policies. See <a href="https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/opt-out-IDE.html">here</a>
+\n\n- Do not enter any confidential, sensitive, or personal information.
+\n\n*For additional help, visit the [Amazon Q User Guide](${userGuideURL}).*`

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/quickActions.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/quickActions.ts
@@ -1,6 +1,6 @@
 export enum QuickAction {
-    Clear = 'clear',
-    Help = 'help',
+    Clear = '/clear',
+    Help = '/help',
 }
 
 export const HELP_QUICK_ACTION = {

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -1,15 +1,31 @@
 import { CredentialsProvider, Server } from '@aws/language-server-runtimes/server-interface'
 import { ChatController } from './chat/chatController'
 import { ChatSessionManagementService } from './chat/chatSessionManagementService'
+import { CLEAR_QUICK_ACTION, HELP_QUICK_ACTION } from './chat/quickActions'
 
 export const QChatServer =
     (service: (credentialsProvider: CredentialsProvider) => ChatSessionManagementService): Server =>
     features => {
-        const { chat, credentialsProvider, logging } = features
+        const { chat, credentialsProvider, logging, lsp } = features
 
         const chatSessionManagementService: ChatSessionManagementService = service(credentialsProvider)
 
         const chatController = new ChatController(chatSessionManagementService, features)
+
+        lsp.addInitializer(() => {
+            return {
+                capabilities: {},
+                awsServerCapabilities: {
+                    chatQuickActionsProvider: {
+                        quickActionsCommandGroups: [
+                            {
+                                commands: [HELP_QUICK_ACTION, CLEAR_QUICK_ACTION],
+                            },
+                        ],
+                    },
+                },
+            }
+        })
 
         chat.onTabAdd(params => {
             logging.log(`Adding tab: ${params.tabId}`)


### PR DESCRIPTION
## Description
- Support `clear` and `help` quick actions
- Register quick actions in the `awsServerCapabilities`

Referenced https://github.com/aws/language-servers/pull/282 and vscode for help text

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
