### PR TITLE
Define quick actions dynamically

### DIFF
--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -11,8 +11,8 @@ import {
     SEND_TO_PROMPT,
     SendToPromptMessage,
     UiMessage,
-    QUICK_ACTIONS_OPTIONS,
-    QuickActionsOptionsMessage,
+    CHAT_OPTIONS,
+    ChatOptionsMessage,
 } from '@aws/chat-client-ui-types'
 import {
     CHAT_REQUEST_METHOD,
@@ -37,13 +37,16 @@ import {
     TabChangeParams,
     TabRemoveParams,
 } from '@aws/language-server-runtimes-types'
-import { MynahUI, MynahUIDataModel } from '@aws/mynah-ui'
+import { MynahUIDataModel, MynahUIProps } from '@aws/mynah-ui'
 import { ServerMessage, TELEMETRY, TelemetryParams } from '../contracts/serverContracts'
 import { ENTER_FOCUS, EXIT_FOCUS } from '../contracts/telemetry'
 import { Messager, OutboundChatApi } from './messager'
 import { InboundChatApi, createMynahUi } from './mynahUi'
 import { TabFactory } from './tabs/tabFactory'
-import { MynahUITabStoreModel } from '@aws/mynah-ui/dist/static'
+
+// Workaround to import MynahUITabStoreModel until mynah exports it
+type FieldType<T, K extends keyof T> = T[K]
+type MynahUITabStoreModel = FieldType<MynahUIProps, 'tabs'>
 
 const DEFAULT_TAB_DATA = {
     tabTitle: 'Chat',
@@ -82,10 +85,10 @@ export const createChat = (clientApi: { postMessage: (msg: UiMessage | ServerMes
             case ERROR_MESSAGE:
                 mynahApi.showError((message as ErrorMessage).params)
                 break
-            case QUICK_ACTIONS_OPTIONS:
-                const params = (message as QuickActionsOptionsMessage).params
+            case CHAT_OPTIONS:
+                const params = (message as ChatOptionsMessage).params
                 const chatConfig: ChatClientConfig = {
-                    quickActionCommands: params.quickActionsCommandGroups,
+                    quickActionCommands: params.quickActionsOptions?.quickActionsCommandGroups,
                 }
                 tabFactory.updateDefaultTabData(chatConfig)
 

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -107,7 +107,7 @@ describe('MynahUI', () => {
             inboundChatApi.sendGenericCommand({ genericCommand, selection, tabId, triggerType })
 
             sinon.assert.calledWithMatch(createTabStub.lastCall, false)
-            sinon.assert.calledTwice(updateStoreSpy)
+            sinon.assert.calledThrice(updateStoreSpy)
         })
 
         it('should not create a new tab if one exits already', () => {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -19,7 +19,7 @@ import {
     LinkClickParams,
     SourceLinkClickParams,
 } from '@aws/language-server-runtimes-types'
-import { ChatItem, ChatItemType, ChatPrompt, MynahUI, NotificationType } from '@aws/mynah-ui'
+import { ChatItem, ChatItemType, ChatPrompt, MynahUI, MynahUIDataModel, NotificationType } from '@aws/mynah-ui'
 import { CopyCodeToClipboardParams, VoteParams } from '../contracts/telemetry'
 import { Messager } from './messager'
 import { TabFactory } from './tabs/tabFactory'
@@ -131,6 +131,10 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
         onReady: messager.onUiReady,
         onTabAdd: (tabId: string) => {
             messager.onTabAdd(tabId)
+            const defaultTabConfig: Partial<MynahUIDataModel> = {
+                quickActionCommands: tabFactory.getDefaultTabData().quickActionCommands,
+            }
+            mynahUi.updateStore(tabId, defaultTabConfig)
         },
         onTabRemove: (tabId: string) => {
             messager.onTabRemove(tabId)

--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -23,7 +23,16 @@ export class TabFactory {
                   ]
                 : [],
         }
+
         return tabData
+    }
+
+    public updateDefaultTabData(defaultTabData: DefaultTabData) {
+        this.defaultTabData = { ...this.defaultTabData, ...defaultTabData }
+    }
+
+    public getDefaultTabData(): DefaultTabData {
+        return this.defaultTabData
     }
 
     private getWelcomeBlock() {

--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -123,26 +123,6 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
         await registerLogCommand(client, extensionContext)
     }
 
-    // Listen for Initialize handshake from LSP server to register quick actions dynamically
-    client.onDidChangeState(({ oldState, newState }) => {
-        if (oldState === State.Starting && newState === State.Running) {
-            console.log('Received initializeResult from server:', client.initializeResult)
-
-            // Activate chat
-            // const enableChat = process.env.ENABLE_CHAT === 'true'
-            // if (enableChat) {
-            //     registerChat(client, extensionContext.extensionUri)
-            // }
-
-            // panel.webview.postMessage({
-            //     command: 'updateConfig',
-            //     params: { config: { /* new config here */ } },
-            // })
-        }
-    })
-
-    await client.start()
-
     // Activate chat server after LSP initialize handshake is done
     const enableChat = process.env.ENABLE_CHAT === 'true'
     if (enableChat) {

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -16,12 +16,14 @@ export const QChatServer =
             return {
                 capabilities: {},
                 awsServerCapabilities: {
-                    chatQuickActionsProvider: {
-                        quickActionsCommandGroups: [
-                            {
-                                commands: [HELP_QUICK_ACTION, CLEAR_QUICK_ACTION],
-                            },
-                        ],
+                    chatOptions: {
+                        quickActionsOptions: {
+                            quickActionsCommandGroups: [
+                                {
+                                    commands: [HELP_QUICK_ACTION, CLEAR_QUICK_ACTION],
+                                },
+                            ],
+                        },
                     },
                 },
             }

--- a/server/hello-world-lsp/src/language-server/helloWorldServer.ts
+++ b/server/hello-world-lsp/src/language-server/helloWorldServer.ts
@@ -82,34 +82,36 @@ export const HelloWorldServerFactory =
                     },
                 },
                 awsServerCapabilities: {
-                    chatQuickActionsProvider: {
-                        quickActionsCommandGroups: [
-                            {
-                                groupName: 'Hello World Actions',
-                                commands: [
-                                    {
-                                        command: 'hello',
-                                        description: 'Say Hello',
-                                    },
-                                    {
-                                        command: 'world',
-                                        description: 'World of Actions',
-                                    },
-                                ],
-                            },
-                            {
-                                commands: [
-                                    {
-                                        command: 'help',
-                                        description: 'Learn more about Amazon Q',
-                                    },
-                                    {
-                                        command: 'clear',
-                                        description: 'Clear this session',
-                                    },
-                                ],
-                            },
-                        ],
+                    chatOptions: {
+                        quickActionsOptions: {
+                            quickActionsCommandGroups: [
+                                {
+                                    groupName: 'Hello World Actions',
+                                    commands: [
+                                        {
+                                            command: 'hello',
+                                            description: 'Say Hello',
+                                        },
+                                        {
+                                            command: 'world',
+                                            description: 'World of Actions',
+                                        },
+                                    ],
+                                },
+                                {
+                                    commands: [
+                                        {
+                                            command: 'help',
+                                            description: 'Learn more about Amazon Q',
+                                        },
+                                        {
+                                            command: 'clear',
+                                            description: 'Clear this session',
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
                     },
                 },
             }


### PR DESCRIPTION
## Problem
The chat client shouldn't have to wait for the language client initialisation to finish before rendering the UI. Chat client should render the chat UI and then once the language client initialisation is done, the chat client should update the UI configuration to reflect the new information obtained during initialisation. For now, this information is only the available quick actions 

## Solution
Created new contract between ide extension and chat client that allows the ide extension to send a message about the initialization result to the chat client. The chat client then uses this information to update the default tab data for existing and any new tabs. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
