### PR TITLE
Fixed partiql tests failing on windows

### DIFF
--- a/server/aws-lsp-partiql/jest.config.js
+++ b/server/aws-lsp-partiql/jest.config.js
@@ -4,7 +4,7 @@ const tsPreset = require('ts-jest/jest-preset')
 module.exports = {
     transform: {
         ...tsPreset.transform,
-        [`/src/partiql-parser-wasm/partiql_playground.js`]: require.resolve('./test-utils/esm-transformer'),
+        [`partiql_playground.js`]: require.resolve('./test-utils/esm-transformer'),
     },
     transformIgnorePatterns: [...(tsPreset.transformIgnorePatterns || [])],
 


### PR DESCRIPTION
## Problem
The partiql tests were failing on windows because jest couldn't transform an esm module to cjs
## Solution
Turned out that the jest configuration had linux style path separators and that's why babel esm transformations didn't apply to the esm file on windows.
Changed the regex matcher to only include the filename. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
