### PR TITLE
Allow "0" to be used as partial token in chat handler

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -215,6 +215,18 @@ describe('ChatController', () => {
             assert.deepStrictEqual(chatResult, expectedCompleteChatResult)
         })
 
+        it('can use 0 as progress token', async () => {
+            const chatResultPromise = chatController.onChatPrompt(
+                { tabId: mockTabId, prompt: { prompt: 'Hello' }, partialResultToken: 0 },
+                mockCancellationToken
+            )
+
+            const chatResult = await chatResultPromise
+
+            sinon.assert.callCount(testFeatures.lsp.sendProgress, mockAssistantResponseList.length)
+            assert.deepStrictEqual(chatResult, expectedCompleteChatResult)
+        })
+
         it('returns a ResponseError if generateAssistantResponse returns an error', async () => {
             generateAssistantResponseStub.callsFake(() => {
                 throw new Error('Error')

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -25,7 +25,14 @@ import { ChatEventParser } from './chatEventParser'
 import { ChatSessionManagementService } from './chatSessionManagementService'
 import { ChatTelemetryController } from './telemetry/chatTelemetryController'
 import { HELP_MESSAGE, QuickAction } from './quickActions'
-import { createAuthFollowUpResult, getAuthFollowUpType, getErrorMessage, isAwsError, isObject } from '../utils'
+import {
+    createAuthFollowUpResult,
+    getAuthFollowUpType,
+    getErrorMessage,
+    isAwsError,
+    isNullish,
+    isObject,
+} from '../utils'
 import { Metric } from '../telemetry/metric'
 import { QChatTriggerContext, TriggerContext } from './contexts/triggerContext'
 
@@ -305,7 +312,7 @@ export class ChatController implements ChatHandlers {
                 return chatResult
             }
 
-            if (partialResultToken) {
+            if (!isNullish(partialResultToken)) {
                 this.#features.lsp.sendProgress(chatRequestType, partialResultToken, chatResult.data)
             }
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -24,6 +24,10 @@ export function isObject(value: unknown): value is { [key: number | string | sym
     return Boolean(value) && typeof value === 'object'
 }
 
+export function isNullish(value: unknown): value is null | undefined {
+    return value === null || value === undefined
+}
+
 export function getCompletionType(suggestion: Suggestion): CodewhispererCompletionType {
     const nonBlankLines = suggestion.content.split('\n').filter(line => line.trim() !== '').length
 


### PR DESCRIPTION
## Problem
The progress completion handler in VS always start the token as 0 then increment after each request. The very first request will not have partial result because 0 is falsey. 

## Solution
partialResultToken can be both numbers and strings, so it is reasonable to expect that 0 should work as a token. Requires https://github.com/aws/language-server-runtimes/pull/171  to work

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
