### PR TITLE
Bump @aws/language-server-runtimes version to 0.2.19

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1"
     },

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.15",
+        "@aws/language-server-runtimes": "^0.2.19",
         "@aws/lsp-partiql": "^0.0.4"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.17"
+        "@aws/language-server-runtimes": "^0.2.19"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -194,7 +194,7 @@
         "@aws-sdk/credential-providers": "^3.614.0",
         "@aws-sdk/types": "^3.535.0",
         "@aws/chat-client-ui-types": "^0.0.6",
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.88.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1"
             },
@@ -64,7 +64,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -84,7 +84,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.15",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "@aws/lsp-partiql": "^0.0.4"
             },
             "devDependencies": {
@@ -108,7 +108,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -128,7 +128,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -150,7 +150,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.17"
+                "@aws/language-server-runtimes": "^0.2.19"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -194,7 +194,7 @@
                 "@aws-sdk/credential-providers": "^3.614.0",
                 "@aws-sdk/types": "^3.535.0",
                 "@aws/chat-client-ui-types": "^0.0.6",
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",
@@ -5035,13 +5035,12 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.18",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.18.tgz",
-            "integrity": "sha512-dVuXDMkVL2JN84IntMhYFifW1ayMji3Km0KuUHD2liMOpbKrSNSQ5Ef319JyWC6j+YT8Y0A/stwR6SatbikdsA==",
-            "license": "Apache-2.0",
+            "version": "0.2.19",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.19.tgz",
+            "integrity": "sha512-4qbpqmRPDpjozUVG6+9bgbmrUtRMCpJUieeAfMjyHvUlWTY4MH+8hKG0299o3c6OXpefwH/IFJ6PWPOsOrE4xA==",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.6",
-                "jose": "^5.8.0",
+                "jose": "^5.9.3",
                 "rxjs": "^7.8.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-protocol": "^3.17.5"
@@ -7412,24 +7411,6 @@
                 "@sinonjs/commons": "^3.0.1",
                 "lodash.get": "^4.4.2",
                 "type-detect": "^4.0.8"
-            }
-        },
-        "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-            "dev": true,
-            "dependencies": {
-                "type-detect": "4.0.8"
-            }
-        },
-        "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/@sinonjs/text-encoding": {
@@ -23115,7 +23096,7 @@
                 "@amzn/codewhisperer-streaming": "*",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.0.6",
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "@aws/lsp-fqn": "^0.0.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@smithy/node-http-handler": "^2.5.0",
@@ -23310,7 +23291,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.614.0",
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "@smithy/shared-ini-file-loader": "^3.1.5",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -23346,7 +23327,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -23360,7 +23341,7 @@
             "version": "0.0.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4",
                 "web-tree-sitter": "0.22.6"
@@ -23393,7 +23374,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -23407,7 +23388,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -23418,7 +23399,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.18",
+                "@aws/language-server-runtimes": "^0.2.19",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -35,7 +35,7 @@
         "@amzn/codewhisperer-streaming": "*",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.0.6",
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "@aws/lsp-fqn": "^0.0.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -21,8 +21,8 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.614.0",
+        "@aws/language-server-runtimes": "^0.2.19",
         "@smithy/shared-ini-file-loader": "^3.1.5",
-        "@aws/language-server-runtimes": "^0.2.18",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.19",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Description

Updating @aws/language-server-runtimes version to 0.2.19
https://github.com/aws/language-server-runtimes/releases/tag/language-server-runtimes%2Fv0.2.19

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
