### PR TITLE
Add app/aws-lsp-partiql-binary/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/dist*
 **/.vscode-test
 !/bin
 *.tsbuildinfo
-app/aws-lsp-partiql-runtimes
+app/aws-lsp-partiql-*
 
 # Mynah
 !mynah-ui/dist


### PR DESCRIPTION
## Problem
app/aws-lsp-partiql-binary/ is being tracked by git.  No other *-binary are tracked by git based on https://github.com/aws/language-servers/tree/main/app. .gitignore was already ignore app/aws-lsp-partiql-runtimes, so this appeared to be a miss in the pattern.

## Solution
Updated app/aws-lsp-partiql-runtimes in .gitignore to app/aws-lsp-partiql-* to ignore the build artifacts as well.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
