### PR TITLE
Send Generic command to new tab if current tab is busy

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "0.x.x",
         "@aws/language-server-runtimes-types": "0.x.x",
-        "@aws/mynah-ui": "^4.9.x"
+        "@aws/mynah-ui": "^4.10.x"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -16,29 +16,34 @@ import { createChat } from './chat'
 import sinon = require('sinon')
 import { TELEMETRY } from '../contracts/serverContracts'
 import { ERROR_MESSAGE_TELEMETRY_EVENT, SEND_TO_PROMPT_TELEMETRY_EVENT } from '../contracts/telemetry'
+import { MynahUI } from '@aws/mynah-ui'
 
 describe('Chat', () => {
     const sandbox = sinon.createSandbox()
+    let mynahUi: MynahUI
     let clientApi: { postMessage: sinon.SinonStub }
 
     beforeEach(() => {
         clientApi = {
             postMessage: sandbox.stub(),
         }
+
+        mynahUi = createChat(clientApi)
     })
 
     afterEach(() => {
         sandbox.restore()
+
+        Object.keys(mynahUi.getAllTabs()).forEach(tabId => {
+            mynahUi.removeTab(tabId, (mynahUi as any).lastEventId)
+        })
     })
 
     it('publishes ready event, when initialized', () => {
-        createChat(clientApi)
         assert.calledOnceWithExactly(clientApi.postMessage, { command: READY_NOTIFICATION_METHOD })
     })
 
     it('publishes telemetry event, when send to prompt is triggered', () => {
-        createChat(clientApi)
-
         const eventParams = { command: SEND_TO_PROMPT, params: { prompt: 'hey' } }
         const sendToPromptEvent = createInboundEvent(eventParams)
         window.dispatchEvent(sendToPromptEvent)
@@ -47,15 +52,13 @@ describe('Chat', () => {
             command: TELEMETRY,
             params: {
                 name: SEND_TO_PROMPT_TELEMETRY_EVENT,
-                tabId: 'tab-1',
+                tabId: mynahUi.getSelectedTabId(),
                 ...eventParams.params,
             },
         })
     })
 
     it('publishes telemetry event, when show error is triggered', () => {
-        createChat(clientApi)
-
         const eventParams = { command: ERROR_MESSAGE, params: { tabId: '123' } }
         const errorEvent = createInboundEvent(eventParams)
         window.dispatchEvent(errorEvent)
@@ -70,17 +73,17 @@ describe('Chat', () => {
     })
 
     it('publishes tab added event, when UI tab is added', () => {
-        const mynahUi = createChat(clientApi)
         const tabId = mynahUi.updateStore('', {})
 
         assert.calledWithMatch(clientApi.postMessage, {
             command: TAB_ADD_NOTIFICATION_METHOD,
             params: { tabId: tabId },
         })
+
+        mynahUi.getAllTabs()
     })
 
     it('publishes tab removed event, when UI tab is removed', () => {
-        const mynahUi = createChat(clientApi)
         const tabId = mynahUi.updateStore('', {})
         mynahUi.removeTab(tabId!, (mynahUi as any).lastEventId)
 
@@ -91,7 +94,6 @@ describe('Chat', () => {
     })
 
     it('publishes tab changed event, when UI tab is changed ', () => {
-        const mynahUi = createChat(clientApi)
         const tabId = mynahUi.updateStore('', {})
         mynahUi.updateStore('', {})
         clientApi.postMessage.resetHistory()
@@ -104,8 +106,6 @@ describe('Chat', () => {
     })
 
     it('generic command creates a chat request', () => {
-        createChat(clientApi)
-
         const genericCommand = 'Fix'
         const selection = 'some code'
         const tabId = '123'
@@ -130,10 +130,9 @@ describe('Chat', () => {
     })
 
     it('complete chat response triggers ui events ', () => {
-        const chat = createChat(clientApi)
-        const endMessageStreamStub = sandbox.stub(chat, 'endMessageStream')
-        const updateLastChatAnswerStub = sandbox.stub(chat, 'updateLastChatAnswer')
-        const updateStoreStub = sandbox.stub(chat, 'updateStore')
+        const endMessageStreamStub = sandbox.stub(mynahUi, 'endMessageStream')
+        const updateLastChatAnswerStub = sandbox.stub(mynahUi, 'updateLastChatAnswer')
+        const updateStoreStub = sandbox.stub(mynahUi, 'updateStore')
 
         const tabId = '123'
         const body = 'some response'
@@ -154,10 +153,9 @@ describe('Chat', () => {
     })
 
     it('partial chat response triggers ui events ', () => {
-        const chat = createChat(clientApi)
-        const endMessageStreamStub = sandbox.stub(chat, 'endMessageStream')
-        const updateLastChatAnswerStub = sandbox.stub(chat, 'updateLastChatAnswer')
-        const updateStoreStub = sandbox.stub(chat, 'updateStore')
+        const endMessageStreamStub = sandbox.stub(mynahUi, 'endMessageStream')
+        const updateLastChatAnswerStub = sandbox.stub(mynahUi, 'updateLastChatAnswer')
+        const updateStoreStub = sandbox.stub(mynahUi, 'updateStore')
 
         const tabId = '123'
         const body = 'some response'

--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -79,8 +79,6 @@ describe('Chat', () => {
             command: TAB_ADD_NOTIFICATION_METHOD,
             params: { tabId: tabId },
         })
-
-        mynahUi.getAllTabs()
     })
 
     it('publishes tab removed event, when UI tab is removed', () => {

--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -19,7 +19,7 @@ import { ERROR_MESSAGE_TELEMETRY_EVENT, SEND_TO_PROMPT_TELEMETRY_EVENT } from '.
 
 describe('Chat', () => {
     const sandbox = sinon.createSandbox()
-    let clientApi: { postMessage: any }
+    let clientApi: { postMessage: sinon.SinonStub }
 
     beforeEach(() => {
         clientApi = {
@@ -94,9 +94,10 @@ describe('Chat', () => {
         const mynahUi = createChat(clientApi)
         const tabId = mynahUi.updateStore('', {})
         mynahUi.updateStore('', {})
+        clientApi.postMessage.resetHistory()
         mynahUi.selectTab(tabId!, (mynahUi as any).lastEventId)
 
-        assert.calledWithMatch(clientApi.postMessage, {
+        assert.calledOnceWithExactly(clientApi.postMessage, {
             command: TAB_CHANGE_NOTIFICATION_METHOD,
             params: { tabId: tabId },
         })
@@ -130,9 +131,9 @@ describe('Chat', () => {
 
     it('complete chat response triggers ui events ', () => {
         const chat = createChat(clientApi)
-        const endMessageStreamStub = sinon.stub(chat, 'endMessageStream')
-        const updateLastChatAnswerStub = sinon.stub(chat, 'updateLastChatAnswer')
-        const updateStoreStub = sinon.stub(chat, 'updateStore')
+        const endMessageStreamStub = sandbox.stub(chat, 'endMessageStream')
+        const updateLastChatAnswerStub = sandbox.stub(chat, 'updateLastChatAnswer')
+        const updateStoreStub = sandbox.stub(chat, 'updateStore')
 
         const tabId = '123'
         const body = 'some response'
@@ -154,9 +155,9 @@ describe('Chat', () => {
 
     it('partial chat response triggers ui events ', () => {
         const chat = createChat(clientApi)
-        const endMessageStreamStub = sinon.stub(chat, 'endMessageStream')
-        const updateLastChatAnswerStub = sinon.stub(chat, 'updateLastChatAnswer')
-        const updateStoreStub = sinon.stub(chat, 'updateStore')
+        const endMessageStreamStub = sandbox.stub(chat, 'endMessageStream')
+        const updateLastChatAnswerStub = sandbox.stub(chat, 'updateLastChatAnswer')
+        const updateStoreStub = sandbox.stub(chat, 'updateStore')
 
         const tabId = '123'
         const body = 'some response'

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -56,6 +56,10 @@ describe('MynahUI', () => {
 
     afterEach(() => {
         sinon.restore()
+
+        Object.keys(mynahUi.getAllTabs()).forEach(tabId => {
+            mynahUi.removeTab(tabId, (mynahUi as any).lastEventId)
+        })
     })
 
     describe('handleChatPrompt', () => {

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -1,4 +1,4 @@
-import { before, afterEach } from 'mocha'
+import { afterEach } from 'mocha'
 import sinon = require('sinon')
 import { assert } from 'sinon'
 import { createMynahUi, InboundChatApi, handleChatPrompt } from './mynahUi'
@@ -14,12 +14,13 @@ describe('MynahUI', () => {
 
     let getSelectedTabIdStub: sinon.SinonStub
     let createTabStub: sinon.SinonStub
+    let getAllTabsStub: sinon.SinonStub
     let updateStoreSpy: sinon.SinonSpy
     let addChatItemSpy: sinon.SinonSpy
     let onChatPromptSpy: sinon.SinonSpy
     let onQuickActionSpy: sinon.SinonSpy
 
-    before(() => {
+    beforeEach(() => {
         outboundChatApi = {
             sendChatPrompt: sinon.stub(),
             sendQuickActionCommand: sinon.stub(),
@@ -48,12 +49,13 @@ describe('MynahUI', () => {
         mynahUi = mynahUiResult[0]
         inboundChatApi = mynahUiResult[1]
         getSelectedTabIdStub = sinon.stub(mynahUi, 'getSelectedTabId')
+        getAllTabsStub = sinon.stub(mynahUi, 'getAllTabs').returns({})
         updateStoreSpy = sinon.spy(mynahUi, 'updateStore')
         addChatItemSpy = sinon.spy(mynahUi, 'addChatItem')
     })
 
     afterEach(() => {
-        sinon.resetHistory()
+        sinon.restore()
     })
 
     describe('handleChatPrompt', () => {
@@ -99,6 +101,8 @@ describe('MynahUI', () => {
 
     describe('sendGenericCommand', () => {
         it('should create a new tab if none exits', () => {
+            // clear create tab stub since set up process calls it twice
+            createTabStub.resetHistory()
             const genericCommand = 'Explain'
             const selection = 'const x = 5;'
             const tabId = ''
@@ -106,11 +110,28 @@ describe('MynahUI', () => {
             getSelectedTabIdStub.returns(undefined)
             inboundChatApi.sendGenericCommand({ genericCommand, selection, tabId, triggerType })
 
-            sinon.assert.calledWithMatch(createTabStub.lastCall, false)
+            sinon.assert.calledOnceWithExactly(createTabStub, false)
+            sinon.assert.calledTwice(updateStoreSpy)
+        })
+
+        it('should create a new tab if current tab is loading', () => {
+            // clear create tab stub since set up process calls it twice
+            createTabStub.resetHistory()
+            getAllTabsStub.returns({ 'tab-1': { store: { loadingChat: true } } })
+
+            const genericCommand = 'Explain'
+            const selection = 'const x = 5;'
+            const tabId = 'tab-1'
+            const triggerType = 'click'
+            getSelectedTabIdStub.returns(tabId)
+            inboundChatApi.sendGenericCommand({ genericCommand, selection, tabId, triggerType })
+
+            sinon.assert.calledOnceWithExactly(createTabStub, false)
             sinon.assert.calledTwice(updateStoreSpy)
         })
 
         it('should not create a new tab if one exits already', () => {
+            createTabStub.resetHistory()
             const genericCommand = 'Explain'
             const selection = 'const x = 5;'
             const tabId = 'tab-1'

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -296,12 +296,12 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
     }
 
     const sendGenericCommand = (params: GenericCommandParams) => {
-        let tabId = mynahUi.getSelectedTabId()
+        let tabId = getOrCreateTabId()
 
         if (!tabId) return
 
         // send to a new tab if the current tab is loading
-        const isCurrentTabLoading = mynahUi.getAllTabs()[tabId].store?.loadingChat
+        const isCurrentTabLoading = mynahUi.getAllTabs()[tabId]?.store?.loadingChat
 
         if (isCurrentTabLoading) {
             tabId = createTabId()


### PR DESCRIPTION
## Problem
If user has an outgoing request and use the generic commands, the chat history becomes a mess. 

Note: 
- Change `sinon.stub` -> `sandbox.stub` in `chat.test` since there is only a `sandbox.restore()`, which affected the other test file.
- Changed `mynah.test` to use `beforeEach` setup as it is difficult to debug shared setup
- Clear all tabs after each test since both test files seem to share the same UI (with the same tab limit)

## Solution
vscode current opens up a new tab if there is an outgoing request. This PR mimics their behavior.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
