### PR TITLE
Fixing issue with random source framework selection

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
@@ -39,7 +39,7 @@ function getKeyIndexOfVersion(key: any) {
     return targetFrameworkKeysArray.indexOf(key)
 }
 
-function findMinimumSourceVersion(projectMetadata: TransformProjectMetadata[], logging: Logging) {
+export function findMinimumSourceVersion(projectMetadata: TransformProjectMetadata[], logging: Logging) {
     var minimumVersionIndex = dummyVersionIndex
     projectMetadata.forEach(project => {
         if (project.ProjectTargetFramework != '' && targetFrameworkMap.has(project.ProjectTargetFramework)) {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
@@ -31,25 +31,31 @@ export const targetFrameworkMap = new Map<string, string>([
     ['net6.0', 'NET_6_0'],
     ['net7.0', 'NET_7_0'],
     ['net8.0', 'NET_8_0'],
-  ]);
-const dummyVersionIndex = 999;
+])
+const dummyVersionIndex = 999
 
-const targetFrameworkKeysArray = Array.from(targetFrameworkMap.keys());
-function getKeyIndexOfVersion( key: any) {
-  return targetFrameworkKeysArray.indexOf(key);
+const targetFrameworkKeysArray = Array.from(targetFrameworkMap.keys())
+function getKeyIndexOfVersion(key: any) {
+    return targetFrameworkKeysArray.indexOf(key)
 }
 
-function findMinimumSourceVersion(projectMetadata : TransformProjectMetadata[], logging: Logging){
-    var minimumVersionIndex = dummyVersionIndex;
+function findMinimumSourceVersion(projectMetadata: TransformProjectMetadata[], logging: Logging) {
+    var minimumVersionIndex = dummyVersionIndex
     projectMetadata.forEach(project => {
-        if(project.ProjectTargetFramework != '' && targetFrameworkMap.has(project.ProjectTargetFramework)){
-            logging.log("Project version to compare " + project.ProjectTargetFramework);
-                minimumVersionIndex = getKeyIndexOfVersion(project.ProjectTargetFramework) < minimumVersionIndex ?
-                 getKeyIndexOfVersion(project.ProjectTargetFramework) : minimumVersionIndex;
-        }});
-    var minimumDotNetVersion = minimumVersionIndex != dummyVersionIndex? targetFrameworkMap.get(targetFrameworkKeysArray[minimumVersionIndex]) : '';
-    logging.log("Selected lowest version is " + minimumDotNetVersion);
-    return minimumDotNetVersion;
+        if (project.ProjectTargetFramework != '' && targetFrameworkMap.has(project.ProjectTargetFramework)) {
+            logging.log('Project version to compare ' + project.ProjectTargetFramework)
+            minimumVersionIndex =
+                getKeyIndexOfVersion(project.ProjectTargetFramework) < minimumVersionIndex
+                    ? getKeyIndexOfVersion(project.ProjectTargetFramework)
+                    : minimumVersionIndex
+        }
+    })
+    var minimumDotNetVersion =
+        minimumVersionIndex != dummyVersionIndex
+            ? targetFrameworkMap.get(targetFrameworkKeysArray[minimumVersionIndex])
+            : ''
+    logging.log('Selected lowest version is ' + minimumDotNetVersion)
+    return minimumDotNetVersion
 }
 
 export function getCWStartTransformRequest(
@@ -57,8 +63,8 @@ export function getCWStartTransformRequest(
     uploadId: string,
     logging: Logging
 ): CodeWhispererTokenUserClient.StartTransformationRequest {
-    const sourceFramework = findMinimumSourceVersion(userInputRequest.ProjectMetadata, logging);
-    logging.log("Lowest sourceFramework for startTransform Request " + sourceFramework);
+    const sourceFramework = findMinimumSourceVersion(userInputRequest.ProjectMetadata, logging)
+    logging.log('Lowest sourceFramework for startTransform Request ' + sourceFramework)
     return {
         workspaceState: {
             uploadId: uploadId,

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
@@ -81,7 +81,11 @@ describe('Test Converter', () => {
             testUserInputRequest.ProgramLanguage = 'csharp'
             testUserInputRequest.ProjectMetadata[0].ProjectTargetFramework = 'net8.0'
 
-            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId, mockedLogging)
+            const startTransformationRequest = getCWStartTransformRequest(
+                testUserInputRequest,
+                testUploadId,
+                mockedLogging
+            )
 
             let expectedStartTransformationRequest = sampleStartTransformationRequest
             expectedStartTransformationRequest.workspaceState.uploadId = testUploadId
@@ -107,7 +111,11 @@ describe('Test Converter', () => {
             testUserInputRequest.ProgramLanguage = 'csharp'
             testUserInputRequest.ProjectMetadata[0].ProjectTargetFramework = 'not supported'
 
-            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId, mockedLogging)
+            const startTransformationRequest = getCWStartTransformRequest(
+                testUserInputRequest,
+                testUploadId,
+                mockedLogging
+            )
 
             let expectedStartTransformationRequest = sampleStartTransformationRequest
             expectedStartTransformationRequest.workspaceState.uploadId = testUploadId
@@ -129,7 +137,11 @@ describe('Test Converter', () => {
             testUserInputRequest.ProgramLanguage = 'csharp'
             testUserInputRequest.ProjectMetadata[0].ProjectTargetFramework = 'net8.0'
 
-            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId, mockedLogging)
+            const startTransformationRequest = getCWStartTransformRequest(
+                testUserInputRequest,
+                testUploadId,
+                mockedLogging
+            )
 
             let expectedStartTransformationRequest = sampleStartTransformationRequest
             expectedStartTransformationRequest.workspaceState.uploadId = testUploadId
@@ -199,163 +211,164 @@ describe('Test Converter', () => {
             })
         })
     })
-    
-    describe('findMinimumSourceVersion', () => {
 
+    describe('findMinimumSourceVersion', () => {
         it('should find the minimum .NET version from project metadata', () => {
-          const loggingMock = { log: sinon.spy() }; // Using Sinon for creating spies
-      
-          const projectMetadata: TransformProjectMetadata[] = [
-            {
-                ProjectTargetFramework: 'net6.0',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            },
-            {
-                ProjectTargetFramework: 'netcoreapp3.1',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            },
-            {
-                ProjectTargetFramework: '',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            }, 
-            {
-                ProjectTargetFramework: 'unknownFramework',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            }, 
-          ];
-      
-          const result = findMinimumSourceVersion(projectMetadata, loggingMock);
-      
-          expect(result).to.equal('NET_CORE_APP_3_1');
-      
-          expect(loggingMock.log.calledWith('Project version to compare net6.0')).to.be.true;
-          expect(loggingMock.log.calledWith('Project version to compare netcoreapp3.1')).to.be.true;
-          expect(loggingMock.log.calledWith('Selected lowest version is NET_CORE_APP_3_1')).to.be.true;
-        });
-      
+            const loggingMock = { log: sinon.spy() } // Using Sinon for creating spies
+
+            const projectMetadata: TransformProjectMetadata[] = [
+                {
+                    ProjectTargetFramework: 'net6.0',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'netcoreapp3.1',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: '',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'unknownFramework',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+            ]
+
+            const result = findMinimumSourceVersion(projectMetadata, loggingMock)
+
+            expect(result).to.equal('NET_CORE_APP_3_1')
+
+            expect(loggingMock.log.calledWith('Project version to compare net6.0')).to.be.true
+            expect(loggingMock.log.calledWith('Project version to compare netcoreapp3.1')).to.be.true
+            expect(loggingMock.log.calledWith('Selected lowest version is NET_CORE_APP_3_1')).to.be.true
+        })
+
         it('should return an empty string when no valid target frameworks are found', () => {
-          const loggingMock = { log: sinon.spy() };
-          const projectMetadata: TransformProjectMetadata[] = [
-            {
-                ProjectTargetFramework: '',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            },
-            {
-                ProjectTargetFramework: 'unknownFramework',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            },
-          ];
-      
-          const result = findMinimumSourceVersion(projectMetadata, loggingMock);
-      
-          expect(result).to.equal('');
-          expect(loggingMock.log.calledWith('Selected lowest version is ')).to.be.true;
-        });
-      
+            const loggingMock = { log: sinon.spy() }
+            const projectMetadata: TransformProjectMetadata[] = [
+                {
+                    ProjectTargetFramework: '',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'unknownFramework',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+            ]
+
+            const result = findMinimumSourceVersion(projectMetadata, loggingMock)
+
+            expect(result).to.equal('')
+            expect(loggingMock.log.calledWith('Selected lowest version is ')).to.be.true
+        })
+
         it('should handle multiple projects with the same minimum version', () => {
-          const loggingMock = { log: sinon.spy() };
-          const projectMetadata: TransformProjectMetadata[] = [
-            {
-                ProjectTargetFramework: 'netcoreapp3.1',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            },
-            {
-                ProjectTargetFramework: 'net461',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            },
-            {
-                ProjectTargetFramework: 'netcoreapp3.1',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            },
-          ];
-      
-          const result = findMinimumSourceVersion(projectMetadata, loggingMock);
-      
-          // Adjust the expectation based on your desired behavior
-          expect(result).to.equal('NET_CORE_APP_3_1'); 
-      
-          expect(loggingMock.log.calledWith('Project version to compare netcoreapp3.1')).to.be.true;
-          expect(loggingMock.log.calledWith('Project version to compare net461')).to.be.true;
-          expect(loggingMock.log.calledWith('Selected version is NET_CORE_APP_3_1')).to.be.true;
-        });
-      
+            const loggingMock = { log: sinon.spy() }
+            const projectMetadata: TransformProjectMetadata[] = [
+                {
+                    ProjectTargetFramework: 'netcoreapp3.1',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'net461',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'netcoreapp3.1',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+            ]
+
+            const result = findMinimumSourceVersion(projectMetadata, loggingMock)
+
+            // Adjust the expectation based on your desired behavior
+            expect(result).to.equal('NET_CORE_APP_3_1')
+
+            expect(loggingMock.log.calledWith('Project version to compare netcoreapp3.1')).to.be.true
+            expect(loggingMock.log.calledWith('Project version to compare net461')).to.be.true
+            expect(loggingMock.log.calledWith('Selected version is NET_CORE_APP_3_1')).to.be.true
+        })
+
         it('should prioritize .NET Core over .NET Framework for the same version number', () => {
-          const loggingMock = { log: sinon.spy() };
-          const projectMetadata: TransformProjectMetadata[] = [
-            {
-                ProjectTargetFramework: 'net472',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            },
-            {
-                ProjectTargetFramework: 'netcoreapp2.0',
-                Name: '',
-                ProjectPath: '',
-                SourceCodeFilePaths: [],
-                ProjectLanguage: '',
-                ProjectType: '',
-                ExternalReferences: []
-            },
-          ];
-      
-          const result = findMinimumSourceVersion(projectMetadata, loggingMock);
-      
-          expect(result).to.equal('NET_CORE_APP_2_0');
-        });
-      
+            const loggingMock = { log: sinon.spy() }
+            const projectMetadata: TransformProjectMetadata[] = [
+                {
+                    ProjectTargetFramework: 'net472',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'netcoreapp2.0',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+            ]
+
+            const result = findMinimumSourceVersion(projectMetadata, loggingMock)
+
+            expect(result).to.equal('NET_CORE_APP_2_0')
+        })
+
         // Add more test cases to cover other scenarios and edge cases
-      });
+    })
 })
-function findMinimumSourceVersion(projectMetadata: TransformProjectMetadata[], loggingMock: { log: sinon.SinonSpy<any[], any> }) {
+function findMinimumSourceVersion(
+    projectMetadata: TransformProjectMetadata[],
+    loggingMock: { log: sinon.SinonSpy<any[], any> }
+) {
     throw new Error('Function not implemented.')
 }
-

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
@@ -250,7 +250,7 @@ describe('Test Converter', () => {
       
           expect(loggingMock.log.calledWith('Project version to compare net6.0')).to.be.true;
           expect(loggingMock.log.calledWith('Project version to compare netcoreapp3.1')).to.be.true;
-          expect(loggingMock.log.calledWith('Selected version is NET_CORE_APP_3_1')).to.be.true;
+          expect(loggingMock.log.calledWith('Selected lowest version is NET_CORE_APP_3_1')).to.be.true;
         });
       
         it('should return an empty string when no valid target frameworks are found', () => {
@@ -279,7 +279,7 @@ describe('Test Converter', () => {
           const result = findMinimumSourceVersion(projectMetadata, loggingMock);
       
           expect(result).to.equal('');
-          expect(loggingMock.log.calledWith('Selected version is ')).to.be.true;
+          expect(loggingMock.log.calledWith('Selected lowest version is ')).to.be.true;
         });
       
         it('should handle multiple projects with the same minimum version', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
@@ -3,7 +3,12 @@ import { AWSError, HttpResponse } from 'aws-sdk'
 import { PromiseResult } from 'aws-sdk/lib/request'
 import { Response } from 'aws-sdk/lib/response'
 import { StartTransformRequest, TransformProjectMetadata } from '../models'
-import { getCWStartTransformRequest, getCWStartTransformResponse, targetFrameworkMap } from '../converter'
+import {
+    findMinimumSourceVersion,
+    getCWStartTransformRequest,
+    getCWStartTransformResponse,
+    targetFrameworkMap,
+} from '../converter'
 import CodeWhispererTokenUserClient = require('../../../client/token/codewhispererbearertokenclient')
 import { Logging } from '@aws/language-server-runtimes/server-interface'
 import { stubInterface } from 'ts-sinon'
@@ -327,48 +332,11 @@ describe('Test Converter', () => {
 
             const result = findMinimumSourceVersion(projectMetadata, loggingMock)
 
-            // Adjust the expectation based on your desired behavior
-            expect(result).to.equal('NET_CORE_APP_3_1')
+            expect(result).to.equal('NET_FRAMEWORK_V_4_6_1')
 
             expect(loggingMock.log.calledWith('Project version to compare netcoreapp3.1')).to.be.true
             expect(loggingMock.log.calledWith('Project version to compare net461')).to.be.true
-            expect(loggingMock.log.calledWith('Selected version is NET_CORE_APP_3_1')).to.be.true
+            expect(loggingMock.log.calledWith('Selected lowest version is NET_FRAMEWORK_V_4_6_1')).to.be.true
         })
-
-        it('should prioritize .NET Core over .NET Framework for the same version number', () => {
-            const loggingMock = { log: sinon.spy() }
-            const projectMetadata: TransformProjectMetadata[] = [
-                {
-                    ProjectTargetFramework: 'net472',
-                    Name: '',
-                    ProjectPath: '',
-                    SourceCodeFilePaths: [],
-                    ProjectLanguage: '',
-                    ProjectType: '',
-                    ExternalReferences: [],
-                },
-                {
-                    ProjectTargetFramework: 'netcoreapp2.0',
-                    Name: '',
-                    ProjectPath: '',
-                    SourceCodeFilePaths: [],
-                    ProjectLanguage: '',
-                    ProjectType: '',
-                    ExternalReferences: [],
-                },
-            ]
-
-            const result = findMinimumSourceVersion(projectMetadata, loggingMock)
-
-            expect(result).to.equal('NET_CORE_APP_2_0')
-        })
-
-        // Add more test cases to cover other scenarios and edge cases
     })
 })
-function findMinimumSourceVersion(
-    projectMetadata: TransformProjectMetadata[],
-    loggingMock: { log: sinon.SinonSpy<any[], any> }
-) {
-    throw new Error('Function not implemented.')
-}

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
@@ -2,10 +2,14 @@ import { expect } from 'chai'
 import { AWSError, HttpResponse } from 'aws-sdk'
 import { PromiseResult } from 'aws-sdk/lib/request'
 import { Response } from 'aws-sdk/lib/response'
-import { StartTransformRequest } from '../models'
+import { StartTransformRequest, TransformProjectMetadata } from '../models'
 import { getCWStartTransformRequest, getCWStartTransformResponse, targetFrameworkMap } from '../converter'
 import CodeWhispererTokenUserClient = require('../../../client/token/codewhispererbearertokenclient')
+import { Logging } from '@aws/language-server-runtimes/server-interface'
+import { stubInterface } from 'ts-sinon'
+import sinon = require('sinon')
 
+const mockedLogging = stubInterface<Logging>()
 const sampleStartTransformationRequest: CodeWhispererTokenUserClient.StartTransformationRequest = {
     workspaceState: {
         uploadId: '',
@@ -77,7 +81,7 @@ describe('Test Converter', () => {
             testUserInputRequest.ProgramLanguage = 'csharp'
             testUserInputRequest.ProjectMetadata[0].ProjectTargetFramework = 'net8.0'
 
-            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId)
+            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId, mockedLogging)
 
             let expectedStartTransformationRequest = sampleStartTransformationRequest
             expectedStartTransformationRequest.workspaceState.uploadId = testUploadId
@@ -103,7 +107,7 @@ describe('Test Converter', () => {
             testUserInputRequest.ProgramLanguage = 'csharp'
             testUserInputRequest.ProjectMetadata[0].ProjectTargetFramework = 'not supported'
 
-            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId)
+            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId, mockedLogging)
 
             let expectedStartTransformationRequest = sampleStartTransformationRequest
             expectedStartTransformationRequest.workspaceState.uploadId = testUploadId
@@ -125,7 +129,7 @@ describe('Test Converter', () => {
             testUserInputRequest.ProgramLanguage = 'csharp'
             testUserInputRequest.ProjectMetadata[0].ProjectTargetFramework = 'net8.0'
 
-            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId)
+            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId, mockedLogging)
 
             let expectedStartTransformationRequest = sampleStartTransformationRequest
             expectedStartTransformationRequest.workspaceState.uploadId = testUploadId
@@ -195,4 +199,163 @@ describe('Test Converter', () => {
             })
         })
     })
+    
+    describe('findMinimumSourceVersion', () => {
+
+        it('should find the minimum .NET version from project metadata', () => {
+          const loggingMock = { log: sinon.spy() }; // Using Sinon for creating spies
+      
+          const projectMetadata: TransformProjectMetadata[] = [
+            {
+                ProjectTargetFramework: 'net6.0',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            },
+            {
+                ProjectTargetFramework: 'netcoreapp3.1',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            },
+            {
+                ProjectTargetFramework: '',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            }, 
+            {
+                ProjectTargetFramework: 'unknownFramework',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            }, 
+          ];
+      
+          const result = findMinimumSourceVersion(projectMetadata, loggingMock);
+      
+          expect(result).to.equal('NET_CORE_APP_3_1');
+      
+          expect(loggingMock.log.calledWith('Project version to compare net6.0')).to.be.true;
+          expect(loggingMock.log.calledWith('Project version to compare netcoreapp3.1')).to.be.true;
+          expect(loggingMock.log.calledWith('Selected version is NET_CORE_APP_3_1')).to.be.true;
+        });
+      
+        it('should return an empty string when no valid target frameworks are found', () => {
+          const loggingMock = { log: sinon.spy() };
+          const projectMetadata: TransformProjectMetadata[] = [
+            {
+                ProjectTargetFramework: '',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            },
+            {
+                ProjectTargetFramework: 'unknownFramework',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            },
+          ];
+      
+          const result = findMinimumSourceVersion(projectMetadata, loggingMock);
+      
+          expect(result).to.equal('');
+          expect(loggingMock.log.calledWith('Selected version is ')).to.be.true;
+        });
+      
+        it('should handle multiple projects with the same minimum version', () => {
+          const loggingMock = { log: sinon.spy() };
+          const projectMetadata: TransformProjectMetadata[] = [
+            {
+                ProjectTargetFramework: 'netcoreapp3.1',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            },
+            {
+                ProjectTargetFramework: 'net461',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            },
+            {
+                ProjectTargetFramework: 'netcoreapp3.1',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            },
+          ];
+      
+          const result = findMinimumSourceVersion(projectMetadata, loggingMock);
+      
+          // Adjust the expectation based on your desired behavior
+          expect(result).to.equal('NET_CORE_APP_3_1'); 
+      
+          expect(loggingMock.log.calledWith('Project version to compare netcoreapp3.1')).to.be.true;
+          expect(loggingMock.log.calledWith('Project version to compare net461')).to.be.true;
+          expect(loggingMock.log.calledWith('Selected version is NET_CORE_APP_3_1')).to.be.true;
+        });
+      
+        it('should prioritize .NET Core over .NET Framework for the same version number', () => {
+          const loggingMock = { log: sinon.spy() };
+          const projectMetadata: TransformProjectMetadata[] = [
+            {
+                ProjectTargetFramework: 'net472',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            },
+            {
+                ProjectTargetFramework: 'netcoreapp2.0',
+                Name: '',
+                ProjectPath: '',
+                SourceCodeFilePaths: [],
+                ProjectLanguage: '',
+                ProjectType: '',
+                ExternalReferences: []
+            },
+          ];
+      
+          const result = findMinimumSourceVersion(projectMetadata, loggingMock);
+      
+          expect(result).to.equal('NET_CORE_APP_2_0');
+        });
+      
+        // Add more test cases to cover other scenarios and edge cases
+      });
 })
+function findMinimumSourceVersion(projectMetadata: TransformProjectMetadata[], loggingMock: { log: sinon.SinonSpy<any[], any> }) {
+    throw new Error('Function not implemented.')
+}
+

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -73,7 +73,7 @@ export class TransformHandler {
             this.logging.log('payload path: ' + payloadFilePath)
 
             const uploadId = await this.preTransformationUploadCode(payloadFilePath)
-            const request = getCWStartTransformRequest(userInputrequest, uploadId)
+            const request = getCWStartTransformRequest(userInputrequest, uploadId, this.logging)
             this.logging.log('send request to start transform api: ' + JSON.stringify(request))
             const response = await this.client.codeModernizerStartCodeTransformation(request)
             this.logging.log('response start transform api: ' + JSON.stringify(response))


### PR DESCRIPTION
## Problem
When multiple projects/ solution is selected with multiple projects, source framework for project is randomly selected. This causes .net8 projects to be selected to transform and backend will reject this request because that project is already transformed

## Solution
Added logic to get minimum version of dot net and set it as source framework

## Significance of source framework here
only for cwspr API


- [ ✔] Pull request title describes the changes without ambiguity
- [ ✔] Added screenshots of visual/UI changes 
- [ ✔] Added Unit test coverage
- [ ✔] Removed all developer references (internal URLs, etc)
- [ ✔] Removed unused code, comments, references, namespaces
- [ ✔] Used constants/readonly where needed
- [ ✔] Used appropriate data structures
- [ ✔] Used consistent naming convention
- [ ✔] Used predefined Toolkit themes for UI elements
- [ ✔] Used appropriate method and property access levels (private vs public)
- [ ✔] Avoided global and singleton references where possible
- [ ✔] Enforced DRY principles (Do not Repeat Yourself)
- [ ✔] All TODOs have an internal tracking reference ID (e.g. SIM ID)
- [ ✔] Resolved merge conflicts with destination branch
- [ ] Reviewed by Huawen
- [x] Optional: Reviewed by Pranav, Sunwoo, Ke, Jiayu