### PR TITLE
Removed unused and vulnerable dependencies

### DIFF
--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,18 +11,16 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/lsp-yaml": "*",
+        "@aws/language-server-runtimes": "^0.2.5",
         "@aws/lsp-json": "*",
-        "@aws/language-server-runtimes": "^0.2.5"
+        "@aws/lsp-yaml": "*"
     },
     "devDependencies": {
         "@types/node": "^20.11.30",
         "assert": "^2.1.0",
         "crypto-browserify": "^3.12.0",
         "fs": "^0.0.1-security",
-        "license-checker": "^25.0.1",
         "os-browserify": "^0.3.0",
-        "oss-attribution-generator": "^1.7.1",
         "path": "^0.12.7",
         "path-browserify": "^1.0.1",
         "pkg": "^5.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,9 +174,7 @@
                 "assert": "^2.1.0",
                 "crypto-browserify": "^3.12.0",
                 "fs": "^0.0.1-security",
-                "license-checker": "^25.0.1",
                 "os-browserify": "^0.3.0",
-                "oss-attribution-generator": "^1.7.1",
                 "path": "^0.12.7",
                 "path-browserify": "^1.0.1",
                 "pkg": "^5.8.1",
@@ -7159,11 +7157,6 @@
             "dev": true,
             "license": "Apache-2.0"
         },
-        "node_modules/abbrev": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/accepts": {
             "version": "1.3.8",
             "dev": true,
@@ -7481,14 +7474,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/array-find-index": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/array-flatten": {
             "version": "1.1.1",
             "dev": true,
@@ -7607,11 +7592,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/asap": {
-            "version": "2.0.6",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/asn1.js": {
             "version": "4.10.1",
@@ -7934,11 +7914,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/bluebird": {
-            "version": "3.7.2",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/bn.js": {
             "version": "5.2.1",
             "dev": true,
@@ -7995,89 +7970,6 @@
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "multicast-dns": "^7.2.5"
-            }
-        },
-        "node_modules/bower": {
-            "version": "1.8.14",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "bower": "bin/bower"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/bower-json": {
-            "version": "0.8.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "deep-extend": "^0.5.1",
-                "ends-with": "^0.2.0",
-                "ext-list": "^2.0.0",
-                "graceful-fs": "^4.1.3",
-                "intersect": "^1.0.1",
-                "sort-keys-length": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/bower-license": {
-            "version": "0.4.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bower-json": "~0.4.0",
-                "npm-license": "~0.3.3",
-                "package-license": "~0.1.1",
-                "raptor-args": "~1.0.1",
-                "treeify": "~1.0.1",
-                "underscore": "~1.5.2"
-            },
-            "bin": {
-                "bower-license": "bin/bower-license"
-            }
-        },
-        "node_modules/bower-license/node_modules/bower-json": {
-            "version": "0.4.0",
-            "dev": true,
-            "dependencies": {
-                "deep-extend": "~0.2.5",
-                "graceful-fs": "~2.0.0",
-                "intersect": "~0.0.3"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/bower-license/node_modules/deep-extend": {
-            "version": "0.2.11",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4"
-            }
-        },
-        "node_modules/bower-license/node_modules/graceful-fs": {
-            "version": "2.0.3",
-            "dev": true,
-            "license": "BSD",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/bower-license/node_modules/intersect": {
-            "version": "0.0.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/bower-license/node_modules/treeify": {
-            "version": "1.0.1",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6"
             }
         },
         "node_modules/bowser": {
@@ -8548,14 +8440,6 @@
                 "node": ">= 0.12.0"
             }
         },
-        "node_modules/code-point-at": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/collect-v8-coverage": {
             "version": "1.0.2",
             "dev": true,
@@ -8992,14 +8876,6 @@
                 }
             }
         },
-        "node_modules/debuglog": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/decamelize": {
             "version": "4.0.0",
             "dev": true,
@@ -9061,15 +8937,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/deep-extend": {
-            "version": "0.5.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
             }
         },
         "node_modules/deep-is": {
@@ -9224,15 +9091,6 @@
             "version": "2.1.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/dezalgo": {
-            "version": "1.0.4",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
-            }
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -9439,13 +9297,6 @@
             "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
-            }
-        },
-        "node_modules/ends-with": {
-            "version": "0.2.0",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/enhanced-resolve": {
@@ -10169,17 +10020,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/ext-list": {
-            "version": "2.2.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "^1.28.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "license": "MIT"
@@ -10496,59 +10336,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/fs-jetpack": {
-            "version": "0.12.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.1",
-                "q": "^1.0.1",
-                "rimraf": "^2.2.8"
-            }
-        },
-        "node_modules/fs-jetpack/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/fs-jetpack/node_modules/minimatch": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/fs-jetpack/node_modules/mkdirp": {
-            "version": "0.5.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
-        "node_modules/fs-jetpack/node_modules/rimraf": {
-            "version": "2.7.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "license": "ISC"
@@ -10848,28 +10635,6 @@
                 "node": ">= 0.4.0"
             }
         },
-        "node_modules/has-ansi": {
-            "version": "0.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^0.2.0"
-            },
-            "bin": {
-                "has-ansi": "cli.js"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/has-ansi/node_modules/ansi-regex": {
-            "version": "0.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/has-bigints": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -10978,11 +10743,6 @@
                 "minimalistic-assert": "^1.0.0",
                 "minimalistic-crypto-utils": "^1.0.1"
             }
-        },
-        "node_modules/hosted-git-info": {
-            "version": "2.8.9",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/hpack.js": {
             "version": "2.1.6",
@@ -11294,11 +11054,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/intersect": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/into-stream": {
             "version": "6.0.0",
             "dev": true,
@@ -11312,14 +11067,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/invert-kv": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/ipaddr.js": {
@@ -11603,14 +11350,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-plain-obj": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-plain-object": {
             "version": "5.0.0",
             "license": "MIT",
@@ -11719,11 +11458,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-utf8": {
-            "version": "0.2.1",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/is-weakref": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -11749,21 +11483,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/is2": {
-            "version": "0.0.11",
-            "dev": true,
-            "dependencies": {
-                "deep-is": "0.1.2"
-            },
-            "engines": {
-                "node": ">=v0.6.0"
-            }
-        },
-        "node_modules/is2/node_modules/deep-is": {
-            "version": "0.1.2",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/isarray": {
             "version": "1.0.0",
@@ -12732,17 +12451,6 @@
                 "shell-quote": "^1.8.1"
             }
         },
-        "node_modules/lcid": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "invert-kv": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/leven": {
             "version": "2.1.0",
             "dev": true,
@@ -12763,147 +12471,10 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/license-checker": {
-            "version": "25.0.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "chalk": "^2.4.1",
-                "debug": "^3.1.0",
-                "mkdirp": "^0.5.1",
-                "nopt": "^4.0.1",
-                "read-installed": "~4.0.3",
-                "semver": "^5.5.0",
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-satisfies": "^4.0.0",
-                "treeify": "^1.1.0"
-            },
-            "bin": {
-                "license-checker": "bin/license-checker"
-            }
-        },
-        "node_modules/license-checker/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/license-checker/node_modules/chalk": {
-            "version": "2.4.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/license-checker/node_modules/color-convert": {
-            "version": "1.9.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/license-checker/node_modules/color-name": {
-            "version": "1.1.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/license-checker/node_modules/debug": {
-            "version": "3.2.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
-        "node_modules/license-checker/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/license-checker/node_modules/has-flag": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/license-checker/node_modules/mkdirp": {
-            "version": "0.5.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
-        "node_modules/license-checker/node_modules/semver": {
-            "version": "5.7.2",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/license-checker/node_modules/supports-color": {
-            "version": "5.5.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/load-json-file": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/load-json-file/node_modules/strip-bom": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-utf8": "^0.2.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/loader-runner": {
             "version": "4.3.0",
@@ -13533,42 +13104,6 @@
             "version": "0.10.31",
             "license": "MIT"
         },
-        "node_modules/nopt": {
-            "version": "4.0.3",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            }
-        },
-        "node_modules/nopt-usage": {
-            "version": "0.1.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/normalize-package-data": {
-            "version": "2.5.0",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-            }
-        },
-        "node_modules/normalize-package-data/node_modules/semver": {
-            "version": "5.7.2",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "dev": true,
@@ -13587,61 +13122,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/npm-license": {
-            "version": "0.3.3",
-            "dev": true,
-            "dependencies": {
-                "mkdirp": "~0.5.0",
-                "nopt": "~3.0.1",
-                "nopt-usage": "^0.1.0",
-                "package-license": "~0.1.1",
-                "pkginfo": "^0.3.0",
-                "read-installed": "~4.0.3",
-                "treeify": "~1.0.1",
-                "underscore": "~1.4.4"
-            },
-            "bin": {
-                "npm-license": "bin/npm-license"
-            }
-        },
-        "node_modules/npm-license/node_modules/mkdirp": {
-            "version": "0.5.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
-        "node_modules/npm-license/node_modules/nopt": {
-            "version": "3.0.6",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "1"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            }
-        },
-        "node_modules/npm-license/node_modules/treeify": {
-            "version": "1.0.1",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/npm-license/node_modules/underscore": {
-            "version": "1.4.4",
-            "dev": true
-        },
-        "node_modules/npm-normalize-package-bin": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
             "dev": true,
@@ -13651,14 +13131,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/number-is-nan": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/nwsapi": {
@@ -13851,397 +13323,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/os-homedir": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/os-locale": {
-            "version": "1.4.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lcid": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/osenv": {
-            "version": "0.1.5",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-            }
-        },
-        "node_modules/oss-attribution-generator": {
-            "version": "1.7.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bluebird": "^3.5.0",
-                "bower": "^1.8.0",
-                "bower-json": "^0.8.1",
-                "bower-license": "^0.4.4",
-                "fs-jetpack": "^0.12.0",
-                "license-checker": "^13.0.3",
-                "lodash": "^4.17.4",
-                "spdx-licenses": "^0.0.3",
-                "taim": "^1.0.2",
-                "yargs": "^7.0.2"
-            },
-            "bin": {
-                "generate-attribution": "index.js"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/ansi-regex": {
-            "version": "0.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/ansi-styles": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/camelcase": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/chalk": {
-            "version": "0.5.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^1.1.0",
-                "escape-string-regexp": "^1.0.0",
-                "has-ansi": "^0.1.0",
-                "strip-ansi": "^0.3.0",
-                "supports-color": "^0.2.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/cliui": {
-            "version": "3.2.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/cliui/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/cliui/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/debug": {
-            "version": "2.6.9",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/decamelize": {
-            "version": "1.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/get-caller-file": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/oss-attribution-generator/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/license-checker": {
-            "version": "13.1.0",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "chalk": "~0.5.1",
-                "debug": "^2.2.0",
-                "mkdirp": "^0.3.5",
-                "nopt": "^2.2.0",
-                "read-installed": "~4.0.3",
-                "semver": "^5.3.0",
-                "spdx": "^0.5.1",
-                "spdx-correct": "^2.0.3",
-                "spdx-satisfies": "^0.1.3",
-                "treeify": "^1.0.1"
-            },
-            "bin": {
-                "license-checker": "bin/license-checker"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/mkdirp": {
-            "version": "0.3.5",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/oss-attribution-generator/node_modules/ms": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/oss-attribution-generator/node_modules/nopt": {
-            "version": "2.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "abbrev": "1"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/semver": {
-            "version": "5.7.2",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/spdx-compare": {
-            "version": "0.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "spdx-expression-parse": "^1.0.0",
-                "spdx-ranges": "^1.0.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/spdx-compare/node_modules/spdx-expression-parse": {
-            "version": "1.0.4",
-            "dev": true,
-            "license": "(MIT AND CC-BY-3.0)"
-        },
-        "node_modules/oss-attribution-generator/node_modules/spdx-correct": {
-            "version": "2.0.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "spdx-expression-parse": "^2.0.1",
-                "spdx-license-ids": "^2.0.1"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/spdx-expression-parse": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "spdx-exceptions": "^2.0.0",
-                "spdx-license-ids": "^2.0.1"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/spdx-license-ids": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "CC0-1.0"
-        },
-        "node_modules/oss-attribution-generator/node_modules/spdx-ranges": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "CC-BY-3.0"
-        },
-        "node_modules/oss-attribution-generator/node_modules/spdx-satisfies": {
-            "version": "0.1.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "spdx-compare": "^0.1.2",
-                "spdx-expression-parse": "^1.0.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/spdx-satisfies/node_modules/spdx-expression-parse": {
-            "version": "1.0.4",
-            "dev": true,
-            "license": "(MIT AND CC-BY-3.0)"
-        },
-        "node_modules/oss-attribution-generator/node_modules/string-width": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/string-width/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/string-width/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/strip-ansi": {
-            "version": "0.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^0.2.1"
-            },
-            "bin": {
-                "strip-ansi": "cli.js"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/supports-color": {
-            "version": "0.2.0",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "supports-color": "cli.js"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/wrap-ansi": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/y18n": {
-            "version": "3.2.2",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/oss-attribution-generator/node_modules/yargs": {
-            "version": "7.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "camelcase": "^3.0.0",
-                "cliui": "^3.2.0",
-                "decamelize": "^1.1.1",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^1.4.0",
-                "read-pkg-up": "^1.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^1.0.2",
-                "which-module": "^1.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^5.0.1"
-            }
-        },
-        "node_modules/oss-attribution-generator/node_modules/yargs-parser": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "camelcase": "^3.0.0",
-                "object.assign": "^4.1.0"
-            }
-        },
         "node_modules/p-cancelable": {
             "version": "2.1.1",
             "license": "MIT",
@@ -14309,11 +13390,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/package-license": {
-            "version": "0.1.2",
-            "dev": true,
-            "license": "Apache2"
-        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "dev": true,
@@ -14339,17 +13415,6 @@
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/parse-json": {
-            "version": "2.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "error-ex": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/parse-srcset": {
@@ -14494,33 +13559,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/pify": {
-            "version": "2.3.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pinkie": {
-            "version": "2.0.4",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/pinkie-promise": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pinkie": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/pino": {
@@ -14748,14 +13786,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/pkginfo": {
-            "version": "0.3.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
             "license": "MIT",
@@ -14858,14 +13888,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/pretty-hrtime": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/pretty-quick": {
@@ -15035,15 +14057,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/q": {
-            "version": "1.5.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.6.0",
-                "teleport": ">=0.2.0"
-            }
-        },
         "node_modules/qs": {
             "version": "6.11.0",
             "dev": true,
@@ -15103,11 +14116,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/ramda": {
-            "version": "0.18.0",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "dev": true,
@@ -15132,11 +14140,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/raptor-args": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/raw-body": {
             "version": "2.5.2",
@@ -15195,102 +14198,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/read-installed": {
-            "version": "4.0.3",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "debuglog": "^1.0.1",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "slide": "~1.1.3",
-                "util-extend": "^1.0.1"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.2"
-            }
-        },
-        "node_modules/read-installed/node_modules/semver": {
-            "version": "5.7.2",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/read-package-json": {
-            "version": "2.1.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "normalize-package-data": "^2.0.0",
-                "npm-normalize-package-bin": "^1.0.0"
-            }
-        },
-        "node_modules/read-pkg": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "load-json-file": "^1.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/read-pkg-up": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/find-up": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/path-exists": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pinkie-promise": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/read-pkg/node_modules/path-type": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/readable-stream": {
             "version": "2.3.8",
             "license": "MIT",
@@ -15307,17 +14214,6 @@
         "node_modules/readable-stream/node_modules/safe-buffer": {
             "version": "5.1.2",
             "license": "MIT"
-        },
-        "node_modules/readdir-scoped-modules": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
-            }
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
@@ -15419,11 +14315,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/require-main-filename": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/requires-port": {
             "version": "1.0.0",
@@ -15882,11 +14773,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/set-blocking": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/set-function-length": {
             "version": "1.2.2",
             "license": "MIT",
@@ -16086,14 +14972,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/slide": {
-            "version": "1.1.6",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/sockjs": {
             "version": "0.3.24",
             "dev": true,
@@ -16138,28 +15016,6 @@
                 "tslib": "2"
             }
         },
-        "node_modules/sort-keys": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-plain-obj": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/sort-keys-length": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sort-keys": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/source-map": {
             "version": "0.7.4",
             "dev": true,
@@ -16196,94 +15052,6 @@
             "version": "0.0.2-1",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/spdx": {
-            "version": "0.5.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "spdx-exceptions": "^1.0.0",
-                "spdx-license-ids": "^1.0.0"
-            }
-        },
-        "node_modules/spdx-compare": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-find-index": "^1.0.2",
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-ranges": "^2.0.0"
-            }
-        },
-        "node_modules/spdx-correct": {
-            "version": "3.2.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-exceptions": {
-            "version": "2.5.0",
-            "dev": true,
-            "license": "CC-BY-3.0"
-        },
-        "node_modules/spdx-expression-parse": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-license-ids": {
-            "version": "3.0.17",
-            "dev": true,
-            "license": "CC0-1.0"
-        },
-        "node_modules/spdx-licenses": {
-            "version": "0.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "0.7.4",
-                "is2": "0.0.11"
-            }
-        },
-        "node_modules/spdx-licenses/node_modules/debug": {
-            "version": "0.7.4",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/spdx-ranges": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "(MIT AND CC-BY-3.0)"
-        },
-        "node_modules/spdx-satisfies": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "spdx-compare": "^1.0.0",
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-ranges": "^2.0.0"
-            }
-        },
-        "node_modules/spdx/node_modules/spdx-exceptions": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "CC-BY-3.0"
-        },
-        "node_modules/spdx/node_modules/spdx-license-ids": {
-            "version": "1.2.2",
-            "dev": true,
-            "license": "Unlicense"
         },
         "node_modules/spdy": {
             "version": "4.0.2",
@@ -16579,85 +15347,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/taim": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "chalk": "^1.1.1",
-                "pretty-hrtime": "^1.0.0",
-                "ramda": "0.18.x"
-            }
-        },
-        "node_modules/taim/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/taim/node_modules/ansi-styles": {
-            "version": "2.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/taim/node_modules/chalk": {
-            "version": "1.1.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/taim/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/taim/node_modules/has-ansi": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/taim/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/taim/node_modules/supports-color": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/tapable": {
             "version": "2.2.1",
             "dev": true,
@@ -16928,14 +15617,6 @@
             "license": "MIT",
             "bin": {
                 "tree-kill": "cli.js"
-            }
-        },
-        "node_modules/treeify": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.6"
             }
         },
         "node_modules/ts-api-utils": {
@@ -17476,10 +16157,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/underscore": {
-            "version": "1.5.2",
-            "dev": true
-        },
         "node_modules/undici-types": {
             "version": "5.26.5",
             "license": "MIT"
@@ -17583,11 +16260,6 @@
             "version": "1.0.2",
             "license": "MIT"
         },
-        "node_modules/util-extend": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/utils-merge": {
             "version": "1.0.1",
             "dev": true,
@@ -17632,15 +16304,6 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
-        },
-        "node_modules/validate-npm-package-license": {
-            "version": "3.0.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
             }
         },
         "node_modules/vary": {
@@ -18287,11 +16950,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/which-module": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/which-typed-array": {
             "version": "1.1.15",


### PR DESCRIPTION
## Problem
We have 9 vulnerabilities in our dependency tree:
```
debug  <=2.6.8
Severity: high

deep-extend  <0.5.1
Severity: critical

pkg  *
Severity: moderate

underscore  1.3.2 - 1.12.0
Severity: critical

bower-license  >=0.1.0
  Depends on vulnerable versions of bower-json
  Depends on vulnerable versions of npm-license
  Depends on vulnerable versions of underscore

```
## Solution
It turns out that 8 out of 9 vulnerabilities (except for `pkg`) are transitive dependency of `license-checker` and `oss-attribution-generator`. These are abandoned projects, and we don't even use them but just declare them in the package.json. 

Removing them fixes the issues. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
