### PR TITLE
Add triggerEmptySuggestionsRequest command to CodeWhisperer server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -556,6 +556,35 @@ export const CodewhispererServerFactory =
             lastUserModificationTime = new Date().getTime()
         })
 
+        const TriggerEmptySuggestionsRequestCommand = 'aws/codewhisperer/triggerEmptySuggestionsRequest'
+
+        lsp.onExecuteCommand(async (params, _token) => {
+            logging.log(`Trying to execute command: ${params.command}`)
+            if (params.command === TriggerEmptySuggestionsRequestCommand) {
+                return await codeWhispererService.generateSuggestions({
+                    fileContext: {
+                        leftFileContent: '',
+                        rightFileContent: '',
+                        filename: '',
+                        programmingLanguage: { languageName: 'typescript' },
+                    },
+                    maxResults: 1,
+                })
+            } else {
+                logging.log(`Unknown command: ${params.command}`)
+            }
+        })
+
+        lsp.addInitializer(() => {
+            return {
+                capabilities: {
+                    executeCommandProvider: {
+                        commands: [TriggerEmptySuggestionsRequestCommand],
+                    },
+                },
+            }
+        })
+
         logging.log('Amazon Q Inline Suggestion server has been initialised')
 
         return () => {


### PR DESCRIPTION
## Problem

CodeWhisperer API calls can fail depending on what permissions are associated with the credentials that are being used by the server/service.

It is useful for a client to have available a mechanism that behaves like a dry-run—in this case, an API call is performed using parameters that either are empty or produce no connection to the end-user.

For example, a destination using the server may wish to render different UIs based on whether the customer has permissions or not without that check implicating the customer in any relevant way—specifically, without having the customer data (e.g., file context) cross the AWS region boundary.

## Solution

Having the following considerations in mind:
- the server always has a copy of the customer's file contents due to file synchronization
- the destination has no current way to tell the server not to include these file contents in an API call
- this can be applicable to some language servers but not necessarily to the majority of them, and they're likely to have different nuances not simple to parameterise, so it's probably best to not make it a part of the protocol

The proposal in this pull request is to introduce a command that destinations can use to request the server to perform a request with no customer data. Destinations can then listen to telemetry events to detect permissions errors.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
