### PR TITLE
Send copy to clipboard message from the chat client

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -21,7 +21,7 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.0.6",
+        "@aws/chat-client-ui-types": "^0.0.7",
         "@aws/language-server-runtimes-types": "^0.0.6",
         "@aws/mynah-ui": "^4.15.11"
     },

--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -59,26 +59,26 @@ describe('Chat', () => {
     })
 
     it('publishes ready event and initial tab add event, when initialized', () => {
-        sinon.assert.callCount(clientApi.postMessage, 4)
+        assert.callCount(clientApi.postMessage, 4)
 
-        sinon.assert.calledWithExactly(clientApi.postMessage.firstCall, {
+        assert.calledWithExactly(clientApi.postMessage.firstCall, {
             command: TELEMETRY,
             params: { name: 'enterFocus' },
         })
-        sinon.assert.calledWithExactly(clientApi.postMessage.secondCall, { command: READY_NOTIFICATION_METHOD })
+        assert.calledWithExactly(clientApi.postMessage.secondCall, { command: READY_NOTIFICATION_METHOD })
 
         assert.calledWithExactly(clientApi.postMessage.thirdCall, {
+            command: TAB_ADD_NOTIFICATION_METHOD,
+            params: { tabId: initialTabId },
+        })
+
+        assert.calledWithExactly(clientApi.postMessage.lastCall, {
             command: TELEMETRY,
             params: {
                 triggerType: 'click',
                 name: TAB_ADD_TELEMETRY_EVENT,
                 tabId: initialTabId,
             },
-        })
-
-        sinon.assert.calledWithExactly(clientApi.postMessage.lastCall, {
-            command: TAB_ADD_NOTIFICATION_METHOD,
-            params: { tabId: initialTabId },
         })
     })
 

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -4,6 +4,8 @@ import {
     AuthFollowUpClickedParams,
     CHAT_OPTIONS,
     ChatOptionsMessage,
+    COPY_TO_CLIPBOARD,
+    CopyCodeToClipboardParams,
     ERROR_MESSAGE,
     ErrorMessage,
     GENERIC_COMMAND,
@@ -82,7 +84,7 @@ export const createChat = (
             case ERROR_MESSAGE:
                 mynahApi.showError((message as ErrorMessage).params)
                 break
-            case CHAT_OPTIONS:
+            case CHAT_OPTIONS: {
                 const params = (message as ChatOptionsMessage).params
                 const chatConfig: ChatClientConfig = params?.quickActions?.quickActionsCommandGroups
                     ? { quickActionCommands: params.quickActions.quickActionsCommandGroups }
@@ -94,6 +96,8 @@ export const createChat = (
                 for (const tabId in allExistingTabs) {
                     mynahUi.updateStore(tabId, chatConfig)
                 }
+                break
+            }
             default:
                 // TODO: Report error?
                 break
@@ -121,6 +125,9 @@ export const createChat = (
         },
         insertToCursorPosition: (params: InsertToCursorPositionParams) => {
             sendMessageToClient({ command: INSERT_TO_CURSOR_POSITION, params })
+        },
+        copyToClipboard: (params: CopyCodeToClipboardParams) => {
+            sendMessageToClient({ command: COPY_TO_CLIPBOARD, params })
         },
         authFollowUpClicked: (params: AuthFollowUpClickedParams) => {
             sendMessageToClient({ command: AUTH_FOLLOW_UP_CLICKED, params })

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -5,6 +5,7 @@
 
 import {
     AuthFollowUpClickedParams,
+    CopyCodeToClipboardParams,
     ErrorParams,
     InsertToCursorPositionParams,
     SendToPromptParams,
@@ -27,7 +28,6 @@ import {
     ADD_MESSAGE_TELEMETRY_EVENT,
     AUTH_FOLLOW_UP_CLICKED_TELEMETRY_EVENT,
     COPY_TO_CLIPBOARD_TELEMETRY_EVENT,
-    CopyCodeToClipboardParams,
     ENTER_FOCUS,
     ERROR_MESSAGE_TELEMETRY_EVENT,
     EXIT_FOCUS,
@@ -49,6 +49,7 @@ export interface OutboundChatApi {
     tabRemoved(params: TabRemoveParams): void
     telemetry(params: TelemetryParams): void
     insertToCursorPosition(params: InsertToCursorPositionParams): void
+    copyToClipboard(params: CopyCodeToClipboardParams): void
     authFollowUpClicked(params: AuthFollowUpClickedParams): void
     followUpClicked(params: FollowUpClickParams): void
     sendFeedback(params: FeedbackParams): void
@@ -116,6 +117,7 @@ export class Messager {
     }
 
     onCopyCodeToClipboard = (params: CopyCodeToClipboardParams): void => {
+        this.chatApi.copyToClipboard(params)
         this.chatApi.telemetry({ ...params, name: COPY_TO_CLIPBOARD_TELEMETRY_EVENT })
     }
 

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -62,9 +62,8 @@ export class Messager {
     constructor(private readonly chatApi: OutboundChatApi) {}
 
     onTabAdd = (tabId: string, triggerType?: TriggerType): void => {
-        this.chatApi.telemetry({ triggerType: triggerType ?? 'click', tabId, name: TAB_ADD_TELEMETRY_EVENT })
-
         this.chatApi.tabAdded({ tabId })
+        this.chatApi.telemetry({ triggerType: triggerType ?? 'click', tabId, name: TAB_ADD_TELEMETRY_EVENT })
     }
 
     onTabChange = (tabId: string): void => {
@@ -88,14 +87,14 @@ export class Messager {
     }
 
     onChatPrompt = (params: ChatParams, triggerType?: string): void => {
+        this.chatApi.sendChatPrompt(params)
+
         // Let the server know about the latest trigger interaction on the tabId
         this.chatApi.telemetry({
             triggerType: triggerType ?? 'click',
             tabId: params.tabId,
             name: ADD_MESSAGE_TELEMETRY_EVENT,
         })
-
-        this.chatApi.sendChatPrompt(params)
     }
 
     onQuickActionCommand = (params: QuickActionParams): void => {
@@ -129,18 +128,18 @@ export class Messager {
     }
 
     onLinkClick = (params: LinkClickParams): void => {
-        this.chatApi.telemetry({ ...params, name: LINK_CLICK_TELEMETRY_EVENT })
         this.chatApi.linkClick(params)
+        this.chatApi.telemetry({ ...params, name: LINK_CLICK_TELEMETRY_EVENT })
     }
 
     onSourceLinkClick = (params: SourceLinkClickParams): void => {
-        this.chatApi.telemetry({ ...params, name: SOURCE_LINK_CLICK_TELEMETRY_EVENT })
         this.chatApi.sourceLinkClick(params)
+        this.chatApi.telemetry({ ...params, name: SOURCE_LINK_CLICK_TELEMETRY_EVENT })
     }
 
     onInfoLinkClick = (params: InfoLinkClickParams): void => {
-        this.chatApi.telemetry({ ...params, name: INFO_LINK_CLICK_TELEMETRY_EVENT })
         this.chatApi.infoLinkClick(params)
+        this.chatApi.telemetry({ ...params, name: INFO_LINK_CLICK_TELEMETRY_EVENT })
     }
 
     onError = (params: ErrorParams): void => {

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -29,6 +29,7 @@ describe('MynahUI', () => {
             tabRemoved: sinon.stub(),
             telemetry: sinon.stub(),
             insertToCursorPosition: sinon.stub(),
+            copyToClipboard: sinon.stub(),
             authFollowUpClicked: sinon.stub(),
             followUpClicked: sinon.stub(),
             sendFeedback: sinon.stub(),

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -4,6 +4,7 @@
  */
 import {
     AuthFollowUpClickedParams,
+    CopyCodeToClipboardParams,
     ErrorParams,
     GenericCommandParams,
     InsertToCursorPositionParams,
@@ -20,7 +21,7 @@ import {
     SourceLinkClickParams,
 } from '@aws/language-server-runtimes-types'
 import { ChatItem, ChatItemType, ChatPrompt, MynahUI, MynahUIDataModel, NotificationType } from '@aws/mynah-ui'
-import { CopyCodeToClipboardParams, VoteParams } from '../contracts/telemetry'
+import { VoteParams } from '../contracts/telemetry'
 import { Messager } from './messager'
 import { TabFactory } from './tabs/tabFactory'
 

--- a/chat-client/src/contracts/telemetry.ts
+++ b/chat-client/src/contracts/telemetry.ts
@@ -1,5 +1,3 @@
-import { CodeSelectionType, ReferenceTrackerInformation } from '@aws/language-server-runtimes-types'
-
 export const ENTER_FOCUS = 'enterFocus'
 export const EXIT_FOCUS = 'exitFocus'
 
@@ -14,17 +12,6 @@ export const LINK_CLICK_TELEMETRY_EVENT = 'linkClick'
 export const INFO_LINK_CLICK_TELEMETRY_EVENT = 'infoLinkClick'
 export const SOURCE_LINK_CLICK_TELEMETRY_EVENT = 'sourceLinkClick'
 export const AUTH_FOLLOW_UP_CLICKED_TELEMETRY_EVENT = 'authFollowupClicked'
-
-export interface CopyCodeToClipboardParams {
-    tabId: string
-    messageId: string
-    code?: string
-    type?: CodeSelectionType
-    referenceTrackerInformation?: ReferenceTrackerInformation[]
-    eventId?: string
-    codeBlockIndex?: number
-    totalCodeBlocks?: number
-}
 
 export enum RelevancyVoteType {
     UP = 'upvote',

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -213,7 +213,7 @@
     "devDependencies": {
         "@aws-sdk/credential-providers": "^3.614.0",
         "@aws-sdk/types": "^3.535.0",
-        "@aws/chat-client-ui-types": "^0.0.6",
+        "@aws/chat-client-ui-types": "^0.0.7",
         "@aws/language-server-runtimes": "^0.2.20",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.88.0",

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -3,6 +3,7 @@ import {
     INSERT_TO_CURSOR_POSITION,
     AUTH_FOLLOW_UP_CLICKED,
     CHAT_OPTIONS,
+    COPY_TO_CLIPBOARD,
 } from '@aws/chat-client-ui-types'
 import {
     ChatResult,
@@ -47,18 +48,21 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri, 
     })
 
     languageClient.onTelemetry(e => {
-        languageClient.info(`vscode client: Received telemetry event from server ${JSON.stringify(e)}`)
+        languageClient.info(`[VSCode Client] Received telemetry event from server ${JSON.stringify(e)}`)
     })
 
     panel.webview.onDidReceiveMessage(async message => {
-        languageClient.info(`vscode client: Received ${JSON.stringify(message)} from chat`)
+        languageClient.info(`[VSCode Client]  Received ${JSON.stringify(message)} from chat`)
 
         switch (message.command) {
+            case COPY_TO_CLIPBOARD:
+                languageClient.info('[VSCode Client] Copy to clipboard event received')
+                break
             case INSERT_TO_CURSOR_POSITION:
                 insertTextAtCursorPosition(message.params.code)
                 break
             case AUTH_FOLLOW_UP_CLICKED:
-                languageClient.info('AuthFollowUp clicked')
+                languageClient.info('[VSCode Client] AuthFollowUp clicked')
                 break
             case chatRequestType.method:
                 const partialResultToken = uuidv4()

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,7 +209,7 @@
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.614.0",
                 "@aws-sdk/types": "^3.535.0",
-                "@aws/chat-client-ui-types": "^0.0.6",
+                "@aws/chat-client-ui-types": "^0.0.7",
                 "@aws/language-server-runtimes": "^0.2.20",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.88.0",
@@ -219,6 +219,15 @@
             },
             "engines": {
                 "vscode": "^1.74.0"
+            }
+        },
+        "client/vscode/node_modules/@aws/chat-client-ui-types": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.0.7.tgz",
+            "integrity": "sha512-lZbMxeguLvRALvvzr70YcrjbFRsIJ6tE19WfDIyVxDFiGn4De0wo2eiLssMwle8AwmvYTF0ZQzbZNlS1cyfVmg==",
+            "dev": true,
+            "dependencies": {
+                "@aws/language-server-runtimes-types": "^0.0.6"
             }
         },
         "core/aws-lsp-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,7 +178,7 @@
             "version": "0.0.6",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.0.6",
+                "@aws/chat-client-ui-types": "^0.0.7",
                 "@aws/language-server-runtimes-types": "^0.0.6",
                 "@aws/mynah-ui": "^4.15.11"
             },
@@ -192,6 +192,14 @@
                 "ts-sinon": "^2.0.2",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^5.1.4"
+            }
+        },
+        "chat-client/node_modules/@aws/chat-client-ui-types": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.0.7.tgz",
+            "integrity": "sha512-lZbMxeguLvRALvvzr70YcrjbFRsIJ6tE19WfDIyVxDFiGn4De0wo2eiLssMwle8AwmvYTF0ZQzbZNlS1cyfVmg==",
+            "dependencies": {
+                "@aws/language-server-runtimes-types": "^0.0.6"
             }
         },
         "client/vscode": {


### PR DESCRIPTION
## Problem
Currently chat client doesn't send a message notifying about copy to clipboard events. It only sends a telemetry message. If a chat client destination wants to listen for copy events and handle the events on their side, they need to listen to telemetry events rather than listening to a dedicated copy to clipboard event. 

## Solution
Chat client now sends a dedicated `COPY_TO_CLIPBOARD` message alongside with the copy information so that destinations can now handle the case explicitly. 

- Tested using the updated sample extension, verified that the extension receives the event when `copy to clipboard` is clicked on the chat UI

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
