### PR TITLE
fix(amaoznq): fix autotrigger often doesn't trigger

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -335,7 +335,11 @@ export const CodewhispererServerFactory =
                     triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
                 })
 
-                if (isAutomaticLspTriggerKind && !autoTriggerResult.shouldTrigger) {
+                if (
+                    isAutomaticLspTriggerKind &&
+                    codewhispererAutoTriggerType === 'Classifier' &&
+                    !autoTriggerResult.shouldTrigger
+                ) {
                     return EMPTY_RESULT
                 }
 


### PR DESCRIPTION
## Problem
customer seeing auto-trigger doesn't seem to be triggering
## Solution
auto-trigger should always trigger on Enter and Special characters, only for Classifier trigger type we need to check the classifier result if it's above threshold
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
