### PR TITLE
Upgraded ts dependency version without CW streaming client upgrade

### DIFF
--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -26,7 +26,7 @@
         "stream-browserify": "^3.0.0",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5.4.5",
+        "typescript": "^5.5.3",
         "umd-compat-loader": "^2.1.2",
         "webpack": "^5.91.0",
         "webpack-cli": "^5.1.4",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -172,7 +172,7 @@
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.88.0",
         "jose": "^5.2.4",
-        "typescript": "^5.4.5",
+        "typescript": "^5.5.3",
         "vscode-languageclient": "^9.0.1"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "server/**"
             ],
             "dependencies": {
-                "typescript": "^5.4.5"
+                "typescript": "^5.5.3"
             },
             "devDependencies": {
                 "@types/node": "^20.12.2",
@@ -123,7 +123,7 @@
                 "stream-browserify": "^3.0.0",
                 "ts-loader": "^9.5.1",
                 "ts-node": "^10.9.2",
-                "typescript": "^5.4.5",
+                "typescript": "^5.5.3",
                 "umd-compat-loader": "^2.1.2",
                 "webpack": "^5.91.0",
                 "webpack-cli": "^5.1.4",
@@ -204,7 +204,7 @@
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",
-                "typescript": "^5.4.5",
+                "typescript": "^5.5.3",
                 "vscode-languageclient": "^9.0.1"
             },
             "engines": {
@@ -4321,18 +4321,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/fetch-http-handler": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.1.tgz",
-            "integrity": "sha512-0w0bgUvZmfa0vHN8a+moByhCJT07WN6AHKEhFSOLsDpnszm+5dLVv5utGaqbhOrZ/aF5x3xuPMs/oMCd+4O5xg==",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.0.3",
-                "@smithy/querystring-builder": "^3.0.3",
-                "@smithy/types": "^3.3.0",
-                "@smithy/util-base64": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
         "node_modules/@smithy/eventstream-serde-config-resolver": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.3.tgz",
@@ -4354,6 +4342,18 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.1.tgz",
+            "integrity": "sha512-0w0bgUvZmfa0vHN8a+moByhCJT07WN6AHKEhFSOLsDpnszm+5dLVv5utGaqbhOrZ/aF5x3xuPMs/oMCd+4O5xg==",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/hash-blob-browser": {
@@ -14132,8 +14132,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.4.5",
-            "license": "Apache-2.0",
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+            "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "package": "npm run compile && npm run package --workspaces --if-present"
     },
     "dependencies": {
-        "typescript": "^5.4.5"
+        "typescript": "^5.5.3"
     },
     "devDependencies": {
         "@types/node": "^20.12.2",


### PR DESCRIPTION
## Problem

Upgrade Typescript dependency as an alternative to this dependabot CR: https://github.com/aws/language-servers/pull/370.

## Solution

Typescript update in CodeWhisperer streaming library was excluded.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
