### PR TITLE
Update Codewhisperer streaming client package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,8 +117,7 @@
         },
         "app/aws-lsp-partiql-binary/node_modules/@aws/lsp-partiql": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@aws/lsp-partiql/-/lsp-partiql-0.0.1.tgz",
-            "integrity": "sha512-5VFghsF9B2KdYUvCZvVnmi4asFkDnUcK5XbaJr2ykrY5pgDzCOowuvqrPmps+52D3FTUgC4BJdjFKJSAsyfMhQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.4"
             }
@@ -249,29 +248,6 @@
                 "vscode": "^1.74.0"
             }
         },
-        "client/vscode/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "client/vscode/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "core/aws-lsp-core": {
             "name": "@aws/lsp-core",
             "version": "0.0.1",
@@ -347,71 +323,113 @@
             "link": true
         },
         "node_modules/@aws-crypto/crc32": {
-            "version": "5.2.0",
+            "version": "3.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/util": "^5.2.0",
+                "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "tslib": "^1.11.1"
             }
         },
-        "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "^3.222.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
+        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+            "version": "1.14.1",
+            "license": "0BSD"
         },
         "node_modules/@aws-crypto/crc32c": {
-            "version": "5.2.0",
+            "version": "3.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/util": "^5.2.0",
+                "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
-                "tslib": "^2.6.2"
+                "tslib": "^1.11.1"
             }
         },
-        "node_modules/@aws-crypto/crc32c/node_modules/@aws-crypto/util": {
-            "version": "5.2.0",
+        "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+            "version": "1.14.1",
+            "license": "0BSD"
+        },
+        "node_modules/@aws-crypto/ie11-detection": {
+            "version": "3.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.222.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
+                "tslib": "^1.11.1"
             }
+        },
+        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+            "version": "1.14.1",
+            "license": "0BSD"
         },
         "node_modules/@aws-crypto/sha1-browser": {
-            "version": "5.2.0",
+            "version": "3.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/supports-web-crypto": "^5.2.0",
-                "@aws-crypto/util": "^5.2.0",
+                "@aws-crypto/ie11-detection": "^3.0.0",
+                "@aws-crypto/supports-web-crypto": "^3.0.0",
+                "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-locate-window": "^3.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
             }
         },
-        "node_modules/@aws-crypto/sha1-browser/node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "5.2.0",
+        "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+            "version": "1.14.1",
+            "license": "0BSD"
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "3.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "tslib": "^2.6.2"
+                "@aws-crypto/ie11-detection": "^3.0.0",
+                "@aws-crypto/sha256-js": "^3.0.0",
+                "@aws-crypto/supports-web-crypto": "^3.0.0",
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
             }
         },
-        "node_modules/@aws-crypto/sha1-browser/node_modules/@aws-crypto/util": {
-            "version": "5.2.0",
+        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+            "version": "1.14.1",
+            "license": "0BSD"
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^3.0.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "license": "0BSD"
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+            "version": "1.14.1",
+            "license": "0BSD"
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "3.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
             }
+        },
+        "node_modules/@aws-crypto/util/node_modules/tslib": {
+            "version": "1.14.1",
+            "license": "0BSD"
         },
         "node_modules/@aws-sdk/client-cognito-identity": {
             "version": "3.598.0",
@@ -533,6 +551,299 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sts": "3.598.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/credential-provider-node": "3.598.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.598.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/credential-provider-node": "3.598.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/core": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^2.2.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/signature-v4": "^3.1.0",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-stream": "^3.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.598.0",
+                "@aws-sdk/credential-provider-http": "3.598.0",
+                "@aws-sdk/credential-provider-process": "3.598.0",
+                "@aws-sdk/credential-provider-sso": "3.598.0",
+                "@aws-sdk/credential-provider-web-identity": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/credential-provider-imds": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.598.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.598.0",
+                "@aws-sdk/credential-provider-http": "3.598.0",
+                "@aws-sdk/credential-provider-ini": "3.598.0",
+                "@aws-sdk/credential-provider-process": "3.598.0",
+                "@aws-sdk/credential-provider-sso": "3.598.0",
+                "@aws-sdk/credential-provider-web-identity": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/credential-provider-imds": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.598.0",
+                "@aws-sdk/token-providers": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.598.0"
+            }
+        },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.598.0",
             "dev": true,
@@ -605,12 +916,44 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sso-oidc": "^3.598.0"
+            }
+        },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
             "version": "3.598.0",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-endpoints": "^2.0.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -677,6 +1020,39 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/core": {
+            "version": "2.2.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.5",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.3",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-middleware": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/credential-provider-imds": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/fetch-http-handler": {
             "version": "3.0.3",
             "dev": true,
@@ -724,6 +1100,17 @@
                 "tslib": "^2.6.2"
             }
         },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/is-array-buffer": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-content-length": {
             "version": "3.0.1",
             "dev": true,
@@ -731,6 +1118,23 @@
             "dependencies": {
                 "@smithy/protocol-http": "^4.0.1",
                 "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-endpoint": {
+            "version": "3.0.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-middleware": "^3.0.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -809,6 +1213,18 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/property-provider": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/protocol-http": {
             "version": "4.0.1",
             "dev": true,
@@ -852,6 +1268,35 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/signature-v4": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
@@ -938,6 +1383,17 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-config-provider": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-browser": {
             "version": "3.0.5",
             "dev": true,
@@ -970,6 +1426,42 @@
                 "node": ">= 10.0.0"
             }
         },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-endpoints": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-hex-encoding": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-middleware": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-retry": {
             "version": "3.0.1",
             "dev": true,
@@ -977,6 +1469,36 @@
             "dependencies": {
                 "@smithy/service-error-classification": "^3.0.1",
                 "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-stream": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^3.0.3",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1019,644 +1541,115 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.598.0",
+            "version": "3.574.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha1-browser": "5.2.0",
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/client-sso-oidc": "3.598.0",
-                "@aws-sdk/client-sts": "3.598.0",
-                "@aws-sdk/core": "3.598.0",
-                "@aws-sdk/credential-provider-node": "3.598.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.598.0",
-                "@aws-sdk/middleware-expect-continue": "3.598.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.598.0",
-                "@aws-sdk/middleware-host-header": "3.598.0",
-                "@aws-sdk/middleware-location-constraint": "3.598.0",
-                "@aws-sdk/middleware-logger": "3.598.0",
-                "@aws-sdk/middleware-recursion-detection": "3.598.0",
-                "@aws-sdk/middleware-sdk-s3": "3.598.0",
-                "@aws-sdk/middleware-signing": "3.598.0",
-                "@aws-sdk/middleware-ssec": "3.598.0",
-                "@aws-sdk/middleware-user-agent": "3.598.0",
-                "@aws-sdk/region-config-resolver": "3.598.0",
-                "@aws-sdk/signature-v4-multi-region": "3.598.0",
-                "@aws-sdk/types": "3.598.0",
-                "@aws-sdk/util-endpoints": "3.598.0",
-                "@aws-sdk/util-user-agent-browser": "3.598.0",
-                "@aws-sdk/util-user-agent-node": "3.598.0",
-                "@aws-sdk/xml-builder": "3.598.0",
-                "@smithy/config-resolver": "^3.0.2",
-                "@smithy/core": "^2.2.1",
-                "@smithy/eventstream-serde-browser": "^3.0.2",
-                "@smithy/eventstream-serde-config-resolver": "^3.0.1",
-                "@smithy/eventstream-serde-node": "^3.0.2",
-                "@smithy/fetch-http-handler": "^3.0.2",
-                "@smithy/hash-blob-browser": "^3.1.0",
-                "@smithy/hash-node": "^3.0.1",
-                "@smithy/hash-stream-node": "^3.1.0",
-                "@smithy/invalid-dependency": "^3.0.1",
-                "@smithy/md5-js": "^3.0.1",
-                "@smithy/middleware-content-length": "^3.0.1",
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-retry": "^3.0.4",
-                "@smithy/middleware-serde": "^3.0.1",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/node-http-handler": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/smithy-client": "^3.1.2",
-                "@smithy/types": "^3.1.0",
-                "@smithy/url-parser": "^3.0.1",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.4",
-                "@smithy/util-defaults-mode-node": "^3.0.4",
-                "@smithy/util-endpoints": "^2.0.2",
-                "@smithy/util-retry": "^3.0.1",
-                "@smithy/util-stream": "^3.0.2",
-                "@smithy/util-utf8": "^3.0.0",
-                "@smithy/util-waiter": "^3.0.1",
+                "@aws-crypto/sha1-browser": "3.0.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.574.0",
+                "@aws-sdk/client-sts": "3.574.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.568.0",
+                "@aws-sdk/middleware-expect-continue": "3.572.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-location-constraint": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-sdk-s3": "3.572.0",
+                "@aws-sdk/middleware-signing": "3.572.0",
+                "@aws-sdk/middleware-ssec": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/signature-v4-multi-region": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@aws-sdk/xml-builder": "3.567.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/eventstream-serde-browser": "^2.2.0",
+                "@smithy/eventstream-serde-config-resolver": "^2.2.0",
+                "@smithy/eventstream-serde-node": "^2.2.0",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-blob-browser": "^2.2.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/hash-stream-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/md5-js": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-stream": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "@smithy/util-waiter": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-browser": {
-            "version": "5.2.0",
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
+            "version": "3.574.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-js": "^5.2.0",
-                "@aws-crypto/supports-web-crypto": "^5.2.0",
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-js": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/util": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "^3.222.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@aws-sdk/util-endpoints": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/abort-controller": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/config-resolver": {
-            "version": "3.0.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/eventstream-codec": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/crc32": "5.2.0",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-hex-encoding": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/eventstream-serde-browser": {
-            "version": "3.0.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/eventstream-serde-universal": "^3.0.2",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/eventstream-serde-config-resolver": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/eventstream-serde-node": {
-            "version": "3.0.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/eventstream-serde-universal": "^3.0.2",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/eventstream-serde-universal": {
-            "version": "3.0.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/eventstream-codec": "^3.1.0",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/fetch-http-handler": {
-            "version": "3.0.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-base64": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/hash-node": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/invalid-dependency": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-content-length": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-retry": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/service-error-classification": "^3.0.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "@smithy/util-retry": "^3.0.1",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-serde": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-stack": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/node-config-provider": {
-            "version": "3.1.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/node-http-handler": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/querystring-parser": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/service-error-classification": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/smithy-client": {
-            "version": "3.1.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-stream": "^3.0.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/url-parser": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/querystring-parser": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-base64": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-body-length-browser": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-body-length-node": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-defaults-mode-node": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/config-resolver": "^3.0.2",
-                "@smithy/credential-provider-imds": "^3.1.1",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-hex-encoding": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-retry": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/service-error-classification": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.574.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1664,46 +1657,46 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.598.0",
+            "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.598.0",
-                "@aws-sdk/middleware-host-header": "3.598.0",
-                "@aws-sdk/middleware-logger": "3.598.0",
-                "@aws-sdk/middleware-recursion-detection": "3.598.0",
-                "@aws-sdk/middleware-user-agent": "3.598.0",
-                "@aws-sdk/region-config-resolver": "3.598.0",
-                "@aws-sdk/types": "3.598.0",
-                "@aws-sdk/util-endpoints": "3.598.0",
-                "@aws-sdk/util-user-agent-browser": "3.598.0",
-                "@aws-sdk/util-user-agent-node": "3.598.0",
-                "@smithy/config-resolver": "^3.0.2",
-                "@smithy/core": "^2.2.1",
-                "@smithy/fetch-http-handler": "^3.0.2",
-                "@smithy/hash-node": "^3.0.1",
-                "@smithy/invalid-dependency": "^3.0.1",
-                "@smithy/middleware-content-length": "^3.0.1",
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-retry": "^3.0.4",
-                "@smithy/middleware-serde": "^3.0.1",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/node-http-handler": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/smithy-client": "^3.1.2",
-                "@smithy/types": "^3.1.0",
-                "@smithy/url-parser": "^3.0.1",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.4",
-                "@smithy/util-defaults-mode-node": "^3.0.4",
-                "@smithy/util-endpoints": "^2.0.2",
-                "@smithy/util-middleware": "^3.0.1",
-                "@smithy/util-retry": "^3.0.1",
-                "@smithy/util-utf8": "^3.0.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1711,1070 +1704,97 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.598.0",
+            "version": "3.574.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/client-sts": "3.598.0",
-                "@aws-sdk/core": "3.598.0",
-                "@aws-sdk/credential-provider-node": "3.598.0",
-                "@aws-sdk/middleware-host-header": "3.598.0",
-                "@aws-sdk/middleware-logger": "3.598.0",
-                "@aws-sdk/middleware-recursion-detection": "3.598.0",
-                "@aws-sdk/middleware-user-agent": "3.598.0",
-                "@aws-sdk/region-config-resolver": "3.598.0",
-                "@aws-sdk/types": "3.598.0",
-                "@aws-sdk/util-endpoints": "3.598.0",
-                "@aws-sdk/util-user-agent-browser": "3.598.0",
-                "@aws-sdk/util-user-agent-node": "3.598.0",
-                "@smithy/config-resolver": "^3.0.2",
-                "@smithy/core": "^2.2.1",
-                "@smithy/fetch-http-handler": "^3.0.2",
-                "@smithy/hash-node": "^3.0.1",
-                "@smithy/invalid-dependency": "^3.0.1",
-                "@smithy/middleware-content-length": "^3.0.1",
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-retry": "^3.0.4",
-                "@smithy/middleware-serde": "^3.0.1",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/node-http-handler": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/smithy-client": "^3.1.2",
-                "@smithy/types": "^3.1.0",
-                "@smithy/url-parser": "^3.0.1",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.4",
-                "@smithy/util-defaults-mode-node": "^3.0.4",
-                "@smithy/util-endpoints": "^2.0.2",
-                "@smithy/util-middleware": "^3.0.1",
-                "@smithy/util-retry": "^3.0.1",
-                "@smithy/util-utf8": "^3.0.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.574.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-browser": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-js": "^5.2.0",
-                "@aws-crypto/supports-web-crypto": "^5.2.0",
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-js": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/util": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "^3.222.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@aws-sdk/util-endpoints": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/abort-controller": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/config-resolver": {
-            "version": "3.0.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/fetch-http-handler": {
-            "version": "3.0.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-base64": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/hash-node": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/invalid-dependency": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-content-length": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-retry": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/service-error-classification": "^3.0.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "@smithy/util-retry": "^3.0.1",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-serde": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-stack": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-config-provider": {
-            "version": "3.1.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-http-handler": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/querystring-parser": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/service-error-classification": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/smithy-client": {
-            "version": "3.1.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-stream": "^3.0.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/url-parser": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/querystring-parser": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-base64": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-browser": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-node": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-node": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/config-resolver": "^3.0.2",
-                "@smithy/credential-provider-imds": "^3.1.1",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-retry": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/service-error-classification": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-js": "^5.2.0",
-                "@aws-crypto/supports-web-crypto": "^5.2.0",
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "^3.222.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@aws-sdk/util-endpoints": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/abort-controller": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/config-resolver": {
-            "version": "3.0.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/fetch-http-handler": {
-            "version": "3.0.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-base64": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/hash-node": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/invalid-dependency": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-content-length": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-retry": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/service-error-classification": "^3.0.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "@smithy/util-retry": "^3.0.1",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-serde": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-stack": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-config-provider": {
-            "version": "3.1.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-http-handler": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/querystring-parser": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/service-error-classification": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/smithy-client": {
-            "version": "3.1.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-stream": "^3.0.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/url-parser": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/querystring-parser": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-base64": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-browser": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-node": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-node": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/config-resolver": "^3.0.2",
-                "@smithy/credential-provider-imds": "^3.1.1",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-retry": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/service-error-classification": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/client-sts": {
+            "version": "3.574.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.574.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2782,559 +1802,99 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.598.0",
+            "version": "3.572.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/client-sso-oidc": "3.598.0",
-                "@aws-sdk/core": "3.598.0",
-                "@aws-sdk/credential-provider-node": "3.598.0",
-                "@aws-sdk/middleware-host-header": "3.598.0",
-                "@aws-sdk/middleware-logger": "3.598.0",
-                "@aws-sdk/middleware-recursion-detection": "3.598.0",
-                "@aws-sdk/middleware-user-agent": "3.598.0",
-                "@aws-sdk/region-config-resolver": "3.598.0",
-                "@aws-sdk/types": "3.598.0",
-                "@aws-sdk/util-endpoints": "3.598.0",
-                "@aws-sdk/util-user-agent-browser": "3.598.0",
-                "@aws-sdk/util-user-agent-node": "3.598.0",
-                "@smithy/config-resolver": "^3.0.2",
-                "@smithy/core": "^2.2.1",
-                "@smithy/fetch-http-handler": "^3.0.2",
-                "@smithy/hash-node": "^3.0.1",
-                "@smithy/invalid-dependency": "^3.0.1",
-                "@smithy/middleware-content-length": "^3.0.1",
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-retry": "^3.0.4",
-                "@smithy/middleware-serde": "^3.0.1",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/node-http-handler": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/smithy-client": "^3.1.2",
-                "@smithy/types": "^3.1.0",
-                "@smithy/url-parser": "^3.0.1",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.4",
-                "@smithy/util-defaults-mode-node": "^3.0.4",
-                "@smithy/util-endpoints": "^2.0.2",
-                "@smithy/util-middleware": "^3.0.1",
-                "@smithy/util-retry": "^3.0.1",
-                "@smithy/util-utf8": "^3.0.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sso-oidc": "3.572.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser": {
-            "version": "5.2.0",
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.572.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
-                "@aws-crypto/sha256-js": "^5.2.0",
-                "@aws-crypto/supports-web-crypto": "^5.2.0",
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util": {
-            "version": "5.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "^3.222.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@aws-sdk/util-endpoints": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/abort-controller": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/config-resolver": {
-            "version": "3.0.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/fetch-http-handler": {
-            "version": "3.0.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-base64": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/hash-node": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/invalid-dependency": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-content-length": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-retry": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/service-error-classification": "^3.0.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "@smithy/util-retry": "^3.0.1",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-serde": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-stack": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-config-provider": {
-            "version": "3.1.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-http-handler": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-parser": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/service-error-classification": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/smithy-client": {
-            "version": "3.1.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-stream": "^3.0.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/url-parser": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/querystring-parser": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-base64": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-browser": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-node": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-node": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/config-resolver": "^3.0.2",
-                "@smithy/credential-provider-imds": "^3.1.1",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-retry": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/service-error-classification": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.572.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3342,62 +1902,15 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.598.0",
+            "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^2.2.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/signature-v4": "^3.1.0",
-                "@smithy/smithy-client": "^3.1.2",
-                "@smithy/types": "^3.1.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/signature-v4": "^2.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
                 "fast-xml-parser": "4.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/core/node_modules/@smithy/middleware-stack": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/core/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/core/node_modules/@smithy/smithy-client": {
-            "version": "3.1.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-stream": "^3.0.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3431,6 +1944,18 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/property-provider": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
             "version": "3.1.0",
             "dev": true,
@@ -3443,33 +1968,12 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.598.0",
+            "version": "3.568.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3477,167 +1981,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.598.0",
+            "version": "3.568.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/fetch-http-handler": "^3.0.2",
-                "@smithy/node-http-handler": "^3.0.1",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/smithy-client": "^3.1.2",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-stream": "^3.0.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/abort-controller": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/fetch-http-handler": {
-            "version": "3.0.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-base64": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-stack": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/smithy-client": {
-            "version": "3.1.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-stream": "^3.0.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-base64": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-stream": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3645,85 +1999,42 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.598.0",
+            "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.598.0",
-                "@aws-sdk/credential-provider-http": "3.598.0",
-                "@aws-sdk/credential-provider-process": "3.598.0",
-                "@aws-sdk/credential-provider-sso": "3.598.0",
-                "@aws-sdk/credential-provider-web-identity": "3.598.0",
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/credential-provider-imds": "^3.1.1",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
+                "@aws-sdk/credential-provider-env": "3.568.0",
+                "@aws-sdk/credential-provider-process": "3.572.0",
+                "@aws-sdk/credential-provider-sso": "3.572.0",
+                "@aws-sdk/credential-provider-web-identity": "3.568.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/credential-provider-imds": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.598.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "@aws-sdk/client-sts": "3.572.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.598.0",
+            "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.598.0",
-                "@aws-sdk/credential-provider-http": "3.598.0",
-                "@aws-sdk/credential-provider-ini": "3.598.0",
-                "@aws-sdk/credential-provider-process": "3.598.0",
-                "@aws-sdk/credential-provider-sso": "3.598.0",
-                "@aws-sdk/credential-provider-web-identity": "3.598.0",
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/credential-provider-imds": "^3.1.1",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.568.0",
+                "@aws-sdk/credential-provider-http": "3.568.0",
+                "@aws-sdk/credential-provider-ini": "3.572.0",
+                "@aws-sdk/credential-provider-process": "3.572.0",
+                "@aws-sdk/credential-provider-sso": "3.572.0",
+                "@aws-sdk/credential-provider-web-identity": "3.568.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/credential-provider-imds": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3731,34 +2042,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.598.0",
+            "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3766,77 +2056,102 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.598.0",
+            "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.598.0",
-                "@aws-sdk/token-providers": "3.598.0",
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
+                "@aws-sdk/client-sso": "3.572.0",
+                "@aws-sdk/token-providers": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
+        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.572.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
-                "@smithy/types": "^3.1.0",
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.572.0",
+                "@aws-sdk/core": "3.572.0",
+                "@aws-sdk/credential-provider-node": "3.572.0",
+                "@aws-sdk/middleware-host-header": "3.567.0",
+                "@aws-sdk/middleware-logger": "3.568.0",
+                "@aws-sdk/middleware-recursion-detection": "3.567.0",
+                "@aws-sdk/middleware-user-agent": "3.572.0",
+                "@aws-sdk/region-config-resolver": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@aws-sdk/util-user-agent-browser": "3.567.0",
+                "@aws-sdk/util-user-agent-node": "3.568.0",
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/core": "^1.4.2",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/hash-node": "^2.2.0",
+                "@smithy/invalid-dependency": "^2.2.0",
+                "@smithy/middleware-content-length": "^2.2.0",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-body-length-browser": "^2.2.0",
+                "@smithy/util-body-length-node": "^2.3.0",
+                "@smithy/util-defaults-mode-browser": "^2.2.1",
+                "@smithy/util-defaults-mode-node": "^2.3.1",
+                "@smithy/util-endpoints": "^1.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+            "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.598.0"
+                "@aws-sdk/client-sso-oidc": "3.572.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.568.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
             },
-            "engines": {
-                "node": ">=16.0.0"
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.568.0"
             }
         },
         "node_modules/@aws-sdk/credential-providers": {
@@ -3865,12 +2180,860 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sts": "3.598.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/credential-provider-node": "3.598.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.598.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/credential-provider-node": "3.598.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^2.2.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/signature-v4": "^3.1.0",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-stream": "^3.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.598.0",
+                "@aws-sdk/credential-provider-http": "3.598.0",
+                "@aws-sdk/credential-provider-process": "3.598.0",
+                "@aws-sdk/credential-provider-sso": "3.598.0",
+                "@aws-sdk/credential-provider-web-identity": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/credential-provider-imds": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.598.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.598.0",
+                "@aws-sdk/credential-provider-http": "3.598.0",
+                "@aws-sdk/credential-provider-ini": "3.598.0",
+                "@aws-sdk/credential-provider-process": "3.598.0",
+                "@aws-sdk/credential-provider-sso": "3.598.0",
+                "@aws-sdk/credential-provider-web-identity": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/credential-provider-imds": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.598.0",
+                "@aws-sdk/token-providers": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.598.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sso-oidc": "^3.598.0"
+            }
+        },
         "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
             "version": "3.598.0",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-endpoints": "^2.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/types": "^3.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.598.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/abort-controller": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/config-resolver": {
+            "version": "3.0.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/core": {
+            "version": "2.2.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.5",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.3",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-middleware": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/credential-provider-imds": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/fetch-http-handler": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/querystring-builder": "^3.0.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/hash-node": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/invalid-dependency": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/is-array-buffer": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-content-length": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-endpoint": {
+            "version": "3.0.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-middleware": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-retry": {
+            "version": "3.0.5",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/service-error-classification": "^3.0.1",
+                "@smithy/smithy-client": "^3.1.3",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-serde": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-stack": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-http-handler": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/querystring-builder": "^3.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/property-provider": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/protocol-http": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-builder": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-parser": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/service-error-classification": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "3.1.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/smithy-client": {
+            "version": "3.1.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-stream": "^3.0.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3888,122 +3051,22 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.598.0",
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/url-parser": {
+            "version": "3.0.1",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@aws-sdk/util-arn-parser": "3.568.0",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
+                "@smithy/querystring-parser": "^3.0.1",
                 "@smithy/types": "^3.1.0",
                 "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/node-config-provider": {
-            "version": "3.1.1",
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-expect-continue": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/crc32": "5.2.0",
-                "@aws-crypto/crc32c": "5.2.0",
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/is-array-buffer": "^3.0.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
+                "@smithy/util-buffer-from": "^3.0.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -4011,51 +3074,9 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-buffer-from": {
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
             "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-buffer-from": "^3.0.0",
@@ -4065,33 +3086,260 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-config-provider": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "3.0.5",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/smithy-client": "^3.1.3",
+                "@smithy/types": "^3.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "3.0.5",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/credential-provider-imds": "^3.1.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/smithy-client": "^3.1.3",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-endpoints": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-hex-encoding": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-middleware": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-retry": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^3.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-stream": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^3.0.3",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-uri-escape": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+            "version": "3.568.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-arn-parser": "3.568.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-config-provider": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-expect-continue": {
+            "version": "3.572.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-flexible-checksums": {
+            "version": "3.572.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/crc32": "3.0.0",
+                "@aws-crypto/crc32c": "3.0.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/is-array-buffer": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.567.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/middleware-location-constraint": {
-            "version": "3.598.0",
+            "version": "3.567.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.568.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.567.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4099,88 +3347,17 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.598.0",
+            "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/types": "3.567.0",
                 "@aws-sdk/util-arn-parser": "3.568.0",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/signature-v4": "^3.1.0",
-                "@smithy/smithy-client": "^3.1.2",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/middleware-stack": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/node-config-provider": {
-            "version": "3.1.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/smithy-client": {
-            "version": "3.1.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-stream": "^3.0.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/signature-v4": "^2.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-config-provider": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4188,47 +3365,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.598.0",
+            "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/signature-v4": "^3.1.0",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/signature-v4": "^2.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-middleware": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4236,124 +3381,34 @@
             }
         },
         "node_modules/@aws-sdk/middleware-ssec": {
-            "version": "3.598.0",
+            "version": "3.567.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
+        "node_modules/@aws-sdk/middleware-token": {
+            "version": "3.425.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
+                "@aws-sdk/token-providers": "3.425.0",
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/types": "^2.3.4",
+                "@smithy/util-middleware": "^2.0.3",
+                "tslib": "^2.5.0"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-ssec/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-sdk-s3": "3.598.0",
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/signature-v4": "^3.1.0",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/token-providers": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sso-oidc": "^3.598.0"
-            }
-        },
-        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/types": {
+        "node_modules/@aws-sdk/middleware-token/node_modules/@aws-sdk/types": {
             "version": "3.425.0",
             "license": "Apache-2.0",
             "dependencies": {
@@ -4362,6 +3417,210 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.572.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@aws-sdk/util-endpoints": "3.572.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.572.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-config-provider": "^2.3.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.572.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-sdk-s3": "3.572.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/signature-v4": "^2.3.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/middleware-host-header": "3.425.0",
+                "@aws-sdk/middleware-logger": "3.425.0",
+                "@aws-sdk/middleware-recursion-detection": "3.425.0",
+                "@aws-sdk/middleware-user-agent": "3.425.0",
+                "@aws-sdk/types": "3.425.0",
+                "@aws-sdk/util-endpoints": "3.425.0",
+                "@aws-sdk/util-user-agent-browser": "3.425.0",
+                "@aws-sdk/util-user-agent-node": "3.425.0",
+                "@smithy/config-resolver": "^2.0.11",
+                "@smithy/fetch-http-handler": "^2.2.1",
+                "@smithy/hash-node": "^2.0.10",
+                "@smithy/invalid-dependency": "^2.0.10",
+                "@smithy/middleware-content-length": "^2.0.12",
+                "@smithy/middleware-endpoint": "^2.0.10",
+                "@smithy/middleware-retry": "^2.0.13",
+                "@smithy/middleware-serde": "^2.0.10",
+                "@smithy/middleware-stack": "^2.0.4",
+                "@smithy/node-config-provider": "^2.0.13",
+                "@smithy/node-http-handler": "^2.1.6",
+                "@smithy/property-provider": "^2.0.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/shared-ini-file-loader": "^2.0.6",
+                "@smithy/smithy-client": "^2.1.9",
+                "@smithy/types": "^2.3.4",
+                "@smithy/url-parser": "^2.0.10",
+                "@smithy/util-base64": "^2.0.0",
+                "@smithy/util-body-length-browser": "^2.0.0",
+                "@smithy/util-body-length-node": "^2.1.0",
+                "@smithy/util-defaults-mode-browser": "^2.0.13",
+                "@smithy/util-defaults-mode-node": "^2.0.15",
+                "@smithy/util-retry": "^2.0.3",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.425.0",
+                "@aws-sdk/util-endpoints": "3.425.0",
+                "@smithy/protocol-http": "^3.0.6",
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.425.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/types": "^2.3.4",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.425.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.425.0",
+                "@smithy/node-config-provider": "^2.0.13",
+                "@smithy/types": "^2.3.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.567.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/util-arn-parser": {
@@ -4375,33 +3634,12 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.598.0",
+            "version": "3.572.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.598.0",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-endpoints": "^2.0.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-endpoints": "^1.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4418,21 +3656,49 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.598.0",
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.567.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/types": "^2.12.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.568.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.567.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@aws-sdk/util-utf8-browser": {
+            "version": "3.259.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.567.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4576,22 +3842,12 @@
                 "unescape-html": "^1.1.0"
             }
         },
-        "node_modules/@aws/mynah-ui/node_modules/marked": {
-            "version": "12.0.2",
-            "license": "MIT",
-            "bin": {
-                "marked": "bin/marked.js"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.7",
+            "version": "7.24.2",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/highlight": "^7.24.7",
+                "@babel/highlight": "^7.24.2",
                 "picocolors": "^1.0.0"
             },
             "engines": {
@@ -4599,7 +3855,7 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.24.7",
+            "version": "7.24.4",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4607,20 +3863,20 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.24.7",
+            "version": "7.24.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.24.7",
-                "@babel/helper-compilation-targets": "^7.24.7",
-                "@babel/helper-module-transforms": "^7.24.7",
-                "@babel/helpers": "^7.24.7",
-                "@babel/parser": "^7.24.7",
-                "@babel/template": "^7.24.7",
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7",
+                "@babel/code-frame": "^7.24.2",
+                "@babel/generator": "^7.24.5",
+                "@babel/helper-compilation-targets": "^7.23.6",
+                "@babel/helper-module-transforms": "^7.24.5",
+                "@babel/helpers": "^7.24.5",
+                "@babel/parser": "^7.24.5",
+                "@babel/template": "^7.24.0",
+                "@babel/traverse": "^7.24.5",
+                "@babel/types": "^7.24.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -4633,6 +3889,53 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@babel/generator": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.24.5",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^2.5.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@babel/parser": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@babel/core/node_modules/json5": {
@@ -4655,41 +3958,39 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.24.7",
+            "version": "7.18.2",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.24.7",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
+                "@babel/types": "^7.18.2",
+                "@jridgewell/gen-mapping": "^0.3.0",
                 "jsesc": "^2.5.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.1.0",
-                "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
-        },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.24.7",
+            "version": "7.23.6",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.24.7",
-                "@babel/helper-validator-option": "^7.24.7",
+                "@babel/compat-data": "^7.23.5",
+                "@babel/helper-validator-option": "^7.23.5",
                 "browserslist": "^4.22.2",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+            "version": "5.1.1",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
             }
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -4701,61 +4002,96 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.24.7",
+            "version": "7.22.20",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.24.7"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.24.7",
+            "version": "7.23.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.24.7",
+            "version": "7.22.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.22.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.24.7",
+            "version": "7.24.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.24.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.24.7",
+            "version": "7.24.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.24.7",
-                "@babel/helper-module-imports": "^7.24.7",
-                "@babel/helper-simple-access": "^7.24.7",
-                "@babel/helper-split-export-declaration": "^7.24.7",
-                "@babel/helper-validator-identifier": "^7.24.7"
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-module-imports": "^7.24.3",
+                "@babel/helper-simple-access": "^7.24.5",
+                "@babel/helper-split-export-declaration": "^7.24.5",
+                "@babel/helper-validator-identifier": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -4765,7 +4101,7 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.7",
+            "version": "7.24.5",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4773,30 +4109,55 @@
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.24.7",
+            "version": "7.24.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.24.7",
+            "version": "7.24.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.7",
+            "version": "7.24.1",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4804,7 +4165,7 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.7",
+            "version": "7.24.5",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4812,7 +4173,7 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.24.7",
+            "version": "7.23.5",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4820,23 +4181,37 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.7",
+            "version": "7.24.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/template": "^7.24.0",
+                "@babel/traverse": "^7.24.5",
+                "@babel/types": "^7.24.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.24.7",
+            "version": "7.24.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.5",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
@@ -4910,7 +4285,7 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.7",
+            "version": "7.18.4",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -4976,11 +4351,11 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.24.7",
+            "version": "7.24.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -5070,11 +4445,11 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.24.7",
+            "version": "7.24.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -5084,13 +4459,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.24.7",
+            "version": "7.24.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-simple-access": "^7.24.7"
+                "@babel/helper-module-transforms": "^7.23.3",
+                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-simple-access": "^7.22.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -5099,37 +4474,119 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/template": {
-            "version": "7.24.7",
+        "node_modules/@babel/runtime": {
+            "version": "7.24.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
-                "@babel/parser": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "regenerator-runtime": "^0.14.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.24.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.23.5",
+                "@babel/parser": "^7.24.0",
+                "@babel/types": "^7.24.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/template/node_modules/@babel/parser": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/template/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.24.7",
+            "version": "7.24.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.24.7",
-                "@babel/helper-environment-visitor": "^7.24.7",
-                "@babel/helper-function-name": "^7.24.7",
-                "@babel/helper-hoist-variables": "^7.24.7",
-                "@babel/helper-split-export-declaration": "^7.24.7",
-                "@babel/parser": "^7.24.7",
-                "@babel/types": "^7.24.7",
+                "@babel/code-frame": "^7.24.2",
+                "@babel/generator": "^7.24.5",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
+                "@babel/helper-hoist-variables": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.24.5",
+                "@babel/parser": "^7.24.5",
+                "@babel/types": "^7.24.5",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/generator": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.24.5",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jsesc": "^2.5.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/parser": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@babel/traverse/node_modules/globals": {
@@ -5141,12 +4598,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.24.7",
+            "version": "7.19.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.7",
-                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/helper-string-parser": "^7.18.10",
+                "@babel/helper-validator-identifier": "^7.18.6",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -5177,21 +4634,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.21.5",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "dev": true,
@@ -5207,7 +4649,7 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.10.1",
+            "version": "4.10.0",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5431,6 +4873,14 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+            "version": "5.3.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/esprima": {
             "version": "4.0.1",
             "dev": true,
@@ -5634,6 +5084,14 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/@jest/fake-timers/node_modules/@sinonjs/fake-timers": {
+            "version": "10.3.0",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.0"
+            }
+        },
         "node_modules/@jest/globals": {
             "version": "29.7.0",
             "dev": true,
@@ -5697,6 +5155,34 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@jest/reporters/node_modules/jest-worker": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "jest-util": "^29.7.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/reporters/node_modules/supports-color": {
+            "version": "8.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/@jest/schemas": {
@@ -6001,7 +5487,7 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "10.3.0",
+            "version": "11.2.2",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -6031,537 +5517,447 @@
             "dev": true,
             "license": "(Unlicense OR Apache-2.0)"
         },
+        "node_modules/@smithy/abort-controller": {
+            "version": "2.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@smithy/chunked-blob-reader": {
-            "version": "3.0.0",
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/chunked-blob-reader-native": {
-            "version": "3.0.0",
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-base64": "^2.3.0",
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@smithy/chunked-blob-reader-native/node_modules/@smithy/util-base64": {
-            "version": "3.0.0",
+        "node_modules/@smithy/config-resolver": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-config-provider": "^2.3.0",
+                "@smithy/util-middleware": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/chunked-blob-reader-native/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/chunked-blob-reader-native/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/core": {
-            "version": "2.2.2",
+            "version": "1.4.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-retry": "^3.0.5",
-                "@smithy/middleware-serde": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-retry": "^2.3.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-middleware": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/middleware-retry": {
-            "version": "3.0.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/service-error-classification": "^3.0.1",
-                "@smithy/smithy-client": "^3.1.3",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "@smithy/util-retry": "^3.0.1",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/middleware-serde": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/middleware-stack": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/node-config-provider": {
-            "version": "3.1.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/service-error-classification": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/smithy-client": {
-            "version": "3.1.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-endpoint": "^3.0.2",
-                "@smithy/middleware-stack": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-stream": "^3.0.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/util-retry": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/service-error-classification": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "3.1.1",
+            "version": "2.3.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/url-parser": "^3.0.1",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/node-config-provider": {
-            "version": "3.1.1",
+        "node_modules/@smithy/eventstream-codec": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
+                "@aws-crypto/crc32": "3.0.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-hex-encoding": "^2.2.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/eventstream-serde-browser": {
+            "version": "2.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/eventstream-serde-universal": "^2.2.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/querystring-parser": {
-            "version": "3.0.1",
+        "node_modules/@smithy/eventstream-serde-config-resolver": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@smithy/eventstream-serde-node": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/eventstream-serde-universal": "^2.2.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/url-parser": {
-            "version": "3.0.1",
+        "node_modules/@smithy/eventstream-serde-universal": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/querystring-parser": "^3.0.1",
-                "@smithy/types": "^3.1.0",
+                "@smithy/eventstream-codec": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "2.5.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-base64": "^2.3.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/hash-blob-browser": {
-            "version": "3.1.0",
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/chunked-blob-reader": "^3.0.0",
-                "@smithy/chunked-blob-reader-native": "^3.0.0",
-                "@smithy/types": "^3.1.0",
+                "@smithy/chunked-blob-reader": "^2.2.0",
+                "@smithy/chunked-blob-reader-native": "^2.2.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@smithy/hash-blob-browser/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@smithy/hash-node": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/hash-stream-node": {
-            "version": "3.1.0",
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-utf8": "^3.0.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/hash-stream-node/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/hash-stream-node/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/hash-stream-node/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/is-array-buffer": {
-            "version": "3.0.0",
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/md5-js": {
-            "version": "3.0.1",
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-utf8": "^3.0.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@smithy/md5-js/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/md5-js/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/md5-js/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "3.0.2",
+            "version": "2.5.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^3.0.1",
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/url-parser": "^3.0.1",
-                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/middleware-serde": "^2.3.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/url-parser": "^2.2.0",
+                "@smithy/util-middleware": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/middleware-serde": {
-            "version": "3.0.1",
+        "node_modules/@smithy/middleware-retry": {
+            "version": "2.3.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/service-error-classification": "^2.1.5",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-retry": "^2.2.0",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/node-config-provider": {
-            "version": "3.1.1",
+        "node_modules/@smithy/middleware-stack": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/querystring-parser": {
-            "version": "3.0.1",
+        "node_modules/@smithy/node-config-provider": {
+            "version": "2.3.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/shared-ini-file-loader": "^2.4.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@smithy/node-http-handler": {
+            "version": "2.5.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/abort-controller": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/url-parser": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/querystring-parser": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "3.1.1",
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/property-provider/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@smithy/protocol-http": {
+            "version": "3.3.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "2.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-uri-escape": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "2.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/service-client-documentation-generator": {
+            "version": "2.2.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "2.1.5",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^2.12.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "3.1.1",
+            "version": "2.4.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/shared-ini-file-loader/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "3.1.0",
+            "version": "2.3.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-hex-encoding": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.1",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
+                "@smithy/is-array-buffer": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-hex-encoding": "^2.2.0",
+                "@smithy/util-middleware": "^2.2.0",
+                "@smithy/util-uri-escape": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@smithy/smithy-client": {
+            "version": "2.5.1",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/middleware-endpoint": "^2.5.1",
+                "@smithy/middleware-stack": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-stream": "^2.2.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/signature-v4/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/signature-v4/node_modules/@smithy/util-hex-encoding": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/signature-v4/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/types": {
             "version": "2.12.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/url-parser": {
+            "version": "2.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "2.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "2.3.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -6581,7 +5977,59 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+        "node_modules/@smithy/util-config-provider": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "2.2.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "2.3.1",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^2.2.0",
+                "@smithy/credential-provider-imds": "^2.3.0",
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/property-provider": "^2.2.0",
+                "@smithy/smithy-client": "^2.5.1",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "1.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^2.3.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
             "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
@@ -6591,210 +6039,54 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/util-config-provider": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-endpoints": {
-            "version": "2.0.2",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-endpoints/node_modules/@smithy/node-config-provider": {
-            "version": "3.1.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.1",
-                "@smithy/shared-ini-file-loader": "^3.1.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-endpoints/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/util-middleware": {
-            "version": "3.0.1",
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.1.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@smithy/util-retry": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/service-error-classification": "^2.1.5",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "3.0.3",
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^3.0.3",
-                "@smithy/node-http-handler": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-hex-encoding": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
+                "@smithy/fetch-http-handler": "^2.5.0",
+                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-base64": "^2.3.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "@smithy/util-hex-encoding": "^2.2.0",
+                "@smithy/util-utf8": "^2.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/abort-controller": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
-            "version": "3.0.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-base64": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/node-http-handler": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.0.1",
-                "@smithy/protocol-http": "^4.0.1",
-                "@smithy/querystring-builder": "^3.0.1",
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/protocol-http": {
-            "version": "4.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/types": {
-            "version": "3.1.0",
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/util-base64": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/util-hex-encoding": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/util-utf8": {
@@ -6809,36 +6101,15 @@
             }
         },
         "node_modules/@smithy/util-waiter": {
-            "version": "3.0.1",
+            "version": "2.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^3.0.1",
-                "@smithy/types": "^3.1.0",
+                "@smithy/abort-controller": "^2.2.0",
+                "@smithy/types": "^2.12.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-waiter/node_modules/@smithy/abort-controller": {
-            "version": "3.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-waiter/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@szmarczak/http-timer": {
@@ -6891,6 +6162,30 @@
                 "@types/babel__traverse": "*"
             }
         },
+        "node_modules/@types/babel__core/node_modules/@babel/parser": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@types/babel__core/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@types/babel__generator": {
             "version": "7.6.8",
             "dev": true,
@@ -6909,11 +6204,24 @@
             }
         },
         "node_modules/@types/babel__traverse": {
-            "version": "7.20.6",
+            "version": "7.20.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.20.7"
+            }
+        },
+        "node_modules/@types/babel__traverse/node_modules/@babel/types": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.24.1",
+                "@babel/helper-validator-identifier": "^7.24.5",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@types/body-parser": {
@@ -7008,7 +6316,7 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.19.3",
+            "version": "4.19.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7084,7 +6392,7 @@
             }
         },
         "node_modules/@types/jsdom": {
-            "version": "21.1.7",
+            "version": "21.1.6",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7138,7 +6446,7 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.14.5",
+            "version": "20.12.11",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -7171,6 +6479,11 @@
         },
         "node_modules/@types/retry": {
             "version": "0.12.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/semver": {
+            "version": "7.5.8",
             "dev": true,
             "license": "MIT"
         },
@@ -7250,12 +6563,11 @@
         },
         "node_modules/@types/uuid": {
             "version": "9.0.8",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-            "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/vscode": {
-            "version": "1.90.0",
+            "version": "1.89.0",
             "dev": true,
             "license": "MIT"
         },
@@ -7281,18 +6593,20 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "7.13.1",
+            "version": "7.8.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "7.13.1",
-                "@typescript-eslint/type-utils": "7.13.1",
-                "@typescript-eslint/utils": "7.13.1",
-                "@typescript-eslint/visitor-keys": "7.13.1",
+                "@typescript-eslint/scope-manager": "7.8.0",
+                "@typescript-eslint/type-utils": "7.8.0",
+                "@typescript-eslint/utils": "7.8.0",
+                "@typescript-eslint/visitor-keys": "7.8.0",
+                "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
+                "semver": "^7.6.0",
                 "ts-api-utils": "^1.3.0"
             },
             "engines": {
@@ -7313,14 +6627,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "7.13.1",
+            "version": "7.8.0",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "7.13.1",
-                "@typescript-eslint/types": "7.13.1",
-                "@typescript-eslint/typescript-estree": "7.13.1",
-                "@typescript-eslint/visitor-keys": "7.13.1",
+                "@typescript-eslint/scope-manager": "7.8.0",
+                "@typescript-eslint/types": "7.8.0",
+                "@typescript-eslint/typescript-estree": "7.8.0",
+                "@typescript-eslint/visitor-keys": "7.8.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -7340,12 +6654,12 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "7.13.1",
+            "version": "7.8.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "7.13.1",
-                "@typescript-eslint/visitor-keys": "7.13.1"
+                "@typescript-eslint/types": "7.8.0",
+                "@typescript-eslint/visitor-keys": "7.8.0"
             },
             "engines": {
                 "node": "^18.18.0 || >=20.0.0"
@@ -7356,12 +6670,12 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "7.13.1",
+            "version": "7.8.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "7.13.1",
-                "@typescript-eslint/utils": "7.13.1",
+                "@typescript-eslint/typescript-estree": "7.8.0",
+                "@typescript-eslint/utils": "7.8.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -7382,7 +6696,7 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "7.13.1",
+            "version": "7.8.0",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7394,12 +6708,12 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "7.13.1",
+            "version": "7.8.0",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/types": "7.13.1",
-                "@typescript-eslint/visitor-keys": "7.13.1",
+                "@typescript-eslint/types": "7.8.0",
+                "@typescript-eslint/visitor-keys": "7.8.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -7421,14 +6735,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "7.13.1",
+            "version": "7.8.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "7.13.1",
-                "@typescript-eslint/types": "7.13.1",
-                "@typescript-eslint/typescript-estree": "7.13.1"
+                "@types/json-schema": "^7.0.15",
+                "@types/semver": "^7.5.8",
+                "@typescript-eslint/scope-manager": "7.8.0",
+                "@typescript-eslint/types": "7.8.0",
+                "@typescript-eslint/typescript-estree": "7.8.0",
+                "semver": "^7.6.0"
             },
             "engines": {
                 "node": "^18.18.0 || >=20.0.0"
@@ -7442,11 +6759,11 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "7.13.1",
+            "version": "7.8.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "7.13.1",
+                "@typescript-eslint/types": "7.8.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -7657,7 +6974,7 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.12.0",
+            "version": "8.11.3",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -7667,8 +6984,8 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/acorn-import-attributes": {
-            "version": "1.9.5",
+        "node_modules/acorn-import-assertions": {
+            "version": "1.9.0",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -7684,21 +7001,18 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.3.3",
+            "version": "8.3.2",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.11.0"
-            },
             "engines": {
                 "node": ">=0.4.0"
             }
         },
         "node_modules/adm-zip": {
-            "version": "0.5.14",
+            "version": "0.5.12",
             "license": "MIT",
             "engines": {
-                "node": ">=12.0"
+                "node": ">=6.0"
             }
         },
         "node_modules/agent-base": {
@@ -7744,7 +7058,7 @@
             }
         },
         "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.16.0",
+            "version": "8.13.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7882,14 +7196,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/args/node_modules/camelcase": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/args/node_modules/chalk": {
             "version": "2.4.2",
             "dev": true,
@@ -7930,14 +7236,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/args/node_modules/leven": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/args/node_modules/mri": {
@@ -8166,7 +7464,7 @@
             }
         },
         "node_modules/aws-sdk": {
-            "version": "2.1643.0",
+            "version": "2.1618.0",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -8564,7 +7862,7 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.23.1",
+            "version": "4.23.0",
             "dev": true,
             "funding": [
                 {
@@ -8582,10 +7880,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001629",
-                "electron-to-chromium": "^1.4.796",
+                "caniuse-lite": "^1.0.30001587",
+                "electron-to-chromium": "^1.4.668",
                 "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.16"
+                "update-browserslist-db": "^1.0.13"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -8630,10 +7928,6 @@
         "node_modules/buffer-xor": {
             "version": "1.0.3",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/buffer/node_modules/isarray": {
-            "version": "1.0.0",
             "license": "MIT"
         },
         "node_modules/bundle-name": {
@@ -8720,7 +8014,7 @@
             }
         },
         "node_modules/camelcase": {
-            "version": "5.3.1",
+            "version": "5.0.0",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8728,7 +8022,7 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001636",
+            "version": "1.0.30001617",
             "dev": true,
             "funding": [
                 {
@@ -8787,17 +8081,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/char-regex": {
@@ -8862,7 +8145,7 @@
             "license": "ISC"
         },
         "node_modules/chrome-trace-event": {
-            "version": "1.0.4",
+            "version": "1.0.3",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9038,6 +8321,57 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "license": "MIT"
+        },
+        "node_modules/concurrently": {
+            "version": "7.0.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "date-fns": "^2.16.1",
+                "lodash": "^4.17.21",
+                "rxjs": "^6.6.3",
+                "spawn-command": "^0.0.2-1",
+                "supports-color": "^8.1.0",
+                "tree-kill": "^1.2.2",
+                "yargs": "^16.2.0"
+            },
+            "bin": {
+                "concurrently": "dist/bin/concurrently.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.0 || >=16.0.0"
+            }
+        },
+        "node_modules/concurrently/node_modules/rxjs": {
+            "version": "6.6.7",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^1.9.0"
+            },
+            "engines": {
+                "npm": ">=2.0.0"
+            }
+        },
+        "node_modules/concurrently/node_modules/supports-color": {
+            "version": "8.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/concurrently/node_modules/tslib": {
+            "version": "1.14.1",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/connect-history-api-fallback": {
             "version": "2.0.0",
@@ -9232,11 +8566,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/cssstyle/node_modules/rrweb-cssom": {
-            "version": "0.6.0",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/data-urls": {
             "version": "5.0.0",
             "dev": true,
@@ -9297,6 +8626,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/date-fns": {
+            "version": "2.30.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0"
+            },
+            "engines": {
+                "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
+            }
+        },
         "node_modules/dateformat": {
             "version": "4.6.3",
             "dev": true,
@@ -9306,7 +8650,7 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.5",
+            "version": "4.3.4",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9374,7 +8718,7 @@
             }
         },
         "node_modules/deep-eql": {
-            "version": "4.1.4",
+            "version": "4.1.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9648,6 +8992,31 @@
                 "url": "https://github.com/fb55/domutils?sponsor=1"
             }
         },
+        "node_modules/downlevel-dts": {
+            "version": "0.10.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.3.2",
+                "shelljs": "^0.8.3",
+                "typescript": "next"
+            },
+            "bin": {
+                "downlevel-dts": "index.js"
+            }
+        },
+        "node_modules/downlevel-dts/node_modules/typescript": {
+            "version": "5.6.0-dev.20240621",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
         "node_modules/duplexify": {
             "version": "4.1.3",
             "dev": true,
@@ -9683,7 +9052,7 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.805",
+            "version": "1.4.763",
             "dev": true,
             "license": "ISC"
         },
@@ -9862,7 +9231,7 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.5.3",
+            "version": "1.5.2",
             "dev": true,
             "license": "MIT"
         },
@@ -9915,7 +9284,7 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.21.5",
+            "version": "0.20.2",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -9926,29 +9295,29 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.21.5",
-                "@esbuild/android-arm": "0.21.5",
-                "@esbuild/android-arm64": "0.21.5",
-                "@esbuild/android-x64": "0.21.5",
-                "@esbuild/darwin-arm64": "0.21.5",
-                "@esbuild/darwin-x64": "0.21.5",
-                "@esbuild/freebsd-arm64": "0.21.5",
-                "@esbuild/freebsd-x64": "0.21.5",
-                "@esbuild/linux-arm": "0.21.5",
-                "@esbuild/linux-arm64": "0.21.5",
-                "@esbuild/linux-ia32": "0.21.5",
-                "@esbuild/linux-loong64": "0.21.5",
-                "@esbuild/linux-mips64el": "0.21.5",
-                "@esbuild/linux-ppc64": "0.21.5",
-                "@esbuild/linux-riscv64": "0.21.5",
-                "@esbuild/linux-s390x": "0.21.5",
-                "@esbuild/linux-x64": "0.21.5",
-                "@esbuild/netbsd-x64": "0.21.5",
-                "@esbuild/openbsd-x64": "0.21.5",
-                "@esbuild/sunos-x64": "0.21.5",
-                "@esbuild/win32-arm64": "0.21.5",
-                "@esbuild/win32-ia32": "0.21.5",
-                "@esbuild/win32-x64": "0.21.5"
+                "@esbuild/aix-ppc64": "0.20.2",
+                "@esbuild/android-arm": "0.20.2",
+                "@esbuild/android-arm64": "0.20.2",
+                "@esbuild/android-x64": "0.20.2",
+                "@esbuild/darwin-arm64": "0.20.2",
+                "@esbuild/darwin-x64": "0.20.2",
+                "@esbuild/freebsd-arm64": "0.20.2",
+                "@esbuild/freebsd-x64": "0.20.2",
+                "@esbuild/linux-arm": "0.20.2",
+                "@esbuild/linux-arm64": "0.20.2",
+                "@esbuild/linux-ia32": "0.20.2",
+                "@esbuild/linux-loong64": "0.20.2",
+                "@esbuild/linux-mips64el": "0.20.2",
+                "@esbuild/linux-ppc64": "0.20.2",
+                "@esbuild/linux-riscv64": "0.20.2",
+                "@esbuild/linux-s390x": "0.20.2",
+                "@esbuild/linux-x64": "0.20.2",
+                "@esbuild/netbsd-x64": "0.20.2",
+                "@esbuild/openbsd-x64": "0.20.2",
+                "@esbuild/sunos-x64": "0.20.2",
+                "@esbuild/win32-arm64": "0.20.2",
+                "@esbuild/win32-ia32": "0.20.2",
+                "@esbuild/win32-x64": "0.20.2"
             }
         },
         "node_modules/escalade": {
@@ -10044,6 +9413,17 @@
                 "ms": "^2.1.1"
             }
         },
+        "node_modules/eslint-import-resolver-node/node_modules/is-core-module": {
+            "version": "2.13.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/eslint-module-utils": {
             "version": "2.8.1",
             "dev": true,
@@ -10124,6 +9504,17 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/eslint-plugin-import/node_modules/is-core-module": {
+            "version": "2.13.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/eslint-plugin-import/node_modules/minimatch": {
@@ -10653,7 +10044,7 @@
             }
         },
         "node_modules/foreground-child": {
-            "version": "3.2.1",
+            "version": "3.1.1",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -11557,11 +10948,11 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.13.1",
+            "version": "2.9.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.0"
+                "has": "^1.0.3"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -11870,8 +11261,7 @@
             }
         },
         "node_modules/isarray": {
-            "version": "2.0.5",
-            "dev": true,
+            "version": "1.0.0",
             "license": "MIT"
         },
         "node_modules/isexe": {
@@ -11910,6 +11300,17 @@
                 "node": ">=10"
             }
         },
+        "node_modules/istanbul-lib-instrument/node_modules/@babel/parser": {
+            "version": "7.24.5",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/istanbul-lib-report": {
             "version": "3.0.1",
             "dev": true,
@@ -11921,17 +11322,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/istanbul-lib-report/node_modules/supports-color": {
-            "version": "7.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/istanbul-lib-source-maps": {
@@ -11947,6 +11337,14 @@
                 "node": ">=10"
             }
         },
+        "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+            "version": "0.6.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/istanbul-reports": {
             "version": "3.1.7",
             "dev": true,
@@ -11960,7 +11358,7 @@
             }
         },
         "node_modules/jackspeak": {
-            "version": "3.4.0",
+            "version": "2.3.6",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -12158,6 +11556,23 @@
                 }
             }
         },
+        "node_modules/jest-config/node_modules/parse-json": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/jest-diff": {
             "version": "29.7.0",
             "dev": true,
@@ -12244,6 +11659,34 @@
             },
             "optionalDependencies": {
                 "fsevents": "^2.3.2"
+            }
+        },
+        "node_modules/jest-haste-map/node_modules/jest-worker": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "jest-util": "^29.7.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-haste-map/node_modules/supports-color": {
+            "version": "8.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/jest-leak-detector": {
@@ -12390,6 +11833,51 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-runner/node_modules/jest-worker": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "jest-util": "^29.7.0",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-runner/node_modules/source-map": {
+            "version": "0.6.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/jest-runner/node_modules/source-map-support": {
+            "version": "0.5.13",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/jest-runner/node_modules/supports-color": {
+            "version": "8.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
         "node_modules/jest-runtime": {
             "version": "29.7.0",
             "dev": true,
@@ -12503,6 +11991,14 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/jest-validate/node_modules/leven": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/jest-watcher": {
             "version": "29.7.0",
             "dev": true,
@@ -12522,17 +12018,30 @@
             }
         },
         "node_modules/jest-worker": {
-            "version": "29.7.0",
+            "version": "27.5.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
-                "jest-util": "^29.7.0",
                 "merge-stream": "^2.0.0",
                 "supports-color": "^8.0.0"
             },
             "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/jest-worker/node_modules/supports-color": {
+            "version": "8.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/jmespath": {
@@ -12543,7 +12052,7 @@
             }
         },
         "node_modules/jose": {
-            "version": "5.4.0",
+            "version": "5.3.0",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -12578,7 +12087,7 @@
             }
         },
         "node_modules/jsdom": {
-            "version": "24.1.0",
+            "version": "24.0.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12587,21 +12096,21 @@
                 "decimal.js": "^10.4.3",
                 "form-data": "^4.0.0",
                 "html-encoding-sniffer": "^4.0.0",
-                "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.4",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
                 "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.10",
+                "nwsapi": "^2.2.7",
                 "parse5": "^7.1.2",
-                "rrweb-cssom": "^0.7.0",
+                "rrweb-cssom": "^0.6.0",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
-                "tough-cookie": "^4.1.4",
+                "tough-cookie": "^4.1.3",
                 "w3c-xmlserializer": "^5.0.0",
                 "webidl-conversions": "^7.0.0",
                 "whatwg-encoding": "^3.1.1",
                 "whatwg-mimetype": "^4.0.0",
                 "whatwg-url": "^14.0.0",
-                "ws": "^8.17.0",
+                "ws": "^8.16.0",
                 "xml-name-validator": "^5.0.0"
             },
             "engines": {
@@ -12710,7 +12219,7 @@
             }
         },
         "node_modules/launch-editor": {
-            "version": "2.7.0",
+            "version": "2.6.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12719,11 +12228,11 @@
             }
         },
         "node_modules/leven": {
-            "version": "3.1.0",
+            "version": "2.1.0",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=6"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/levn": {
@@ -12828,12 +12337,17 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "5.1.1",
+            "version": "10.2.2",
             "dev": true,
             "license": "ISC",
-            "dependencies": {
-                "yallist": "^3.0.2"
+            "engines": {
+                "node": "14 || >=16.14"
             }
+        },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/make-dir": {
             "version": "4.0.0",
@@ -12862,6 +12376,16 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/marked": {
+            "version": "12.0.2",
+            "license": "MIT",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/md5.js": {
             "version": "1.3.5",
             "dev": true,
@@ -12881,13 +12405,13 @@
             }
         },
         "node_modules/memfs": {
-            "version": "4.9.3",
+            "version": "4.9.2",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@jsonjoy.com/json-pack": "^1.0.3",
                 "@jsonjoy.com/util": "^1.1.2",
-                "tree-dump": "^1.0.1",
+                "sonic-forest": "^1.0.0",
                 "tslib": "^2.0.0"
             },
             "engines": {
@@ -12925,11 +12449,11 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.7",
+            "version": "4.0.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "braces": "^3.0.3",
+                "braces": "^3.0.2",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -13031,7 +12555,7 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
+            "version": "7.1.1",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -13087,27 +12611,6 @@
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/mocha/node_modules/debug": {
-            "version": "4.3.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/mocha/node_modules/debug/node_modules/ms": {
-            "version": "2.1.2",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/mocha/node_modules/diff": {
             "version": "5.0.0",
             "dev": true,
@@ -13150,12 +12653,18 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/mocha/node_modules/yargs-parser": {
-            "version": "20.2.4",
+        "node_modules/mocha/node_modules/supports-color": {
+            "version": "8.1.1",
             "dev": true,
-            "license": "ISC",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/mock-fs": {
@@ -13278,16 +12787,8 @@
                 "path-to-regexp": "^6.2.1"
             }
         },
-        "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-            "version": "11.2.2",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.0"
-            }
-        },
         "node_modules/node-abi": {
-            "version": "3.65.0",
+            "version": "3.62.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13689,23 +13190,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/parse-json": {
-            "version": "5.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "lines-and-columns": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/parse-srcset": {
             "version": "1.0.2",
             "license": "MIT"
@@ -13786,14 +13270,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "10.2.2",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "14 || >=16.14"
-            }
-        },
         "node_modules/path-to-regexp": {
             "version": "6.2.2",
             "dev": true,
@@ -13844,7 +13320,7 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
+            "version": "1.0.0",
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -14083,54 +13559,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/pkg/node_modules/@babel/generator": {
-            "version": "7.18.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.18.2",
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "jsesc": "^2.5.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/pkg/node_modules/@babel/parser": {
-            "version": "7.18.4",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/pkg/node_modules/@babel/types": {
-            "version": "7.19.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.18.10",
-                "@babel/helper-validator-identifier": "^7.18.6",
-                "to-fast-properties": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/pkg/node_modules/is-core-module": {
-            "version": "2.9.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
             "license": "MIT",
@@ -14198,7 +13626,7 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.3.2",
+            "version": "3.2.5",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -14556,10 +13984,6 @@
                 "util-deprecate": "~1.0.1"
             }
         },
-        "node_modules/readable-stream/node_modules/isarray": {
-            "version": "1.0.0",
-            "license": "MIT"
-        },
         "node_modules/readable-stream/node_modules/safe-buffer": {
             "version": "5.1.2",
             "license": "MIT"
@@ -14623,6 +14047,11 @@
             "engines": {
                 "node": ">= 10.13.0"
             }
+        },
+        "node_modules/regenerator-runtime": {
+            "version": "0.14.1",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.2",
@@ -14727,6 +14156,17 @@
                 "node": ">=10"
             }
         },
+        "node_modules/resolve/node_modules/is-core-module": {
+            "version": "2.13.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/responselike": {
             "version": "2.0.1",
             "license": "MIT",
@@ -14755,7 +14195,7 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.4.1",
+            "version": "1.3.1",
             "dev": true,
             "license": "MIT"
         },
@@ -14783,7 +14223,7 @@
             }
         },
         "node_modules/rrweb-cssom": {
-            "version": "0.7.1",
+            "version": "0.6.0",
             "dev": true,
             "license": "MIT"
         },
@@ -14843,6 +14283,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/safe-array-concat/node_modules/isarray": {
+            "version": "2.0.5",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -15183,8 +14628,6 @@
         },
         "node_modules/shelljs": {
             "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-            "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -15201,8 +14644,6 @@
         },
         "node_modules/shelljs/node_modules/interpret": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -15211,8 +14652,6 @@
         },
         "node_modules/shelljs/node_modules/rechoir": {
             "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
             "dev": true,
             "dependencies": {
                 "resolve": "^1.1.6"
@@ -15223,8 +14662,6 @@
         },
         "node_modules/shx": {
             "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-            "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15320,31 +14757,12 @@
                 "url": "https://opencollective.com/sinon"
             }
         },
-        "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
-            "version": "11.2.2",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.0"
-            }
-        },
         "node_modules/sinon/node_modules/diff": {
             "version": "5.2.0",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
-            }
-        },
-        "node_modules/sinon/node_modules/supports-color": {
-            "version": "7.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/sisteransi": {
@@ -15386,12 +14804,30 @@
                 "atomic-sleep": "^1.0.0"
             }
         },
+        "node_modules/sonic-forest": {
+            "version": "1.0.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tree-dump": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
         "node_modules/source-map": {
-            "version": "0.6.1",
+            "version": "0.7.4",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">= 8"
             }
         },
         "node_modules/source-map-js": {
@@ -15402,13 +14838,26 @@
             }
         },
         "node_modules/source-map-support": {
-            "version": "0.5.13",
+            "version": "0.5.21",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
+        },
+        "node_modules/source-map-support/node_modules/source-map": {
+            "version": "0.6.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/spawn-command": {
+            "version": "0.0.2-1",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/spdy": {
             "version": "4.0.2",
@@ -15675,17 +15124,14 @@
             "license": "MIT"
         },
         "node_modules/supports-color": {
-            "version": "8.1.1",
+            "version": "7.2.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/supports-preserve-symlinks-flag": {
@@ -15752,7 +15198,7 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.31.1",
+            "version": "5.31.0",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -15810,34 +15256,12 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
-            "version": "27.5.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "merge-stream": "^2.0.0",
-                "supports-color": "^8.0.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            }
-        },
         "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
             "version": "6.0.2",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "randombytes": "^2.1.0"
-            }
-        },
-        "node_modules/terser/node_modules/source-map-support": {
-            "version": "0.5.21",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
             }
         },
         "node_modules/test-exclude": {
@@ -15989,6 +15413,14 @@
                 "tslib": "2"
             }
         },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tree-kill": "cli.js"
+            }
+        },
         "node_modules/ts-api-utils": {
             "version": "1.3.0",
             "dev": true,
@@ -16001,7 +15433,7 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "29.1.5",
+            "version": "29.1.2",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16018,11 +15450,10 @@
                 "ts-jest": "cli.js"
             },
             "engines": {
-                "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+                "node": "^16.10.0 || ^18.0.0 || >=20.0.0"
             },
             "peerDependencies": {
                 "@babel/core": ">=7.0.0-beta.0 <8",
-                "@jest/transform": "^29.0.0",
                 "@jest/types": "^29.0.0",
                 "babel-jest": "^29.0.0",
                 "jest": "^29.0.0",
@@ -16030,9 +15461,6 @@
             },
             "peerDependenciesMeta": {
                 "@babel/core": {
-                    "optional": true
-                },
-                "@jest/transform": {
                     "optional": true
                 },
                 "@jest/types": {
@@ -16082,14 +15510,6 @@
             "peerDependencies": {
                 "typescript": "*",
                 "webpack": "^5.0.0"
-            }
-        },
-        "node_modules/ts-loader/node_modules/source-map": {
-            "version": "0.7.4",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/ts-lsp-client": {
@@ -16306,17 +15726,6 @@
                 "url": "https://opencollective.com/sinon"
             }
         },
-        "node_modules/ts-sinon/node_modules/supports-color": {
-            "version": "7.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/tsconfig-paths": {
             "version": "3.15.0",
             "dev": true,
@@ -16329,15 +15738,15 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.6.3",
+            "version": "2.6.2",
             "license": "0BSD"
         },
         "node_modules/tsx": {
-            "version": "4.15.6",
+            "version": "4.10.4",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "~0.21.4",
+                "esbuild": "~0.20.2",
                 "get-tsconfig": "^4.7.5"
             },
             "bin": {
@@ -16546,7 +15955,7 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.16",
+            "version": "1.0.15",
             "dev": true,
             "funding": [
                 {
@@ -16565,7 +15974,7 @@
             "license": "MIT",
             "dependencies": {
                 "escalade": "^3.1.2",
-                "picocolors": "^1.0.1"
+                "picocolors": "^1.0.0"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -16746,6 +16155,11 @@
             "version": "5.2.0",
             "license": "MIT"
         },
+        "node_modules/vscode-oniguruma": {
+            "version": "1.7.0",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/vscode-uri": {
             "version": "3.0.8",
             "license": "MIT"
@@ -16802,7 +16216,7 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.92.0",
+            "version": "5.91.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16812,10 +16226,10 @@
                 "@webassemblyjs/wasm-edit": "^1.12.1",
                 "@webassemblyjs/wasm-parser": "^1.12.1",
                 "acorn": "^8.7.1",
-                "acorn-import-attributes": "^1.9.5",
+                "acorn-import-assertions": "^1.9.0",
                 "browserslist": "^4.21.10",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.0",
+                "enhanced-resolve": "^5.16.0",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -16928,7 +16342,7 @@
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/ajv": {
-            "version": "8.16.0",
+            "version": "8.13.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17035,7 +16449,7 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/ajv": {
-            "version": "8.16.0",
+            "version": "8.13.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17084,15 +16498,15 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/glob": {
-            "version": "10.4.1",
+            "version": "10.3.15",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "path-scurry": "^1.11.1"
+                "jackspeak": "^2.3.6",
+                "minimatch": "^9.0.1",
+                "minipass": "^7.0.4",
+                "path-scurry": "^1.11.0"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
@@ -17479,7 +16893,7 @@
             }
         },
         "node_modules/yaml-language-server/node_modules/ajv": {
-            "version": "8.16.0",
+            "version": "8.14.0",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -17560,7 +16974,7 @@
             }
         },
         "node_modules/yargs-parser": {
-            "version": "20.2.9",
+            "version": "20.2.4",
             "license": "ISC",
             "engines": {
                 "node": ">=10"
@@ -17619,7 +17033,7 @@
             }
         },
         "node_modules/zx": {
-            "version": "8.1.2",
+            "version": "8.1.0",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -17630,7 +17044,7 @@
             },
             "optionalDependencies": {
                 "@types/fs-extra": "^11.0.4",
-                "@types/node": ">=20.12.12"
+                "@types/node": ">=20.12.11"
             }
         },
         "server/aws-lsp-buildspec": {
@@ -17694,89 +17108,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "server/aws-lsp-codewhisperer/node_modules/@amzn/codewhisperer-streaming": {
-            "resolved": "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming",
-            "link": true
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/crc32": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/crc32/node_modules/tslib": {
-            "version": "1.14.1",
-            "license": "0BSD"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/ie11-detection": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-            "version": "1.14.1",
-            "license": "0BSD"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/sha256-browser": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/ie11-detection": "^3.0.0",
-                "@aws-crypto/sha256-js": "^3.0.0",
-                "@aws-crypto/supports-web-crypto": "^3.0.0",
-                "@aws-crypto/util": "^3.0.0",
-                "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-            "version": "1.14.1",
-            "license": "0BSD"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/sha256-js": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "license": "0BSD"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-            "version": "1.14.1",
-            "license": "0BSD"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/util": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/util/node_modules/tslib": {
-            "version": "1.14.1",
-            "license": "0BSD"
-        },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.425.0",
             "license": "Apache-2.0",
@@ -17815,22 +17146,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/middleware-token": {
-            "version": "3.425.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/token-providers": "3.425.0",
-                "@aws-sdk/types": "3.425.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/protocol-http": "^3.0.6",
-                "@smithy/types": "^2.3.4",
-                "@smithy/util-middleware": "^2.0.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.425.0",
             "license": "Apache-2.0",
@@ -17859,50 +17174,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/token-providers": {
-            "version": "3.425.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/middleware-host-header": "3.425.0",
-                "@aws-sdk/middleware-logger": "3.425.0",
-                "@aws-sdk/middleware-recursion-detection": "3.425.0",
-                "@aws-sdk/middleware-user-agent": "3.425.0",
-                "@aws-sdk/types": "3.425.0",
-                "@aws-sdk/util-endpoints": "3.425.0",
-                "@aws-sdk/util-user-agent-browser": "3.425.0",
-                "@aws-sdk/util-user-agent-node": "3.425.0",
-                "@smithy/config-resolver": "^2.0.11",
-                "@smithy/fetch-http-handler": "^2.2.1",
-                "@smithy/hash-node": "^2.0.10",
-                "@smithy/invalid-dependency": "^2.0.10",
-                "@smithy/middleware-content-length": "^2.0.12",
-                "@smithy/middleware-endpoint": "^2.0.10",
-                "@smithy/middleware-retry": "^2.0.13",
-                "@smithy/middleware-serde": "^2.0.10",
-                "@smithy/middleware-stack": "^2.0.4",
-                "@smithy/node-config-provider": "^2.0.13",
-                "@smithy/node-http-handler": "^2.1.6",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/protocol-http": "^3.0.6",
-                "@smithy/shared-ini-file-loader": "^2.0.6",
-                "@smithy/smithy-client": "^2.1.9",
-                "@smithy/types": "^2.3.4",
-                "@smithy/url-parser": "^2.0.10",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.1.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.13",
-                "@smithy/util-defaults-mode-node": "^2.0.15",
-                "@smithy/util-retry": "^2.0.3",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/types": {
             "version": "3.425.0",
             "license": "Apache-2.0",
@@ -17923,45 +17194,6 @@
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.568.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/util-retry": {
-            "version": "3.374.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-retry": "^1.0.3",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/util-retry/node_modules/@smithy/service-error-classification": {
-            "version": "1.1.0",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/util-retry/node_modules/@smithy/util-retry": {
-            "version": "1.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/service-error-classification": "^1.1.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
             }
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/util-user-agent-browser": {
@@ -17995,771 +17227,8 @@
                 }
             }
         },
-        "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.259.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@aws/lsp-fqn": {
-            "resolved": "core/aws-lsp-fqn",
-            "link": true
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@babel/runtime": {
-            "version": "7.24.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/abort-controller": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/config-resolver": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-config-provider": "^2.3.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/credential-provider-imds": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/url-parser": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/eventstream-codec": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-hex-encoding": "^2.2.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/eventstream-serde-browser": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/eventstream-serde-universal": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/eventstream-serde-config-resolver": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/eventstream-serde-node": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/eventstream-serde-universal": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/eventstream-serde-universal": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/eventstream-codec": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/fetch-http-handler": {
-            "version": "2.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/querystring-builder": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-base64": "^2.3.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/hash-node": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-buffer-from": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/invalid-dependency": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/is-array-buffer": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-content-length": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-endpoint": {
-            "version": "2.5.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-serde": "^2.3.0",
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/shared-ini-file-loader": "^2.4.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/url-parser": "^2.2.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-retry": {
-            "version": "2.3.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/service-error-classification": "^2.1.5",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-middleware": "^2.2.0",
-                "@smithy/util-retry": "^2.2.0",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-serde": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-stack": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/node-config-provider": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/shared-ini-file-loader": "^2.4.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/node-http-handler": {
-            "version": "2.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^2.2.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/querystring-builder": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/property-provider": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/protocol-http": {
-            "version": "3.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/querystring-builder": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-uri-escape": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/querystring-parser": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/service-client-documentation-generator": {
-            "version": "2.2.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/service-error-classification": {
-            "version": "2.1.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/shared-ini-file-loader": {
-            "version": "2.4.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/smithy-client": {
-            "version": "2.5.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/middleware-endpoint": "^2.5.1",
-                "@smithy/middleware-stack": "^2.2.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-stream": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/types": {
-            "version": "2.12.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/url-parser": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/querystring-parser": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-base64": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-body-length-browser": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-body-length-node": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-buffer-from": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-config-provider": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "2.2.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-defaults-mode-node": {
-            "version": "2.3.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/config-resolver": "^2.2.0",
-                "@smithy/credential-provider-imds": "^2.3.0",
-                "@smithy/node-config-provider": "^2.3.0",
-                "@smithy/property-provider": "^2.2.0",
-                "@smithy/smithy-client": "^2.5.1",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-hex-encoding": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-middleware": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-retry": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/service-error-classification": "^2.1.5",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-stream": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/fetch-http-handler": "^2.5.0",
-                "@smithy/node-http-handler": "^2.5.0",
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-base64": "^2.3.0",
-                "@smithy/util-buffer-from": "^2.2.0",
-                "@smithy/util-hex-encoding": "^2.2.0",
-                "@smithy/util-utf8": "^2.3.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-uri-escape": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@tsconfig/node14": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT"
-        },
         "server/aws-lsp-codewhisperer/node_modules/@types/node": {
             "version": "14.18.63",
-            "dev": true,
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/ansi-sequence-parser": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/bowser": {
-            "version": "2.11.0",
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/chalk": {
-            "version": "4.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/cliui": {
-            "version": "7.0.4",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "wrap-ansi": "^7.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/color-convert": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/color-name": {
-            "version": "1.1.4",
-            "dev": true,
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/concat-map": {
-            "version": "0.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/concurrently": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.1.0",
-                "date-fns": "^2.16.1",
-                "lodash": "^4.17.21",
-                "rxjs": "^6.6.3",
-                "spawn-command": "^0.0.2-1",
-                "supports-color": "^8.1.0",
-                "tree-kill": "^1.2.2",
-                "yargs": "^16.2.0"
-            },
-            "bin": {
-                "concurrently": "dist/bin/concurrently.js"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.0 || >=16.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/concurrently/node_modules/rxjs": {
-            "version": "6.6.7",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^1.9.0"
-            },
-            "engines": {
-                "npm": ">=2.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/concurrently/node_modules/tslib": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "0BSD"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/date-fns": {
-            "version": "2.30.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.21.0"
-            },
-            "engines": {
-                "node": ">=0.11"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/date-fns"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/escalade": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "ISC"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/get-caller-file": {
-            "version": "2.0.5",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/glob": {
-            "version": "7.2.3",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/has-flag": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/inflight": {
-            "version": "1.0.6",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/inherits": {
-            "version": "2.0.4",
-            "dev": true,
-            "license": "ISC"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/jsonc-parser": {
-            "version": "3.2.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/lodash": {
-            "version": "4.17.21",
-            "dev": true,
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/lunr": {
-            "version": "2.3.9",
             "dev": true,
             "license": "MIT"
         },
@@ -18775,169 +17244,48 @@
             }
         },
         "server/aws-lsp-codewhisperer/node_modules/minimatch": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/once": {
-            "version": "1.4.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/require-directory": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/rimraf": {
-            "version": "3.0.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/shiki": {
-            "version": "0.14.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-sequence-parser": "^1.1.0",
-                "jsonc-parser": "^3.2.0",
-                "vscode-oniguruma": "^1.7.0",
-                "vscode-textmate": "^8.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/spawn-command": {
-            "version": "0.0.2-1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/supports-color": {
-            "version": "8.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/tree-kill": {
-            "version": "1.2.2",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "tree-kill": "cli.js"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/tslib": {
-            "version": "2.6.3",
-            "license": "0BSD"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/typedoc": {
-            "version": "0.25.13",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "lunr": "^2.3.9",
-                "marked": "^4.3.0",
-                "minimatch": "^9.0.3",
-                "shiki": "^0.14.7"
-            },
-            "bin": {
-                "typedoc": "bin/typedoc"
-            },
-            "engines": {
-                "node": ">= 16"
-            },
-            "peerDependencies": {
-                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/typedoc/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/typedoc/node_modules/minimatch": {
-            "version": "9.0.4",
+            "version": "5.1.6",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": ">=10"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/shiki": {
+            "version": "0.11.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jsonc-parser": "^3.0.0",
+                "vscode-oniguruma": "^1.6.1",
+                "vscode-textmate": "^6.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/typedoc": {
+            "version": "0.23.23",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lunr": "^2.3.9",
+                "marked": "^4.2.4",
+                "minimatch": "^5.1.1",
+                "shiki": "^0.11.1"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 14.14"
+            },
+            "peerDependencies": {
+                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
             }
         },
         "server/aws-lsp-codewhisperer/node_modules/typescript": {
-            "version": "5.4.5",
+            "version": "4.9.5",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -18945,86 +17293,17 @@
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=14.17"
+                "node": ">=4.2.0"
             }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/uuid": {
-            "version": "9.0.1",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/vscode-oniguruma": {
-            "version": "1.7.0",
-            "dev": true,
-            "license": "MIT"
         },
         "server/aws-lsp-codewhisperer/node_modules/vscode-textmate": {
-            "version": "8.0.0",
+            "version": "6.0.0",
             "dev": true,
             "license": "MIT"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/wrappy": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "ISC"
-        },
-        "server/aws-lsp-codewhisperer/node_modules/y18n": {
-            "version": "5.0.8",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/yargs": {
-            "version": "16.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^7.0.2",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.0",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^20.2.2"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/yargs-parser": {
-            "version": "20.2.4",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
         },
         "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming": {
             "version": "0.0.1",
+            "hasInstallScript": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -19035,7 +17314,6 @@
                 "@aws-sdk/middleware-user-agent": "3.425.0",
                 "@aws-sdk/region-config-resolver": "3.425.0",
                 "@aws-sdk/types": "3.425.0",
-                "@aws-sdk/util-retry": "^3.374.0",
                 "@aws-sdk/util-user-agent-browser": "3.425.0",
                 "@aws-sdk/util-user-agent-node": "3.425.0",
                 "@smithy/config-resolver": "^2.0.11",
@@ -19063,20 +17341,35 @@
                 "@smithy/util-retry": "^2.0.3",
                 "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.5.0",
-                "uuid": "^9.0.1"
+                "uuid": "^8.3.2"
             },
             "devDependencies": {
                 "@smithy/service-client-documentation-generator": "^2.0.0",
                 "@tsconfig/node14": "1.0.3",
                 "@types/node": "^14.14.31",
-                "@types/uuid": "^9.0.8",
+                "@types/uuid": "^8.3.0",
                 "concurrently": "7.0.0",
+                "downlevel-dts": "0.10.1",
                 "rimraf": "^3.0.0",
-                "typedoc": "0.25.13",
-                "typescript": "~5.4.5"
+                "typedoc": "0.23.23",
+                "typescript": "~4.9.5"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/node_modules/@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
+        },
+        "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "server/aws-lsp-json": {
@@ -19119,27 +17412,6 @@
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
-            }
-        },
-        "server/aws-lsp-s3/node_modules/@aws-sdk/types": {
-            "version": "3.598.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "server/aws-lsp-s3/node_modules/@smithy/types": {
-            "version": "3.1.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "server/aws-lsp-yaml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3656,6 +3656,39 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/util-retry": {
+            "version": "3.374.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.374.0.tgz",
+            "integrity": "sha512-0p/trhYU+Ys8j3vMnWCvAkSOL6JRMooV9dVlQ+o7EHbQs9kDtnyucMUHU09ahHSIPTA/n/013hv7bzIt3MyKQg==",
+            "deprecated": "This package has moved to @smithy/util-retry",
+            "dependencies": {
+                "@smithy/util-retry": "^1.0.3",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-retry/node_modules/@smithy/service-error-classification": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.1.0.tgz",
+            "integrity": "sha512-OCTEeJ1igatd5kFrS2VDlYbainNNpf7Lj1siFOxnRWqYOP9oNvC5HOJBd3t+Z8MbrmehBtuDJ2QqeBsfeiNkww==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-retry/node_modules/@smithy/util-retry": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.1.0.tgz",
+            "integrity": "sha512-ygQW5HBqYXpR3ua09UciS0sL7UGJzGiktrKkOuEJwARoUuzz40yaEGU6xd9Gs7KBmAaFC8gMfnghHtwZ2nyBCQ==",
+            "dependencies": {
+                "@smithy/service-error-classification": "^1.1.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
         "node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.567.0",
             "license": "Apache-2.0",
@@ -17080,6 +17113,7 @@
             ],
             "dependencies": {
                 "@amzn/codewhisperer-streaming": "*",
+                "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/language-server-runtimes": "0.x.x",
                 "@aws/lsp-fqn": "^0.0.1",
                 "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -31,13 +31,14 @@
     },
     "dependencies": {
         "@amzn/codewhisperer-streaming": "*",
+        "@aws-sdk/util-retry": "^3.374.0",
         "@aws/language-server-runtimes": "0.x.x",
         "@aws/lsp-fqn": "^0.0.1",
         "@smithy/node-http-handler": "^2.5.0",
-        "hpagent": "^1.2.0",
         "adm-zip": "^0.5.10",
         "aws-sdk": "^2.1403.0",
         "got": "^11.8.5",
+        "hpagent": "^1.2.0",
         "js-md5": "^0.8.3",
         "proxy-http-agent": "^1.0.1",
         "uuid": "^9.0.1",
@@ -52,8 +53,8 @@
         "ts-mocha": "^10.0.0",
         "ts-sinon": "^2.0.2",
         "vscode-languageserver-textdocument": "^1.0.11",
-        "webpack-cli": "^5.1.4",
-        "webpack": "^5.88.2"
+        "webpack": "^5.88.2",
+        "webpack-cli": "^5.1.4"
     },
     "prettier": {
         "printWidth": 120,

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/README.md
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/README.md
@@ -408,6 +408,13 @@ ListFeatureEvaluations
 </details>
 <details>
 <summary>
+ResumeTransformation
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/resumetransformationcommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/resumetransformationcommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/resumetransformationcommandoutput.html)
+</details>
+<details>
+<summary>
 SendTelemetryEvent
 </summary>
 
@@ -461,4 +468,95 @@ GenerateTaskAssistPlan
 </summary>
 
 [Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/generatetaskassistplancommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/generatetaskassistplancommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/generatetaskassistplancommandoutput.html)
+</details>
+<details>
+<summary>
+CreateAssignment
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/createassignmentcommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/createassignmentcommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/createassignmentcommandoutput.html)
+</details>
+<details>
+<summary>
+CreateResolution
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/createresolutioncommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/createresolutioncommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/createresolutioncommandoutput.html)
+</details>
+<details>
+<summary>
+DeleteAssignment
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/deleteassignmentcommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/deleteassignmentcommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/deleteassignmentcommandoutput.html)
+</details>
+<details>
+<summary>
+GetConversation
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/getconversationcommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/getconversationcommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/getconversationcommandoutput.html)
+</details>
+<details>
+<summary>
+GetIdentityMetadata
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/getidentitymetadatacommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/getidentitymetadatacommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/getidentitymetadatacommandoutput.html)
+</details>
+<details>
+<summary>
+GetTroubleshootingResults
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/gettroubleshootingresultscommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/gettroubleshootingresultscommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/gettroubleshootingresultscommandoutput.html)
+</details>
+<details>
+<summary>
+ListConversations
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/listconversationscommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/listconversationscommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/listconversationscommandoutput.html)
+</details>
+<details>
+<summary>
+PassRequest
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/passrequestcommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/passrequestcommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/passrequestcommandoutput.html)
+</details>
+<details>
+<summary>
+SendMessage
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/sendmessagecommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/sendmessagecommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/sendmessagecommandoutput.html)
+</details>
+<details>
+<summary>
+StartConversation
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/startconversationcommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/startconversationcommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/startconversationcommandoutput.html)
+</details>
+<details>
+<summary>
+StartTroubleshootingAnalysis
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/starttroubleshootinganalysiscommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/starttroubleshootinganalysiscommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/starttroubleshootinganalysiscommandoutput.html)
+</details>
+<details>
+<summary>
+StartTroubleshootingResolutionExplanation
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/starttroubleshootingresolutionexplanationcommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/starttroubleshootingresolutionexplanationcommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/starttroubleshootingresolutionexplanationcommandoutput.html)
+</details>
+<details>
+<summary>
+UpdateTroubleshootingCommandResult
+</summary>
+
+[Command API Reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/classes/updatetroubleshootingcommandresultcommand.html) / [Input](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/updatetroubleshootingcommandresultcommandinput.html) / [Output](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-codewhispererstreaming/interfaces/updatetroubleshootingcommandresultcommandoutput.html)
 </details>

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/package.json
@@ -8,14 +8,17 @@
         "build:docs": "typedoc",
         "build:es": "tsc -p tsconfig.es.json",
         "build:types": "tsc -p tsconfig.types.json",
+        "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
         "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-        "prepack": "npm run clean && npm run build"
+        "prepack": "npm run clean && npm run build",
+        "postinstall": "npm run build"
     },
     "main": "./dist-cjs/index.js",
     "types": "./dist-types/index.d.ts",
     "module": "./dist-es/index.js",
     "sideEffects": false,
     "dependencies": {
+        "tslib": "^2.5.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/middleware-host-header": "3.425.0",
@@ -25,7 +28,6 @@
         "@aws-sdk/middleware-user-agent": "3.425.0",
         "@aws-sdk/region-config-resolver": "3.425.0",
         "@aws-sdk/types": "3.425.0",
-        "@aws-sdk/util-retry": "^3.374.0",
         "@aws-sdk/util-user-agent-browser": "3.425.0",
         "@aws-sdk/util-user-agent-node": "3.425.0",
         "@smithy/config-resolver": "^2.0.11",
@@ -52,18 +54,18 @@
         "@smithy/util-defaults-mode-node": "^2.0.15",
         "@smithy/util-retry": "^2.0.3",
         "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0",
-        "uuid": "^9.0.1"
+        "uuid": "^8.3.2"
     },
     "devDependencies": {
-        "@smithy/service-client-documentation-generator": "^2.0.0",
         "@tsconfig/node14": "1.0.3",
-        "@types/node": "^14.14.31",
-        "@types/uuid": "^9.0.8",
         "concurrently": "7.0.0",
+        "downlevel-dts": "0.10.1",
         "rimraf": "^3.0.0",
-        "typedoc": "0.25.13",
-        "typescript": "~5.4.5"
+        "typedoc": "0.23.23",
+        "typescript": "~4.9.5",
+        "@smithy/service-client-documentation-generator": "^2.0.0",
+        "@types/node": "^14.14.31",
+        "@types/uuid": "^8.3.0"
     },
     "engines": {
         "node": ">=14.0.0"

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/commands/ExportResultArchiveCommand.ts
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/commands/ExportResultArchiveCommand.ts
@@ -54,6 +54,12 @@ export interface ExportResultArchiveCommandOutput extends ExportResultArchiveRes
  * const input = { // ExportResultArchiveRequest
  *   exportId: "STRING_VALUE", // required
  *   exportIntent: "TRANSFORMATION" || "TASK_ASSIST", // required
+ *   exportContext: { // ExportContext Union: only one key present
+ *     transformationExportContext: { // TransformationExportContext
+ *       downloadArtifactId: "STRING_VALUE", // required
+ *       downloadArtifactType: "ClientInstructions" || "Logs", // required
+ *     },
+ *   },
  * };
  * const command = new ExportResultArchiveCommand(input);
  * const response = await client.send(command);

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/commands/GenerateAssistantResponseCommand.ts
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/commands/GenerateAssistantResponseCommand.ts
@@ -91,6 +91,53 @@ export interface GenerateAssistantResponseCommandOutput extends GenerateAssistan
  *                   },
  *                 },
  *               },
+ *               relevantDocuments: [ // RelevantDocumentList
+ *                 { // RelevantTextDocument
+ *                   relativeFilePath: "STRING_VALUE", // required
+ *                   programmingLanguage: {
+ *                     languageName: "STRING_VALUE", // required
+ *                   },
+ *                   text: "STRING_VALUE",
+ *                   documentSymbols: [
+ *                     {
+ *                       name: "STRING_VALUE", // required
+ *                       type: "DECLARATION" || "USAGE", // required
+ *                       source: "STRING_VALUE",
+ *                     },
+ *                   ],
+ *                 },
+ *               ],
+ *             },
+ *             shellState: { // ShellState
+ *               shellName: "STRING_VALUE", // required
+ *               shellHistory: [ // ShellHistory
+ *                 { // ShellHistoryEntry
+ *                   command: "STRING_VALUE", // required
+ *                   directory: "STRING_VALUE",
+ *                   exitCode: Number("int"),
+ *                   stdout: "STRING_VALUE",
+ *                   stderr: "STRING_VALUE",
+ *                 },
+ *               ],
+ *             },
+ *             gitState: { // GitState
+ *               status: "STRING_VALUE",
+ *             },
+ *             envState: { // EnvState
+ *               operatingSystem: "STRING_VALUE",
+ *               currentWorkingDirectory: "STRING_VALUE",
+ *               environmentVariables: [ // EnvironmentVariables
+ *                 { // EnvironmentVariable
+ *                   key: "STRING_VALUE",
+ *                   value: "STRING_VALUE",
+ *                 },
+ *               ],
+ *             },
+ *             appStudioContext: { // AppStudioState
+ *               namespace: "STRING_VALUE", // required
+ *               propertyName: "STRING_VALUE", // required
+ *               propertyValue: "STRING_VALUE",
+ *               propertyContext: "STRING_VALUE", // required
  *             },
  *             diagnostic: { // Diagnostic Union: only one key present
  *               textDocumentDiagnostic: { // TextDocumentDiagnostic
@@ -172,6 +219,53 @@ export interface GenerateAssistantResponseCommandOutput extends GenerateAssistan
  *                 end: "<Position>", // required
  *               },
  *             },
+ *             relevantDocuments: [
+ *               {
+ *                 relativeFilePath: "STRING_VALUE", // required
+ *                 programmingLanguage: {
+ *                   languageName: "STRING_VALUE", // required
+ *                 },
+ *                 text: "STRING_VALUE",
+ *                 documentSymbols: [
+ *                   {
+ *                     name: "STRING_VALUE", // required
+ *                     type: "DECLARATION" || "USAGE", // required
+ *                     source: "STRING_VALUE",
+ *                   },
+ *                 ],
+ *               },
+ *             ],
+ *           },
+ *           shellState: {
+ *             shellName: "STRING_VALUE", // required
+ *             shellHistory: [
+ *               {
+ *                 command: "STRING_VALUE", // required
+ *                 directory: "STRING_VALUE",
+ *                 exitCode: Number("int"),
+ *                 stdout: "STRING_VALUE",
+ *                 stderr: "STRING_VALUE",
+ *               },
+ *             ],
+ *           },
+ *           gitState: {
+ *             status: "STRING_VALUE",
+ *           },
+ *           envState: {
+ *             operatingSystem: "STRING_VALUE",
+ *             currentWorkingDirectory: "STRING_VALUE",
+ *             environmentVariables: [
+ *               {
+ *                 key: "STRING_VALUE",
+ *                 value: "STRING_VALUE",
+ *               },
+ *             ],
+ *           },
+ *           appStudioContext: {
+ *             namespace: "STRING_VALUE", // required
+ *             propertyName: "STRING_VALUE", // required
+ *             propertyValue: "STRING_VALUE",
+ *             propertyContext: "STRING_VALUE", // required
  *           },
  *           diagnostic: {//  Union: only one key present
  *             textDocumentDiagnostic: {
@@ -221,7 +315,9 @@ export interface GenerateAssistantResponseCommandOutput extends GenerateAssistan
  *       },
  *     },
  *     chatTriggerType: "MANUAL" || "DIAGNOSTIC", // required
+ *     customizationArn: "STRING_VALUE",
  *   },
+ *   profileArn: "STRING_VALUE",
  * };
  * const command = new GenerateAssistantResponseCommand(input);
  * const response = await client.send(command);

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/commands/GenerateTaskAssistPlanCommand.ts
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/commands/GenerateTaskAssistPlanCommand.ts
@@ -91,6 +91,53 @@ export interface GenerateTaskAssistPlanCommandOutput extends GenerateTaskAssistP
  *                   },
  *                 },
  *               },
+ *               relevantDocuments: [ // RelevantDocumentList
+ *                 { // RelevantTextDocument
+ *                   relativeFilePath: "STRING_VALUE", // required
+ *                   programmingLanguage: {
+ *                     languageName: "STRING_VALUE", // required
+ *                   },
+ *                   text: "STRING_VALUE",
+ *                   documentSymbols: [
+ *                     {
+ *                       name: "STRING_VALUE", // required
+ *                       type: "DECLARATION" || "USAGE", // required
+ *                       source: "STRING_VALUE",
+ *                     },
+ *                   ],
+ *                 },
+ *               ],
+ *             },
+ *             shellState: { // ShellState
+ *               shellName: "STRING_VALUE", // required
+ *               shellHistory: [ // ShellHistory
+ *                 { // ShellHistoryEntry
+ *                   command: "STRING_VALUE", // required
+ *                   directory: "STRING_VALUE",
+ *                   exitCode: Number("int"),
+ *                   stdout: "STRING_VALUE",
+ *                   stderr: "STRING_VALUE",
+ *                 },
+ *               ],
+ *             },
+ *             gitState: { // GitState
+ *               status: "STRING_VALUE",
+ *             },
+ *             envState: { // EnvState
+ *               operatingSystem: "STRING_VALUE",
+ *               currentWorkingDirectory: "STRING_VALUE",
+ *               environmentVariables: [ // EnvironmentVariables
+ *                 { // EnvironmentVariable
+ *                   key: "STRING_VALUE",
+ *                   value: "STRING_VALUE",
+ *                 },
+ *               ],
+ *             },
+ *             appStudioContext: { // AppStudioState
+ *               namespace: "STRING_VALUE", // required
+ *               propertyName: "STRING_VALUE", // required
+ *               propertyValue: "STRING_VALUE",
+ *               propertyContext: "STRING_VALUE", // required
  *             },
  *             diagnostic: { // Diagnostic Union: only one key present
  *               textDocumentDiagnostic: { // TextDocumentDiagnostic
@@ -172,6 +219,53 @@ export interface GenerateTaskAssistPlanCommandOutput extends GenerateTaskAssistP
  *                 end: "<Position>", // required
  *               },
  *             },
+ *             relevantDocuments: [
+ *               {
+ *                 relativeFilePath: "STRING_VALUE", // required
+ *                 programmingLanguage: {
+ *                   languageName: "STRING_VALUE", // required
+ *                 },
+ *                 text: "STRING_VALUE",
+ *                 documentSymbols: [
+ *                   {
+ *                     name: "STRING_VALUE", // required
+ *                     type: "DECLARATION" || "USAGE", // required
+ *                     source: "STRING_VALUE",
+ *                   },
+ *                 ],
+ *               },
+ *             ],
+ *           },
+ *           shellState: {
+ *             shellName: "STRING_VALUE", // required
+ *             shellHistory: [
+ *               {
+ *                 command: "STRING_VALUE", // required
+ *                 directory: "STRING_VALUE",
+ *                 exitCode: Number("int"),
+ *                 stdout: "STRING_VALUE",
+ *                 stderr: "STRING_VALUE",
+ *               },
+ *             ],
+ *           },
+ *           gitState: {
+ *             status: "STRING_VALUE",
+ *           },
+ *           envState: {
+ *             operatingSystem: "STRING_VALUE",
+ *             currentWorkingDirectory: "STRING_VALUE",
+ *             environmentVariables: [
+ *               {
+ *                 key: "STRING_VALUE",
+ *                 value: "STRING_VALUE",
+ *               },
+ *             ],
+ *           },
+ *           appStudioContext: {
+ *             namespace: "STRING_VALUE", // required
+ *             propertyName: "STRING_VALUE", // required
+ *             propertyValue: "STRING_VALUE",
+ *             propertyContext: "STRING_VALUE", // required
  *           },
  *           diagnostic: {//  Union: only one key present
  *             textDocumentDiagnostic: {
@@ -221,6 +315,7 @@ export interface GenerateTaskAssistPlanCommandOutput extends GenerateTaskAssistP
  *       },
  *     },
  *     chatTriggerType: "MANUAL" || "DIAGNOSTIC", // required
+ *     customizationArn: "STRING_VALUE",
  *   },
  *   workspaceState: { // WorkspaceState
  *     uploadId: "STRING_VALUE", // required
@@ -286,6 +381,9 @@ export interface GenerateTaskAssistPlanCommandOutput extends GenerateTaskAssistP
  *
  * @throws {@link InternalServerException} (server fault)
  *  This exception is thrown when an unexpected error occurred during the processing of a request.
+ *
+ * @throws {@link ServiceQuotaExceededException} (client fault)
+ *  This exception is thrown when request was denied due to caller exceeding their usage limits
  *
  * @throws {@link ThrottlingException} (client fault)
  *  This exception is thrown when request was denied due to request throttling.

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/models/models_0.ts
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/models/models_0.ts
@@ -110,6 +110,7 @@ export class ThrottlingException extends __BaseException {
  * @enum
  */
 export const ValidationExceptionReason = {
+    CONTENT_LENGTH_EXCEEDS_THRESHOLD: 'CONTENT_LENGTH_EXCEEDS_THRESHOLD',
     INVALID_CONVERSATION_ID: 'INVALID_CONVERSATION_ID',
 } as const
 /**
@@ -143,6 +144,47 @@ export class ValidationException extends __BaseException {
         this.reason = opts.reason
     }
 }
+
+/**
+ * @public
+ * Description of a user's context when they are calling Q Chat from AppStudio
+ */
+export interface AppStudioState {
+    /**
+     * @public
+     * The namespace of the context. Examples: 'ui.Button', 'ui.Table.DataSource', 'ui.Table.RowActions.Button', 'logic.invokeAWS', 'logic.JavaScript'
+     */
+    namespace: string | undefined
+
+    /**
+     * @public
+     * The name of the property. Examples: 'visibility', 'disability', 'value', 'code'
+     */
+    propertyName: string | undefined
+
+    /**
+     * @public
+     * The value of the property.
+     */
+    propertyValue?: string
+
+    /**
+     * @public
+     * Context about how the property is used
+     */
+    propertyContext: string | undefined
+}
+
+/**
+ * @internal
+ */
+export const AppStudioStateFilterSensitiveLog = (obj: AppStudioState): any => ({
+    ...obj,
+    ...(obj.namespace && { namespace: SENSITIVE_STRING }),
+    ...(obj.propertyName && { propertyName: SENSITIVE_STRING }),
+    ...(obj.propertyValue && { propertyValue: SENSITIVE_STRING }),
+    ...(obj.propertyContext && { propertyContext: SENSITIVE_STRING }),
+})
 
 /**
  * @public
@@ -234,8 +276,8 @@ export const FollowupPromptFilterSensitiveLog = (obj: FollowupPrompt): any => ({
  * Represents span in a text
  */
 export interface Span {
-    start: number
-    end: number
+    start?: number
+    end?: number
 }
 
 /**
@@ -772,6 +814,45 @@ export namespace CursorState {
 
 /**
  * @public
+ * Represents an IDE retrieved relevant Text Document / File
+ */
+export interface RelevantTextDocument {
+    /**
+     * @public
+     * Filepath relative to the root of the workspace
+     */
+    relativeFilePath: string | undefined
+
+    /**
+     * @public
+     * The text document's language identifier.
+     */
+    programmingLanguage?: ProgrammingLanguage
+
+    /**
+     * @public
+     * Content of the text document
+     */
+    text?: string
+
+    /**
+     * @public
+     * DocumentSymbols parsed from a text document
+     */
+    documentSymbols?: DocumentSymbol[]
+}
+
+/**
+ * @internal
+ */
+export const RelevantTextDocumentFilterSensitiveLog = (obj: RelevantTextDocument): any => ({
+    ...obj,
+    ...(obj.relativeFilePath && { relativeFilePath: SENSITIVE_STRING }),
+    ...(obj.text && { text: SENSITIVE_STRING }),
+})
+
+/**
+ * @public
  * Represents the state of an Editor
  */
 export interface EditorState {
@@ -786,6 +867,12 @@ export interface EditorState {
      * Position of the cursor
      */
     cursorState?: CursorState
+
+    /**
+     * @public
+     * Represents IDE provided relevant files
+     */
+    relevantDocuments?: RelevantTextDocument[]
 }
 
 /**
@@ -795,6 +882,164 @@ export const EditorStateFilterSensitiveLog = (obj: EditorState): any => ({
     ...obj,
     ...(obj.document && { document: TextDocumentFilterSensitiveLog(obj.document) }),
     ...(obj.cursorState && { cursorState: obj.cursorState }),
+    ...(obj.relevantDocuments && {
+        relevantDocuments: obj.relevantDocuments.map(item => RelevantTextDocumentFilterSensitiveLog(item)),
+    }),
+})
+
+/**
+ * @public
+ * An environment variable
+ */
+export interface EnvironmentVariable {
+    /**
+     * @public
+     * The key of an environment variable
+     */
+    key?: string
+
+    /**
+     * @public
+     * The value of an environment variable
+     */
+    value?: string
+}
+
+/**
+ * @internal
+ */
+export const EnvironmentVariableFilterSensitiveLog = (obj: EnvironmentVariable): any => ({
+    ...obj,
+    ...(obj.key && { key: SENSITIVE_STRING }),
+    ...(obj.value && { value: SENSITIVE_STRING }),
+})
+
+/**
+ * @public
+ * State related to the user's environment
+ */
+export interface EnvState {
+    /**
+     * @public
+     * The name of the operating system in use
+     */
+    operatingSystem?: string
+
+    /**
+     * @public
+     * The current working directory of the environment
+     */
+    currentWorkingDirectory?: string
+
+    /**
+     * @public
+     * The environment variables set in the current environment
+     */
+    environmentVariables?: EnvironmentVariable[]
+}
+
+/**
+ * @internal
+ */
+export const EnvStateFilterSensitiveLog = (obj: EnvState): any => ({
+    ...obj,
+    ...(obj.currentWorkingDirectory && { currentWorkingDirectory: SENSITIVE_STRING }),
+    ...(obj.environmentVariables && {
+        environmentVariables: obj.environmentVariables.map(item => EnvironmentVariableFilterSensitiveLog(item)),
+    }),
+})
+
+/**
+ * @public
+ * State related to the Git VSC
+ */
+export interface GitState {
+    /**
+     * @public
+     * The output of the command `git status --porcelain=v1 -b`
+     */
+    status?: string
+}
+
+/**
+ * @internal
+ */
+export const GitStateFilterSensitiveLog = (obj: GitState): any => ({
+    ...obj,
+    ...(obj.status && { status: SENSITIVE_STRING }),
+})
+
+/**
+ * @public
+ * An single entry in the shell history
+ */
+export interface ShellHistoryEntry {
+    /**
+     * @public
+     * The shell command that was run
+     */
+    command: string | undefined
+
+    /**
+     * @public
+     * The directory the command was ran in
+     */
+    directory?: string
+
+    /**
+     * @public
+     * The exit code of the command after it finished
+     */
+    exitCode?: number
+
+    /**
+     * @public
+     * The stdout from the command
+     */
+    stdout?: string
+
+    /**
+     * @public
+     * The stderr from the command
+     */
+    stderr?: string
+}
+
+/**
+ * @internal
+ */
+export const ShellHistoryEntryFilterSensitiveLog = (obj: ShellHistoryEntry): any => ({
+    ...obj,
+    ...(obj.command && { command: SENSITIVE_STRING }),
+    ...(obj.directory && { directory: SENSITIVE_STRING }),
+    ...(obj.stdout && { stdout: SENSITIVE_STRING }),
+    ...(obj.stderr && { stderr: SENSITIVE_STRING }),
+})
+
+/**
+ * @public
+ * Represents the state of a shell
+ */
+export interface ShellState {
+    /**
+     * @public
+     * The name of the current shell
+     */
+    shellName: string | undefined
+
+    /**
+     * @public
+     * The history previous shell commands for the current shell
+     */
+    shellHistory?: ShellHistoryEntry[]
+}
+
+/**
+ * @internal
+ */
+export const ShellStateFilterSensitiveLog = (obj: ShellState): any => ({
+    ...obj,
+    ...(obj.shellHistory && { shellHistory: obj.shellHistory.map(item => ShellHistoryEntryFilterSensitiveLog(item)) }),
 })
 
 /**
@@ -810,6 +1055,30 @@ export interface UserInputMessageContext {
 
     /**
      * @public
+     * Shell state chat message context.
+     */
+    shellState?: ShellState
+
+    /**
+     * @public
+     * Git state chat message context.
+     */
+    gitState?: GitState
+
+    /**
+     * @public
+     * Environment state chat message context.
+     */
+    envState?: EnvState
+
+    /**
+     * @public
+     * The state of a user's AppStudio UI when sending a message.
+     */
+    appStudioContext?: AppStudioState
+
+    /**
+     * @public
      * Diagnostic chat message context.
      */
     diagnostic?: Diagnostic
@@ -821,6 +1090,10 @@ export interface UserInputMessageContext {
 export const UserInputMessageContextFilterSensitiveLog = (obj: UserInputMessageContext): any => ({
     ...obj,
     ...(obj.editorState && { editorState: EditorStateFilterSensitiveLog(obj.editorState) }),
+    ...(obj.shellState && { shellState: ShellStateFilterSensitiveLog(obj.shellState) }),
+    ...(obj.gitState && { gitState: GitStateFilterSensitiveLog(obj.gitState) }),
+    ...(obj.envState && { envState: EnvStateFilterSensitiveLog(obj.envState) }),
+    ...(obj.appStudioContext && { appStudioContext: AppStudioStateFilterSensitiveLog(obj.appStudioContext) }),
     ...(obj.diagnostic && { diagnostic: DiagnosticFilterSensitiveLog(obj.diagnostic) }),
 })
 
@@ -1256,6 +1529,8 @@ export interface ConversationState {
      * Trigger Reason for Chat
      */
     chatTriggerType: ChatTriggerType | string | undefined
+
+    customizationArn?: string
 }
 
 /**
@@ -1266,6 +1541,68 @@ export const ConversationStateFilterSensitiveLog = (obj: ConversationState): any
     ...(obj.history && { history: obj.history.map(item => ChatMessageFilterSensitiveLog(item)) }),
     ...(obj.currentMessage && { currentMessage: ChatMessageFilterSensitiveLog(obj.currentMessage) }),
 })
+
+/**
+ * @public
+ * @enum
+ */
+export const TransformationDownloadArtifactType = {
+    CLIENT_INSTRUCTIONS: 'ClientInstructions',
+    LOGS: 'Logs',
+} as const
+/**
+ * @public
+ */
+export type TransformationDownloadArtifactType =
+    (typeof TransformationDownloadArtifactType)[keyof typeof TransformationDownloadArtifactType]
+
+/**
+ * @public
+ * Transformation export context
+ */
+export interface TransformationExportContext {
+    downloadArtifactId: string | undefined
+    downloadArtifactType: TransformationDownloadArtifactType | string | undefined
+}
+
+/**
+ * @public
+ * Export Context
+ */
+export type ExportContext = ExportContext.TransformationExportContextMember | ExportContext.$UnknownMember
+
+/**
+ * @public
+ */
+export namespace ExportContext {
+    /**
+     * @public
+     * Transformation export context
+     */
+    export interface TransformationExportContextMember {
+        transformationExportContext: TransformationExportContext
+        $unknown?: never
+    }
+
+    /**
+     * @public
+     */
+    export interface $UnknownMember {
+        transformationExportContext?: never
+        $unknown: [string, any]
+    }
+
+    export interface Visitor<T> {
+        transformationExportContext: (value: TransformationExportContext) => T
+        _: (name: string, value: any) => T
+    }
+
+    export const visit = <T>(value: ExportContext, visitor: Visitor<T>): T => {
+        if (value.transformationExportContext !== undefined)
+            return visitor.transformationExportContext(value.transformationExportContext)
+        return visitor._(value.$unknown[0], value.$unknown[1])
+    }
+}
 
 /**
  * @public
@@ -1370,6 +1707,26 @@ export const ResultArchiveStreamFilterSensitiveLog = (obj: ResultArchiveStream):
 
 /**
  * @public
+ * This exception is thrown when request was denied due to caller exceeding their usage limits
+ */
+export class ServiceQuotaExceededException extends __BaseException {
+    readonly name: 'ServiceQuotaExceededException' = 'ServiceQuotaExceededException'
+    readonly $fault: 'client' = 'client'
+    /**
+     * @internal
+     */
+    constructor(opts: __ExceptionOptionType<ServiceQuotaExceededException, __BaseException>) {
+        super({
+            name: 'ServiceQuotaExceededException',
+            $fault: 'client',
+            ...opts,
+        })
+        Object.setPrototypeOf(this, ServiceQuotaExceededException.prototype)
+    }
+}
+
+/**
+ * @public
  * Represents a Workspace state uploaded to S3 for Async Code Actions
  */
 export interface WorkspaceState {
@@ -1402,6 +1759,8 @@ export interface GenerateAssistantResponseRequest {
      * Structure to represent the current state of a chat conversation.
      */
     conversationState: ConversationState | undefined
+
+    profileArn?: string
 }
 
 /**
@@ -1449,6 +1808,12 @@ export interface ExportResultArchiveRequest {
      * Export Intent
      */
     exportIntent: ExportIntent | string | undefined
+
+    /**
+     * @public
+     * Export Context
+     */
+    exportContext?: ExportContext
 }
 
 /**

--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/protocols/Aws_restJson1.ts
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/protocols/Aws_restJson1.ts
@@ -14,6 +14,7 @@ import {
 import { CodeWhispererStreamingServiceException as __BaseException } from '../models/CodeWhispererStreamingServiceException'
 import {
     AccessDeniedException,
+    AppStudioState,
     AssistantResponseEvent,
     AssistantResponseMessage,
     BinaryMetadataEvent,
@@ -27,8 +28,12 @@ import {
     Diagnostic,
     DocumentSymbol,
     EditorState,
+    EnvState,
+    EnvironmentVariable,
+    ExportContext,
     FollowupPrompt,
     FollowupPromptEvent,
+    GitState,
     InternalServerException,
     InvalidStateEvent,
     MessageMetadataEvent,
@@ -36,15 +41,20 @@ import {
     ProgrammingLanguage,
     Range,
     Reference,
+    RelevantTextDocument,
     ResourceNotFoundException,
     ResultArchiveStream,
     RuntimeDiagnostic,
+    ServiceQuotaExceededException,
+    ShellHistoryEntry,
+    ShellState,
     Span,
     SupplementaryWebLink,
     SupplementaryWebLinksEvent,
     TextDocument,
     TextDocumentDiagnostic,
     ThrottlingException,
+    TransformationExportContext,
     UserInputMessage,
     UserInputMessageContext,
     ValidationException,
@@ -83,6 +93,7 @@ export const se_ExportResultArchiveCommand = async (
     let body: any
     body = JSON.stringify(
         take(input, {
+            exportContext: _ => _json(_),
             exportId: [],
             exportIntent: [],
         })
@@ -115,6 +126,7 @@ export const se_GenerateAssistantResponseCommand = async (
     body = JSON.stringify(
         take(input, {
             conversationState: _ => _json(_),
+            profileArn: [],
         })
     )
     return new __HttpRequest({
@@ -314,6 +326,9 @@ const de_GenerateTaskAssistPlanCommandError = async (
         case 'ResourceNotFoundException':
         case 'com.amazon.aws.codewhisperer#ResourceNotFoundException':
             throw await de_ResourceNotFoundExceptionRes(parsedOutput, context)
+        case 'ServiceQuotaExceededException':
+        case 'com.amazon.aws.codewhisperer#ServiceQuotaExceededException':
+            throw await de_ServiceQuotaExceededExceptionRes(parsedOutput, context)
         case 'ThrottlingException':
         case 'com.amazon.aws.codewhisperer#ThrottlingException':
             throw await de_ThrottlingExceptionRes(parsedOutput, context)
@@ -403,6 +418,26 @@ const de_ResourceNotFoundExceptionRes = async (
     })
     Object.assign(contents, doc)
     const exception = new ResourceNotFoundException({
+        $metadata: deserializeMetadata(parsedOutput),
+        ...contents,
+    })
+    return __decorateServiceException(exception, parsedOutput.body)
+}
+
+/**
+ * deserializeAws_restJson1ServiceQuotaExceededExceptionRes
+ */
+const de_ServiceQuotaExceededExceptionRes = async (
+    parsedOutput: any,
+    context: __SerdeContext
+): Promise<ServiceQuotaExceededException> => {
+    const contents: any = map({})
+    const data: any = parsedOutput.body
+    const doc = take(data, {
+        message: __expectString,
+    })
+    Object.assign(contents, doc)
+    const exception = new ServiceQuotaExceededException({
         $metadata: deserializeMetadata(parsedOutput),
         ...contents,
     })
@@ -586,6 +621,8 @@ const de_SupplementaryWebLinksEvent_event = async (
     Object.assign(contents, _json(data))
     return contents
 }
+// se_AppStudioState omitted.
+
 // se_AssistantResponseMessage omitted.
 
 // se_ChatHistory omitted.
@@ -604,7 +641,17 @@ const de_SupplementaryWebLinksEvent_event = async (
 
 // se_EditorState omitted.
 
+// se_EnvironmentVariable omitted.
+
+// se_EnvironmentVariables omitted.
+
+// se_EnvState omitted.
+
+// se_ExportContext omitted.
+
 // se_FollowupPrompt omitted.
+
+// se_GitState omitted.
 
 // se_Position omitted.
 
@@ -616,7 +663,17 @@ const de_SupplementaryWebLinksEvent_event = async (
 
 // se_References omitted.
 
+// se_RelevantDocumentList omitted.
+
+// se_RelevantTextDocument omitted.
+
 // se_RuntimeDiagnostic omitted.
+
+// se_ShellHistory omitted.
+
+// se_ShellHistoryEntry omitted.
+
+// se_ShellState omitted.
 
 // se_Span omitted.
 
@@ -627,6 +684,8 @@ const de_SupplementaryWebLinksEvent_event = async (
 // se_TextDocument omitted.
 
 // se_TextDocumentDiagnostic omitted.
+
+// se_TransformationExportContext omitted.
 
 // se_UserInputMessage omitted.
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.test.ts
@@ -194,6 +194,7 @@ describe('ChatEventParser', () => {
                 {
                     licenseName: 'MIT',
                     repository: 'langauge-servers',
+                    recommendationContentSpan: undefined,
                     information: ChatEventParser.getReferencedInformation({
                         licenseName: 'MIT',
                         repository: 'langauge-servers',

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.ts
@@ -40,6 +40,12 @@ export class ChatEventParser implements ChatResult {
     static mapReferenceData(reference: Reference): ReferenceTrackerInformation {
         return {
             ...reference,
+            recommendationContentSpan: reference.recommendationContentSpan
+                ? {
+                      start: reference.recommendationContentSpan.start ?? 0,
+                      end: reference.recommendationContentSpan.end ?? 0,
+                  }
+                : undefined,
             information: ChatEventParser.getReferencedInformation(reference),
         }
     }


### PR DESCRIPTION
## Problem

Codewhisperer streaming client package used in Codewhisperer LSP is 2 months old and outdated.

## Solution

* Updated `@amzn/codewhisperer-streaming` package to latest version used in AWS Toolkit https://github.com/aws/aws-toolkit-vscode. Tested Chat functionality with sample VSCode extension.
* [`Reference.recommendationContentSpan`](https://github.com/aws/language-servers/pull/327/files#diff-21a75ff27b821e42265decb7a14a13858a5244ba32b4fb3eca9cc55ba3e4c8ecR279-R280) interface is not compatible with Chat [`ReferenceTrackerInformation`](https://github.com/aws/language-server-runtimes/blob/4480b87a81c84dda229538fed7cbf165a44dc971/types/chat.ts#L36-L39) class anymore: `start` and `end` fields are defined as optional now. I had to adjusted [`chatEventParser`](https://github.com/aws/language-servers/pull/327/files#r1648984413) to handle this change. Correctness needs to be checked.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
