### PR TITLE
Add ca certificate config in CW SDK client

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -87,7 +87,7 @@
                 "ENABLE_CUSTOM_COMMANDS": "true",
                 "ENABLE_CHAT": "true"
                 // "HTTPS_PROXY": "http://127.0.0.1:8888",
-                // "NODE_EXTRA_CA_CERTS": "/path/to/cert.pem"
+                // "AWS_CA_BUNDLE": "/path/to/cert.pem"
             },
             "preLaunchTask": "npm: compile"
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -87,6 +87,7 @@
                 "ENABLE_CUSTOM_COMMANDS": "true",
                 "ENABLE_CHAT": "true"
                 // "HTTPS_PROXY": "http://127.0.0.1:8888",
+                // "NODE_EXTRA_CA_CERTS": "/path/to/cert.pem"
             },
             "preLaunchTask": "npm: compile"
         },

--- a/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
+++ b/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
@@ -1,5 +1,7 @@
 import { CodeWhispererStreaming } from '@amzn/codewhisperer-streaming'
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
+import { readFileSync } from 'fs'
+
 const codeWhispererRegion = 'us-east-1'
 
 const codeWhispererEndpoint = 'https://codewhisperer.us-east-1.amazonaws.com/'
@@ -11,11 +13,35 @@ export class StreamingClient {
 }
 export async function createStreamingClient(credentialsProvider: any): Promise<CodeWhispererStreaming> {
     const creds = credentialsProvider.getCredentials('bearer')
+
+    let clientOptions;
+    const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
+    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
+
+    if (proxyUrl) {
+        const { NodeHttpHandler } = require('@smithy/node-http-handler')
+        const { HttpsProxyAgent } = require('hpagent')
+
+        const agent = new HttpsProxyAgent({
+            proxy: proxyUrl,
+            ca: certs,
+        })
+
+        clientOptions = {
+            requestHandler: new NodeHttpHandler({
+                httpAgent: agent,
+                httpsAgent: agent,
+            }),
+        }
+    }
+
+
     const streamingClient = new CodeWhispererStreaming({
         region: codeWhispererRegion,
         endpoint: codeWhispererEndpoint,
         token: { token: creds.token },
         retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
+        requestHandler: clientOptions?.requestHandler
     })
     return streamingClient
 }

--- a/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
+++ b/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
@@ -14,7 +14,7 @@ export class StreamingClient {
 export async function createStreamingClient(credentialsProvider: any): Promise<CodeWhispererStreaming> {
     const creds = credentialsProvider.getCredentials('bearer')
 
-    let clientOptions;
+    let clientOptions
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
     const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
 
@@ -35,13 +35,12 @@ export async function createStreamingClient(credentialsProvider: any): Promise<C
         }
     }
 
-
     const streamingClient = new CodeWhispererStreaming({
         region: codeWhispererRegion,
         endpoint: codeWhispererEndpoint,
         token: { token: creds.token },
         retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
-        requestHandler: clientOptions?.requestHandler
+        requestHandler: clientOptions?.requestHandler,
     })
     return streamingClient
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -53,16 +53,12 @@ export abstract class CodeWhispererServiceBase {
 
     abstract generateSuggestions(request: GenerateSuggestionsRequest): Promise<GenerateSuggestionsResponse>
 
-    constructor(credentialsProvider: CredentialsProvider, additionalAwsConfig: AWSConfig = {}) {
+    constructor(credentialsProvider: CredentialsProvider, additionalAwsConfig: AWS.ConfigurationOptions = {}) {
         this.updateAwsConfiguration(additionalAwsConfig)
     }
 
-    updateAwsConfiguration = (awsConfig: AWSConfig) => {
-        if (awsConfig?.proxy) {
-            AWS.config.update({
-                httpOptions: { agent: awsConfig.proxy },
-            })
-        }
+    updateAwsConfiguration = (awsConfig: AWS.ConfigurationOptions) => {
+        AWS.config.update(awsConfig)
     }
 
     generateItemId = () => uuidv4()
@@ -71,7 +67,7 @@ export abstract class CodeWhispererServiceBase {
 export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
     client: CodeWhispererSigv4Client
 
-    constructor(credentialsProvider: CredentialsProvider, additionalAwsConfig: AWSConfig = {}) {
+    constructor(credentialsProvider: CredentialsProvider, additionalAwsConfig: AWS.ConfigurationOptions = {}) {
         super(credentialsProvider, additionalAwsConfig)
 
         const options: CodeWhispererSigv4ClientConfigurationOptions = {
@@ -112,7 +108,7 @@ export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
 export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
     client: CodeWhispererTokenClient
 
-    constructor(credentialsProvider: CredentialsProvider, additionalAwsConfig: AWSConfig = {}) {
+    constructor(credentialsProvider: CredentialsProvider, additionalAwsConfig: AWS.ConfigurationOptions = {}) {
         super(credentialsProvider, additionalAwsConfig)
 
         const options: CodeWhispererTokenClientConfigurationOptions = {

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -10,7 +10,7 @@ import { readFileSync } from 'fs'
 export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credentialsProvider => {
     let additionalAwsConfig = {}
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-    const certs = process.env.NODE_EXTRA_CA_CERTS ? [readFileSync(process.env.NODE_EXTRA_CA_CERTS)] : undefined
+    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
 
     if (proxyUrl) {
         const { getProxyHttpAgent } = require('proxy-http-agent')
@@ -19,7 +19,7 @@ export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credenti
             ca: certs,
         })
         additionalAwsConfig = {
-            proxy: proxyAgent,
+            httpOptions: proxyAgent,
         }
     }
     return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
@@ -28,7 +28,7 @@ export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credenti
 export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(credentialsProvider => {
     let additionalAwsConfig = {}
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-    const certs = process.env.NODE_EXTRA_CA_CERTS ? [readFileSync(process.env.NODE_EXTRA_CA_CERTS)] : undefined
+    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
 
     if (proxyUrl) {
         const { getProxyHttpAgent } = require('proxy-http-agent')
@@ -46,7 +46,7 @@ export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(credential
 export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken(credentialsProvider => {
     let additionalAwsConfig = {}
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-    const certs = process.env.NODE_EXTRA_CA_CERTS ? [readFileSync(process.env.NODE_EXTRA_CA_CERTS)] : undefined
+    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
 
     if (proxyUrl) {
         const { getProxyHttpAgent } = require('proxy-http-agent')
@@ -55,7 +55,7 @@ export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken
             ca: certs,
         })
         additionalAwsConfig = {
-            proxy: proxyAgent,
+            httpOptions: proxyAgent,
         }
     }
     return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
@@ -64,14 +64,16 @@ export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken
 export const QNetTransformServerTokenProxy = QNetTransformServerToken(credentialsProvider => {
     let additionalAwsConfig = {}
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
+    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
 
     if (proxyUrl) {
         const { getProxyHttpAgent } = require('proxy-http-agent')
         const proxyAgent = getProxyHttpAgent({
             proxy: proxyUrl,
+            ca: certs,
         })
         additionalAwsConfig = {
-            proxy: proxyAgent,
+            httpOptions: proxyAgent,
         }
     }
     return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
@@ -81,7 +83,7 @@ export const QChatServerProxy = QChatServer(credentialsProvider => {
     let clientOptions: ChatSessionServiceConfig | undefined
 
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-    const certs = process.env.NODE_EXTRA_CA_CERTS ? [readFileSync(process.env.NODE_EXTRA_CA_CERTS)] : undefined
+    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
 
     if (proxyUrl) {
         const { NodeHttpHandler } = require('@smithy/node-http-handler')

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -5,15 +5,18 @@ import { CodewhispererServerFactory } from './codeWhispererServer'
 import { CodeWhispererServiceIAM, CodeWhispererServiceToken } from './codeWhispererService'
 import { QNetTransformServerToken } from './netTransformServer'
 import { QChatServer } from './qChatServer'
+import { readFileSync } from 'fs'
 
 export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credentialsProvider => {
     let additionalAwsConfig = {}
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
+    const certs = process.env.NODE_EXTRA_CA_CERTS ? [readFileSync(process.env.NODE_EXTRA_CA_CERTS)] : undefined
 
     if (proxyUrl) {
         const { getProxyHttpAgent } = require('proxy-http-agent')
         const proxyAgent = getProxyHttpAgent({
             proxy: proxyUrl,
+            ca: certs,
         })
         additionalAwsConfig = {
             proxy: proxyAgent,
@@ -25,14 +28,16 @@ export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credenti
 export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(credentialsProvider => {
     let additionalAwsConfig = {}
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
+    const certs = process.env.NODE_EXTRA_CA_CERTS ? [readFileSync(process.env.NODE_EXTRA_CA_CERTS)] : undefined
 
     if (proxyUrl) {
         const { getProxyHttpAgent } = require('proxy-http-agent')
         const proxyAgent = getProxyHttpAgent({
             proxy: proxyUrl,
+            ca: certs,
         })
         additionalAwsConfig = {
-            proxy: proxyAgent,
+            httpOptions: proxyAgent,
         }
     }
     return new CodeWhispererServiceIAM(credentialsProvider, additionalAwsConfig)
@@ -41,11 +46,13 @@ export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(credential
 export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken(credentialsProvider => {
     let additionalAwsConfig = {}
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
+    const certs = process.env.NODE_EXTRA_CA_CERTS ? [readFileSync(process.env.NODE_EXTRA_CA_CERTS)] : undefined
 
     if (proxyUrl) {
         const { getProxyHttpAgent } = require('proxy-http-agent')
         const proxyAgent = getProxyHttpAgent({
             proxy: proxyUrl,
+            ca: certs,
         })
         additionalAwsConfig = {
             proxy: proxyAgent,
@@ -74,6 +81,7 @@ export const QChatServerProxy = QChatServer(credentialsProvider => {
     let clientOptions: ChatSessionServiceConfig | undefined
 
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
+    const certs = process.env.NODE_EXTRA_CA_CERTS ? [readFileSync(process.env.NODE_EXTRA_CA_CERTS)] : undefined
 
     if (proxyUrl) {
         const { NodeHttpHandler } = require('@smithy/node-http-handler')
@@ -93,6 +101,7 @@ export const QChatServerProxy = QChatServer(credentialsProvider => {
             // this mimics aws-sdk-v3-js-proxy
             const agent = new HttpsProxyAgent({
                 proxy: proxyUrl,
+                ca: certs,
             })
 
             return {


### PR DESCRIPTION
## Problem
Unable to connect to Q via specific proxy settings

## Solution
Pass ca cert to CodeWhisperer SDK client

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
