### PR TITLE
Add automated workflow to publish chat-client to npm registry

### DIFF
--- a/.github/workflows/publish-chat-client.yaml
+++ b/.github/workflows/publish-chat-client.yaml
@@ -1,0 +1,13 @@
+name: Publish Codewhisperer Language Server to npmjs
+
+on:
+    push:
+        tags:
+            - 'chat-client/v**'
+
+jobs:
+    publish:
+        uses: ./.github/workflows/publish-to-npm.yaml
+        with:
+            workspace: 'chat-client'
+        secrets: inherit

--- a/chat-client/.npmignore
+++ b/chat-client/.npmignore
@@ -1,4 +1,7 @@
+build/
 node_modules/
+src/
 package-lock.json
 .*
 tsconfig.*
+webpack.*.config.js


### PR DESCRIPTION
## Problem
`@aws/chat-client` package is not publish to npm, and proper semver versioning history was not maintained.

## Solution

Added automated workflow to publish new version of `chat-client` to npm. Current version `0.0.4` is published manually https://www.npmjs.com/package/@aws/chat-client

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
