### PR TITLE
[PartiQL release] Updating package-lock.json before releasing the partiql server 0.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,15 @@
                 "webpack-cli": "^5.1.4"
             }
         },
+        "app/aws-lsp-partiql-binary/node_modules/@aws/lsp-partiql": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@aws/lsp-partiql/-/lsp-partiql-0.0.1.tgz",
+            "integrity": "sha512-5VFghsF9B2KdYUvCZvVnmi4asFkDnUcK5XbaJr2ykrY5pgDzCOowuvqrPmps+52D3FTUgC4BJdjFKJSAsyfMhQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws/language-server-runtimes": "^0.2.4"
+            }
+        },
         "app/aws-lsp-s3-binary": {
             "name": "@aws/lsp-s3-binary",
             "version": "0.0.1",
@@ -212,7 +221,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "0.x.x",
                 "@aws/language-server-runtimes-types": "0.x.x",
-                "@aws/mynah-ui": "^4.9.x"
+                "@aws/mynah-ui": "^4.10.x"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -1787,10 +1796,21 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.9.1",
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.11.0.tgz",
+            "integrity": "sha512-AjTzZNeGJqolHkmsc2NduLVn7bK7YPatEAmEozsnzKZ3CM+9NPZ5Wg/6/JDWvc3+Z1AMUEbZ290qPUkXeFCpRA==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {
+                "escape-html": "^1.0.3",
+                "just-clone": "^6.2.0",
+                "marked": "^12.0.2",
+                "prismjs": "1.29.0",
+                "sanitize-html": "^2.12.1",
+                "unescape-html": "^1.1.0"
+            },
+            "peerDependencies": {
+                "escape-html": "^1.0.3",
                 "just-clone": "^6.2.0",
                 "marked": "^12.0.2",
                 "prismjs": "1.29.0",
@@ -7443,7 +7463,6 @@
         },
         "node_modules/escape-html": {
             "version": "1.0.3",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
@@ -16666,7 +16685,7 @@
         },
         "server/aws-lsp-partiql": {
             "name": "@aws/lsp-partiql",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.4"


### PR DESCRIPTION
## Problem
`npm ci` fails because the `package.json` and `package-lock.json` are out of sync after we bumped the partiql server 
## Solution
Ran `npm install` locally which updated the package-lock and now they are in sync
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
