### PR TITLE
Add retry to pollTransformation

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -57,7 +57,6 @@ export enum CancellationJobStatus {
 export enum PollTransformationStatus {
     TIMEOUT = 'TIMEOUT',
     NOT_FOUND = 'NOT_FOUND',
-    RETRY = 'RETRY',
     FAILED = 'FAILED',
 }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -53,6 +53,14 @@ export enum CancellationJobStatus {
     TIMED_OUT,
 }
 
+// status specific to pollTransformation
+export enum PollTransformationStatus {
+    TIMEOUT = 'TIMEOUT',
+    NOT_FOUND = 'NOT_FOUND',
+    RETRY = 'RETRY',
+    FAILED = 'FAILED',
+}
+
 export interface CancelTransformResponse {
     TransformationJobStatus: CancellationJobStatus
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -196,7 +196,7 @@ export class TransformHandler {
     async getTransformationPlan(request: GetTransformPlanRequest) {
         let getTransformationPlanAttempt = 0
         let getTransformationPlanMaxAttempts = 3
-        while (getTransformationPlanAttempt <= getTransformationPlanMaxAttempts) {
+        while (true) {
             try {
                 const getCodeTransformationPlanRequest = {
                     transformationJobId: request.TransformationJobId,
@@ -214,18 +214,19 @@ export class TransformHandler {
             } catch (e: any) {
                 const errorMessage = (e as Error).message ?? 'Error in GetTransformationPlan API call'
                 this.logging.log('Error: ' + errorMessage)
-                if (getTransformationPlanAttempt === getTransformationPlanMaxAttempts) {
+
+                getTransformationPlanAttempt += 1
+                if (getTransformationPlanAttempt >= getTransformationPlanMaxAttempts) {
                     this.logging.log(
                         `CodeTransformation: GetTransformationPlan failed after ${getTransformationPlanMaxAttempts} attempts.`
                     )
                     throw e
-                } else {
-                    getTransformationPlanAttempt += 1
-                    this.logging.log(
-                        `poll : ${getTransformationPlanAttempt} attempt to get transformation plan failed, retry in 10 seconds or exit after ${getTransformationPlanMaxAttempts} attempts.`
-                    )
-                    await this.sleep(10 * 1000)
                 }
+
+                this.logging.log(
+                    `poll : Attempt ${getTransformationPlanAttempt}/${getTransformationPlanMaxAttempts} to get transformation plan failed`
+                )
+                await this.sleep(10 * 1000)
             }
         }
     }
@@ -233,7 +234,7 @@ export class TransformHandler {
     async cancelTransformation(request: CancelTransformRequest) {
         let cancelTransformationAttempt = 0
         let cancelTransformationMaxAttempts = 3
-        while (cancelTransformationAttempt <= cancelTransformationMaxAttempts) {
+        while (true) {
             try {
                 const stopCodeTransformationRequest = {
                     transformationJobId: request.TransformationJobId,
@@ -258,20 +259,21 @@ export class TransformHandler {
             } catch (e: any) {
                 const errorMessage = (e as Error).message ?? 'Error in CancelTransformation API call'
                 this.logging.log('Error: ' + errorMessage)
-                if (cancelTransformationAttempt === cancelTransformationMaxAttempts) {
+
+                cancelTransformationAttempt += 1
+                if (cancelTransformationAttempt >= cancelTransformationMaxAttempts) {
                     this.logging.log(
                         `CodeTransformation: CancelTransformation failed after ${cancelTransformationMaxAttempts} attempts.`
                     )
                     return {
                         TransformationJobStatus: CancellationJobStatus.FAILED_TO_CANCEL,
                     } as CancelTransformResponse
-                } else {
-                    cancelTransformationAttempt += 1
-                    this.logging.log(
-                        `poll : ${cancelTransformationAttempt} attempt to cancel transformation failed, retry in 10 seconds or exit after ${cancelTransformationMaxAttempts} attempts.`
-                    )
-                    await this.sleep(10 * 1000)
                 }
+
+                this.logging.log(
+                    `poll : Attempt ${cancelTransformationAttempt}/${cancelTransformationMaxAttempts} to get transformation plan failed`
+                )
+                await this.sleep(10 * 1000)
             }
         }
     }
@@ -334,18 +336,19 @@ export class TransformHandler {
             } catch (e: any) {
                 const errorMessage = (e as Error).message ?? 'Error in GetTransformation API call'
                 this.logging.log('poll : error polling transformation job from the server: ' + errorMessage)
+
+                getTransformAttempt += 1
                 if (getTransformAttempt >= getTransformMaxAttempts) {
                     this.logging.log(
                         `CodeTransformation: GetTransformation failed after ${getTransformMaxAttempts} attempts.`
                     )
                     status = PollTransformationStatus.FAILED
                     break
-                } else {
-                    getTransformAttempt += 1
-                    this.logging.log(
-                        `poll : ${getTransformAttempt} attempt to poll transformation status failed, retry in 10 seconds or exit after ${getTransformMaxAttempts} attempts.`
-                    )
                 }
+
+                this.logging.log(
+                    `poll : Attempt ${getTransformAttempt}/${getTransformMaxAttempts} to get transformation plan failed`
+                )
             }
         }
         this.logging.log('poll : returning response from server : ' + JSON.stringify(response))

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -1,5 +1,6 @@
 import { CodeWhispererStreaming, ExportIntent } from '@amzn/codewhisperer-streaming'
 import { Logging, Workspace } from '@aws/language-server-runtimes/server-interface'
+import * as fs from 'fs'
 import got from 'got'
 import { v4 as uuidv4 } from 'uuid'
 import {
@@ -27,6 +28,7 @@ import {
 import * as validation from './validation'
 import path = require('path')
 import AdmZip = require('adm-zip')
+import { Console } from 'console'
 import { supportedProjects, unsupportedViewComponents } from './resources/SupportedProjects'
 import { String } from 'aws-sdk/clients/codebuild'
 import { ProjectMetadata } from 'aws-sdk/clients/lookoutvision'

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -1,6 +1,5 @@
 import { CodeWhispererStreaming, ExportIntent } from '@amzn/codewhisperer-streaming'
 import { Logging, Workspace } from '@aws/language-server-runtimes/server-interface'
-import * as fs from 'fs'
 import got from 'got'
 import { v4 as uuidv4 } from 'uuid'
 import {
@@ -28,7 +27,6 @@ import {
 import * as validation from './validation'
 import path = require('path')
 import AdmZip = require('adm-zip')
-import { Console } from 'console'
 import { supportedProjects, unsupportedViewComponents } from './resources/SupportedProjects'
 import { String } from 'aws-sdk/clients/codebuild'
 import { ProjectMetadata } from 'aws-sdk/clients/lookoutvision'

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -268,7 +268,7 @@ export class TransformHandler {
                 } else {
                     cancelTransformationAttempt += 1
                     this.logging.log(
-                        `poll : ${cancelTransformationAttempt} attempt to cancel transformation status failed, retry in 10 seconds or exit after ${cancelTransformationMaxAttempts} attempts.`
+                        `poll : ${cancelTransformationAttempt} attempt to cancel transformation failed, retry in 10 seconds or exit after ${cancelTransformationMaxAttempts} attempts.`
                     )
                     await this.sleep(10 * 1000)
                 }


### PR DESCRIPTION
## Problem

In the `transformHandler.ts`, polling to get transform status will return `FAILED` as job status if caught one error. But the error can be caused by network issue or the API call timeout.

## Solution
This PR adds the retry policy to `pollTransformation` from the server, it will retry 3 times after the first failure occurs. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
