### PR TITLE
Send feedback as telemetry back

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -175,7 +175,6 @@ export class ChatController implements ChatHandlers {
     onReady() {}
 
     onSendFeedback({ tabId, feedbackPayload }: FeedbackParams) {
-        // this is not an actual telemetry, toolkit needs to intercept this
         this.#features.telemetry.emitMetric({
             name: 'amazonq_sendFeedback',
             data: {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -1,5 +1,5 @@
 import { GenerateAssistantResponseCommandOutput } from '@amzn/codewhisperer-streaming'
-import { FollowUpClickParams, chatRequestType } from '@aws/language-server-runtimes/protocol'
+import { FeedbackParams, chatRequestType } from '@aws/language-server-runtimes/protocol'
 import {
     CancellationToken,
     Chat,
@@ -174,7 +174,22 @@ export class ChatController implements ChatHandlers {
 
     onReady() {}
 
-    onSendFeedback() {}
+    onSendFeedback({ tabId, feedbackPayload }: FeedbackParams) {
+        // this is not an actual telemetry, toolkit needs to intercept this
+        this.#features.telemetry.emitMetric({
+            name: 'amazonq_sendFeedback',
+            data: {
+                comment: JSON.stringify({
+                    type: 'codewhisperer-chat-answer-feedback',
+                    conversationId: this.#telemetryController.getConversationId(tabId) ?? '',
+                    messageId: feedbackPayload.messageId,
+                    reason: feedbackPayload.selectedOption,
+                    userComment: feedbackPayload.comment,
+                }),
+                sentiment: 'Negative',
+            },
+        })
+    }
 
     onSourceLinkClick() {}
 


### PR DESCRIPTION
## Description

Unfortunately, we have to send a fake telemetry which seems to be the only way in time constraint. We will intercept it on toolkit side and handle it differently.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
