### PR TITLE
Allow sending document without active focus in Chat requests

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentContext.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentContext.test.ts
@@ -99,35 +99,6 @@ describe('DocumentContext', () => {
 
             assert.deepStrictEqual(result, expected)
         })
-
-        it('returns undefined cursorState if the end position was collapsed', async () => {
-            const documentContextExtractor = new DocumentContextExtractor({ characterLimits: 0 })
-
-            const expected: DocumentContext = {
-                programmingLanguage: { languageName: 'typescript' },
-                relativeFilePath: 'file://test.ts',
-                documentSymbols: [],
-                text: '',
-                hasCodeSnippet: false,
-                totalEditorCharacters: mockTypescriptCodeBlock.length,
-                cursorState: undefined,
-            }
-
-            const result = await documentContextExtractor.extractDocumentContext(mockTSDocument, {
-                range: {
-                    start: {
-                        line: 1,
-                        character: 13,
-                    },
-                    end: {
-                        line: 1,
-                        character: 13,
-                    },
-                },
-            })
-
-            assert.deepStrictEqual(result, expected)
-        })
     })
 
     it('handles other languages correctly', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContexts.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContexts.test.ts
@@ -1,0 +1,95 @@
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { QChatTriggerContext } from './triggerContext'
+import assert = require('assert')
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { DocumentContext, DocumentContextExtractor } from './documentContext'
+import sinon = require('sinon')
+
+describe('QChatTriggerContext', () => {
+    let testFeatures: TestFeatures
+
+    const filePath = 'file://test.ts'
+    const mockTSDocument = TextDocument.create(filePath, 'typescript', 1, '')
+    const mockDocumentContext: DocumentContext = {
+        text: '',
+        programmingLanguage: { languageName: 'typescript' },
+        relativeFilePath: 'file://test.ts',
+        documentSymbols: [],
+        hasCodeSnippet: false,
+        totalEditorCharacters: 0,
+    }
+
+    beforeEach(() => {
+        testFeatures = new TestFeatures()
+        sinon.stub(DocumentContextExtractor.prototype, 'extractDocumentContext').resolves(mockDocumentContext)
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    it('returns null if text document is not defined in params', async () => {
+        const triggerContext = new QChatTriggerContext(testFeatures.workspace, testFeatures.logging)
+
+        const documentContext = await triggerContext.extractDocumentContext({
+            cursorState: [
+                {
+                    position: {
+                        line: 5,
+                        character: 0,
+                    },
+                },
+            ],
+            textDocument: undefined,
+        })
+
+        assert.deepStrictEqual(documentContext, undefined)
+    })
+
+    it('returns null if text document is not found', async () => {
+        const triggerContext = new QChatTriggerContext(testFeatures.workspace, testFeatures.logging)
+
+        const documentContext = await triggerContext.extractDocumentContext({
+            cursorState: [
+                {
+                    position: {
+                        line: 5,
+                        character: 0,
+                    },
+                },
+            ],
+            textDocument: {
+                uri: filePath,
+            },
+        })
+
+        assert.deepStrictEqual(documentContext, undefined)
+    })
+
+    it('passes default cursor state if no cursor is found', async () => {
+        const triggerContext = new QChatTriggerContext(testFeatures.workspace, testFeatures.logging)
+
+        const documentContext = await triggerContext.extractDocumentContext({
+            cursorState: [],
+            textDocument: {
+                uri: filePath,
+            },
+        })
+
+        assert.deepStrictEqual(documentContext, undefined)
+    })
+
+    it('includes cursor state from the parameters and text document if found', async () => {
+        const triggerContext = new QChatTriggerContext(testFeatures.workspace, testFeatures.logging)
+
+        testFeatures.openDocument(mockTSDocument)
+        const documentContext = await triggerContext.extractDocumentContext({
+            cursorState: [],
+            textDocument: {
+                uri: filePath,
+            },
+        })
+
+        assert.deepStrictEqual(documentContext, mockDocumentContext)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/utils.ts
@@ -61,10 +61,6 @@ export function getExtendedCodeBlockRange(
  * reflects the position in the entire document needs to be adjusted.
  */
 export function getSelectionWithinExtendedRange(selection: Range, extendedRange: Range): Range | undefined {
-    if (selection.start.line === selection.end.line && selection.start.character === selection.end.character) {
-        return undefined
-    }
-
     return {
         start: {
             line: selection.start.line - extendedRange.start.line,


### PR DESCRIPTION
## Description
The expected behavior is that users can ask questions about active document so we need to include a default position and allow collapsed position.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
