### PR TITLE
Prevent runtime from crashing if FQN worker file is missing

### DIFF
--- a/core/aws-lsp-fqn/src/browser/fqnWorkerPool.ts
+++ b/core/aws-lsp-fqn/src/browser/fqnWorkerPool.ts
@@ -1,7 +1,13 @@
-import { ExtractorResult, FqnExtractorInput, IFqnWorkerPool } from '../common/types'
+import { CanExecuteResult, ExtractorResult, FqnExtractorInput, IFqnWorkerPool } from '../common/types'
 
 // TODO: implement logic for browser/webworker environment
 export class FqnWorkerPool implements IFqnWorkerPool {
+    static canExecute(): CanExecuteResult {
+        return {
+            success: true,
+        }
+    }
+
     public async exec(_input: FqnExtractorInput): Promise<ExtractorResult> {
         return Promise.resolve({
             success: true,

--- a/core/aws-lsp-fqn/src/common/types.ts
+++ b/core/aws-lsp-fqn/src/common/types.ts
@@ -71,6 +71,11 @@ export interface FqnExtractorInput {
     selection: Range
 }
 
+export type CanExecuteResult = {
+    success: boolean
+    error?: string
+}
+
 export interface IFqnWorkerPool {
     exec(input: FqnExtractorInput): Promise<ExtractorResult>
     dispose(): void

--- a/core/aws-lsp-fqn/src/index.ts
+++ b/core/aws-lsp-fqn/src/index.ts
@@ -1,7 +1,8 @@
-import { ExtractorResult, FqnExtractorInput, IFqnWorkerPool, WorkerPoolConfig } from './common/types'
+import { CanExecuteResult, ExtractorResult, FqnExtractorInput, IFqnWorkerPool, WorkerPoolConfig } from './common/types'
 
 export * from './common/types'
 export declare class FqnWorkerPool implements IFqnWorkerPool {
+    static canExecute(): CanExecuteResult
     constructor(workerPoolConfig?: WorkerPoolConfig)
     exec(input: FqnExtractorInput): Promise<ExtractorResult>
     dispose(): void

--- a/core/aws-lsp-fqn/src/node/fqnWorkerPool.ts
+++ b/core/aws-lsp-fqn/src/node/fqnWorkerPool.ts
@@ -1,8 +1,18 @@
 import path = require('path')
 import { CommonFqnWorkerPool } from '../common/commonFqnWorkerPool'
-import { WorkerPoolConfig } from '../common/types'
+import { CanExecuteResult, WorkerPoolConfig } from '../common/types'
+import { existsSync } from 'fs'
 
 export class FqnWorkerPool extends CommonFqnWorkerPool {
+    static canExecute(): CanExecuteResult {
+        const workerFileExists = existsSync('./aws-lsp-fqn-worker.js')
+
+        return {
+            success: workerFileExists,
+            error: !workerFileExists ? 'Worker file not found' : undefined,
+        }
+    }
+
     constructor(options?: WorkerPoolConfig) {
         super(path.resolve(__dirname, './aws-lsp-fqn-worker.js'), options)
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentFqnExtractor.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentFqnExtractor.ts
@@ -68,7 +68,7 @@ export class DocumentFqnExtractor {
         range: Range,
         languageId = document.languageId
     ): Promise<DocumentSymbol[]> {
-        return !this.#workerPool || DocumentFqnExtractor.FQN_SUPPORTED_LANGUAGE_SET.has(languageId)
+        return this.#workerPool && DocumentFqnExtractor.FQN_SUPPORTED_LANGUAGE_SET.has(languageId)
             ? this.#extractSymbols(document, range, languageId as FqnSupportedLanguages)
             : []
     }


### PR DESCRIPTION
## Problem

(Unsure if without this, it actually crashes....)
FQN is actually not required for Q chat to work, so we should not crash the runtime if the file doesn't exist.

## Solution
Unfortunately, I had about 30min of time for this so this is hacky, but tried to keep it somewhat flexible. If `@aws/lsp-fqn` is actually not being released, I think this should be okay. I am writing a proposal for a worker feature anyway, so that should include error handling.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
