### PR TITLE
Fixing Windows problems - prettier CRLF and linux cp tool

### DIFF
--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -19,6 +19,7 @@ jobs:
             - name: Build
               run: |
                   npm ci
+                  npm run check:formatting
                   npm run compile
             - name: Test
               run: |

--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -59,7 +59,7 @@ jobs:
                   node-version: 18
             - name: Build
               run: |
-                  npm install
+                  npm ci
                   npm run compile
             - name: Test
               run: |
@@ -76,7 +76,7 @@ jobs:
                   node-version: 18
             - name: Build
               run: |
-                  npm install
+                  npm ci
                   npm run compile
             - name: Create binaries
               run: |

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -11,9 +11,8 @@
     "license": "Apache-2.0",
     "scripts": {
         "compile": "tsc --build && npm run package",
-        "test:prettier": "prettier . --check",
         "test:unit": "ts-mocha -b 'src/**/*.test.ts'",
-        "test": "npm run test:prettier && npm run test:unit",
+        "test": "npm run test:unit",
         "fix:prettier": "prettier . --write",
         "package": "webpack"
     },

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -162,7 +162,7 @@
     "scripts": {
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -b && npm run compile:chat-client",
-        "compile:chat-client": "npm run compile --prefix ../../chat-client && cp -R ../../chat-client/build ."
+        "compile:chat-client": "npm run compile --prefix ../../chat-client && shx cp -R ../../chat-client/build ."
     },
     "devDependencies": {
         "@aws/language-server-runtimes": "^0.2.6",

--- a/core/aws-lsp-core/package.json
+++ b/core/aws-lsp-core/package.json
@@ -22,7 +22,7 @@
         "compile": "tsc --build",
         "test": "npm run test-unit",
         "test-unit": "mocha './out/**/*.test.js'",
-        "prepack": "cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
+        "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
                 "husky": "^9.0.11",
                 "prettier": "^3.2.5",
                 "pretty-quick": "^4.0.0",
+                "shx": "^0.3.4",
                 "ts-node": "^10.9.1"
             }
         },
@@ -15178,6 +15179,63 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/shelljs": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
+            },
+            "bin": {
+                "shjs": "bin/shjs"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/shelljs/node_modules/interpret": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/shelljs/node_modules/rechoir": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+            "dev": true,
+            "dependencies": {
+                "resolve": "^1.1.6"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/shx": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+            "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.3",
+                "shelljs": "^0.8.5"
+            },
+            "bin": {
+                "shx": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "scripts": {
         "prepare": "husky install .husky",
         "lint": "eslint app/ chat-client/ client/ core/ script/ server/ --ext .ts,.tsx --ignore-path .gitignore && prettier --check .",
+        "check:formatting": "prettier --check .",
         "format": "prettier --write .",
         "format-staged": "npx pretty-quick --staged",
         "clean": "ts-node ./script/clean.ts",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "husky": "^9.0.11",
         "prettier": "^3.2.5",
         "pretty-quick": "^4.0.0",
+        "shx": "^0.3.4",
         "ts-node": "^10.9.1"
     },
     "prettier": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -25,8 +25,7 @@
         "lint:bundle:webworker": "webpack --config webpack.lint.config.js && eslint bundle/aws-lsp-codewhisperer-webworker.js # Verify compatibility with web runtime target",
         "lint:src": "eslint src/ --ext .ts,.tsx",
         "test:unit": "ts-mocha -b 'src/**/*.test.ts'",
-        "test:prettier": "prettier . --check",
-        "test": "npm run lint && npm run test:prettier && npm run test:unit",
+        "test": "npm run lint && npm run test:unit",
         "fix:prettier": "prettier . --write",
         "prepack": "npm run compile && ts-node ../../script/link_bundled_dependencies.ts"
     },

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -21,7 +21,7 @@
     "scripts": {
         "compile": "tsc --build",
         "test": "ts-mocha -b 'src/**/*.test.ts'",
-        "prepack": "cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
+        "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.5",

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -22,7 +22,7 @@
     ],
     "scripts": {
         "compile": "tsc --build",
-        "prepack": "cp ../../LICENSE ../../NOTICE ../../SECURITY.md .",
+        "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md .",
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {


### PR DESCRIPTION
## Problem
The package fails builds on Windows. One of the reason is that we have `cp` in our npm scripts which only works on linux. 
Another problem was that we ran `prettier -- check` in some subpackages. In windows git automatically converts linux's `LF` line endings into Windows' `CRLF` when pulling files. It works generally, because git also converts them back to the linux's `LF` before staging or committing the files. And our husky git hooks also run prettier before committing so that prettier will convert the line endings to linux's LF even if git wouldn't. 
But it all breaks because we had npm script that ran `prettier check` on running. And the command fails on windows as it notices `CRLF` line endings which are not allowed.
## Solution
- Use shx tool to make linux-specific calls cross platform
- Run prettier check only as part of the Linux-based GitHub action and not as part of tests 
- Also used `npm ci` instead of `npm install` in the windows GitHub actions (related to https://github.com/aws/language-servers/pull/317)
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
