### PR TITLE
Add Chat modify code telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11563,7 +11563,6 @@
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4.9.1"
@@ -18936,6 +18935,7 @@
                 "adm-zip": "^0.5.10",
                 "aws-sdk": "^2.1403.0",
                 "deepmerge": "^4.3.1",
+                "fastest-levenshtein": "^1.0.16",
                 "got": "^11.8.5",
                 "hpagent": "^1.2.0",
                 "js-md5": "^0.8.3",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -43,7 +43,7 @@
         "got": "^11.8.5",
         "hpagent": "^1.2.0",
         "js-md5": "^0.8.3",
-        "fastest-levenshtein": "^1.0.15",
+        "fastest-levenshtein": "^1.0.16",
         "proxy-http-agent": "^1.0.1",
         "uuid": "^9.0.1",
         "vscode-uri": "^3.0.8"

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -43,6 +43,7 @@
         "got": "^11.8.5",
         "hpagent": "^1.2.0",
         "js-md5": "^0.8.3",
+        "fastest-levenshtein": "^1.0.15",
         "proxy-http-agent": "^1.0.1",
         "uuid": "^9.0.1",
         "vscode-uri": "^3.0.8"

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -42,7 +42,7 @@ export class ChatController implements ChatHandlers {
         this.#features = features
         this.#chatSessionManagementService = chatSessionManagementService
         this.#triggerContext = new QChatTriggerContext(features.workspace, features.logging)
-        this.#telemetryController = new ChatTelemetryController(features.credentialsProvider, features.telemetry)
+        this.#telemetryController = new ChatTelemetryController(features)
     }
 
     dispose() {
@@ -58,7 +58,7 @@ export class ChatController implements ChatHandlers {
         if (!session) {
             this.#log('Get session error', params.tabId)
             return new ResponseError<ChatResult>(
-                ErrorCodes.InvalidParams,
+                LSPErrorCodes.RequestFailed,
                 'error' in sessionResult ? sessionResult.error : 'Unknown error'
             )
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -48,6 +48,7 @@ export class ChatController implements ChatHandlers {
     dispose() {
         this.#chatSessionManagementService.dispose()
         this.#triggerContext.dispose()
+        this.#telemetryController.dispose()
     }
 
     async onChatPrompt(params: ChatParams, token: CancellationToken): Promise<ChatResult | ResponseError<ChatResult>> {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.test.ts
@@ -14,7 +14,7 @@ describe('TelemetryController', () => {
 
     beforeEach(() => {
         testFeatures = new TestFeatures()
-        telemetryController = new ChatTelemetryController(testFeatures.credentialsProvider, testFeatures.telemetry)
+        telemetryController = new ChatTelemetryController(testFeatures)
     })
 
     it('able to set and get activeTabId', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -305,7 +305,6 @@ export class ChatTelemetryController {
                         },
                     })
                     break
-
                 case ChatUIEventName.LinkClick:
                 case ChatUIEventName.InfoLinkClick:
                     this.emitInteractWithMessageMetric(params.tabId, {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -323,6 +323,10 @@ export class ChatTelemetryController {
             }
         }
     }
+
+    public dispose() {
+        this.#codeDiffTracker.shutdown()
+    }
 }
 
 export function convertToTelemetryUserIntent(userIntent?: UserIntent) {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/clientTelemetry.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/clientTelemetry.ts
@@ -73,7 +73,10 @@ export type SourceLinkClickParams = ServerInterface.SourceLinkClickParams &
     BaseClientTelemetryParams<ChatUIEventName.SourceLinkClick>
 
 export type InsertToCursorPositionParams = ServerInterface.InsertToCursorPositionParams &
-    BaseClientTelemetryParams<ChatUIEventName.InsertToCursorPosition>
+    BaseClientTelemetryParams<ChatUIEventName.InsertToCursorPosition> & {
+        cursorState?: ServerInterface.CursorState[]
+        textDocument?: ServerInterface.TextDocumentIdentifier
+    }
 
 export type ClientTelemetryEvent =
     | BaseClientTelemetryParams<ChatUIEventName.EnterFocusChat>

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.test.ts
@@ -1,0 +1,139 @@
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { CodeDiffTracker } from './codeDiffTracker'
+import sinon = require('sinon')
+import assert = require('assert')
+
+describe('codeDiffTracker', () => {
+    let codeDiffTracker: CodeDiffTracker
+    let mockRecordMetric: sinon.SinonStub
+    const flushInterval = 1000
+    const timeElapsedThreshold = 5000
+    const maxQueueSize = 3
+
+    beforeEach(() => {
+        sinon.useFakeTimers({
+            now: 0,
+            shouldAdvanceTime: false,
+        })
+        const testFeatures = new TestFeatures()
+        mockRecordMetric = sinon.stub()
+        codeDiffTracker = new CodeDiffTracker(testFeatures.workspace, testFeatures.logging, mockRecordMetric, {
+            flushInterval,
+            timeElapsedThreshold,
+            maxQueueSize,
+        })
+        testFeatures.openDocument(TextDocument.create('test.cs', 'typescript', 1, 'test'))
+    })
+
+    afterEach(() => {
+        sinon.clock.restore()
+        sinon.restore()
+    })
+
+    it('shutdown should flush the queue', async () => {
+        const mockEntry = {
+            startPosition: {
+                line: 0,
+                character: 0,
+            },
+            endPosition: {
+                line: 20,
+                character: 0,
+            },
+            fileUrl: 'test.cs',
+            // fake timer starts at 0
+            time: -timeElapsedThreshold,
+            originalString: "console.log('test console')",
+        }
+
+        // use negative time so we don't have to move the timer which would cause the interval to run
+        codeDiffTracker.enqueue(mockEntry)
+
+        codeDiffTracker.enqueue({
+            startPosition: {
+                line: 0,
+                character: 0,
+            },
+            endPosition: {
+                line: 20,
+                character: 0,
+            },
+            fileUrl: 'test.cs',
+            // fake timer starts at 0
+            time: -timeElapsedThreshold + 100,
+            originalString: "console.log('test console')",
+        })
+
+        await codeDiffTracker.shutdown()
+        sinon.assert.calledOnce(mockRecordMetric)
+        sinon.assert.calledWith(mockRecordMetric, mockEntry, sinon.match.number)
+    })
+
+    it('queue should be flushed after time elapsed threshold is reached', async () => {
+        const mockEntry = {
+            startPosition: {
+                line: 0,
+                character: 0,
+            },
+            endPosition: {
+                line: 20,
+                character: 0,
+            },
+            fileUrl: 'test.cs',
+            time: 0,
+            originalString: "console.log('test console')",
+        }
+        codeDiffTracker.enqueue(mockEntry)
+
+        const mockEntry2 = {
+            startPosition: {
+                line: 1,
+                character: 1,
+            },
+            endPosition: {
+                line: 20,
+                character: 0,
+            },
+            fileUrl: 'test.cs',
+            time: 1000,
+            originalString: "console.log('test console 2')",
+        }
+        codeDiffTracker.enqueue(mockEntry2)
+
+        await sinon.clock.tickAsync(timeElapsedThreshold)
+
+        sinon.assert.calledOnce(mockRecordMetric)
+        sinon.assert.calledWith(mockRecordMetric, mockEntry, sinon.match.number)
+
+        mockRecordMetric.resetHistory()
+        await sinon.clock.tickAsync(flushInterval)
+
+        sinon.assert.calledOnce(mockRecordMetric)
+        sinon.assert.calledWith(mockRecordMetric, mockEntry2, sinon.match.number)
+    })
+
+    it('queue does not exceed the size', async () => {
+        const mockEntry = {
+            startPosition: {
+                line: 0,
+                character: 0,
+            },
+            endPosition: {
+                line: 20,
+                character: 0,
+            },
+            fileUrl: 'test.cs',
+            time: 0,
+            originalString: "console.log('test console')",
+        }
+
+        for (let i = 0; i < maxQueueSize + 5; i++) {
+            codeDiffTracker.enqueue(mockEntry)
+        }
+
+        await sinon.clock.tickAsync(timeElapsedThreshold)
+
+        assert.strictEqual(mockRecordMetric.callCount, maxQueueSize)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
@@ -22,12 +22,6 @@ export interface CodeDiffTrackerOptions {
  * The current calculation method is (Levenshtein edit distance / acceptedSuggestion.length).
  */
 export class CodeDiffTracker<T extends AcceptedSuggestionEntry = AcceptedSuggestionEntry> {
-    #eventQueue: T[]
-    #interval?: NodeJS.Timeout
-    #workspace: Features['workspace']
-    #logging: Features['logging']
-    #recordMetric: (entry: T, codeModificationPercentage: number) => void
-
     /**
      * time indication the flush frequency of which the checks are
      */
@@ -38,6 +32,11 @@ export class CodeDiffTracker<T extends AcceptedSuggestionEntry = AcceptedSuggest
     private static readonly TIME_ELAPSED_THRESHOLD = 1000 * 60 * 5 // 5 minutes
     private static readonly DEFAULT_MAX_QUEUE_SIZE = 10000
 
+    #eventQueue: T[]
+    #interval?: NodeJS.Timeout
+    #workspace: Features['workspace']
+    #logging: Features['logging']
+    #recordMetric: (entry: T, codeModificationPercentage: number) => void
     #flushInterval: number
     #timeElapsedThreshold: number
     #maxQueueSize: number

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
@@ -1,5 +1,5 @@
 import { distance } from 'fastest-levenshtein'
-import { Position } from 'vscode-languageserver-textdocument'
+import { Position } from '@aws/language-server-runtimes/server-interface'
 import { Features } from '../types'
 import { getErrorMessage } from '../utils'
 

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
@@ -16,7 +16,6 @@ export interface AcceptedSuggestionEntry {
  * The current calculation method is (Levenshtein edit distance / acceptedSuggestion.length).
  */
 export class CodeDiffTracker<T extends AcceptedSuggestionEntry> {
-    // This should be a union if there are other types
     #eventQueue: T[]
     #interval?: NodeJS.Timeout
     #workspace: Features['workspace']
@@ -35,17 +34,17 @@ export class CodeDiffTracker<T extends AcceptedSuggestionEntry> {
 
     /**
      * This function calculates the Levenshtein edit distance of currString from original accepted String
-     * then return a percentage against the length of accepted string (capped by 1,0)
+     * then return a percentage against the length of accepted string (capped by 1)
      * @param currString the current string in the same location as the previously accepted suggestion
      * @param acceptedString the accepted suggestion that was inserted into the editor
      */
     public static checkDiff(currString?: string, acceptedString?: string): number {
-        if (!currString || !acceptedString || currString.length === 0 || acceptedString.length === 0) {
-            return 1.0
+        if (!currString || !acceptedString) {
+            return 1
         }
 
         const diff = distance(currString, acceptedString)
-        return Math.min(1.0, diff / acceptedString.length)
+        return Math.min(1, diff / acceptedString.length)
     }
 
     constructor(
@@ -76,8 +75,8 @@ export class CodeDiffTracker<T extends AcceptedSuggestionEntry> {
 
         try {
             await this.flush()
-        } finally {
-            this.#eventQueue = []
+        } catch (e) {
+            this.#logging.log(`Error encountered while performing the final flush: ${e}`)
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
@@ -107,6 +107,7 @@ export enum ChatTelemetryEventName {
     AddMessage = 'amazonq_addMessage',
     RunCommand = 'amazonq_runCommand',
     MessageResponseError = 'amazonq_messageResponseError',
+    ModifyCode = 'amazonq_modifyCode',
 }
 
 export interface ChatTelemetryEventMap {
@@ -119,6 +120,13 @@ export interface ChatTelemetryEventMap {
     [ChatTelemetryEventName.AddMessage]: AddMessageEvent
     [ChatTelemetryEventName.RunCommand]: RunCommandEvent
     [ChatTelemetryEventName.MessageResponseError]: MessageResponseErrorEvent
+    [ChatTelemetryEventName.ModifyCode]: ModifyCodeEvent
+}
+
+export type ModifyCodeEvent = {
+    cwsprChatConversationId: string
+    cwsprChatMessageId: string
+    cwsprChatModificationPercentage: number
 }
 
 export type AddMessageEvent = {


### PR DESCRIPTION
## Description 

- Track document position and inserted code when user uses the insert code to cursor functionality and insert to a queue
- When an entry has been added for at least five minutes, we use use fastest-levenshtein to calculate edit distance between the current text in the same position and the original inserted text.
 
We are able to get the E2E flow working in VS by forcing the cursor state and document identifier through, but they should be added to the interface later on.

✅ Tested E2E flow in Visual Studio 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
