### PR TITLE
fix: partiql - don't report diagnostics for quoted identifiers

### DIFF
--- a/server/aws-lsp-partiql/src/server/language-service.test.ts
+++ b/server/aws-lsp-partiql/src/server/language-service.test.ts
@@ -24,12 +24,17 @@ describe('PartiQL validation parsing', () => {
     initSync(partiQlServerBinary)
 
     parserTestData.forEach(testData => {
-        it(`should correctly parse errors for ${testData.errorType}.`, async () => {
+        it(`should correctly parse errors for ${testData.errorType}.`, () => {
             const parsedQuery = JSON.parse(parse_as_json(normalizeQuery(testData.input)))
             const error = parsedQuery.errors[0]
             const diagnosticsMessage = convertObjectToParserError(error).message
             expect(diagnosticsMessage).toBe(testData.expectedOutput)
         })
+    })
+
+    it('should not give errors for quoted identifiers', () => {
+        const parsedQuery = JSON.parse(parse_as_json(normalizeQuery('SELECT "test" from "yay"')))
+        expect(parsedQuery.errors).toBeUndefined()
     })
 })
 
@@ -127,7 +132,7 @@ const edgeCaseParserTestData: edgeCaseParserDataType[] = [
 describe('error parsing edge-cases', () => {
     // These inputs should throw errors.
     edgeCaseParserTestData.forEach(testData => {
-        it(`should throw when ${testData.name}.`, async () => {
+        it(`should throw when ${testData.name}.`, () => {
             expect(() => {
                 convertObjectToParserError(testData.input)
             }).toThrowError(
@@ -169,7 +174,7 @@ describe('lexer error parsing edge-cases', () => {
     // These inputs should throw errors. These tests are to handle specific cases which will normally be caught
     // by the parsing before it reaches the lexer error parsing.
     edgeCaseLexerTestData.forEach(testData => {
-        it(`should throw when ${testData.name}.`, async () => {
+        it(`should throw when ${testData.name}.`, () => {
             expect(() => {
                 convertObjectToLexerError(testData.input)
             }).toThrowError(`${testData.specificErrorString}`)

--- a/server/aws-lsp-partiql/src/server/language-service.ts
+++ b/server/aws-lsp-partiql/src/server/language-service.ts
@@ -5,7 +5,7 @@ import { initSync, parse_as_json } from '../partiql-parser-wasm/partiql_playgrou
 import { convertObjectToParserError } from './error-parsing/parser-errors'
 
 export function normalizeQuery(data: string): string {
-    return data != null ? data.replace(/\"/g, '\\"') : ''
+    return data != null ? data : ''
 }
 
 export function createPartiQLLanguageService() {


### PR DESCRIPTION
## Problem

Queries like 

```
SELECT * 
FROM "TableName"."IndexName" 
```
should not result in diagnostics. (see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ql-reference.select.html)

Currently these result in diagnostics with the error `InvalidInput("\")` which is coming from the extra `\` we add in `normalizeQuery`. The query is directly send to the wasm module [here](https://github.com/aws/language-servers/blob/main/server/aws-lsp-partiql/src/partiql-parser-wasm/partiql_playground.js#L181) so the extra escaping of the `"` doesn't seem to be necessary. 

Same bug was present in the partiql-playground package using the same WASM module and was fixed in the same way in https://github.com/partiql/partiql-rust-playground/pull/16.

## Solution

Removed the replacement of `\"` by `\\"` in the preparing of the document before sending it to the wasm module.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
