### PR TITLE
Implement sample device auth SSO flow in LSP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -277,6 +277,10 @@
             "resolved": "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming",
             "link": true
         },
+        "node_modules/@amzn/device-sso-auth-lsp": {
+            "resolved": "server/device-sso-auth-lsp",
+            "link": true
+        },
         "node_modules/@aws-crypto/crc32": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
@@ -1464,9 +1468,9 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.12.tgz",
-            "integrity": "sha512-rFJjOVii/HveixknmJhYzU0eDU+NI016VYzASJjqnoYSpCZJ1SRmiD1vixNKU0hiGTDpUKrFId9h0a8+SDwNfw==",
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.13.tgz",
+            "integrity": "sha512-ltBOEFCffRLJbaDDXe0UvOYl8mCR5Lru/kY0hEYHZrqp5Dpo8dhLTNfwd6+Cj9vAfbVxmGllwbn5+0CrqFF8WQ==",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.6",
                 "jose": "^5.6.3",
@@ -16514,6 +16518,17 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "server/device-sso-auth-lsp": {
+            "name": "@amzn/device-sso-auth-lsp",
+            "version": "0.0.1",
+            "dependencies": {
+                "@aws/language-server-runtimes": "^0.2.6",
+                "vscode-languageserver": "^9.0.1"
+            },
+            "devDependencies": {
+                "ts-loader": "^9.4.4"
             }
         },
         "server/hello-world-lsp": {

--- a/server/device-sso-auth-lsp/README.md
+++ b/server/device-sso-auth-lsp/README.md
@@ -1,0 +1,49 @@
+# Device Auth Language Server
+
+This is an example implementation of Device authentication SSO flow for AWS Language Servers project.
+
+It is port of [SSO flow implementation in VSCode sample client](../../client/vscode/src/sso/builderId.ts), but as LSP server.
+
+[`SsoAuthServer`](./src/language-server/SsoAuthServer.ts) Server implementation is the entry point for this Server. 
+
+Supports only [`standalone`]() AWS Server Runtime, as it requires NodeJS `fs` access.
+
+## Supported features
+
+### Custom commands
+
+Commands sent from client to server using [workspace/executeCommand](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand) LSP capability.
+
+### ssoAuth/authDevice/getToken command
+
+When this command is invoked, it will initiate SSO Device Authentication flow using provided Identity Provider URL. Server prompts Client to display message when called.
+
+When device is authenticated and bearer token is resolved, token will be cached on the filesystem.
+
+Cached token data will be used in subsequent calls to refresh token, instead of invoking the flow again.
+
+Params: 
+```typescript
+{
+    /**
+     * Command identifier
+     */
+    command: "ssoAuth/authDevice/getToken",
+    arguments?: {
+        /**
+         * Identity provide URL for authentication. Defaults to 'https://view.awsapps.com/start', if not set.
+         */
+       startUrl?: string
+    }
+}
+```
+
+Response: 
+```typescript
+{
+    /**
+     * Bearer token resolved after SSO flow completed.
+     */
+    token: string
+}
+```

--- a/server/device-sso-auth-lsp/README.md
+++ b/server/device-sso-auth-lsp/README.md
@@ -6,7 +6,7 @@ It is port of [SSO flow implementation in VSCode sample client](../../client/vsc
 
 [`SsoAuthServer`](./src/language-server/SsoAuthServer.ts) Server implementation is the entry point for this Server. 
 
-Supports only [`standalone`]() AWS Server Runtime, as it requires NodeJS `fs` access.
+Supports only [`standalone`](https://github.com/aws/language-server-runtimes/blob/main/runtimes/runtimes/standalone.ts) AWS Server Runtime, as it requires NodeJS `fs` access.
 
 ## Supported features
 

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@amzn/device-sso-auth-lsp",
+    "version": "0.0.1",
+    "description": "Device SSO Authentication flow over LSP Server",
+    "main": "out/index.js",
+    "scripts": {
+        "compile": "tsc --build"
+    },
+    "dependencies": {
+        "@aws/language-server-runtimes": "^0.2.6",
+        "vscode-languageserver": "^9.0.1"
+    },
+    "devDependencies": {
+        "ts-loader": "^9.4.4"
+    }
+}

--- a/server/device-sso-auth-lsp/src/index.ts
+++ b/server/device-sso-auth-lsp/src/index.ts
@@ -1,0 +1,1 @@
+export { SsoAuthServer } from './language-server/SsoAuthServer'

--- a/server/device-sso-auth-lsp/src/language-server/SsoAuthServer.ts
+++ b/server/device-sso-auth-lsp/src/language-server/SsoAuthServer.ts
@@ -1,0 +1,90 @@
+import {
+    CredentialsProvider,
+    Logging,
+    Lsp,
+    MessageType,
+    Server,
+    Telemetry,
+    Workspace,
+} from '@aws/language-server-runtimes/server-interface'
+import { CancellationToken, ExecuteCommandParams } from 'vscode-languageserver/node'
+import { BuilderIdConnectionBuilder, SsoConnection } from './sso/builderId'
+
+const AUTH_DEVICE_COMMAND = 'ssoAuth/authDevice/getToken'
+
+export const SsoAuthServer: Server = (features: {
+    credentialsProvider: CredentialsProvider
+    lsp: Lsp
+    workspace: Workspace
+    logging: Logging
+    telemetry: Telemetry
+}) => {
+    const { lsp, logging } = features
+    let activeBuilderIdConnection: SsoConnection | undefined
+
+    const onInitializedHandler = async () => {}
+
+    const resolveBearerToken = async (startUrl: string) => {
+        activeBuilderIdConnection = await BuilderIdConnectionBuilder.build(
+            {
+                openSsoPortalLink: async (
+                    startUrl: string,
+                    authorization: { readonly verificationUri: string; readonly userCode: string }
+                ) => {
+                    logging.log(`SSO Auth flow for ${startUrl}`)
+                    logging.log(
+                        `To proceed, open the login page ${authorization.verificationUri} and provide this code to confirm the access request: ${authorization.userCode}`
+                    )
+
+                    lsp.window.showMessage({
+                        type: MessageType.Info,
+                        message: `To proceed, open the login page ${authorization.verificationUri} and provide this code to confirm the access request: ${authorization.userCode}`,
+                    })
+
+                    return true
+                },
+            },
+            startUrl
+        )
+
+        const token = await activeBuilderIdConnection.getToken()
+
+        logging.log('Resolved SSO token ' + JSON.stringify(token))
+
+        return {
+            token: token.accessToken,
+        }
+    }
+
+    const onExecuteCommandHandler = async (params: ExecuteCommandParams, _token: CancellationToken): Promise<any> => {
+        switch (params.command) {
+            case AUTH_DEVICE_COMMAND:
+                logging.log('Auth Device command called')
+
+                // @ts-ignore
+                return await resolveBearerToken(params.arguments?.startUrl)
+        }
+        return
+    }
+
+    lsp.addInitializer(() => {
+        logging.log('SSO Auth capability has been initialised')
+
+        return {
+            capabilities: {
+                executeCommandProvider: {
+                    commands: [AUTH_DEVICE_COMMAND],
+                },
+            },
+        }
+    })
+    lsp.onInitialized(onInitializedHandler)
+    lsp.onExecuteCommand(onExecuteCommandHandler)
+
+    logging.log('SSO Auth capability server has been initialised')
+
+    // disposable
+    return () => {
+        // Do nothing
+    }
+}

--- a/server/device-sso-auth-lsp/src/language-server/sso/builderId.ts
+++ b/server/device-sso-auth-lsp/src/language-server/sso/builderId.ts
@@ -1,0 +1,413 @@
+import {
+    AuthorizationPendingException,
+    CreateTokenRequest,
+    RegisterClientRequest,
+    SSOOIDC,
+    SlowDownException,
+    StartDeviceAuthorizationRequest,
+} from '@aws-sdk/client-sso-oidc'
+import { randomUUID } from 'crypto'
+import { RequiredProps, assertHasProps, hasProps, hasStringProps, selectFrom } from '../tsUtils'
+import { SsoProfile as BaseSsoProfile, ClientRegistration, SsoToken, isExpired } from './model'
+
+import * as fs from 'fs'
+import * as path from 'path'
+const TOKEN_CACHE_DIR = path.join(__dirname, '.cache')
+
+// For the Proof of concept, this file's code was copied (and culled) from the AWS Toolkit for VS Code repo
+// https://github.com/aws/aws-toolkit-vscode/blob/5d621c8405a8b20ffe571ad0ba10ae700178e051/src/auth/auth.ts
+// https://github.com/aws/aws-toolkit-vscode/blob/5d621c8405a8b20ffe571ad0ba10ae700178e051/src/auth/connection.ts
+// https://github.com/aws/aws-toolkit-vscode/blob/5d621c8405a8b20ffe571ad0ba10ae700178e051/src/auth/sso/cache.ts
+// https://github.com/aws/aws-toolkit-vscode/blob/5d621c8405a8b20ffe571ad0ba10ae700178e051/src/auth/sso/clients.ts
+// https://github.com/aws/aws-toolkit-vscode/blob/5d621c8405a8b20ffe571ad0ba10ae700178e051/src/auth/sso/ssoAccessTokenProvider.ts
+
+export interface SsoAccess {
+    readonly token: SsoToken
+    readonly region: string
+    readonly startUrl: string
+    readonly registration?: ClientRegistration
+}
+
+export const builderIdStartUrl = 'https://view.awsapps.com/start'
+export const ssoAccountAccessScopes = ['sso:account:access']
+export const codewhispererScopes = [
+    'codewhisperer:completions',
+    'codewhisperer:analysis',
+    'codewhisperer:conversations',
+]
+export const defaultSsoRegion = 'us-east-1'
+const defaultScopes = [...ssoAccountAccessScopes, ...codewhispererScopes]
+const clientRegistrationType = 'public'
+const deviceGrantType = 'urn:ietf:params:oauth:grant-type:device_code'
+const refreshGrantType = 'refresh_token'
+
+export function sleep(duration: number = 0): Promise<void> {
+    return new Promise(r => setTimeout(r, Math.max(duration, 0)))
+}
+
+function keyedDebounce<T, U extends any[], K extends string = string>(
+    fn: (key: K, ...args: U) => Promise<T>
+): typeof fn {
+    const pending = new Map<K, Promise<T>>()
+
+    return (key, ...args) => {
+        if (pending.has(key)) {
+            return pending.get(key)!
+        }
+
+        const promise = fn(key, ...args).finally(() => pending.delete(key))
+        pending.set(key, promise)
+
+        return promise
+    }
+}
+
+const backoffDelayMs = 5000
+async function pollForTokenWithProgress<T>(
+    fn: () => Promise<T>,
+    authorization: Awaited<ReturnType<OidcClient['startDeviceAuthorization']>>,
+    interval = authorization.interval ?? backoffDelayMs
+) {
+    async function poll() {
+        while (authorization.expiresAt.getTime() - Date.now() > interval) {
+            try {
+                return await fn()
+            } catch (err) {
+                if (!hasStringProps(err, 'name')) {
+                    throw err
+                }
+
+                if (err instanceof SlowDownException) {
+                    interval += backoffDelayMs
+                } else if (!(err instanceof AuthorizationPendingException)) {
+                    throw err
+                }
+            }
+
+            await sleep(interval)
+        }
+
+        throw new Error('Timed-out waiting for browser login flow to complete')
+    }
+
+    return await poll()
+}
+
+export interface SsoProfile extends BaseSsoProfile {
+    readonly ssoRegion: string
+}
+
+export interface SsoConnection extends SsoProfile {
+    readonly id: string
+
+    /**
+     * Retrieves a bearer token, refreshing or re-authenticating as-needed.
+     *
+     * This should be called for each new API request sent. It is up to the caller to
+     * handle cases where the service rejects the token.
+     */
+    getToken(): Promise<Pick<SsoToken, 'accessToken' | 'expiresAt'>>
+}
+
+export class OidcClient {
+    public constructor(
+        private readonly client: SSOOIDC,
+        private readonly clock: { Date: typeof Date }
+    ) {}
+
+    public async registerClient(request: RegisterClientRequest) {
+        const response = await this.client.registerClient(request)
+        assertHasProps(response, 'clientId', 'clientSecret', 'clientSecretExpiresAt')
+
+        return {
+            scopes: request.scopes,
+            clientId: response.clientId,
+            clientSecret: response.clientSecret,
+            expiresAt: new this.clock.Date(response.clientSecretExpiresAt * 1000),
+        }
+    }
+
+    public async startDeviceAuthorization(request: StartDeviceAuthorizationRequest) {
+        const response = await this.client.startDeviceAuthorization(request)
+        assertHasProps(response, 'expiresIn', 'deviceCode', 'userCode', 'verificationUri')
+
+        return {
+            deviceCode: response.deviceCode,
+            userCode: response.userCode,
+            verificationUri: response.verificationUri,
+            expiresAt: new this.clock.Date(response.expiresIn * 1000 + this.clock.Date.now()),
+            interval: response.interval ? response.interval * 1000 : undefined,
+        }
+    }
+
+    public async createToken(request: CreateTokenRequest) {
+        const response = await this.client.createToken(request as CreateTokenRequest)
+        assertHasProps(response, 'accessToken', 'expiresIn')
+
+        return {
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken,
+            tokenType: response.tokenType,
+            expiresAt: new this.clock.Date(response.expiresIn * 1000 + this.clock.Date.now()),
+        }
+    }
+
+    public static create(region: string) {
+        const client = new SSOOIDC({
+            region,
+            // TODO : I don't know if we have to set endpoint for the PoC
+            // endpoint: foo
+        })
+
+        return new this(client, { Date })
+    }
+}
+
+/**
+ *  SSO flow (RFC: https://tools.ietf.org/html/rfc8628)
+ *    1. Get a client id (SSO-OIDC identifier, formatted per RFC6749).
+ *       - Toolkit code: {@link SsoAccessTokenProvider.registerClient}
+ *          - Calls {@link OidcClient.registerClient}
+ *       - RETURNS:
+ *         - ClientSecret
+ *         - ClientId
+ *         - ClientSecretExpiresAt
+ *       - Client registration is valid for potentially months and creates state
+ *         server-side, so the client SHOULD cache them to disk.
+ *    2. Start device authorization.
+ *       - Toolkit code: {@link SsoAccessTokenProvider.authorize}
+ *          - Calls {@link OidcClient.startDeviceAuthorization}
+ *       - RETURNS (RFC: https://tools.ietf.org/html/rfc8628#section-3.2):
+ *         - DeviceCode             : Device verification code
+ *         - UserCode               : User verification code
+ *         - VerificationUri        : User verification URI on the authorization server
+ *         - VerificationUriComplete: User verification URI including the `user_code`
+ *         - ExpiresIn              : Lifetime (seconds) of `device_code` and `user_code`
+ *         - Interval               : Minimum time (seconds) the client SHOULD wait between polling intervals.
+ *    3. Poll for the access token.
+ *       - Toolkit code: {@link SsoAccessTokenProvider.authorize}
+ *          - Calls {@link OidcClient.pollForToken}
+ *       - RETURNS:
+ *         - AccessToken
+ *         - ExpiresIn
+ *         - RefreshToken (optional)
+ *    4. (Repeat) Tokens SHOULD be refreshed if expired and a refresh token is available.
+ *        - Toolkit code: {@link SsoAccessTokenProvider.refreshToken}
+ *          - Calls {@link OidcClient.createToken}
+ *        - RETURNS:
+ *         - AccessToken
+ *         - ExpiresIn
+ *         - RefreshToken (optional)
+ */
+export class SsoAccessTokenProvider {
+    private readonly TOKEN_CACHE_FILE = path.join(TOKEN_CACHE_DIR, 'token.json')
+    private readonly REGISTRATION_CACHE_FILE = path.join(TOKEN_CACHE_DIR, 'registration.json')
+
+    public constructor(
+        private readonly profile: Pick<SsoProfile, 'startUrl' | 'region' | 'scopes' | 'identifier'>,
+        private readonly uiHandler: UiHandler | undefined = undefined,
+        private readonly oidc = OidcClient.create(profile.region)
+    ) {}
+
+    public async invalidate(): Promise<void> {
+        await fs.promises.unlink(this.TOKEN_CACHE_FILE)
+        await fs.promises.unlink(this.REGISTRATION_CACHE_FILE)
+    }
+
+    public async getToken(): Promise<SsoToken | undefined> {
+        const data = await this.loadCachedToken()
+
+        if (!data || !isExpired(data.token)) {
+            return data?.token
+        }
+
+        if (data.registration && !isExpired(data.registration) && hasProps(data.token, 'refreshToken')) {
+            const refreshed = await this.refreshToken(data.token, data.registration)
+
+            return refreshed.token
+        } else {
+            await this.invalidate()
+        }
+    }
+
+    private async loadCachedToken(): Promise<SsoAccess | undefined> {
+        try {
+            const tokenData = await fs.promises.readFile(this.TOKEN_CACHE_FILE, 'utf8')
+
+            const parsedToken = JSON.parse(tokenData)
+            parsedToken.token.expiresAt = new Date(parsedToken.token.expiresAt)
+            parsedToken.registration.expiresAt = new Date(parsedToken.registration.expiresAt)
+
+            return parsedToken
+        } catch (err) {
+            // Todo: handle errors
+        }
+    }
+
+    private async loadCachedRegistrationData(): Promise<ClientRegistration | undefined> {
+        try {
+            const registrationData = await fs.promises.readFile(this.REGISTRATION_CACHE_FILE, 'utf8')
+
+            const parsedData = JSON.parse(registrationData)
+            parsedData.token.expiresAt = new Date(parsedData.expiresAt)
+
+            return JSON.parse(registrationData)
+        } catch (err) {
+            // Todo: handle errors
+        }
+    }
+
+    private async saveCachedToken(data: SsoAccess): Promise<void> {
+        await fs.promises.mkdir(TOKEN_CACHE_DIR, { recursive: true })
+        await fs.promises.writeFile(this.TOKEN_CACHE_FILE, JSON.stringify(data))
+    }
+
+    private async saveRegisrationData(data: ClientRegistration): Promise<void> {
+        await fs.promises.mkdir(TOKEN_CACHE_DIR, { recursive: true })
+        await fs.promises.writeFile(this.REGISTRATION_CACHE_FILE, JSON.stringify(data))
+    }
+
+    public async createToken(): Promise<SsoToken> {
+        const access = await this.runFlow()
+        const identity = this.tokenCacheKey
+        await this.saveCachedToken(access)
+
+        return { ...access.token, identity }
+    }
+
+    private async runFlow() {
+        let cachedRegistration = await this.loadCachedRegistrationData()
+        if (cachedRegistration === undefined) {
+            cachedRegistration = await this.registerClient()
+            await this.saveRegisrationData(cachedRegistration)
+        }
+
+        return await this.authorize(cachedRegistration)
+    }
+
+    private async refreshToken(token: RequiredProps<SsoToken, 'refreshToken'>, registration: ClientRegistration) {
+        try {
+            const clientInfo = selectFrom(registration, 'clientId', 'clientSecret')
+            const response = await this.oidc.createToken({ ...clientInfo, ...token, grantType: refreshGrantType })
+            const refreshed = this.formatToken(response as SsoToken, registration)
+            await this.saveCachedToken(refreshed)
+
+            return refreshed
+        } catch (err) {
+            throw err
+        }
+    }
+
+    private formatToken(token: SsoToken, registration: ClientRegistration) {
+        return { token, registration, region: this.profile.region, startUrl: this.profile.startUrl }
+    }
+
+    protected get tokenCacheKey() {
+        return this.profile.identifier ?? this.profile.startUrl
+    }
+
+    private async authorize(registration: ClientRegistration) {
+        const authorization = await this.oidc.startDeviceAuthorization({
+            startUrl: this.profile.startUrl,
+            clientId: registration.clientId,
+            clientSecret: registration.clientSecret,
+        })
+
+        if (!this.uiHandler) {
+            throw new Error('UI handler is not provided')
+        }
+
+        if (!(await this.uiHandler?.openSsoPortalLink(this.profile.startUrl, authorization))) {
+            throw new Error('user cancelled')
+        }
+
+        const tokenRequest = {
+            clientId: registration.clientId,
+            clientSecret: registration.clientSecret,
+            deviceCode: authorization.deviceCode,
+            grantType: deviceGrantType,
+        }
+
+        const token = await pollForTokenWithProgress(() => this.oidc.createToken(tokenRequest), authorization)
+        return this.formatToken(token, registration)
+    }
+
+    private async registerClient(): Promise<ClientRegistration> {
+        return this.oidc.registerClient({
+            clientName: 'AWS SSO Language Server',
+            clientType: clientRegistrationType,
+            scopes: this.profile.scopes,
+        })
+    }
+
+    public static create(profile: Pick<SsoProfile, 'startUrl' | 'region' | 'scopes' | 'identifier'>) {
+        return new this(profile)
+    }
+}
+
+interface UiHandler {
+    openSsoPortalLink(
+        startUrl: string,
+        authorization: { readonly verificationUri: string; readonly userCode: string }
+    ): Promise<boolean>
+}
+
+export class BuilderIdConnectionBuilder {
+    private static readonly getToken = keyedDebounce(BuilderIdConnectionBuilder._getToken.bind(this))
+    public static uiHandler: UiHandler
+
+    public static async build(uiHandler: UiHandler, startUrl: string = builderIdStartUrl): Promise<SsoConnection> {
+        BuilderIdConnectionBuilder.uiHandler = uiHandler
+
+        const awsBuilderIdSsoProfile = BuilderIdConnectionBuilder.createBuilderIdProfile(defaultScopes, startUrl)
+        const connection = await BuilderIdConnectionBuilder.createConnection(awsBuilderIdSsoProfile)
+        return connection
+    }
+
+    private static createBuilderIdProfile(scopes = [...ssoAccountAccessScopes], startUrl: string): SsoProfile {
+        return {
+            scopes,
+            region: 'foo',
+            ssoRegion: defaultSsoRegion,
+            startUrl,
+        }
+    }
+
+    private static async createConnection(profile: SsoProfile): Promise<SsoConnection> {
+        const id = randomUUID()
+        const tokenProvider = BuilderIdConnectionBuilder.getTokenProvider(id, {
+            ...profile,
+        })
+
+        ;(await tokenProvider.getToken()) ?? (await tokenProvider.createToken())
+
+        return BuilderIdConnectionBuilder.getSsoConnection(id, profile, tokenProvider)
+    }
+
+    private static getTokenProvider(id: string, profile: SsoProfile): SsoAccessTokenProvider {
+        const provider = new SsoAccessTokenProvider(
+            {
+                identifier: id,
+                startUrl: profile.startUrl,
+                scopes: profile.scopes,
+                region: profile.ssoRegion,
+            },
+            BuilderIdConnectionBuilder.uiHandler
+        )
+
+        return provider
+    }
+
+    private static getSsoConnection(id: string, profile: SsoProfile, provider: SsoAccessTokenProvider): SsoConnection {
+        return {
+            id,
+            ...profile,
+            getToken: () => BuilderIdConnectionBuilder.getToken(id, provider),
+        }
+    }
+
+    private static async _getToken(id: string, provider: SsoAccessTokenProvider): Promise<SsoToken> {
+        const token = await provider.getToken()
+        return token ?? provider.createToken()
+    }
+}

--- a/server/device-sso-auth-lsp/src/language-server/sso/model.ts
+++ b/server/device-sso-auth-lsp/src/language-server/sso/model.ts
@@ -1,0 +1,74 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// For the Proof of concept, this file's code was copied from the AWS Toolkit for VS Code repo
+// https://github.com/aws/aws-toolkit-vscode/blob/5d621c8405a8b20ffe571ad0ba10ae700178e051/src/auth/sso/model.ts
+
+// import * as vscode from 'vscode'
+
+export interface SsoToken {
+    /**
+     * An optional identity associated with this token.
+     */
+    readonly identity?: string
+
+    /**
+     * A base64 encoded string returned by the SSO-OIDC service. This token must be treated as an
+     * opaque UTF-8 string and must not be decoded.
+     */
+    readonly accessToken: string
+
+    /**
+     * The expiration time of the accessToken.
+     */
+    readonly expiresAt: Date
+
+    /**
+     * Should always be `Bearer` if present.
+     */
+    readonly tokenType?: string
+
+    /**
+     * Opaque token that may be used to 'refresh' the authentication session after expiration.
+     */
+    readonly refreshToken?: string
+}
+
+export interface ClientRegistration {
+    /**
+     * Unique registration id.
+     */
+    readonly clientId: string
+
+    /**
+     * Secret key associated with the registration.
+     */
+    readonly clientSecret: string
+
+    /**
+     * The expiration time of the registration.
+     */
+    readonly expiresAt: Date
+
+    /**
+     * Scope of the client registration. Applies to all tokens created using this registration.
+     */
+    readonly scopes?: string[]
+}
+
+export interface SsoProfile {
+    readonly region: string
+    readonly startUrl: string
+    readonly accountId?: string
+    readonly roleName?: string
+    readonly scopes?: string[]
+    readonly identifier?: string
+}
+
+// Most SSO 'expirables' are fairly long lived, so a one minute buffer is plenty.
+const expirationBufferMs = 60000
+export function isExpired(expirable: { expiresAt: Date }): boolean {
+    return Date.now() + expirationBufferMs >= expirable.expiresAt.getTime()
+}

--- a/server/device-sso-auth-lsp/src/language-server/tsUtils.ts
+++ b/server/device-sso-auth-lsp/src/language-server/tsUtils.ts
@@ -1,0 +1,152 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// For the Proof of concept, this file's code was copied from the AWS Toolkit for VS Code repo
+// https://github.com/aws/aws-toolkit-vscode/blob/5d621c8405a8b20ffe571ad0ba10ae700178e051/src/shared/utilities/tsUtils.ts
+
+export function stringOrProp(obj: any, prop: string): string {
+    if (obj === undefined || typeof obj === 'string') {
+        return obj ?? ''
+    }
+    return obj[prop] ?? ''
+}
+
+export function getMissingProps<T>(obj: T, ...props: (keyof T)[]): typeof props {
+    return props.filter(prop => obj[prop] === undefined)
+}
+
+export function hasProps<T, K extends keyof T>(obj: T, ...props: K[]): obj is Readonly<RequiredProps<T, K>> {
+    return getMissingProps(obj, ...props).length === 0
+}
+
+export function hasStringProps<T, K extends PropertyKey>(obj: T, ...props: K[]): obj is T & { [P in K]: string } {
+    return props.filter(prop => typeof (obj as unknown as Record<K, unknown>)[prop] !== 'string').length === 0
+}
+
+export function assertHasProps<T, K extends keyof T>(
+    obj: T | undefined,
+    ...props: K[]
+): asserts obj is Readonly<RequiredProps<T, K>> {
+    if (!isNonNullable(obj)) {
+        throw new TypeError(`Object was null or undefined, expected properties: ${props.join(', ')}`)
+    }
+
+    const missing = getMissingProps(obj, ...props)
+    if (missing.length > 0) {
+        throw new TypeError(`Object was missing properties: ${missing.join(', ')}`)
+    }
+
+    // May be easier/cleaner to just copy the object rather than freezing it
+    // Should also check the properties and make sure they're all data descriptors
+    Object.freeze(obj)
+}
+
+export function selectFrom<T, K extends keyof T>(obj: T, ...props: K[]): { [P in K]: T[P] } {
+    return props.map(p => [p, obj[p]] as const).reduce((a, [k, v]) => ((a[k] = v), a), {} as { [P in K]: T[P] })
+}
+
+export function isNonNullable<T>(obj: T | void): obj is NonNullable<T> {
+    return obj !== undefined && obj !== null
+}
+
+export function isKeyOf<T extends object>(key: PropertyKey, obj: T): key is keyof T {
+    return key in obj
+}
+
+export function hasKey<T extends object, K extends PropertyKey>(obj: T, key: K): obj is T & { [P in K]: unknown } {
+    return isKeyOf(key, obj)
+}
+
+/**
+ * Stricter form of {@link Object.keys} that gives slightly better types for object literals.
+ */
+export function keys<T extends Record<string, any>>(obj: T): [keyof T & string] {
+    return Object.keys(obj) as [keyof T & string]
+}
+
+/**
+ * Stricter form of {@link Object.entries} that gives slightly better types for object literals.
+ */
+export function entries<T extends Record<string, U>, U>(obj: T): { [P in keyof T]: [P, T[P]] }[keyof T][] {
+    return Object.entries(obj) as { [P in keyof T]: [P, T[P]] }[keyof T][]
+}
+
+export function isThenable<T>(obj: unknown): obj is Thenable<T> {
+    return isNonNullable(obj) && typeof (obj as Thenable<T>).then === 'function'
+}
+
+export type ConstantMap<K, V> = Omit<ReadonlyMap<K, V>, 'get' | 'has'> & {
+    get(key: K): V
+    get(key: any): V | undefined
+    has(key: any): key is K
+}
+
+export function createConstantMap<T extends PropertyKey, U extends PropertyKey>(obj: {
+    readonly [P in T]: U
+}): ConstantMap<T, U> {
+    return new Map<T, U>(Object.entries(obj) as [T, U][]) as unknown as ConstantMap<T, U>
+}
+
+export function createFactoryFunction<T extends new (...args: any[]) => any>(ctor: T): FactoryFunction<T> {
+    return (...args) => new ctor(...args)
+}
+
+type NoSymbols<T> = { [Property in keyof T]: Property extends symbol ? never : Property }[keyof T]
+export type InterfaceNoSymbol<T> = Pick<T, NoSymbols<T>>
+/**
+ * Narrows a type from the public keys of class T, which is _semantically_ an interface (and behaviorly, in almost all cases).
+ *
+ * Note: TypeScript types are purely structural so externally the result looks the same as
+ * one declared with the `interface` keyword. The only difference from a literal `interface`
+ * is that it cannot be re-declared for extension.
+ */
+export type ClassToInterfaceType<T> = Pick<T, keyof T>
+
+type Expand<T> = T extends infer O ? { [K in keyof O]+?: O[K] } : never
+/**
+ * Forces a type to be resolved into its literal types.
+ *
+ * Normally imported types are left 'as-is' and are unable to be mapped. This alias uses
+ * type inference to effectively generate a type literal of the target type.
+ *
+ */
+export type ExpandWithObject<T> = Expand<T> extends Record<string, unknown> ? Expand<T> : never
+
+/**
+ * Given two types, this yields a type that includes only the fields where both types were the exact same
+ * This is _almost_ equivalent to (T1 | T2) & T2 & T2, except that this type is distributive
+ */
+export type SharedTypes<T1, T2> = {
+    [P in keyof T1 & keyof T2]: (T1[P] | T2[P]) & T1[P] & T2[P]
+}
+
+/* All of the string keys of the shared type */
+export type SharedProp<T1, T2> = string & keyof SharedTypes<T1, T2>
+
+/* Any key that can be accumulated (i.e. an array) */
+export type AccumulableKeys<T> = NonNullable<
+    {
+        [P in keyof T]: NonNullable<T[P]> extends any[] ? P : never
+    }[keyof T]
+>
+
+/** Similar to the nullish coalescing operator, but for types that can never occur */
+export type Coalesce<T, U> = [T] extends [never] ? U : T
+
+/** Makes all keys `K` of `T` non-nullable */
+export type RequiredProps<T, K extends keyof T> = T & { [P in K]-?: NonNullable<T[P]> }
+
+/** Analagous to shifting an array but for tuples */
+export type Shift<T extends any[]> = T extends [infer _, ...infer U] ? U : []
+
+/** Transforms a type into a mutable version */
+export type Mutable<T> = { -readonly [P in keyof T]: T[P] }
+
+export type FactoryFunction<T extends abstract new (...args: any[]) => any> = (
+    ...args: ConstructorParameters<T>
+) => InstanceType<T>
+
+/** Can be used to isolate all number fields of a record `T` */
+export type NumericKeys<T> = { [P in keyof T]-?: T[P] extends number | undefined ? P : never }[keyof T]

--- a/server/device-sso-auth-lsp/tsconfig.json
+++ b/server/device-sso-auth-lsp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./out"
+    },
+    "include": ["src"]
+}


### PR DESCRIPTION
## Description

This is port of Device Auth SSO flow, implemented in sample VSCode client to LSP Server.

It implements custom `ssoAuth/authDevice/getToken` LSP command to retrieve SSO token, and start SSO flow if required. See [README](https://github.com/aws/language-servers/compare/device-auth-sso-lsp?expand=1#diff-5e02c79a2bd5dfb1d2c367fb1cb46e2de9c7ba54b3e85d296230551288b4f702) with more detailed documentation.

Caches token on filesystem and supports only `standalone` runtime.

This Capability can be used to inject device token management flow as part of  Language Servers runtime bundles.

Requires this PR to be released in Language Server Runtimes repo https://github.com/aws/language-server-runtimes/pull/185

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
