### PR TITLE
chore: Increment @aws/lsp-partiql to 0.0.2

### DIFF
--- a/server/aws-lsp-partiql/CHANGELOG.md
+++ b/server/aws-lsp-partiql/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## [0.0.2] - 2024-06-18
+- Fix: don't report diagnostics for quoted identifiers
+
 ## [0.0.1] - 2024-05-31
 - Initial release of PArtiQL Language Server implementation

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -3,7 +3,7 @@
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
     "description": "PartiQL language server",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/aws/language-servers"


### PR DESCRIPTION

### Problem

We need to bump a version of PartiQL server for release

### Solution

Version is bumped to 0.0.2

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
