### PR TITLE
Fix unit testing in VSC and update aws-lsp-identity test scripts to conform to repo

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    exclude: ['./**/node_modules/**'],
+    'fail-zero': true,
+    'forbid-only': true,
+    'forbid-pending': true,
+    timeout: 5000,
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -135,22 +135,26 @@
             "preLaunchTask": "npm: compile"
         },
         {
+            "name": "Unit Tests",
             "type": "node",
             "request": "launch",
             "preLaunchTask": "watch",
-            "name": "Unit Tests",
-            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-            "args": ["${workspaceRoot}/out/test/unit/**/*.js"],
-            "cwd": "${workspaceRoot}"
+            "program": "${workspaceFolder}/node_modules/.bin/mocha",
+            "args": ["--forbid-only=false", "--forbid-pending=false", "./**/out/**/*.test.js"],
+            "outFiles": ["${workspaceFolder}/**/out/**/*.(m|c|)js", "!**/node_modules/**"],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal"
         },
         {
+            "name": "Unit Tests (Current File)",
             "type": "node",
             "request": "launch",
             "preLaunchTask": "watch",
-            "name": "Unit Tests (Current File)",
-            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-            "args": ["${workspaceRoot}/out/test/unit/**/${fileBasenameNoExtension}.js"],
-            "cwd": "${workspaceRoot}"
+            "program": "${workspaceFolder}/node_modules/.bin/mocha",
+            "args": ["--forbid-only=false", "--forbid-pending=false", "./**/out/**/${fileBasenameNoExtension}.js"],
+            "outFiles": ["${workspaceFolder}/**/out/**/*.(m|c|)js", "!**/node_modules/**"],
+            "cwd": "${workspaceRoot}",
+            "console": "integratedTerminal"
         }
     ],
     "compounds": [

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -15,7 +15,8 @@
     "scripts": {
         "clean": "rm -fr ./out tsconfig.tsbuildinfo",
         "compile": "tsc --build --verbose",
-        "test": "ts-mocha -b 'src/**/*.test.ts'"
+        "test": "npm run test-unit",
+        "test-unit": "mocha 'out/**/*.test.js'"
     },
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",


### PR DESCRIPTION
"Unit Tests" and "Unit Tests (Current File)" didn't do anything and seemed to not be configured for the current state of the repo where there doesn't appear to be a "test" directory (outside of chat-client, which its "test" directory didn't conform to the launch.json configurations above anyway) and tests end with '.test.js'.  Unit tests can be run from VSC using both configs with this update.

Added .mocharc to and set some sane defaults.

Updated aws-lsp-identity package.json test scripts to conform to other packages in repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
