### PR TITLE
Add identity center login to the sample extension

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -31,8 +31,12 @@
                 "title": "AWS LSP - Clear credentials from LSP Server"
             },
             {
-                "command": "awslsp.resolveBearerToken",
-                "title": "AWS LSP - Obtain bearer token and send to LSP Server"
+                "command": "awslsp.resolveBearerToken.BuilderID",
+                "title": "AWS LSP - Obtain bearer token and send to LSP Server - BuilderID"
+            },
+            {
+                "command": "awslsp.resolveBearerToken.IDC",
+                "title": "AWS LSP - Obtain bearer token and send to LSP Server - Identity Center"
             },
             {
                 "command": "awslsp.clearBearerToken",

--- a/client/vscode/src/credentialsActivation.ts
+++ b/client/vscode/src/credentialsActivation.ts
@@ -11,7 +11,8 @@ import {
     RequestType,
     ResponseMessage,
 } from 'vscode-languageclient/node'
-import { BuilderIdConnectionBuilder, SsoConnection } from './sso/builderId'
+import { SSOConnectionBuilder, SsoConnection } from './sso/connectionBuilder'
+import { LoginType } from './sso/model'
 
 /**
  * Request for custom notifications that Update Credentials and tokens.
@@ -128,7 +129,14 @@ export async function registerBearerTokenProviderSupport(
 
     extensionContext.subscriptions.push(
         ...[
-            commands.registerCommand('awslsp.resolveBearerToken', createResolveBearerTokenCommand(languageClient)),
+            commands.registerCommand(
+                'awslsp.resolveBearerToken.BuilderID',
+                createResolveBearerTokenCommand(languageClient, 'builderId')
+            ),
+            commands.registerCommand(
+                'awslsp.resolveBearerToken.IDC',
+                createResolveBearerTokenCommand(languageClient, 'idc')
+            ),
             commands.registerCommand('awslsp.clearBearerToken', createClearTokenCommand(languageClient)),
         ]
     )
@@ -228,9 +236,9 @@ function createGetConnectionMetadataRequestHandler(languageClient: LanguageClien
  * In this simulation, the user is asked for a profile name. That profile's credentials are
  * resolved and sent. (basic profile types only in this proof of concept)
  */
-function createResolveBearerTokenCommand(languageClient: LanguageClient) {
+function createResolveBearerTokenCommand(languageClient: LanguageClient, loginType: LoginType = 'builderId') {
     return async () => {
-        activeBuilderIdConnection = await BuilderIdConnectionBuilder.build()
+        activeBuilderIdConnection = await SSOConnectionBuilder.build(loginType)
 
         const token = await activeBuilderIdConnection.getToken()
 

--- a/client/vscode/src/sso/model.ts
+++ b/client/vscode/src/sso/model.ts
@@ -58,6 +58,7 @@ export interface ClientRegistration {
     readonly scopes?: string[]
 }
 
+export type LoginType = 'builderId' | 'idc'
 export interface SsoProfile {
     readonly region: string
     readonly startUrl: string
@@ -65,9 +66,11 @@ export interface SsoProfile {
     readonly roleName?: string
     readonly scopes?: string[]
     readonly identifier?: string
+    readonly loginType: LoginType
 }
 
 export const builderIdStartUrl = 'https://view.awsapps.com/start'
+export const idcStartUrl = 'https://amzn.awsapps.com/start'
 
 export async function openSsoPortalLink(
     startUrl: string,


### PR DESCRIPTION
## Problem
The sample extension currently doesn't support identity center login which means some functionality can't be tested using the sample extension 

## Solution
Updated the sample extension so that now the extension exposes two versions of `Obtain token` command, one for builderid and one for identity center. 

I tested both options and logging in through both methods work as expected. Also verified that list customizations request is successful after Identity center login 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
