### PR TITLE
Fix servers not starting in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,7 +57,7 @@
             "args": ["--extensionDevelopmentPath=${workspaceFolder}/client/vscode"],
             "outFiles": ["${workspaceFolder}/client/vscode/out/**/*.js"],
             "env": {
-                "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-partiql-runtimes/out/aws-lsp-partiql-runtimes.js"
+                "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-partiql-runtimes/build/aws-lsp-partiql-binary.js"
             },
             "preLaunchTask": "npm: compile"
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,14 +38,26 @@
             "preLaunchTask": "npm: compile"
         },
         {
-            "name": "YAML/JSON Server",
+            "name": "YAML Server",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}/client/vscode"],
             "outFiles": ["${workspaceFolder}/client/vscode/out/**/*.js"],
             "env": {
-                "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-yaml-json-runtimes/out/index.js"
+                "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-yaml-runtimes/out/index.js"
+            },
+            "preLaunchTask": "npm: compile"
+        },
+        {
+            "name": "JSON Server",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}/client/vscode"],
+            "outFiles": ["${workspaceFolder}/client/vscode/out/**/*.js"],
+            "env": {
+                "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-json-runtimes/out/index.js"
             },
             "preLaunchTask": "npm: compile"
         },

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/lsp-partiql": "^0.0.1",
+        "@aws/lsp-partiql": "^0.0.2",
         "@aws/language-server-runtimes": "^0.2.5"
     },
     "devDependencies": {

--- a/client/vscode/src/extension.ts
+++ b/client/vscode/src/extension.ts
@@ -6,6 +6,7 @@ let client: LanguageClient
 
 export async function activate(context: ExtensionContext) {
     client = await activateDocumentsLanguageServer(context)
+    client.start()
     return
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,20 +85,13 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.5",
-                "@aws/lsp-partiql": "^0.0.1"
+                "@aws/lsp-partiql": "^0.0.2"
             },
             "devDependencies": {
                 "ts-loader": "^9.4.4",
                 "ts-lsp-client": "^1.0.3",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4"
-            }
-        },
-        "app/aws-lsp-partiql-runtimes/node_modules/@aws/lsp-partiql": {
-            "version": "0.0.1",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.4"
             }
         },
         "app/aws-lsp-s3-runtimes": {


### PR DESCRIPTION
## Problem
https://github.com/aws/language-servers/issues/374

>PartiQL / JSON / YAML server are not able to launch after https://github.com/aws/language-servers/pull/328 and https://github.com/aws/language-servers/pull/326

## Solution
- Explicitly start the Language Client after config
- Fix launch configuration for PartiQL, YAML, and JSON servers
- chore: Update PartiQL server used in the runtime app

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
