### PR TITLE
Export proxy servers as well

### DIFF
--- a/server/aws-lsp-codewhisperer/src/index.ts
+++ b/server/aws-lsp-codewhisperer/src/index.ts
@@ -1,3 +1,4 @@
 export * from './language-server/codeWhispererSecurityScanServer'
 export * from './language-server/codeWhispererServer'
 export * from './language-server/qChatServer'
+export * from './language-server/proxy-server'


### PR DESCRIPTION
## Problem
Currently the package doesn't export proxy servers,  running the following is failing when I run `npm pack` and test:

```
const assert = require('assert')
import {CodeWhispererSecurityScanServerTokenProxy, CodeWhispererServerIAM,CodeWhispererServerIAMProxy, CodeWhispererServerToken, CodeWhispererServerTokenProxy, QChatServer, QChatServerProxy, SecurityScanServerToken} from '@aws/lsp-codewhisperer'

assert.ok(CodeWhispererServerIAMProxy)
assert.ok(CodeWhispererServerTokenProxy)
assert.ok(CodeWhispererSecurityScanServerTokenProxy)
assert.ok(QChatServerProxy)
```


## Solution

Export proxy servers as well

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
