### PR TITLE
Fixing issue with random source framework selection

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
@@ -1,47 +1,71 @@
 import { AWSError } from 'aws-sdk'
 import { PromiseResult } from 'aws-sdk/lib/request'
-import { StartTransformRequest, StartTransformResponse } from './models'
+import { StartTransformRequest, StartTransformResponse, TransformProjectMetadata } from './models'
 import CodeWhispererTokenUserClient = require('../../client/token/codewhispererbearertokenclient')
+import { Logging } from '@aws/language-server-runtimes/server-interface'
 
+//sequence of targetFrameworkMap matters a lot because we are using as sorted indices of old to new .net versions
 export const targetFrameworkMap = new Map<string, string>([
-    ['net8.0', 'NET_8_0'],
-    ['net7.0', 'NET_7_0'],
-    ['net6.0', 'NET_6_0'],
-    ['net5.0', 'NET_5_0'],
-    ['netcoreapp3.1', 'NET_CORE_APP_3_1'],
-    ['netcoreapp3.0', 'NET_CORE_APP_3_0'],
-    ['netcoreapp2.2', 'NET_CORE_APP_2_2'],
-    ['netcoreapp2.1', 'NET_CORE_APP_2_1'],
-    ['netcoreapp2.0', 'NET_CORE_APP_2_0'],
-    ['netcoreapp1.1', 'NET_CORE_APP_1_1'],
-    ['netcoreapp1.0', 'NET_CORE_APP_1_0'],
-    ['net481', 'NET_FRAMEWORK_V_4_8'],
-    ['net48', 'NET_FRAMEWORK_V_4_8'],
-    ['net472', 'NET_FRAMEWORK_V_4_7_2'],
-    ['net471', 'NET_FRAMEWORK_V_4_7_1'],
-    ['net47', 'NET_FRAMEWORK_V_4_7'],
-    ['net462', 'NET_FRAMEWORK_V_4_6_2'],
-    ['net461', 'NET_FRAMEWORK_V_4_6_1'],
-    ['net46', 'NET_FRAMEWORK_V_4_6'],
-    ['net452', 'NET_FRAMEWORK_V_4_5_2'],
-    ['net451', 'NET_FRAMEWORK_V_4_5_1'],
-    ['net45', 'NET_FRAMEWORK_V_4_5'],
-    ['net403', 'NET_FRAMEWORK_V_4_0'],
-    ['net40', 'NET_FRAMEWORK_V_4_0'],
     ['net35', 'NET_FRAMEWORK_V_3_5'],
+    ['net40', 'NET_FRAMEWORK_V_4_0'],
+    ['net403', 'NET_FRAMEWORK_V_4_0'],
+    ['net45', 'NET_FRAMEWORK_V_4_5'],
+    ['net451', 'NET_FRAMEWORK_V_4_5_1'],
+    ['net452', 'NET_FRAMEWORK_V_4_5_2'],
+    ['net46', 'NET_FRAMEWORK_V_4_6'],
+    ['net461', 'NET_FRAMEWORK_V_4_6_1'],
+    ['net462', 'NET_FRAMEWORK_V_4_6_2'],
+    ['net47', 'NET_FRAMEWORK_V_4_7'],
+    ['net471', 'NET_FRAMEWORK_V_4_7_1'],
+    ['net472', 'NET_FRAMEWORK_V_4_7_2'],
+    ['net48', 'NET_FRAMEWORK_V_4_8'],
+    ['net481', 'NET_FRAMEWORK_V_4_8'],
+    ['netcoreapp1.0', 'NET_CORE_APP_1_0'],
+    ['netcoreapp1.1', 'NET_CORE_APP_1_1'],
+    ['netcoreapp2.0', 'NET_CORE_APP_2_0'],
+    ['netcoreapp2.1', 'NET_CORE_APP_2_1'],
+    ['netcoreapp2.2', 'NET_CORE_APP_2_2'],
+    ['netcoreapp3.0', 'NET_CORE_APP_3_0'],
+    ['netcoreapp3.1', 'NET_CORE_APP_3_1'],
+    ['net5.0', 'NET_5_0'],
+    ['net6.0', 'NET_6_0'],
+    ['net7.0', 'NET_7_0'],
+    ['net8.0', 'NET_8_0'],
 ])
+
+const dummyVersionIndex = 999
+
+const targetFrameworkKeysArray = Array.from(targetFrameworkMap.keys())
+function getKeyIndexOfVersion(key: any) {
+    return targetFrameworkKeysArray.indexOf(key)
+}
+
+export function findMinimumSourceVersion(projectMetadata: TransformProjectMetadata[], logging: Logging) {
+    var minimumVersionIndex = dummyVersionIndex
+    projectMetadata.forEach(project => {
+        if (project.ProjectTargetFramework != '' && targetFrameworkMap.has(project.ProjectTargetFramework)) {
+            logging.log('Project version to compare ' + project.ProjectTargetFramework)
+            minimumVersionIndex =
+                getKeyIndexOfVersion(project.ProjectTargetFramework) < minimumVersionIndex
+                    ? getKeyIndexOfVersion(project.ProjectTargetFramework)
+                    : minimumVersionIndex
+        }
+    })
+    var minimumDotNetVersion =
+        minimumVersionIndex != dummyVersionIndex
+            ? targetFrameworkMap.get(targetFrameworkKeysArray[minimumVersionIndex])
+            : ''
+    logging.log('Selected lowest version is ' + minimumDotNetVersion)
+    return minimumDotNetVersion
+}
 
 export function getCWStartTransformRequest(
     userInputRequest: StartTransformRequest,
-    uploadId: string
+    uploadId: string,
+    logging: Logging
 ): CodeWhispererTokenUserClient.StartTransformationRequest {
-    const targetProject = userInputRequest.ProjectMetadata.find(project => project.ProjectTargetFramework != '')
-    const sourceFramework =
-        targetProject == undefined
-            ? ''
-            : targetFrameworkMap.has(targetProject.ProjectTargetFramework)
-              ? targetFrameworkMap.get(targetProject.ProjectTargetFramework)
-              : ''
+    const sourceFramework = findMinimumSourceVersion(userInputRequest.ProjectMetadata, logging)
+    logging.log('Lowest sourceFramework for startTransform Request ' + sourceFramework)
     return {
         workspaceState: {
             uploadId: uploadId,

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
@@ -2,10 +2,14 @@ import { expect } from 'chai'
 import { AWSError, HttpResponse } from 'aws-sdk'
 import { PromiseResult } from 'aws-sdk/lib/request'
 import { Response } from 'aws-sdk/lib/response'
-import { StartTransformRequest } from '../models'
-import { getCWStartTransformRequest, getCWStartTransformResponse, targetFrameworkMap } from '../converter'
+import { StartTransformRequest, TransformProjectMetadata } from '../models'
+import { findMinimumSourceVersion, getCWStartTransformRequest, getCWStartTransformResponse, targetFrameworkMap } from '../converter'
 import CodeWhispererTokenUserClient = require('../../../client/token/codewhispererbearertokenclient')
+import { Logging } from '@aws/language-server-runtimes/server-interface'
+import { stubInterface } from 'ts-sinon'
+import sinon = require('sinon')
 
+const mockedLogging = stubInterface<Logging>()
 const sampleStartTransformationRequest: CodeWhispererTokenUserClient.StartTransformationRequest = {
     workspaceState: {
         uploadId: '',
@@ -77,7 +81,7 @@ describe('Test Converter', () => {
             testUserInputRequest.ProgramLanguage = 'csharp'
             testUserInputRequest.ProjectMetadata[0].ProjectTargetFramework = 'net8.0'
 
-            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId)
+            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId, mockedLogging)
 
             let expectedStartTransformationRequest = sampleStartTransformationRequest
             expectedStartTransformationRequest.workspaceState.uploadId = testUploadId
@@ -103,7 +107,7 @@ describe('Test Converter', () => {
             testUserInputRequest.ProgramLanguage = 'csharp'
             testUserInputRequest.ProjectMetadata[0].ProjectTargetFramework = 'not supported'
 
-            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId)
+            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId, mockedLogging)
 
             let expectedStartTransformationRequest = sampleStartTransformationRequest
             expectedStartTransformationRequest.workspaceState.uploadId = testUploadId
@@ -125,7 +129,7 @@ describe('Test Converter', () => {
             testUserInputRequest.ProgramLanguage = 'csharp'
             testUserInputRequest.ProjectMetadata[0].ProjectTargetFramework = 'net8.0'
 
-            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId)
+            const startTransformationRequest = getCWStartTransformRequest(testUserInputRequest, testUploadId, mockedLogging)
 
             let expectedStartTransformationRequest = sampleStartTransformationRequest
             expectedStartTransformationRequest.workspaceState.uploadId = testUploadId
@@ -193,6 +197,129 @@ describe('Test Converter', () => {
                 UnSupportedProjects: unsupportedProjects,
                 ContainsUnsupportedViews: containsUnsupportedViews,
             })
+        })
+    })
+
+    describe('findMinimumSourceVersion', () => {
+        it('should find the minimum .NET version from project metadata', () => {
+            const loggingMock = { log: sinon.spy() } // Using Sinon for creating spies
+
+            const projectMetadata: TransformProjectMetadata[] = [
+                {
+                    ProjectTargetFramework: 'net6.0',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'netcoreapp3.1',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: '',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'unknownFramework',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+            ]
+
+            const result = findMinimumSourceVersion(projectMetadata, loggingMock)
+
+            expect(result).to.equal('NET_CORE_APP_3_1')
+
+            expect(loggingMock.log.calledWith('Project version to compare net6.0')).to.be.true
+            expect(loggingMock.log.calledWith('Project version to compare netcoreapp3.1')).to.be.true
+            expect(loggingMock.log.calledWith('Selected lowest version is NET_CORE_APP_3_1')).to.be.true
+        })
+
+        it('should return an empty string when no valid target frameworks are found', () => {
+            const loggingMock = { log: sinon.spy() }
+            const projectMetadata: TransformProjectMetadata[] = [
+                {
+                    ProjectTargetFramework: '',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'unknownFramework',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+            ]
+
+            const result = findMinimumSourceVersion(projectMetadata, loggingMock)
+
+            expect(result).to.equal('')
+            expect(loggingMock.log.calledWith('Selected lowest version is ')).to.be.true
+        })
+
+        it('should handle multiple projects with the same minimum version', () => {
+            const loggingMock = { log: sinon.spy() }
+            const projectMetadata: TransformProjectMetadata[] = [
+                {
+                    ProjectTargetFramework: 'netcoreapp3.1',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'net461',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+                {
+                    ProjectTargetFramework: 'netcoreapp3.1',
+                    Name: '',
+                    ProjectPath: '',
+                    SourceCodeFilePaths: [],
+                    ProjectLanguage: '',
+                    ProjectType: '',
+                    ExternalReferences: [],
+                },
+            ]
+
+            const result = findMinimumSourceVersion(projectMetadata, loggingMock)
+
+            expect(result).to.equal('NET_FRAMEWORK_V_4_6_1')
+
+            expect(loggingMock.log.calledWith('Project version to compare netcoreapp3.1')).to.be.true
+            expect(loggingMock.log.calledWith('Project version to compare net461')).to.be.true
+            expect(loggingMock.log.calledWith('Selected lowest version is NET_FRAMEWORK_V_4_6_1')).to.be.true
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -73,7 +73,7 @@ export class TransformHandler {
             this.logging.log('payload path: ' + payloadFilePath)
 
             const uploadId = await this.preTransformationUploadCode(payloadFilePath)
-            const request = getCWStartTransformRequest(userInputrequest, uploadId)
+            const request = getCWStartTransformRequest(userInputrequest, uploadId, this.logging)
             this.logging.log('send request to start transform api: ' + JSON.stringify(request))
             const response = await this.client.codeModernizerStartCodeTransformation(request)
             this.logging.log('response start transform api: ' + JSON.stringify(response))


### PR DESCRIPTION
Please refer https://github.com/aws/language-servers/pull/416
below code change is exact same only against main branch

## Problem
When multiple projects/ solution is selected with multiple projects, source framework for project is randomly selected. This causes .net8 projects to be selected to transform and backend will reject this request because that project is already transformed

## Solution
Added logic to get minimum version of dot net and set it as source framework

## Significance of source framework here
only for cwspr API


- [ ✔] Pull request title describes the changes without ambiguity
- [ ✔] Added screenshots of visual/UI changes 
- [ ✔] Added Unit test coverage
- [ ✔] Removed all developer references (internal URLs, etc)
- [ ✔] Removed unused code, comments, references, namespaces
- [ ✔] Used constants/readonly where needed
- [ ✔] Used appropriate data structures
- [ ✔] Used consistent naming convention
- [ ✔] Used predefined Toolkit themes for UI elements
- [ ✔] Used appropriate method and property access levels (private vs public)
- [ ✔] Avoided global and singleton references where possible
- [ ✔] Enforced DRY principles (Do not Repeat Yourself)
- [ ✔] All TODOs have an internal tracking reference ID (e.g. SIM ID)
- [ ✔] Resolved merge conflicts with destination branch
- [ ] Reviewed by Huawen
- [x] Optional: Reviewed by Pranav, Sunwoo, Ke, Jiayu