### PR TITLE
Update prepack script to copy instead of symlink bundled dependencies

### DIFF
--- a/script/link_bundled_dependencies.ts
+++ b/script/link_bundled_dependencies.ts
@@ -18,29 +18,46 @@ if (bundleDependencies.length === 0) {
     process.exit(0)
 }
 
+// Function to copy directory recursively, resolving symlinks
+function copyDir(src: string, dest: string) {
+    if (!fs.existsSync(dest)) {
+        fs.mkdirSync(dest, { recursive: true })
+    }
+    fs.readdirSync(src).forEach(file => {
+        const srcFile = path.join(src, file)
+        const destFile = path.join(dest, file)
+        const resolvedSrcFile = fs.realpathSync(srcFile)
+
+        if (fs.lstatSync(resolvedSrcFile).isDirectory()) {
+            copyDir(resolvedSrcFile, destFile)
+        } else {
+            fs.copyFileSync(resolvedSrcFile, destFile)
+        }
+    })
+}
+
 // Loop through each bundleDependency
 for (const dependency of bundleDependencies) {
     const dependencyPath = path.join(rootDir, 'node_modules', dependency)
 
     // Check if the dependency exists in the root node_modules directory
     if (fs.existsSync(dependencyPath)) {
-        // Create a symlink for the dependency
-        const linkLocation = path.join('node_modules', dependency)
-        const linkTarget = fs.realpathSync(dependencyPath)
+        // Resolve any symlinks to get the real path
+        const resolvedDependencyPath = fs.realpathSync(dependencyPath)
+
+        // Determine the target location within the package
+        const targetLocation = path.join('node_modules', dependency)
 
         try {
-            // Create the directory if it doesn't exist
-            fs.mkdirSync(path.dirname(linkLocation), { recursive: true })
-
             // Clear contents or remove the last folder in the path
-            if (fs.existsSync(linkLocation)) {
-                fs.rmSync(linkLocation, { recursive: true, force: true })
+            if (fs.existsSync(targetLocation)) {
+                fs.rmSync(targetLocation, { recursive: true, force: true })
             }
-            // Create the symlink
-            fs.symlinkSync(linkTarget, linkLocation, 'junction')
-            console.log(`Symlink created for ${dependency}`)
+            // Copy the dependency from the resolved path
+            copyDir(resolvedDependencyPath, targetLocation)
+            console.log(`Copied ${dependency} from ${resolvedDependencyPath}`)
         } catch (err) {
-            console.error(`ERROR: Failed to create symlink for ${dependency}. ${err}`)
+            console.error(`ERROR: Failed to copy ${dependency} from ${resolvedDependencyPath}. ${err}`)
             process.exit(1)
         }
     } else {


### PR DESCRIPTION
## Problem
Running `npm pack` in `aws-lsp-codewhisperer` directory references files from parent directories (which are mostly dependencies of bundledDependencies, that don't need to be part of the final bundle) which causes `npm publish` to fail.


## Solution
This PR updates our prepack script to copy bundled dependencies instead of symlinking them. When I run `npm pack` with this configuration I don't see any files from the wrong scope being referenced


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
