### PR TITLE
Update StartTransform error message

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -86,7 +86,11 @@ export class TransformHandler {
                 containsUnsupportedViews
             )
         } catch (error) {
-            const errorMessage = (error as Error).message ?? 'Error in StartTransformation API call'
+            let errorMessage = (error as Error).message ?? 'Error in StartTransformation API call'
+            if (errorMessage.includes('Invalid transformation specification')) {
+                errorMessage =
+                    'Your profile credentials are not allow-listed or lack the necessary access. Please check your credentials.'
+            }
             this.logging.log(errorMessage)
             throw new Error(errorMessage)
         } finally {


### PR DESCRIPTION
## Problem
When StartTransform is failed due to the credentials are not allow-listed, the logged error message is "Invalid transformation specification" which is confusing. 

## Solution
Update the error message indicating permissions issues.

[ ✔] Pull request title describes the changes without ambiguity
[ ✔] Added screenshots of visual/UI changes
[ ✔] Added Unit test coverage
[ ✔] Removed all developer references (internal URLs, etc)
[ ✔] Removed unused code, comments, references, namespaces
[ ✔] Used constants/readonly where needed
[ ✔] Used appropriate data structures
[ ✔] Used consistent naming convention
[ ✔] Used predefined Toolkit themes for UI elements
[ ✔] Used appropriate method and property access levels (private vs public)
[ ✔] Avoided global and singleton references where possible
[ ✔] Enforced DRY principles (Do not Repeat Yourself)
[ ✔] All TODOs have an internal tracking reference ID (e.g. SIM ID)
[ ✔] Resolved merge conflicts with destination branch
[ ✔] Reviewed by Huawen
[ ✔] Optional: Reviewed by Pranav, Sunwoo, Ke, Jiayu

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
