### PR TITLE
Releasing CodeWhisperer Language Server 0.0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15457,7 +15457,7 @@
         },
         "server/aws-lsp-codewhisperer": {
             "name": "@aws/lsp-codewhisperer",
-            "version": "0.0.11",
+            "version": "0.0.12",
             "bundleDependencies": [
                 "@amzn/codewhisperer-streaming",
                 "@aws/lsp-fqn"

--- a/server/aws-lsp-codewhisperer/CHANGELOG.md
+++ b/server/aws-lsp-codewhisperer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.12] - 2024-08-19
+- Allow sending document without active focus in Chat requests
+- Implement sample device auth SSO flow in LSP server
+
 ## [0.0.11] - 2024-08-14
 - Fix issue with source framework selection on transform
 

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/lsp-codewhisperer",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "description": "CodeWhisperer Language Server",
     "main": "out/index.js",
     "repository": {


### PR DESCRIPTION
## Problem

CodeWhisperer Language Server release is required.

## Solution

Increment the version and update the changelog for the release.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
