### PR TITLE
Change from linear delay to exp delay for .NET transform API calls

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -1,5 +1,5 @@
 import { CodeWhispererStreaming, ExportIntent } from '@amzn/codewhisperer-streaming'
-import { integer, Logging, Workspace } from '@aws/language-server-runtimes/server-interface'
+import { Logging, Workspace } from '@aws/language-server-runtimes/server-interface'
 import * as fs from 'fs'
 import got from 'got'
 import { v4 as uuidv4 } from 'uuid'
@@ -196,7 +196,6 @@ export class TransformHandler {
     async getTransformationPlan(request: GetTransformPlanRequest) {
         let getTransformationPlanAttempt = 0
         let getTransformationPlanMaxAttempts = 3
-        let exponentialDelayFactor = 2
         while (true) {
             try {
                 const getCodeTransformationPlanRequest = {


### PR DESCRIPTION
## Problem
Following up to https://github.com/aws/language-servers/pull/441, the previous PR added a linear delay to each retry, that may fall to synchronization problems
## Solution
Changing from linear delay to exponential delay to avoid synchronization problems
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
