### PR TITLE
Make sure clear quick action doesn't get stuck loading

### DIFF
--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -84,9 +84,8 @@ describe('MynahUI', () => {
 
             assert.notCalled(onChatPromptSpy)
             assert.calledWith(onQuickActionSpy, { quickAction: prompt.command, prompt: prompt.prompt, tabId })
-            assert.calledTwice(updateStoreSpy)
+            assert.calledOnce(updateStoreSpy)
             assert.calledWith(updateStoreSpy.firstCall, tabId, { chatItems: [] })
-            assert.calledWith(updateStoreSpy.secondCall, tabId, { loadingChat: false, promptInputDisabledState: false })
         })
 
         it('should handle quick actions', () => {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -46,11 +46,6 @@ export const handleChatPrompt = (
             mynahUi.updateStore(tabId, {
                 chatItems: [],
             })
-
-            mynahUi.updateStore(tabId, {
-                loadingChat: false,
-                promptInputDisabledState: false,
-            })
         } else if (prompt.command === '/help') {
             userPrompt = DEFAULT_HELP_PROMPT
         }
@@ -69,7 +64,6 @@ export const handleChatPrompt = (
         // Send chat prompt to server
         messager.onChatPrompt({ prompt, tabId }, triggerType)
     }
-
     // Add user prompt to UI
     mynahUi.addChatItem(tabId, {
         type: ChatItemType.PROMPT,
@@ -279,6 +273,11 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
     const addChatResponse = (chatResult: ChatResult, tabId: string, isPartialResult: boolean) => {
         if (isPartialResult) {
             mynahUi.updateLastChatAnswer(tabId, { ...chatResult })
+            return
+        }
+
+        // If chat response from server is an empty object don't do anything
+        if (Object.keys(chatResult).length === 0) {
             return
         }
 


### PR DESCRIPTION
## Problem
/clear quick action caused a `generating your answer` chat item to be added that would not go away because the server would respond with an empty object causing the chat client to create an empty chat item. This would cause mynah to create a chat item that assumed it was going to be filled with data and therefore had the `generating your answer` string

## Solution
chat client will not try to create a chat item if the server response is an empty object 
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
