### PR TITLE
Run workflows on Windows

### DIFF
--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
     test:
         name: Test
-        runs-on: [ubuntu-latest, windows-latest]
+        runs-on: ubuntu-latest
         steps:
             - name: Sync Code
               uses: actions/checkout@v3
@@ -25,7 +25,48 @@ jobs:
                   npm run test
     build:
         name: Package
-        runs-on: [ubuntu-latest, windows-latest]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Sync Code
+              uses: actions/checkout@v3
+            - name: Set up Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18
+            - name: Build
+              run: |
+                  npm install
+                  npm run compile
+            - name: Create binaries
+              run: |
+                  npm run package
+            # TODO : Can we easily create ARM binaries from GitHub?
+            - name: Attach binaries
+              uses: actions/upload-artifact@v3
+              with:
+                  name: langauge-servers
+                  # Make sure you don't include node_modules
+                  path: app/**/bin/*
+    test-windows:
+        name: Test (Windows)
+        runs-on: windows-latest
+        steps:
+            - name: Sync Code
+              uses: actions/checkout@v3
+            - name: Set up Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18
+            - name: Build
+              run: |
+                  npm install
+                  npm run compile
+            - name: Test
+              run: |
+                  npm run test
+    build-windows:
+        name: Package (Windows)
+        runs-on: windows-latest
         steps:
             - name: Sync Code
               uses: actions/checkout@v3

--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
     test:
         name: Test
-        runs-on: ubuntu-latest
+        runs-on: [ubuntu-latest, windows-latest]
         steps:
             - name: Sync Code
               uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
                   npm run test
     build:
         name: Package
-        runs-on: ubuntu-latest
+        runs-on: [ubuntu-latest, windows-latest]
         steps:
             - name: Sync Code
               uses: actions/checkout@v3

--- a/server/aws-lsp-yaml/patchYamlPackage.js
+++ b/server/aws-lsp-yaml/patchYamlPackage.js
@@ -40,7 +40,7 @@ const filePathToPatchPathUnsafeEval = {
 
 function getPatchProcCommand(filePath, pathToPatch) {
     if (process.platform === 'win32') {
-        return execFileSync('git', ['apply', pathToPatch], {
+        return execFileSync('git', ['apply', '--ignore-whitespace', pathToPatch], {
             cwd: rootPackage,
             encoding: 'utf-8',
             timeout: 2000,


### PR DESCRIPTION
## Problem

Recently code committed to one of the monorepo subpackages resulted in build errors on Windows machines. This project targets cross-platform execution and development targets, and should not block engineers.

## Solution

Configure CI Build and Test workflows to run in Windows runners to catch build problems for every code contribution.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
