### PR TITLE
Automate publishing to npm from Github Workflows

### DIFF
--- a/.github/workflows/publish-lsp-amazonq.yaml
+++ b/.github/workflows/publish-lsp-amazonq.yaml
@@ -1,0 +1,13 @@
+name: Publish Amazon Q Language Server to npmjs
+
+on:
+    push:
+        tags:
+            - 'lsp-codewhisperer/v**'
+
+jobs:
+    publish:
+        uses: ./.github/workflows/publish-to-npm.yaml
+        with:
+            workspace: 'server/aws-lsp-codewhisperer'
+        secrets: inherit

--- a/.github/workflows/publish-lsp-codewhisperer.yaml
+++ b/.github/workflows/publish-lsp-codewhisperer.yaml
@@ -1,4 +1,4 @@
-name: Publish Amazon Q Language Server to npmjs
+name: Publish Codewhisperer Language Server to npmjs
 
 on:
     push:

--- a/.github/workflows/publish-lsp-core.yaml
+++ b/.github/workflows/publish-lsp-core.yaml
@@ -1,0 +1,13 @@
+name: Publish Core Language Server utils package to npmjs
+
+on:
+    push:
+        tags:
+            - 'lsp-core/v**'
+
+jobs:
+    publish:
+        uses: ./.github/workflows/publish-to-npm.yaml
+        with:
+            workspace: 'core/aws-lsp-core'
+        secrets: inherit

--- a/.github/workflows/publish-lsp-json.yaml
+++ b/.github/workflows/publish-lsp-json.yaml
@@ -1,0 +1,13 @@
+name: Publish JSON Language Server to npmjs
+
+on:
+    push:
+        tags:
+            - 'lsp-json/v**'
+
+jobs:
+    publish:
+        uses: ./.github/workflows/publish-to-npm.yaml
+        with:
+            workspace: 'server/aws-lsp-json'
+        secrets: inherit

--- a/.github/workflows/publish-lsp-partiql.yaml
+++ b/.github/workflows/publish-lsp-partiql.yaml
@@ -1,0 +1,13 @@
+name: Publish PartiQL Language Server to npmjs
+
+on:
+    push:
+        tags:
+            - 'lsp-partiql/v**'
+
+jobs:
+    publish:
+        uses: ./.github/workflows/publish-to-npm.yaml
+        with:
+            workspace: 'server/aws-lsp-partiql'
+        secrets: inherit

--- a/.github/workflows/publish-lsp-yaml.yaml
+++ b/.github/workflows/publish-lsp-yaml.yaml
@@ -1,0 +1,13 @@
+name: Publish JSON Language Server to npmjs
+
+on:
+    push:
+        tags:
+            - 'lsp-yaml/v**'
+
+jobs:
+    publish:
+        uses: ./.github/workflows/publish-to-npm.yaml
+        with:
+            workspace: 'server/aws-lsp-yaml'
+        secrets: inherit

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,0 +1,25 @@
+name: Reusable Publish Package to npmjs workflow
+
+on:
+    workflow_call:
+        inputs:
+            workspace:
+                required: true
+                type: string
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            # Setup .npmrc file to publish to npm
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20.x'
+                  registry-url: 'https://registry.npmjs.org'
+                  scope: '@aws'
+            - run: npm ci
+            - run: npm run compile
+            - run: npm publish --workspace ${{ inputs.workspace }}
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Problem

Publishing packages from Language Server monorepo requires manual steps

## Solution

Introducing workflows, which allow trigger publishing to npm from Github Action. Workflows will be triggered only when git tag with specific format is created per package we want to release:

* [@aws/lsp-codewhisperer](https://www.npmjs.com/package/@aws/lsp-codewhisperer): `lsp-codewhisperer/v**`
* [@aws/lsp-core](https://www.npmjs.com/package/@aws/lsp-core): `lsp-core/v**`
* [@aws/lsp-json](https://www.npmjs.com/package/@aws/lsp-json): `lsp-json/v**`
* [@aws/lsp-partiql](https://www.npmjs.com/package/@aws/lsp-partiql): `lsp-partiql/v**`
* [@aws/lsp-yaml](https://www.npmjs.com/package/@aws/lsp-yaml): `lsp-yaml/v**`

Tags can be created using during release process using Github Releases webpage or manually using git CLI. This change also helps to align git tags formats we use.

Workflows will attempt to publish current version of packages, as set in their package.json, so proper release process still has to be followed to bump the version and merge release branches into main.

## Testing
Tested in my personal fork, verified that publishing attempt happens, but fails due to version conflict, which is expected.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
