### PR TITLE
Set message can be voted; fix clear command

### DIFF
--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -84,10 +84,9 @@ describe('MynahUI', () => {
 
             assert.notCalled(onChatPromptSpy)
             assert.calledWith(onQuickActionSpy, { quickAction: prompt.command, prompt: prompt.prompt, tabId })
-            assert.calledThrice(updateStoreSpy)
+            assert.calledTwice(updateStoreSpy)
             assert.calledWith(updateStoreSpy.firstCall, tabId, { chatItems: [] })
             assert.calledWith(updateStoreSpy.secondCall, tabId, { loadingChat: false, promptInputDisabledState: false })
-            assert.calledWith(updateStoreSpy.thirdCall, tabId, { loadingChat: true, promptInputDisabledState: true })
         })
 
         it('should handle quick actions', () => {
@@ -97,7 +96,11 @@ describe('MynahUI', () => {
             handleChatPrompt(mynahUi, tabId, prompt, messager)
 
             assert.notCalled(onChatPromptSpy)
-            assert.calledWith(onQuickActionSpy, { quickAction: prompt.command, prompt: prompt.prompt, tabId })
+            assert.calledWith(onQuickActionSpy, {
+                quickAction: prompt.command,
+                prompt: 'What can Amazon Q help me with?',
+                tabId,
+            })
             assert.calledOnce(updateStoreSpy)
             assert.calledWith(updateStoreSpy, tabId, { loadingChat: true, promptInputDisabledState: true })
         })

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -1,7 +1,7 @@
 import { afterEach } from 'mocha'
 import sinon = require('sinon')
 import { assert } from 'sinon'
-import { createMynahUi, InboundChatApi, handleChatPrompt } from './mynahUi'
+import { createMynahUi, InboundChatApi, handleChatPrompt, DEFAULT_HELP_PROMPT } from './mynahUi'
 import { Messager, OutboundChatApi } from './messager'
 import { TabFactory } from './tabs/tabFactory'
 import { ChatItemType, MynahUI } from '@aws/mynah-ui'
@@ -98,7 +98,7 @@ describe('MynahUI', () => {
             assert.notCalled(onChatPromptSpy)
             assert.calledWith(onQuickActionSpy, {
                 quickAction: prompt.command,
-                prompt: 'What can Amazon Q help me with?',
+                prompt: DEFAULT_HELP_PROMPT,
                 tabId,
             })
             assert.calledOnce(updateStoreSpy)

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -50,15 +50,25 @@ export const handleChatPrompt = (
                 loadingChat: false,
                 promptInputDisabledState: false,
             })
-
-            return
         }
+
         // Send prompt when quick action command attached
         messager.onQuickActionCommand({
             quickAction: prompt.command,
             prompt: prompt.prompt,
             tabId,
         })
+
+        if (prompt.command === '/clear') {
+            return
+        } else if (prompt.command === '/help') {
+            mynahUi.addChatItem(tabId, {
+                type: ChatItemType.PROMPT,
+                body: 'What can Amazon Q help me with?',
+            })
+
+            return
+        }
     } else {
         // Send chat prompt to server
         messager.onChatPrompt({ prompt, tabId }, triggerType)

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -50,6 +50,8 @@ export const handleChatPrompt = (
                 loadingChat: false,
                 promptInputDisabledState: false,
             })
+
+            return
         }
         // Send prompt when quick action command attached
         messager.onQuickActionCommand({

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -39,6 +39,7 @@ export const handleChatPrompt = (
     triggerType?: TriggerType,
     _eventId?: string
 ) => {
+    let userPrompt = prompt.escapedPrompt
     if (prompt.command) {
         // Temporary solution to handle clear quick actions on the client side
         if (prompt.command === '/clear') {
@@ -50,23 +51,18 @@ export const handleChatPrompt = (
                 loadingChat: false,
                 promptInputDisabledState: false,
             })
+        } else if (prompt.command === '/help') {
+            userPrompt = 'What can Amazon Q help me with?'
         }
 
         // Send prompt when quick action command attached
         messager.onQuickActionCommand({
             quickAction: prompt.command,
-            prompt: prompt.prompt,
+            prompt: userPrompt,
             tabId,
         })
 
         if (prompt.command === '/clear') {
-            return
-        } else if (prompt.command === '/help') {
-            mynahUi.addChatItem(tabId, {
-                type: ChatItemType.PROMPT,
-                body: 'What can Amazon Q help me with?',
-            })
-
             return
         }
     } else {
@@ -77,7 +73,7 @@ export const handleChatPrompt = (
     // Add user prompt to UI
     mynahUi.addChatItem(tabId, {
         type: ChatItemType.PROMPT,
-        body: prompt.escapedPrompt,
+        body: userPrompt,
     })
 
     // Set UI to loading state

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -52,7 +52,7 @@ export const handleChatPrompt = (
                 promptInputDisabledState: false,
             })
         } else if (prompt.command === '/help') {
-            userPrompt = 'What can Amazon Q help me with?'
+            userPrompt = DEFAULT_HELP_PROMPT
         }
 
         // Send prompt when quick action command attached
@@ -365,6 +365,7 @@ ${params.message}`,
     return [mynahUi, api]
 }
 
+export const DEFAULT_HELP_PROMPT = 'What can Amazon Q help me with?'
 const uiComponentsTexts = {
     mainTitle: 'Amazon Q (Preview)',
     copy: 'Copy',

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -3,13 +3,7 @@ import {
     CodeWhispererStreaming,
     GenerateAssistantResponseCommandInput,
 } from '@amzn/codewhisperer-streaming'
-import {
-    ChatResult,
-    ErrorCodes,
-    LSPErrorCodes,
-    ResponseError,
-    TextDocument,
-} from '@aws/language-server-runtimes/server-interface'
+import { ChatResult, LSPErrorCodes, ResponseError, TextDocument } from '@aws/language-server-runtimes/server-interface'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as assert from 'assert'
 import sinon from 'ts-sinon'
@@ -47,7 +41,7 @@ describe('ChatController', () => {
     const expectedCompleteChatResult: ChatResult = {
         messageId: mockMessageId,
         body: 'Hello World!',
-        canBeVoted: undefined,
+        canBeVoted: true,
         codeReference: undefined,
         followUp: undefined,
         relatedContent: undefined,

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.test.ts
@@ -22,7 +22,7 @@ describe('ChatEventParser', () => {
                 data: {
                     messageId: mockMessageId,
                     body: undefined,
-                    canBeVoted: undefined,
+                    canBeVoted: true,
                     codeReference: undefined,
                     followUp: undefined,
                     relatedContent: undefined,
@@ -50,7 +50,7 @@ describe('ChatEventParser', () => {
                 data: {
                     messageId: mockMessageId,
                     body: undefined,
-                    canBeVoted: undefined,
+                    canBeVoted: true,
                     codeReference: undefined,
                     followUp: undefined,
                     relatedContent: undefined,
@@ -76,7 +76,7 @@ describe('ChatEventParser', () => {
                 data: {
                     messageId: mockMessageId,
                     body: 'This is an ',
-                    canBeVoted: undefined,
+                    canBeVoted: true,
                     codeReference: undefined,
                     followUp: undefined,
                     relatedContent: undefined,
@@ -95,7 +95,7 @@ describe('ChatEventParser', () => {
                 data: {
                     messageId: mockMessageId,
                     body: 'This is an assistant response.',
-                    canBeVoted: undefined,
+                    canBeVoted: true,
                     codeReference: undefined,
                     followUp: undefined,
                     relatedContent: undefined,
@@ -135,7 +135,7 @@ describe('ChatEventParser', () => {
                         },
                     ],
                 },
-                canBeVoted: undefined,
+                canBeVoted: true,
                 codeReference: undefined,
                 relatedContent: undefined,
             },
@@ -180,7 +180,7 @@ describe('ChatEventParser', () => {
         const expectedData: ChatResult = {
             messageId: mockMessageId,
             body: 'This is an assistant response.',
-            canBeVoted: undefined,
+            canBeVoted: true,
             relatedContent: {
                 content: [
                     {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatEventParser.ts
@@ -109,7 +109,7 @@ export class ChatEventParser implements ChatResult {
         const chatResult: ChatResult = {
             messageId: this.messageId,
             body: this.body,
-            canBeVoted: this.canBeVoted,
+            canBeVoted: this.canBeVoted ?? true,
             relatedContent: this.relatedContent,
             followUp: this.followUp,
             codeReference: this.codeReference,


### PR DESCRIPTION
## Description

- A spinner is showing up after the screen is cleared.  We should just terminate early in the chat-client chat request logic for `/clear` command
- Thumbs up and down are not showing up due to missing `canBeVoted` - we should set `canBeVoted` to true by default unless otherwise specified

As a bonus, we will add a default `What can Amazon Q help me with?` for `/help` command like vscode does

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
