### PR TITLE
Disable YAML patching

### DIFF
--- a/app/aws-lsp-yaml-binary/src/tests/yamlServerCFInteg.test.ts
+++ b/app/aws-lsp-yaml-binary/src/tests/yamlServerCFInteg.test.ts
@@ -68,7 +68,7 @@ describe('Test YamlServer with CloudFormation schema', () => {
         client.exit()
     })
 
-    it('should return hover item without header and footer, YAML', async () => {
+    it.skip('should return hover item without header and footer, YAML', async () => {
         const docUri = 'hover.yml'
         client.didOpen({
             textDocument: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,8 +60,9 @@
             "name": "@aws/lsp-codewhisperer-binary",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.5",
-                "@aws/lsp-codewhisperer": "*"
+                "@aws/language-server-runtimes": "0.x.x",
+                "@aws/lsp-codewhisperer": "*",
+                "copyfiles": "^2.4.1"
             },
             "bin": {
                 "aws-lsp-codewhisperer-binary": "out/index.js"
@@ -5106,7 +5107,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -5119,7 +5119,6 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -5504,7 +5503,6 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/base64-js": {
@@ -6158,7 +6156,6 @@
         },
         "node_modules/cliui": {
             "version": "7.0.4",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
@@ -6224,7 +6221,6 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -6235,7 +6231,6 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/colorette": {
@@ -6307,7 +6302,6 @@
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/concurrently": {
@@ -6408,7 +6402,6 @@
         },
         "node_modules/copyfiles": {
             "version": "2.4.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "glob": "^7.0.5",
@@ -6426,7 +6419,6 @@
         },
         "node_modules/copyfiles/node_modules/brace-expansion": {
             "version": "1.1.11",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -6435,7 +6427,6 @@
         },
         "node_modules/copyfiles/node_modules/minimatch": {
             "version": "3.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -6446,7 +6437,6 @@
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/create-ecdh": {
@@ -7033,7 +7023,6 @@
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/emojis-list": {
@@ -7168,7 +7157,6 @@
         },
         "node_modules/escalade": {
             "version": "3.1.2",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -7904,7 +7892,6 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/fsevents": {
@@ -7936,7 +7923,6 @@
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
@@ -8004,7 +7990,6 @@
         },
         "node_modules/glob": {
             "version": "7.2.3",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -8039,7 +8024,6 @@
         },
         "node_modules/glob/node_modules/brace-expansion": {
             "version": "1.1.11",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -8048,7 +8032,6 @@
         },
         "node_modules/glob/node_modules/minimatch": {
             "version": "3.1.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -8546,7 +8529,6 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
@@ -8681,7 +8663,6 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -10319,7 +10300,6 @@
         },
         "node_modules/mkdirp": {
             "version": "1.0.4",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "mkdirp": "bin/cmd.js"
@@ -10612,7 +10592,6 @@
         },
         "node_modules/noms": {
             "version": "0.0.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "inherits": "^2.0.1",
@@ -10621,12 +10600,10 @@
         },
         "node_modules/noms/node_modules/isarray": {
             "version": "0.0.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/noms/node_modules/readable-stream": {
             "version": "1.0.34",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -10637,7 +10614,6 @@
         },
         "node_modules/noms/node_modules/string_decoder": {
             "version": "0.10.31",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/nopt": {
@@ -11457,7 +11433,6 @@
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -11986,7 +11961,6 @@
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/process-warning": {
@@ -12353,7 +12327,6 @@
         },
         "node_modules/readable-stream": {
             "version": "2.3.8",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -12367,7 +12340,6 @@
         },
         "node_modules/readable-stream/node_modules/safe-buffer": {
             "version": "5.1.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/readdir-scoped-modules": {
@@ -12452,7 +12424,6 @@
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -13392,7 +13363,6 @@
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
@@ -13400,7 +13370,6 @@
         },
         "node_modules/string_decoder/node_modules/safe-buffer": {
             "version": "5.1.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/string-length": {
@@ -13417,7 +13386,6 @@
         },
         "node_modules/string-width": {
             "version": "4.2.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -13444,7 +13412,6 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -13776,7 +13743,6 @@
         },
         "node_modules/through2": {
             "version": "2.0.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "readable-stream": "~2.3.6",
@@ -14364,7 +14330,6 @@
         },
         "node_modules/untildify": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -14440,7 +14405,6 @@
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/util-extend": {
@@ -15174,7 +15138,6 @@
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -15274,7 +15237,6 @@
         },
         "node_modules/xtend": {
             "version": "4.0.2",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4"
@@ -15282,7 +15244,6 @@
         },
         "node_modules/y18n": {
             "version": "5.0.8",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=10"
@@ -15398,7 +15359,6 @@
         },
         "node_modules/yargs": {
             "version": "16.2.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cliui": "^7.0.2",
@@ -15415,7 +15375,6 @@
         },
         "node_modules/yargs-parser": {
             "version": "20.2.4",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=10"
@@ -15767,7 +15726,6 @@
         "server/aws-lsp-yaml": {
             "name": "@aws/lsp-yaml",
             "version": "0.0.1",
-            "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.5",

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -22,7 +22,6 @@
     ],
     "scripts": {
         "compile": "tsc --build",
-        "postinstall": "node patchYamlPackage.js",
         "prepack": "cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {

--- a/server/aws-lsp-yaml/src/language-service/yamlLanguageService.ts
+++ b/server/aws-lsp-yaml/src/language-service/yamlLanguageService.ts
@@ -59,7 +59,6 @@ export class YamlLanguageService implements AwsLanguageService {
     private updateSchemaMapping(documentUri: string): void {
         this.yamlService.configure({
             hover: true,
-            hoverSettings: { showSource: false, showTitle: false },
             completion: true,
             format: true,
             validate: true,


### PR DESCRIPTION
## Problem
YAML patching script is using commands that are. not working on Windows machines, resulting in failed `npm install` script
## Solution
Temporarily disable patching to unblock development on Windows machines, until a long term solution is developed. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
