### PR TITLE
Add SsoTokenChanged, profile bug fixes, and testability of aws-lsp-id enity in vscode client

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -172,20 +172,6 @@
             "args": ["--forbid-only=false", "--forbid-pending=false", "./**/out/**/${fileBasenameNoExtension}.js"],
             "outFiles": ["${workspaceFolder}/**/out/**/*.(m|c|)js", "!**/node_modules/**"],
             "console": "integratedTerminal"
-        },
-        {
-            "name": "ts-mocha (current tab)",
-            "type": "node",
-            "request": "launch",
-            "program": "${workspaceFolder}/node_modules/.bin/ts-mocha",
-            "args": ["--forbid-only=false", "--forbid-pending=false", "${file}"],
-            "outFiles": [
-                "${workspaceFolder}/**/src/**/*.ts",
-                "${workspaceFolder}/**/out/**/*.ts",
-                "${workspaceFolder}/**/out/**/*.(m|c|)js",
-                "!**/node_modules/**"
-            ],
-            "console": "integratedTerminal"
         }
     ],
     "compounds": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -135,6 +135,25 @@
             "preLaunchTask": "npm: compile"
         },
         {
+            "name": "Identity Server + VSCode Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}/client/vscode", "--disable-extensions"],
+            "env": {
+                "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-identity-runtimes/out/standalone.js",
+                "ENABLE_IDENTITY": "true",
+                "ENABLE_TOKEN_PROVIDER": "true"
+            },
+            "outFiles": [
+                "${workspaceFolder}/client/vscode/out/**/*.js",
+                "${workspaceFolder}/app/aws-lsp-identity-runtimes/out/**/*.js",
+                "${workspaceFolder}/server/aws-lsp-identity/out/**/*.js"
+            ],
+            "autoAttachChildProcesses": true,
+            "preLaunchTask": "watch"
+        },
+        {
             "name": "Unit Tests",
             "type": "node",
             "request": "launch",
@@ -160,10 +179,13 @@
             "request": "launch",
             "program": "${workspaceFolder}/node_modules/.bin/ts-mocha",
             "args": ["--forbid-only=false", "--forbid-pending=false", "${file}"],
-            "outFiles": ["${workspaceFolder}/**/out/**/*.(m|c|)js", "!**/node_modules/**"],
-            "console": "integratedTerminal",
-            "pauseForSourceMap": true,
-            "stopOnEntry": true
+            "outFiles": [
+                "${workspaceFolder}/**/src/**/*.ts",
+                "${workspaceFolder}/**/out/**/*.ts",
+                "${workspaceFolder}/**/out/**/*.(m|c|)js",
+                "!**/node_modules/**"
+            ],
+            "console": "integratedTerminal"
         }
     ],
     "compounds": [

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/language-server-runtimes": "^0.2.20",
         "@aws/aws-lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "@aws/aws-lsp-identity-runtimes",
+    "version": "0.1.0",
+    "description": "Identity Server Runtimes",
+    "main": "out/standalone.js",
+    "scripts": {
+        "compile": "tsc --build"
+    },
+    "dependencies": {
+        "@aws/language-server-runtimes": "^0.2.18",
+        "@aws/aws-lsp-identity": "^0.0.1"
+    }
+}

--- a/app/aws-lsp-identity-runtimes/src/standalone.ts
+++ b/app/aws-lsp-identity-runtimes/src/standalone.ts
@@ -1,0 +1,11 @@
+import { standalone } from '@aws/language-server-runtimes/runtimes'
+import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
+import { IdentityServer } from '@aws/aws-lsp-identity'
+
+const props: RuntimeProps = {
+    version: '0.1.0',
+    servers: [IdentityServer],
+    name: 'Identity Server',
+}
+
+standalone(props)

--- a/app/aws-lsp-identity-runtimes/tsconfig.json
+++ b/app/aws-lsp-identity-runtimes/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./out"
+    },
+    "include": ["src"]
+}

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -74,6 +74,11 @@
             {
                 "command": "aws.qNetTransform.startTransform",
                 "title": "Start Transform"
+            },
+            {
+                "command": "aws.aws-lsp-identity.test",
+                "title": "Test Command",
+                "category": "Identity"
             }
         ],
         "menus": {

--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -21,6 +21,7 @@ import { registerInlineCompletion } from './inlineCompletionActivation'
 import { registerLogCommand, registerTransformCommand } from './sampleCommandActivation'
 import { randomUUID } from 'crypto'
 import { registerCustomizations } from './customizationActivation'
+import { registerIdentity } from './identityActivation'
 
 export async function activateDocumentsLanguageServer(extensionContext: ExtensionContext) {
     /**
@@ -151,6 +152,11 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
     const enableCustomizations = process.env.ENABLE_CUSTOMIZATIONS === 'true'
     if (enableCustomizations) {
         registerCustomizations(client)
+    }
+
+    const enableIdentity = process.env.ENABLE_IDENTITY === 'true'
+    if (enableIdentity) {
+        await registerIdentity(client)
     }
 
     return client

--- a/client/vscode/src/extension.ts
+++ b/client/vscode/src/extension.ts
@@ -6,10 +6,9 @@ let client: LanguageClient
 
 export async function activate(context: ExtensionContext) {
     client = await activateDocumentsLanguageServer(context)
-    client.start()
-    return
+    await client.start()
 }
 
 export async function deactivate() {
-    client.stop()
+    await client.stop()
 }

--- a/client/vscode/src/identityActivation.ts
+++ b/client/vscode/src/identityActivation.ts
@@ -1,0 +1,69 @@
+import { commands, window } from 'vscode'
+import {
+    ListProfilesError,
+    ListProfilesParams,
+    ListProfilesResult,
+    ProfileKind,
+    SsoTokenChangedParams,
+    UpdateProfileError,
+    UpdateProfileParams,
+    UpdateProfileResult,
+} from '@aws/language-server-runtimes/protocol'
+
+import { LanguageClient, ProtocolNotificationType, ProtocolRequestType } from 'vscode-languageclient/node'
+
+const ssoTokenChangedRequestType = new ProtocolNotificationType<SsoTokenChangedParams, void>(
+    'aws/identity/ssoTokenChanged'
+)
+
+const listProfilesRequestType = new ProtocolRequestType<
+    ListProfilesParams,
+    ListProfilesResult,
+    never,
+    ListProfilesError,
+    void
+>('aws/identity/listProfiles')
+
+const updateProfileRequestType = new ProtocolRequestType<
+    UpdateProfileParams,
+    UpdateProfileResult,
+    never,
+    UpdateProfileError,
+    void
+>('aws/identity/updateProfile')
+
+export async function registerIdentity(client: LanguageClient): Promise<void> {
+    client.onNotification(ssoTokenChangedRequestType, ssoTokenChangedHandler)
+
+    commands.registerCommand('aws.aws-lsp-identity.test', execTestCommand.bind(null, client))
+}
+
+function ssoTokenChangedHandler(params: SsoTokenChangedParams): void {
+    window.showInformationMessage(`SsoTokenChanged raised: ${JSON.stringify(params)}`)
+}
+
+// Put whatever calls to the aws-lsp-identity server you want to experiment with/debug here
+async function execTestCommand(client: LanguageClient): Promise<void> {
+    const result1 = await client.sendRequest(updateProfileRequestType, {
+        profile: {
+            kinds: [ProfileKind.SsoTokenProfile],
+            name: 'codecatalyst',
+            settings: {
+                region: 'us-west-2',
+                sso_session: 'codecatalyst2',
+            },
+        },
+        ssoSession: {
+            name: 'codecatalyst2',
+            settings: {
+                sso_region: 'us-east-1',
+                sso_start_url: 'https://view.awsapps.com/start',
+                sso_registration_scopes: ['codecatalyst:read_write'],
+            },
+        },
+    } as UpdateProfileParams)
+    window.showInformationMessage(`UpdateProfile: ${JSON.stringify(result1)}`)
+
+    const result2 = await client.sendRequest(listProfilesRequestType, {})
+    window.showInformationMessage(`ListProfiles: ${JSON.stringify(result2)}`)
+}

--- a/client/vscode/src/identityActivation.ts
+++ b/client/vscode/src/identityActivation.ts
@@ -1,39 +1,17 @@
 import { commands, window } from 'vscode'
 import {
-    ListProfilesError,
-    ListProfilesParams,
-    ListProfilesResult,
+    listProfilesRequestType,
     ProfileKind,
     SsoTokenChangedParams,
-    UpdateProfileError,
+    ssoTokenChangedRequestType,
     UpdateProfileParams,
-    UpdateProfileResult,
+    updateProfileRequestType,
 } from '@aws/language-server-runtimes/protocol'
 
-import { LanguageClient, ProtocolNotificationType, ProtocolRequestType } from 'vscode-languageclient/node'
-
-const ssoTokenChangedRequestType = new ProtocolNotificationType<SsoTokenChangedParams, void>(
-    'aws/identity/ssoTokenChanged'
-)
-
-const listProfilesRequestType = new ProtocolRequestType<
-    ListProfilesParams,
-    ListProfilesResult,
-    never,
-    ListProfilesError,
-    void
->('aws/identity/listProfiles')
-
-const updateProfileRequestType = new ProtocolRequestType<
-    UpdateProfileParams,
-    UpdateProfileResult,
-    never,
-    UpdateProfileError,
-    void
->('aws/identity/updateProfile')
+import { LanguageClient } from 'vscode-languageclient/node'
 
 export async function registerIdentity(client: LanguageClient): Promise<void> {
-    client.onNotification(ssoTokenChangedRequestType, ssoTokenChangedHandler)
+    client.onNotification(ssoTokenChangedRequestType.method, ssoTokenChangedHandler)
 
     commands.registerCommand('aws.aws-lsp-identity.test', execTestCommand.bind(null, client))
 }
@@ -44,7 +22,7 @@ function ssoTokenChangedHandler(params: SsoTokenChangedParams): void {
 
 // Put whatever calls to the aws-lsp-identity server you want to experiment with/debug here
 async function execTestCommand(client: LanguageClient): Promise<void> {
-    const result1 = await client.sendRequest(updateProfileRequestType, {
+    const result1 = await client.sendRequest(updateProfileRequestType.method, {
         profile: {
             kinds: [ProfileKind.SsoTokenProfile],
             name: 'codecatalyst',
@@ -64,6 +42,6 @@ async function execTestCommand(client: LanguageClient): Promise<void> {
     } as UpdateProfileParams)
     window.showInformationMessage(`UpdateProfile: ${JSON.stringify(result1)}`)
 
-    const result2 = await client.sendRequest(listProfilesRequestType, {})
+    const result2 = await client.sendRequest(listProfilesRequestType.method, {})
     window.showInformationMessage(`ListProfiles: ${JSON.stringify(result2)}`)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,14 @@
                 "webpack-cli": "^5.1.4"
             }
         },
+        "app/aws-lsp-identity-runtimes": {
+            "name": "@aws/aws-lsp-identity-runtimes",
+            "version": "0.1.0",
+            "dependencies": {
+                "@aws/aws-lsp-identity": "^0.0.1",
+                "@aws/language-server-runtimes": "^0.2.19"
+            }
+        },
         "app/aws-lsp-json-runtimes": {
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
@@ -4996,6 +5004,10 @@
         },
         "node_modules/@aws/aws-lsp-identity": {
             "resolved": "server/aws-lsp-identity",
+            "link": true
+        },
+        "node_modules/@aws/aws-lsp-identity-runtimes": {
+            "resolved": "app/aws-lsp-identity-runtimes",
             "link": true
         },
         "node_modules/@aws/chat-client": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
             "version": "0.1.0",
             "dependencies": {
                 "@aws/aws-lsp-identity": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.19"
+                "@aws/language-server-runtimes": "^0.2.20"
             }
         },
         "app/aws-lsp-json-runtimes": {
@@ -5047,9 +5047,10 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.19",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.19.tgz",
-            "integrity": "sha512-4qbpqmRPDpjozUVG6+9bgbmrUtRMCpJUieeAfMjyHvUlWTY4MH+8hKG0299o3c6OXpefwH/IFJ6PWPOsOrE4xA==",
+            "version": "0.2.20",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.20.tgz",
+            "integrity": "sha512-Q28yvQ3hA1Nl4GHru5YwP5dojbP12DwZFB+n1TWHvJ1QjIFBnERjBEp3UIU0FJigscTXoTO+mATftY55WEYWEA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.6",
                 "jose": "^5.9.3",
@@ -23303,7 +23304,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.614.0",
-                "@aws/language-server-runtimes": "^0.2.19",
+                "@aws/language-server-runtimes": "^0.2.20",
                 "@smithy/shared-ini-file-loader": "^3.1.5",
                 "vscode-languageserver": "^9.0.1"
             },

--- a/server/aws-lsp-identity/README.md
+++ b/server/aws-lsp-identity/README.md
@@ -2,20 +2,3 @@
 
 The aws-lsp-identity almost exclusively uses bespoke JSON-RPC requests/notifications and is not a traditional LSP server despite the name that
 follows convention.  It provides identity and authx related functions, starting with SSO token handling.
-
-## Handling imports
-
-The language-server-runtimes protocol and server-interface modules do not export identity-management types as these types are intended to
-only be consumed by this server, so those top-level namespaces are not polluted.  All import statements in this package should be specific to the 
-identity-management namespace for this reason.  Alway import from server-interace, not protocol.
-
-For example:
-```
-// These are not the types you're looking for...
-import { ListProfilesParams } from '@aws/language-server-runtimes/server-interface'
-import { ListProfilesParams } from '@aws/language-server-runtimes/protocol'
-import { ListProfilesParams } from '@aws/language-server-runtimes/protocol/identity-management'
-
-// This is the way
-import { ListProfilesParams } from '@aws/language-server-runtimes/server-interface/identity-management'
-```

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.614.0",
-        "@aws/language-server-runtimes": "^0.2.19",
+        "@aws/language-server-runtimes": "^0.2.20",
         "@smithy/shared-ini-file-loader": "^3.1.5",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-identity/src/index.ts
+++ b/server/aws-lsp-identity/src/index.ts
@@ -1,1 +1,2 @@
+export { IdentityServer } from './language-server/identityServer'
 export * as sharedConfig from './sharedConfig'

--- a/server/aws-lsp-identity/src/language-server/identityServer.ts
+++ b/server/aws-lsp-identity/src/language-server/identityServer.ts
@@ -1,32 +1,18 @@
 import { ProfileService } from './profiles/profileService'
 import {
+    CancellationToken,
     ListProfilesParams,
     SsoTokenChangedParams,
     UpdateProfileParams,
     IdentityManagement,
-    Chat,
-    CredentialsProvider,
-    Logging,
-    Lsp,
     Server,
-    Telemetry,
-    Workspace,
 } from '@aws/language-server-runtimes/server-interface'
 import { SharedConfigProfileStore } from './profiles/sharedConfigProfileStore'
 import { IdentityService } from './identityService'
-import { CancellationToken } from 'vscode-languageserver'
 
 export const IdentityServerFactory =
     (identityService: IdentityService, profileService: ProfileService): Server =>
-    (features: {
-        credentialsProvider: CredentialsProvider
-        chat: Chat
-        lsp: Lsp
-        workspace: Workspace
-        logging: Logging
-        telemetry: Telemetry
-        identityManagement: IdentityManagement
-    }) => {
+    (features: { identityManagement: IdentityManagement }) => {
         const { identityManagement: idMgmt } = features
 
         const ssoTokenChangedHandler = async (sender: object, e: SsoTokenChangedParams) => {

--- a/server/aws-lsp-identity/src/language-server/identityServer.ts
+++ b/server/aws-lsp-identity/src/language-server/identityServer.ts
@@ -1,0 +1,55 @@
+import { ProfileService } from './profiles/profileService'
+import {
+    ListProfilesParams,
+    SsoTokenChangedParams,
+    UpdateProfileParams,
+    IdentityManagement,
+    Chat,
+    CredentialsProvider,
+    Logging,
+    Lsp,
+    Server,
+    Telemetry,
+    Workspace,
+} from '@aws/language-server-runtimes/server-interface'
+import { SharedConfigProfileStore } from './profiles/sharedConfigProfileStore'
+import { IdentityService } from './identityService'
+import { CancellationToken } from 'vscode-languageserver'
+
+export const IdentityServerFactory =
+    (identityService: IdentityService, profileService: ProfileService): Server =>
+    (features: {
+        credentialsProvider: CredentialsProvider
+        chat: Chat
+        lsp: Lsp
+        workspace: Workspace
+        logging: Logging
+        telemetry: Telemetry
+        identityManagement: IdentityManagement
+    }) => {
+        const { identityManagement: idMgmt } = features
+
+        const ssoTokenChangedHandler = async (sender: object, e: SsoTokenChangedParams) => {
+            idMgmt.sendSsoTokenChanged(e)
+        }
+        identityService.SsoTokenChanged.add(ssoTokenChangedHandler)
+
+        idMgmt.onListProfiles(
+            async (params: ListProfilesParams, token: CancellationToken) =>
+                await profileService.listProfiles(params, token)
+        )
+        idMgmt.onUpdateProfile(
+            async (params: UpdateProfileParams, token: CancellationToken) =>
+                await profileService.updateProfile(params, token)
+        )
+
+        // disposable
+        return () => {
+            identityService.SsoTokenChanged.remove(ssoTokenChangedHandler)
+        }
+    }
+
+const identityService = new IdentityService()
+const profileService = new ProfileService(new SharedConfigProfileStore())
+
+export const IdentityServer = IdentityServerFactory(identityService, profileService)

--- a/server/aws-lsp-identity/src/language-server/identityService.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.ts
@@ -1,0 +1,6 @@
+import { SsoTokenChangedParams } from '@aws/language-server-runtimes/protocol'
+import { AsyncEvent } from '../utils/asyncEvent'
+
+export class IdentityService {
+    SsoTokenChanged: AsyncEvent<SsoTokenChangedParams> = new AsyncEvent<SsoTokenChangedParams>()
+}

--- a/server/aws-lsp-identity/src/language-server/identityService.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.ts
@@ -1,4 +1,4 @@
-import { SsoTokenChangedParams } from '@aws/language-server-runtimes/protocol'
+import { SsoTokenChangedParams } from '@aws/language-server-runtimes/server-interface'
 import { AsyncEvent } from '../utils/asyncEvent'
 
 export class IdentityService {

--- a/server/aws-lsp-identity/src/language-server/profiles/profileService.test.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/profileService.test.ts
@@ -1,10 +1,10 @@
 import { ProfileData, profileDuckTypers, ProfileService, ProfileStore, ssoSessionDuckTyper } from './profileService'
 import {
     AwsErrorCodes,
+    AwsResponseError,
     Profile,
     ProfileKind,
     SsoSession,
-    UpdateProfileError,
     UpdateProfileParams,
 } from '@aws/language-server-runtimes/server-interface'
 import { normalizeParsedIniData } from '../../sharedConfig/saveKnownFiles'
@@ -177,19 +177,19 @@ describe('ProfileService', async () => {
         })
     })
 
-    async function expectUpdateProfileError(
+    async function expectAwsResponseError(
         service: ProfileService,
         params: UpdateProfileParams,
         code: string,
         message: string
     ): Promise<void> {
-        const error = await expect(service.updateProfile(params)).rejectedWith(UpdateProfileError)
+        const error = await expect(service.updateProfile(params)).rejectedWith(AwsResponseError)
         expect(error.message).equal(message)
         expect(error?.data?.awsErrorCode).equal(code)
     }
 
     it('updateProfile throws on no profile', async () => {
-        expectUpdateProfileError(sut, { profile: undefined! }, AwsErrorCodes.E_INVALID_PROFILE, 'Profile required.')
+        expectAwsResponseError(sut, { profile: undefined! }, AwsErrorCodes.E_INVALID_PROFILE, 'Profile required.')
     })
 
     it('updateProfile throws on non-SSO token profile', async () => {
@@ -201,7 +201,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile },
             AwsErrorCodes.E_INVALID_PROFILE,
@@ -218,7 +218,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(sut, { profile }, AwsErrorCodes.E_INVALID_PROFILE, 'Profile name required.')
+        await expectAwsResponseError(sut, { profile }, AwsErrorCodes.E_INVALID_PROFILE, 'Profile name required.')
     })
 
     it('updateProfile throws on no settings', async () => {
@@ -227,7 +227,7 @@ describe('ProfileService', async () => {
             name: 'profile-name',
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile: profile as Profile },
             AwsErrorCodes.E_INVALID_PROFILE,
@@ -244,7 +244,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile },
             AwsErrorCodes.E_INVALID_PROFILE,
@@ -261,7 +261,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile },
             AwsErrorCodes.E_INVALID_PROFILE,
@@ -286,7 +286,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile, ssoSession, options: { createNonexistentProfile: false } },
             AwsErrorCodes.E_CANNOT_CREATE_PROFILE,
@@ -303,7 +303,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile: profile1, ssoSession },
             AwsErrorCodes.E_INVALID_SSO_SESSION,
@@ -316,7 +316,7 @@ describe('ProfileService', async () => {
             name: 'ssoSession',
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile: profile1, ssoSession: ssoSession as SsoSession },
             AwsErrorCodes.E_INVALID_SSO_SESSION,
@@ -333,7 +333,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile: profile1, ssoSession },
             AwsErrorCodes.E_INVALID_SSO_SESSION,
@@ -350,7 +350,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile: profile1, ssoSession },
             AwsErrorCodes.E_INVALID_SSO_SESSION,
@@ -367,7 +367,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile: profile1, ssoSession },
             AwsErrorCodes.E_INVALID_PROFILE,
@@ -386,7 +386,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile: profile1, ssoSession, options: { createNonexistentSsoSession: false } },
             AwsErrorCodes.E_CANNOT_CREATE_SSO_SESSION,
@@ -405,7 +405,7 @@ describe('ProfileService', async () => {
             },
         }
 
-        await expectUpdateProfileError(
+        await expectAwsResponseError(
             sut,
             { profile: profile3, ssoSession, options: { updateSharedSsoSession: false } },
             AwsErrorCodes.E_CANNOT_OVERWRITE_SSO_SESSION,

--- a/server/aws-lsp-identity/src/utils/asyncEvent.test.ts
+++ b/server/aws-lsp-identity/src/utils/asyncEvent.test.ts
@@ -1,0 +1,44 @@
+import { AsyncEvent } from './asyncEvent'
+import { expect } from 'chai'
+
+describe('SimpleEvent', () => {
+    it('Handlers get called, but not after removal', async () => {
+        const sut = new AsyncEvent<string>()
+
+        const actualSender = {}
+        let actualEventArg: string
+
+        let handler1Called: boolean = false
+        sut.add(async (sender: object, e: string) => {
+            expect(sender).to.equal(actualSender)
+            expect(e).to.equal(actualEventArg)
+            handler1Called = true
+        })
+
+        let handler2Called: boolean = false
+        const handler2 = async (sender: object, e: string) => {
+            expect(sender).to.equal(actualSender)
+            expect(e).to.equal(actualEventArg)
+            handler2Called = true
+        }
+        sut.add(handler2)
+
+        await sut.raise(actualSender, (actualEventArg = 'test1'))
+
+        expect(handler1Called).to.be.true
+        expect(handler2Called).to.be.true
+
+        handler1Called = false
+        handler2Called = false
+
+        expect(handler1Called).to.be.false
+        expect(handler2Called).to.be.false
+
+        sut.remove(handler2)
+
+        await sut.raise(actualSender, (actualEventArg = 'test2'))
+
+        expect(handler1Called).to.be.true
+        expect(handler2Called).to.be.false
+    })
+})

--- a/server/aws-lsp-identity/src/utils/asyncEvent.ts
+++ b/server/aws-lsp-identity/src/utils/asyncEvent.ts
@@ -1,0 +1,19 @@
+export type AsyncEventHandler<TEventArg> = (sender: object, e: TEventArg) => Promise<void>
+
+export class AsyncEvent<TEventArg> {
+    private handlers = new Set<AsyncEventHandler<TEventArg>>()
+
+    add(handler: AsyncEventHandler<TEventArg>) {
+        this.handlers.add(handler)
+    }
+
+    remove(handler: AsyncEventHandler<TEventArg>) {
+        this.handlers.delete(handler)
+    }
+
+    async raise(sender: object, e: TEventArg) {
+        for (const handler of this.handlers) {
+            await handler(sender, e)
+        }
+    }
+}

--- a/server/aws-lsp-identity/src/utils/duckTyper.ts
+++ b/server/aws-lsp-identity/src/utils/duckTyper.ts
@@ -25,7 +25,7 @@ export class DuckTyper {
     // don't match a rule.  For example, if there is property that doesn't
     // match a rule, 'optional' means that property is implicitly
     // optional and 'disallow' means it is implicitly disallowed.
-    eval(value: object, options?: { unmatchedProperty: 'optional' | 'disallow' }): boolean {
+    eval(value?: object, options?: { unmatchedProperty: 'optional' | 'disallow' }): boolean {
         if (!value) {
             return false
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -61,6 +61,9 @@
             "path": "./app/aws-lsp-codewhisperer-runtimes"
         },
         {
+            "path": "./app/aws-lsp-identity-runtimes"
+        },
+        {
             "path": "./app/aws-lsp-s3-runtimes"
         },
         {


### PR DESCRIPTION
This PR pending merge and publication of new @aws/language-server-runtimes package due to protocol updates.  See https://github.com/aws/language-server-runtimes/pull/222 for details.

## SsoTokenChanged
1. Added simple AsyncEvent implementation of event pattern to support easy usage in the identity server as well as chaining to JSON-RPC server to send.  Existing Node and JavaScript events were too heavyweight and unsuitable for this application.

## Add IdentityServer app
1. Added app/aws-lsp-identity-runtimes modeled after other apps in the app folder to support launching standalone runtime of identity server.

## Profile-related bug fixes/enhancements
1. Added outFiles to support debugging of ts-mocha launch.json configuration.
2. Removed notes about using identity-management for imports instead of service-interface after guidance in prior PR.
3. Removed unnecessary statements for collating profiles and ssoSessions with the shared config files versions in ProfileService.
4. Added ensureSsoAccountAccessScope (added to UpdateProfileParams in separate language-server-runtimes PR as well) option to UpdateProfile to allow opt-out of automatically adding sso:account:access to sso_registration_scopes.  This functionality was moved from sharedConfigProfileStorage to ProfileService.
5. Added additional comments and unit tests
6. Changed sharedConfigProfileStorage.save from removing settings that were missing to not change them in sharedConfig.  Removal now supported by explicit undefined property which is in line with how data is sent and received through LSP messages (i.e. if the client just doesn't touch a setting, the right thing happens in all cases whereas before the client couldn't really remove a setting, only force it to undefined which would be invalid in an INI file).
7. By extension of the above, if the settings property is undefined, the whole section is removed from shared config as a section with no settings makes no sense.  This keeps the behavior the same at both section and setting level and adds support for section deletes in the future.

## Testability in vscode client
1. Added launch.json entry to support debugging of aws-lsp-identity server using sample vscode client.  
8. Added "Identity: Test Command" to be able to test various functionality during the development process.  This may become more formalized later, but is sufficient to enable dev loop for now.
9. Added identityActivation modeled after other activations in the same folder.  This is where a developer can try out new APIs quickly.