### PR TITLE
Fix export for chat-client npm package; release v0.0.5

### DIFF
--- a/chat-client/.npmignore
+++ b/chat-client/.npmignore
@@ -1,4 +1,3 @@
-build/
 node_modules/
 src/
 package-lock.json

--- a/chat-client/CHANGELOG.md
+++ b/chat-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.5] - 2024-10-10
+
+### Fixed
+
+- Export built chat client app in `./build` directory
+
 ## [0.0.4] - 2024-10-09
 
 ### Fixed

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/chat-client",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "AWS Chat Client",
     "main": "out/index.js",
     "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,7 +167,7 @@
         },
         "chat-client": {
             "name": "@aws/chat-client",
-            "version": "0.0.4",
+            "version": "0.0.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.0.6",


### PR DESCRIPTION
## Problem
Chat client package doesn't export built bundle into npm.

## Solution

Publish `build` directory to npm.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
