### PR TITLE
Removing manually setting job status to failed after any error from cwspr API

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
@@ -209,7 +209,7 @@ describe('Test Transform handler ', () => {
             const request = JSON.parse(requestString) as GetTransformRequest
             const res = await transformHandler.getTransformation(request)
 
-            expect(res.TransformationJob.status).to.equal('COMPLETED')
+            expect(res?.TransformationJob.status).to.equal('COMPLETED')
         })
     })
 
@@ -233,7 +233,7 @@ describe('Test Transform handler ', () => {
             const request = JSON.parse(requestString) as GetTransformRequest
             const res = await transformHandler.getTransformation(request)
 
-            expect(res.TransformationJob.status).to.equal('FAILED')
+            expect(res?.TransformationJob.status).to.equal('FAILED')
         })
     })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -341,7 +341,7 @@ export class TransformHandler {
                     this.logging.log(
                         `CodeTransformation: GetTransformation failed after ${getTransformMaxAttempts} attempts.`
                     )
-                    status = PollTransformationStatus.FAILED
+                    status = PollTransformationStatus.NOT_FOUND
                     break
                 }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -187,10 +187,7 @@ export class TransformHandler {
         } catch (e: any) {
             const errorMessage = (e as Error).message ?? 'Error in GetTransformation API call'
             this.logging.log('Error: ' + errorMessage)
-
-            return {
-                TransformationJob: { status: 'FAILED' },
-            } as GetTransformResponse
+            return null
         }
     }
     async getTransformationPlan(request: GetTransformPlanRequest) {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -68,7 +68,7 @@ export const QNetTransformServerToken =
                         const request = params as GetTransformRequest
                         logging.log('Calling getTransform request with job Id: ' + request.TransformationJobId)
                         const response = await transformHandler.getTransformation(request)
-                        if(response != null){
+                        if (response != null) {
                             emitTransformationJobReceivedTelemetry(telemetry, response)
                         }
                         return response

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -68,7 +68,9 @@ export const QNetTransformServerToken =
                         const request = params as GetTransformRequest
                         logging.log('Calling getTransform request with job Id: ' + request.TransformationJobId)
                         const response = await transformHandler.getTransformation(request)
-                        emitTransformationJobReceivedTelemetry(telemetry, response)
+                        if(response != null){
+                            emitTransformationJobReceivedTelemetry(telemetry, response)
+                        }
                         return response
                     }
                     case PollTransformCommand: {


### PR DESCRIPTION
## Problem
In LSP, we were setting job status to failed on any API failure from cwspr. 
## Solution
fixing to ignore this error and poll again. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
