### PR TITLE
Clean up logging and remove q data from response error

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -267,13 +267,7 @@ describe('ChatController', () => {
                 mockCancellationToken
             )
 
-            assert.deepStrictEqual(
-                chatResult,
-                new ResponseError(LSPErrorCodes.RequestFailed, 'some error', {
-                    ...expectedCompleteChatResult,
-                    body: 'Hello World',
-                })
-            )
+            assert.deepStrictEqual(chatResult, new ResponseError(LSPErrorCodes.RequestFailed, 'some error'))
         })
 
         it('returns a ResponseError if response streams return an invalid state event', async () => {
@@ -298,13 +292,7 @@ describe('ChatController', () => {
                 mockCancellationToken
             )
 
-            assert.deepStrictEqual(
-                chatResult,
-                new ResponseError(LSPErrorCodes.RequestFailed, 'invalid state', {
-                    ...expectedCompleteChatResult,
-                    body: 'Hello World',
-                })
-            )
+            assert.deepStrictEqual(chatResult, new ResponseError(LSPErrorCodes.RequestFailed, 'invalid state'))
         })
 
         describe('#extractDocumentContext', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
@@ -57,13 +57,10 @@ describe('ChatSessionManagementService', () => {
             assert.strictEqual(chatSessionManagementService.getSession(mockSessionId).data, result.data)
         })
 
-        it('creating a session with an existing id should return an error', () => {
-            chatSessionManagementService.createSession(mockSessionId)
+        it('creating a session with an existing id should return existing session', () => {
+            const createdSession = chatSessionManagementService.createSession(mockSessionId)
 
-            sinon.assert.match(chatSessionManagementService.createSession(mockSessionId), {
-                success: false,
-                error: sinon.match.string,
-            })
+            assert.deepStrictEqual(chatSessionManagementService.createSession(mockSessionId), createdSession)
         })
 
         it('deleting session should dispose the chat session service and delete from map', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
@@ -46,9 +46,8 @@ export class ChatSessionManagementService {
             }
         } else if (this.#sessionByTab.has(tabId)) {
             return {
-                success: false,
-                data: this.#sessionByTab.get(tabId),
-                error: 'Session already exists',
+                success: true,
+                data: this.#sessionByTab.get(tabId)!,
             }
         }
 


### PR DESCRIPTION
## Description

- Clean up some unneeded logging. 
- Remove partial response data from response error since they won't be encrypted.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
