### PR TITLE
Increment @aws/lsp-partiql to 0.0.3

### DIFF
--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/lsp-partiql": "^0.0.2",
+        "@aws/lsp-partiql": "^0.0.3",
         "@aws/language-server-runtimes": "^0.2.5"
     },
     "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.5",
-                "@aws/lsp-partiql": "^0.0.2"
+                "@aws/lsp-partiql": "^0.0.3"
             },
             "devDependencies": {
                 "ts-loader": "^9.4.4",
@@ -18526,7 +18526,7 @@
         },
         "server/aws-lsp-partiql": {
             "name": "@aws/lsp-partiql",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.12",

--- a/server/aws-lsp-partiql/CHANGELOG.md
+++ b/server/aws-lsp-partiql/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## [0.0.3] - 2024-07-26
+- Features: Add syntax-highlighting, hover help and signature help support to this server
+
 ## [0.0.2] - 2024-06-18
 - Fix: don't report diagnostics for quoted identifiers
 
 ## [0.0.1] - 2024-05-31
-- Initial release of PArtiQL Language Server implementation
+- Initial release of PartiQL Language Server implementation

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -3,7 +3,7 @@
     "author": "Amazon Web Services",
     "license": "Apache-2.0",
     "description": "PartiQL language server",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/aws/language-servers"


### PR DESCRIPTION
## Problem
We need to bump a version of PartiQL server for release
## Solution

Version is bumped to 0.0.3

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
