### PR TITLE
Fix publish to npm workflows names

### DIFF
--- a/.github/workflows/publish-chat-client.yaml
+++ b/.github/workflows/publish-chat-client.yaml
@@ -1,4 +1,4 @@
-name: Publish Codewhisperer Language Server to npmjs
+name: Publish Chat Client to npmjs
 
 on:
     push:

--- a/.github/workflows/publish-lsp-codewhisperer.yaml
+++ b/.github/workflows/publish-lsp-codewhisperer.yaml
@@ -1,4 +1,4 @@
-name: Publish Codewhisperer Language Server to npmjs
+name: Publish Amazon Q Language Server to npmjs
 
 on:
     push:

--- a/.github/workflows/publish-lsp-yaml.yaml
+++ b/.github/workflows/publish-lsp-yaml.yaml
@@ -1,4 +1,4 @@
-name: Publish JSON Language Server to npmjs
+name: Publish YAML Language Server to npmjs
 
 on:
     push:


### PR DESCRIPTION
## Problem
`name` field in some Github workflows is incorrect.

## Solution

Fix names of workflows.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
