### PR TITLE
Add PartiQL files to VSCode dev extension activation

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -17,7 +17,8 @@
     "main": "./out/extension.js",
     "activationEvents": [
         "onLanguage:yaml",
-        "onLanguage:typescript"
+        "onLanguage:typescript",
+        "onLanguage:partiql"
     ],
     "contributes": {
         "commands": [
@@ -157,7 +158,19 @@
                     "description": "Traces the communication between VS Code and the language server."
                 }
             }
-        }
+        },
+        "languages": [
+            {
+                "id": "partiql",
+                "extensions": [
+                    ".pql"
+                ],
+                "aliases": [
+                    "PartiQL",
+                    "partiql"
+                ]
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -95,6 +95,9 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
             // java is illustrative of code-handling language servers
             { scheme: 'file', language: 'java' },
             { scheme: 'untitled', language: 'java' },
+            // partiql is illustrative of query-handling language servers
+            { scheme: 'file', pattern: '**/*.pql' },
+            { scheme: 'untitled', pattern: '**/*.pql' },
         ],
         initializationOptions: {},
         synchronize: {

--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -96,12 +96,12 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
             { scheme: 'file', language: 'java' },
             { scheme: 'untitled', language: 'java' },
             // partiql is illustrative of query-handling language servers
-            { scheme: 'file', pattern: '**/*.pql' },
-            { scheme: 'untitled', pattern: '**/*.pql' },
+            { scheme: 'file', language: 'partiql' },
+            { scheme: 'untitled', language: 'partiql' },
         ],
         initializationOptions: {},
         synchronize: {
-            fileEvents: workspace.createFileSystemWatcher('**/*.{json,java,yml,yaml,ts}'),
+            fileEvents: workspace.createFileSystemWatcher('**/*.{json,java,yml,yaml,ts,pql}'),
         },
     }
 


### PR DESCRIPTION
## Problem 

For testing the PartiQL LSP server, we now have to create files which have the wrong extension.

## Solution 

Add partiql language to the extension and activate when a PartiQL file is opened.


<img width="461" alt="Screenshot 2024-07-23 at 14 21 23" src="https://github.com/user-attachments/assets/191d59e4-1d77-46e1-8e22-81bdd56dce2f">

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
