### PR TITLE
update @aws/language-server-runtimes dependency to 0.2.15

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1"
     },

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "@aws/lsp-partiql": "^0.0.4"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.14"
+        "@aws/language-server-runtimes": "^0.2.15"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -185,7 +185,7 @@
         "@aws-sdk/credential-providers": "^3.614.0",
         "@aws-sdk/types": "^3.535.0",
         "@aws/chat-client-ui-types": "^0.0.6",
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.88.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1"
             },
@@ -64,7 +64,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -84,7 +84,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "@aws/lsp-partiql": "^0.0.4"
             },
             "devDependencies": {
@@ -108,7 +108,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -128,7 +128,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -150,7 +150,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.14"
+                "@aws/language-server-runtimes": "^0.2.15"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -194,7 +194,7 @@
                 "@aws-sdk/credential-providers": "^3.614.0",
                 "@aws-sdk/types": "^3.535.0",
                 "@aws/chat-client-ui-types": "^0.0.6",
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",
@@ -1468,9 +1468,10 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.14.tgz",
-            "integrity": "sha512-F5r3k9iW90Nhk/lrw84tBOiRNVgfwntIoxbRp5GlPrgCjps6hXE1SR9GdYbxPsKv8W1Pi93zs5+xEQzPbQPsUw==",
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.15.tgz",
+            "integrity": "sha512-3JH7hwIKCn8S9jzwrfcs/AKblixPA8zmdWuETgGDihiCPGrRoXz6rj3C5WhIoY//yHfI5YXkNEh18krG/Zs3aA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.6",
                 "jose": "^5.7.0",
@@ -15450,7 +15451,7 @@
                 "@amzn/codewhisperer-streaming": "*",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.0.6",
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "@aws/lsp-fqn": "^0.0.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@smithy/node-http-handler": "^2.5.0",
@@ -16442,7 +16443,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -16456,7 +16457,7 @@
             "version": "0.0.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4",
                 "web-tree-sitter": "0.22.6"
@@ -16489,7 +16490,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -16503,7 +16504,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -16514,7 +16515,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.14",
+                "@aws/language-server-runtimes": "^0.2.15",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -34,7 +34,7 @@
         "@amzn/codewhisperer-streaming": "*",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.0.6",
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "@aws/lsp-fqn": "^0.0.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.14",
+        "@aws/language-server-runtimes": "^0.2.15",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Notes
Depend on the latest @aws/language-server-runtimes 0.2.15 that honors shared aws config in the standalone runtime

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
