### PR TITLE
[Team review] removing manually setting job status to failed after any error from cwspr API

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -186,9 +186,7 @@ export class TransformHandler {
             const errorMessage = (e as Error).message ?? 'Error in GetTransformation API call'
             this.logging.log('Error: ' + errorMessage)
 
-            return {
-                TransformationJob: { status: 'FAILED' },
-            } as GetTransformResponse
+            return null
         }
     }
     async getTransformationPlan(request: GetTransformPlanRequest) {
@@ -290,8 +288,7 @@ export class TransformHandler {
             } catch (e: any) {
                 const errorMessage = (e as Error).message ?? 'Error in GetTransformation API call'
                 this.logging.log('CodeTransformation: GetTransformation error = ' + errorMessage)
-                status = 'FAILED'
-                break
+                continue
             }
         }
         this.logging.log('poll : returning response from server : ' + JSON.stringify(response))


### PR DESCRIPTION
## Problem
In LSP, we were setting job status to failed on any API failure from cwspr. 
## Solution
fixing to ignore this error and poll again. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
