### PR TITLE
Bump @aws/lsp-partiql to 0.0.3 in app package

### DIFF
--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/lsp-partiql": "^0.0.2",
+        "@aws/lsp-partiql": "^0.0.3",
         "@aws/language-server-runtimes": "^0.2.5"
     },
     "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,22 +85,13 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.5",
-                "@aws/lsp-partiql": "^0.0.2"
+                "@aws/lsp-partiql": "^0.0.3"
             },
             "devDependencies": {
                 "ts-loader": "^9.4.4",
                 "ts-lsp-client": "^1.0.3",
                 "webpack": "^5.88.2",
                 "webpack-cli": "^5.1.4"
-            }
-        },
-        "app/aws-lsp-partiql-runtimes/node_modules/@aws/lsp-partiql": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/@aws/lsp-partiql/-/lsp-partiql-0.0.2.tgz",
-            "integrity": "sha512-+Ep0az6ktQpCaGm53mYkX48wY6AgIdT2o9d/gD5rKio6hLp8ukV9Vd6auT2DwEKeMFp/qcSJTrUQpZvhTF6rMQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.4"
             }
         },
         "app/aws-lsp-s3-runtimes": {

--- a/server/aws-lsp-partiql/CHANGELOG.md
+++ b/server/aws-lsp-partiql/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.0.3] - 2024-07-31
+- Features: Add syntax-highlighting, keywords hovering, function signature help and auto-completion support to this server
+
 ## [0.0.2] - 2024-06-18
 - Fix: don't report diagnostics for quoted identifiers
 


### PR DESCRIPTION
## Problem
Releasing new @aws/lsp-partiql, version 0.0.3. In PR #407, only the server package has been upgraded.

## Solution
 Upgrade the version in app package accordingly. Also update the CHANGELOG.md for partiql server.

## License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
