### PR TITLE
[Team Review] Add logging when polling get transformation status failed

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -356,6 +356,12 @@ export class TransformHandler {
             }
         }
         this.logging.log('poll : returning response from server : ' + JSON.stringify(response))
+        if (failureStates.includes(status)) {
+            this.logging.log(
+                `Transformation job for job ${request.TransformationJobId} is ${status} due to "${response.transformationJob.reason}". 
+                Please close Visual Studio, delete the bin and obj folders for the projects, and try running the transformation again.`
+            )
+        }
         return {
             TransformationJob: response.transformationJob,
         } as GetTransformResponse


### PR DESCRIPTION
## Problem
The "FAILED" status during polling transformation is typically due to build validation failures. Currently, no guidance is logged when the job status fails. 

## Solution
Add logs to recommend that customers clear the binary cache and retry.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
