### PR TITLE
Releasing @aws/lsp-codewhisperer@0.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15436,7 +15436,7 @@
         },
         "server/aws-lsp-codewhisperer": {
             "name": "@aws/lsp-codewhisperer",
-            "version": "0.0.12",
+            "version": "0.0.13",
             "bundleDependencies": [
                 "@amzn/codewhisperer-streaming",
                 "@aws/lsp-fqn"

--- a/server/aws-lsp-codewhisperer/CHANGELOG.md
+++ b/server/aws-lsp-codewhisperer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.13] - 2024-09-02
+- Add retry to pollTransformation
+- Fix autotrigger - LF
+- Add sql to supported file types
+- Fix: failed to upload due to cert validation failed
+
 ## [0.0.12] - 2024-08-19
 - Allow sending document without active focus in Chat requests
 

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/lsp-codewhisperer",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "CodeWhisperer Language Server",
     "main": "out/index.js",
     "repository": {


### PR DESCRIPTION
## Problem

CodeWhisperer Language Server 0.0.13 release is required. 

## Solution

Increment the version and update the changelog for the release.
- Add retry to pollTransformation
- Fix autotrigger - LF
- Add sql to supported file types
- Fix: failed to upload due to cert validation failed

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
