### PR TITLE
Bump mynah version in chat client

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "0.x.x",
         "@aws/language-server-runtimes-types": "0.x.x",
-        "@aws/mynah-ui": "^4.10.x"
+        "@aws/mynah-ui": "^4.11.x"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -289,9 +289,7 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
         const tabId = getOrCreateTabId()
         if (!tabId) return
 
-        const markdownSelection = ['\n```\n', params.selection, '\n```'].join('')
-
-        mynahUi.addToUserPrompt(tabId, markdownSelection)
+        mynahUi.addToUserPrompt(tabId, params.selection, 'code')
         messager.onSendToPrompt(params, tabId)
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,7 +219,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "0.x.x",
                 "@aws/language-server-runtimes-types": "0.x.x",
-                "@aws/mynah-ui": "^4.10.x"
+                "@aws/mynah-ui": "^4.11.x"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",


### PR DESCRIPTION
## Description

Updating mynah to the latest version, this gets rid of the outdated `ws` dependency downstream. 

Also with mynah 4.10, the ability to specify `code` option in `addToUserPrompt` was introduced, updated the chat client to make use of it

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
