### PR TITLE
Emit initial add tab event

### DIFF
--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -15,8 +15,13 @@ import { assert } from 'sinon'
 import { createChat } from './chat'
 import sinon = require('sinon')
 import { TELEMETRY } from '../contracts/serverContracts'
-import { ERROR_MESSAGE_TELEMETRY_EVENT, SEND_TO_PROMPT_TELEMETRY_EVENT } from '../contracts/telemetry'
+import {
+    ERROR_MESSAGE_TELEMETRY_EVENT,
+    SEND_TO_PROMPT_TELEMETRY_EVENT,
+    TAB_ADD_TELEMETRY_EVENT,
+} from '../contracts/telemetry'
 import { MynahUI } from '@aws/mynah-ui'
+import { INITIAL_TAB_ID } from './mynahUi'
 
 describe('Chat', () => {
     const sandbox = sinon.createSandbox()
@@ -39,8 +44,23 @@ describe('Chat', () => {
         })
     })
 
-    it('publishes ready event, when initialized', () => {
-        assert.calledOnceWithExactly(clientApi.postMessage, { command: READY_NOTIFICATION_METHOD })
+    it('publishes ready event and initial tab add event, when initialized', () => {
+        sinon.assert.callCount(clientApi.postMessage, 3)
+
+        sinon.assert.calledWithExactly(clientApi.postMessage.getCall(0), { command: READY_NOTIFICATION_METHOD })
+
+        assert.calledWithExactly(clientApi.postMessage.getCall(1), {
+            command: TELEMETRY,
+            params: {
+                triggerType: 'click',
+                name: TAB_ADD_TELEMETRY_EVENT,
+                tabId: INITIAL_TAB_ID,
+            },
+        })
+        sinon.assert.calledWithExactly(clientApi.postMessage.getCall(2), {
+            command: TAB_ADD_NOTIFICATION_METHOD,
+            params: { tabId: INITIAL_TAB_ID },
+        })
     })
 
     it('publishes telemetry event, when send to prompt is triggered', () => {

--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -47,9 +47,9 @@ describe('Chat', () => {
     it('publishes ready event and initial tab add event, when initialized', () => {
         sinon.assert.callCount(clientApi.postMessage, 3)
 
-        sinon.assert.calledWithExactly(clientApi.postMessage.getCall(0), { command: READY_NOTIFICATION_METHOD })
+        sinon.assert.calledWithExactly(clientApi.postMessage.firstCall, { command: READY_NOTIFICATION_METHOD })
 
-        assert.calledWithExactly(clientApi.postMessage.getCall(1), {
+        assert.calledWithExactly(clientApi.postMessage.secondCall, {
             command: TELEMETRY,
             params: {
                 triggerType: 'click',
@@ -57,7 +57,7 @@ describe('Chat', () => {
                 tabId: INITIAL_TAB_ID,
             },
         })
-        sinon.assert.calledWithExactly(clientApi.postMessage.getCall(2), {
+        sinon.assert.calledWithExactly(clientApi.postMessage.thirdCall, {
             command: TAB_ADD_NOTIFICATION_METHOD,
             params: { tabId: INITIAL_TAB_ID },
         })

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -24,6 +24,8 @@ import { CopyCodeToClipboardParams, VoteParams } from '../contracts/telemetry'
 import { Messager } from './messager'
 import { TabFactory } from './tabs/tabFactory'
 
+export const INITIAL_TAB_ID = 'tab-1'
+
 export interface InboundChatApi {
     addChatResponse(params: ChatResult, tabId: string, isPartialResult: boolean): void
     sendToPrompt(params: SendToPromptParams): void
@@ -127,8 +129,10 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
         onChatPrompt(tabId, prompt, eventId) {
             handleChatPrompt(mynahUi, tabId, prompt, messager, 'click', eventId)
         },
-
-        onReady: messager.onUiReady,
+        onReady: () => {
+            messager.onUiReady()
+            messager.onTabAdd(INITIAL_TAB_ID)
+        },
         onTabAdd: (tabId: string) => {
             messager.onTabAdd(tabId)
         },
@@ -223,7 +227,7 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
             messager.onInfoLinkClick(payload)
         },
         tabs: {
-            'tab-1': {
+            [INITIAL_TAB_ID]: {
                 isSelected: true,
                 store: tabFactory.createTab(true),
             },
@@ -236,6 +240,10 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
             texts: uiComponentsTexts,
         },
     })
+
+    const getTabStore = (tabId = mynahUi.getSelectedTabId()) => {
+        return tabId ? mynahUi.getAllTabs()[tabId]?.store : undefined
+    }
 
     const createTabId = () => {
         const tabId = mynahUi.updateStore('', tabFactory.createTab(false))
@@ -301,9 +309,7 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
         if (!tabId) return
 
         // send to a new tab if the current tab is loading
-        const isCurrentTabLoading = mynahUi.getAllTabs()[tabId]?.store?.loadingChat
-
-        if (isCurrentTabLoading) {
+        if (getTabStore(tabId)?.loadingChat) {
             tabId = createTabId()
             if (!tabId) return
         }
@@ -329,6 +335,11 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
             body: `**${params.title}** 
 ${params.message}`,
         }
+
+        mynahUi.updateStore(tabId, {
+            loadingChat: false,
+            promptInputDisabledState: false,
+        })
 
         mynahUi.addChatItem(params.tabId, answer)
         messager.onError(params)


### PR DESCRIPTION
## Description

If toolkit has to keep track of the tabs, it is difficult to do so currently because there isn't an event for the initial tab. So chat-client should emit an event on start up.

I think setting trigger to "click" might make sense, but unsure about this.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
