### PR TITLE
Rename customization server to configuration server

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/src/token-standalone.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/src/token-standalone.ts
@@ -3,8 +3,8 @@ import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
 import {
     CodeWhispererSecurityScanServerTokenProxy,
     CodeWhispererServerTokenProxy,
-    CustomizationServerTokenProxy,
     QChatServerProxy,
+    QConfigurationServerTokenProxy,
     QNetTransformServerTokenProxy,
 } from '@aws/lsp-codewhisperer/out/language-server/proxy-server'
 
@@ -18,7 +18,7 @@ const props: RuntimeProps = {
     servers: [
         CodeWhispererServerTokenProxy,
         CodeWhispererSecurityScanServerTokenProxy,
-        CustomizationServerTokenProxy,
+        QConfigurationServerTokenProxy,
         QNetTransformServerTokenProxy,
         QChatServerProxy,
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.17",
+                "@aws/language-server-runtimes": "^0.2.18",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1"
             },
@@ -64,7 +64,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.17",
+                "@aws/language-server-runtimes": "^0.2.18",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -108,7 +108,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.17",
+                "@aws/language-server-runtimes": "^0.2.18",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -128,7 +128,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.17",
+                "@aws/language-server-runtimes": "^0.2.18",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -16455,7 +16455,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.17",
+                "@aws/language-server-runtimes": "^0.2.18",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -16469,7 +16469,7 @@
             "version": "0.0.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.17",
+                "@aws/language-server-runtimes": "^0.2.18",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4",
                 "web-tree-sitter": "0.22.6"
@@ -16502,7 +16502,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.17",
+                "@aws/language-server-runtimes": "^0.2.18",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -16516,7 +16516,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.17",
+                "@aws/language-server-runtimes": "^0.2.18",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -16527,7 +16527,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.17",
+                "@aws/language-server-runtimes": "^0.2.18",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -121,7 +121,7 @@ export const QChatServerProxy = QChatServer(credentialsProvider => {
         .withConfig(clientOptions)
 })
 
-export const CustomizationServerTokenProxy = QConfigurationServerToken(credentialsProvider => {
+export const QConfigurationServerTokenProxy = QConfigurationServerToken(credentialsProvider => {
     let additionalAwsConfig = {}
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
     const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined


### PR DESCRIPTION
## Problem
The proxy version of `QConfigurationServer` was wrongly named as `QCustomizationServerTokenProxy` where it should have been named as Configuration server

## Solution
Renamed to `QConfigurationServerTokenProxy`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
