### PR TITLE
Enable Project Validation

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -50,7 +50,6 @@ export class TransformHandler {
         var unsupportedProjects: string[] = []
         const isProject = validation.isProject(userInputrequest)
         const containsUnsupportedViews = await validation.checkForUnsupportedViews(userInputrequest, isProject)
-        /*
         if (isProject) {
             let isValid = validation.validateProject(userInputrequest)
             if (!isValid) {
@@ -63,7 +62,7 @@ export class TransformHandler {
         } else {
             unsupportedProjects = validation.validateSolution(userInputrequest)
         }
-*/
+
         const artifactManager = new ArtifactManager(
             this.workspace,
             this.logging,

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/validation.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/validation.ts
@@ -14,7 +14,7 @@ export function validateProject(userInputrequest: StartTransformRequest): boolea
     var selectedProject = userInputrequest.ProjectMetadata.find(
         project => project.ProjectPath == userInputrequest.SelectedProjectPath
     )
-    if (selectedProject) return supportedProjects.includes(selectedProject.ProjectType)
+    if (selectedProject) return supportedProjects.includes(selectedProject?.ProjectType)
     return false
 }
 


### PR DESCRIPTION
## Problem
Project Type validation was disabled. Only valid project types can be used for transformation.

## Solution
Enable Project Type Validation. If the project type is not valid return NotSupported in case of a project transformation or the unsupported projects list in case of a solution transformation.
 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
