### PR TITLE
Fixing typo in /help quick action

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/quickActions.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/quickActions.ts
@@ -30,7 +30,7 @@ export const HELP_MESSAGE = `I'm Amazon Q, a generative AI assistant. Learn more
 \n\n### Examples of questions I can answer:
 \n\n- When should I use ElastiCache?
 \n\n- How do I create an Application Load Balancer?
-\n\n- Explain the <selected code> and ask clarifying questions about it.
+\n\n- Explain selected code and ask clarifying questions about it.
 \n\n- What is the syntax of declaring a variable in TypeScript?
 \n\n### Special Commands
 \n\n- /clear - Clear the conversation.


### PR DESCRIPTION
## Problem
Typo in /help quick action where `selected code` was missing from the example questions.

![image](https://github.com/aws/language-servers/assets/166408483/e171d20f-2a5f-4fa2-adda-660a4781bd8e)

## Solution
Update text to include the missing string

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
