### PR TITLE
Revert dependabot

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -136,7 +136,7 @@
         "@aws/language-server-runtimes": "^0.2.6",
         "@aws/chat-client-ui-types": "0.x.x",
         "@aws-sdk/credential-providers": "^3.540.0",
-        "@aws-sdk/types": "^3.577.0",
+        "@aws-sdk/types": "^3.535.0",
         "@types/vscode": "^1.88.0",
         "jose": "^5.2.4",
         "typescript": "^5.4.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -230,7 +230,7 @@
             "license": "MIT",
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.540.0",
-                "@aws-sdk/types": "^3.577.0",
+                "@aws-sdk/types": "^3.535.0",
                 "@aws/chat-client-ui-types": "0.x.x",
                 "@aws/language-server-runtimes": "^0.2.6",
                 "@types/vscode": "^1.88.0",
@@ -526,19 +526,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dev": true,
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-s3": {
             "version": "3.574.0",
             "license": "Apache-2.0",
@@ -649,18 +636,6 @@
                 "@smithy/util-middleware": "^2.2.0",
                 "@smithy/util-retry": "^2.2.0",
                 "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -825,30 +800,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-sts": {
             "version": "3.572.0",
             "license": "Apache-2.0",
@@ -949,19 +900,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "peer": true,
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/core": {
             "version": "3.572.0",
             "license": "Apache-2.0",
@@ -993,37 +931,12 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dev": true,
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.568.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/property-provider": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1043,18 +956,6 @@
                 "@smithy/smithy-client": "^2.5.1",
                 "@smithy/types": "^2.12.0",
                 "@smithy/util-stream": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1083,18 +984,6 @@
                 "@aws-sdk/client-sts": "3.572.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-node": {
             "version": "3.572.0",
             "license": "Apache-2.0",
@@ -1116,18 +1005,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-process": {
             "version": "3.572.0",
             "license": "Apache-2.0",
@@ -1135,18 +1012,6 @@
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/property-provider": "^2.2.0",
                 "@smithy/shared-ini-file-loader": "^2.4.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1237,18 +1102,6 @@
                 "@aws-sdk/client-sso-oidc": "3.572.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
             "version": "3.568.0",
             "license": "Apache-2.0",
@@ -1263,18 +1116,6 @@
             },
             "peerDependencies": {
                 "@aws-sdk/client-sts": "^3.568.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-providers": {
@@ -1353,19 +1194,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dev": true,
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
             "version": "3.568.0",
             "license": "Apache-2.0",
@@ -1382,36 +1210,12 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-expect-continue": {
             "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/protocol-http": "^3.3.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1436,36 +1240,12 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.567.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/protocol-http": "^3.3.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1485,35 +1265,11 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-logger": {
             "version": "3.568.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1527,18 +1283,6 @@
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/protocol-http": "^3.3.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1564,18 +1308,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-signing": {
             "version": "3.572.0",
             "license": "Apache-2.0",
@@ -1592,35 +1324,11 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-ssec": {
             "version": "3.567.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.567.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1669,18 +1377,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.572.0",
             "license": "Apache-2.0",
@@ -1696,18 +1392,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/region-config-resolver/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
             "version": "3.572.0",
             "license": "Apache-2.0",
@@ -1716,18 +1400,6 @@
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/protocol-http": "^3.3.0",
                 "@smithy/signature-v4": "^2.3.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
                 "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
@@ -1885,22 +1557,10 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
-            "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
+            "version": "3.567.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-            "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
-            "dependencies": {
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1924,18 +1584,6 @@
                 "@aws-sdk/types": "3.567.0",
                 "@smithy/types": "^2.12.0",
                 "@smithy/util-endpoints": "^1.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1991,18 +1639,6 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.568.0",
             "license": "Apache-2.0",
@@ -2022,18 +1658,6 @@
                 "aws-crt": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-            "version": "3.567.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
-            "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/util-utf8-browser": {
@@ -16113,7 +15737,7 @@
                 "@aws-sdk/middleware-token": "3.425.0",
                 "@aws-sdk/middleware-user-agent": "3.425.0",
                 "@aws-sdk/region-config-resolver": "3.425.0",
-                "@aws-sdk/types": "3.577.0",
+                "@aws-sdk/types": "3.425.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws-sdk/util-user-agent-browser": "3.425.0",
                 "@aws-sdk/util-user-agent-node": "3.425.0",
@@ -16158,29 +15782,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/node_modules/@aws-sdk/types": {
-            "version": "3.577.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.577.0.tgz",
-            "integrity": "sha512-FT2JZES3wBKN/alfmhlo+3ZOq/XJ0C7QOZcDNrpKjB0kqYoKjhVKZ/Hx6ArR0czkKfHzBBEs6y40ebIHx2nSmA==",
-            "dependencies": {
-                "@smithy/types": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-            "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "server/aws-lsp-json": {
             "name": "@aws/lsp-json",
             "version": "0.0.1",
@@ -16217,7 +15818,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.550.0",
-                "@aws-sdk/types": "^3.577.0",
+                "@aws-sdk/types": "^3.535.0",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -642,19 +642,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/eventstream-serde-node": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
-            "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
-            "dependencies": {
-                "@smithy/eventstream-serde-universal": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-sso": {
             "version": "3.572.0",
             "license": "Apache-2.0",
@@ -3604,62 +3591,15 @@
             }
         },
         "node_modules/@smithy/eventstream-serde-node": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.0.tgz",
-            "integrity": "sha512-baRPdMBDMBExZXIUAoPGm/hntixjt/VFpU6+VmCyiYJYzRHRxoaI1MN+5XE+hIS8AJ2GCHLMFEIOLzq9xx1EgQ==",
+            "version": "2.2.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/eventstream-serde-universal": "^3.0.0",
-                "@smithy/types": "^3.0.0",
+                "@smithy/eventstream-serde-universal": "^2.2.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/eventstream-codec": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.0.0.tgz",
-            "integrity": "sha512-PUtyEA0Oik50SaEFCZ0WPVtF9tz/teze2fDptW6WRXl+RrEenH8UbEjudOz8iakiMl3lE3lCVqYf2Y+znL8QFQ==",
-            "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^3.0.0",
-                "@smithy/util-hex-encoding": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/eventstream-serde-universal": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.0.tgz",
-            "integrity": "sha512-HNFfShmotWGeAoW4ujP8meV9BZavcpmerDbPIjkJbxKbN8RsUcpRQ/2OyIxWNxXNH2GWCAxuSB7ynmIGJlQ3Dw==",
-            "dependencies": {
-                "@smithy/eventstream-codec": "^3.0.0",
-                "@smithy/types": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/types": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-            "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/util-hex-encoding": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-            "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/eventstream-serde-universal": {
@@ -15744,7 +15684,7 @@
                 "@smithy/config-resolver": "^2.0.11",
                 "@smithy/eventstream-serde-browser": "^2.0.10",
                 "@smithy/eventstream-serde-config-resolver": "^2.0.10",
-                "@smithy/eventstream-serde-node": "^3.0.0",
+                "@smithy/eventstream-serde-node": "^2.0.10",
                 "@smithy/fetch-http-handler": "^2.2.1",
                 "@smithy/hash-node": "^2.0.10",
                 "@smithy/invalid-dependency": "^2.0.10",

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
@@ -31,7 +31,7 @@
         "@smithy/config-resolver": "^2.0.11",
         "@smithy/eventstream-serde-browser": "^2.0.10",
         "@smithy/eventstream-serde-config-resolver": "^2.0.10",
-        "@smithy/eventstream-serde-node": "^3.0.0",
+        "@smithy/eventstream-serde-node": "^2.0.10",
         "@smithy/fetch-http-handler": "^2.2.1",
         "@smithy/hash-node": "^2.0.10",
         "@smithy/invalid-dependency": "^2.0.10",

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
@@ -24,7 +24,7 @@
         "@aws-sdk/middleware-token": "3.425.0",
         "@aws-sdk/middleware-user-agent": "3.425.0",
         "@aws-sdk/region-config-resolver": "3.425.0",
-        "@aws-sdk/types": "3.577.0",
+        "@aws-sdk/types": "3.425.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws-sdk/util-user-agent-browser": "3.425.0",
         "@aws-sdk/util-user-agent-node": "3.425.0",

--- a/server/aws-lsp-s3/package.json
+++ b/server/aws-lsp-s3/package.json
@@ -8,7 +8,7 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.550.0",
-        "@aws-sdk/types": "^3.577.0",
+        "@aws-sdk/types": "^3.535.0",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"


### PR DESCRIPTION
## Problem
The dependencies in the streaming client package have been pinned due to incompatibility with newer versions: https://github.com/aws/aws-toolkit-vscode/pull/4448

This fails our build if package-lock.json is recreated

## Solution
Revert the version bumps 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
