### PR TITLE
Add cache for client registration and sso token

### DIFF
--- a/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.test.ts
+++ b/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.test.ts
@@ -1,0 +1,222 @@
+import mock = require('mock-fs')
+import { FileSystemSsoCache } from './fileSystemSsoCache'
+import { expect, use } from 'chai'
+import { DirectoryItems } from 'mock-fs/lib/filesystem'
+import { getSSOTokenFilepath, SSOToken } from '@smithy/shared-ini-file-loader'
+import { SsoClientRegistration } from './ssoCache'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+use(require('chai-as-promised'))
+
+const sut = new FileSystemSsoCache()
+
+const ssoRegion = 'us-east-1'
+const ssoStartUrl = 'https://nowhere'
+const clientName = 'my-test-client'
+
+const clientRegistrationId = JSON.stringify({
+    region: ssoRegion,
+    startUrl: ssoStartUrl,
+    tool: clientName,
+})
+
+const clientRegistration: SsoClientRegistration = {
+    clientId: 'someclientid',
+    clientSecret: 'someclientsecret',
+    expiresAt: '2019-11-14T04:05:45Z',
+    scopes: ['codewhisperer:completions', 'codewhisperer:analysis'],
+}
+
+const ssoSessionName = 'my-sso-session'
+
+const ssoToken: SSOToken = {
+    clientId: 'someclientid',
+    clientSecret: 'someclientsecret',
+    region: 'us-east-1',
+    startUrl: 'https://nowhere',
+    accessToken: 'someaccesstoken',
+    refreshToken: 'somerefreshtoken',
+    expiresAt: '2024-09-25T18:09:20.455Z',
+    registrationExpiresAt: '2024-12-09T19:59:06.000Z',
+}
+
+afterEach(() => {
+    mock.restore()
+})
+
+function setupTest(args?: {
+    clientRegistrationId?: string
+    clientRegistration?: SsoClientRegistration
+    ssoSessionName?: string
+    ssoToken?: SSOToken
+}): void {
+    // Just for sanity, safe to call restore if mock not currently active
+    mock.restore()
+
+    args = { ...{ clientRegistrationId, clientRegistration, ssoSessionName, ssoToken }, ...args }
+
+    const mockConfig: DirectoryItems = {}
+    mockConfig[getSSOTokenFilepath(args.clientRegistrationId!)] = JSON.stringify(args.clientRegistration)
+    mockConfig[getSSOTokenFilepath(args.ssoSessionName!)] = JSON.stringify(args.ssoToken)
+
+    mock(mockConfig)
+}
+
+describe('FileSystemSsoCache', () => {
+    it('getSsoClientRegistration returns valid registration', async () => {
+        setupTest()
+
+        const actual = await sut.getSsoClientRegistration(clientName, ssoRegion, ssoStartUrl)
+
+        expect(actual).to.not.be.null.and.not.undefined
+        expect(actual?.clientId).to.equal('someclientid')
+        expect(actual?.clientSecret).to.equal('someclientsecret')
+        expect(actual?.expiresAt).to.equal('2019-11-14T04:05:45Z')
+        expect(actual?.scopes).to.deep.equal(['codewhisperer:completions', 'codewhisperer:analysis'])
+    })
+
+    it('getSsoClientRegistration returns undefined when file does not exist', async () => {
+        setupTest()
+
+        const actual = await sut.getSsoClientRegistration('does', 'not', 'exist')
+
+        expect(actual).to.be.undefined
+    })
+
+    it('getSsoClientRegistration returns undefined on invalid registration', async () => {
+        setupTest({ clientRegistration: {} as SsoClientRegistration })
+
+        const actual = await sut.getSsoClientRegistration(clientName, ssoRegion, ssoStartUrl)
+
+        expect(actual).to.be.undefined
+    })
+
+    it('setSsoClientRegistration writes new valid registration', async () => {
+        setupTest()
+
+        await sut.setSsoClientRegistration('new', 'client', 'id', {
+            clientId: 'someclientid',
+            clientSecret: 'someclientsecret',
+            expiresAt: '2024-10-14T12:00:00.000Z',
+            scopes: ['sso:account:access', 'codewhisperer:analysis'],
+        })
+
+        const actual = await sut.getSsoClientRegistration('new', 'client', 'id')
+
+        expect(actual).to.not.be.null.and.not.undefined
+        expect(actual?.clientId).to.equal('someclientid')
+        expect(actual?.clientSecret).to.equal('someclientsecret')
+        expect(actual?.expiresAt).to.equal('2024-10-14T12:00:00.000Z')
+        expect(actual?.scopes).to.deep.equal(['sso:account:access', 'codewhisperer:analysis'])
+    })
+
+    it('setSsoClientRegistration writes updated existing registration', async () => {
+        setupTest()
+
+        await sut.setSsoClientRegistration(clientName, ssoRegion, ssoStartUrl, {
+            clientId: 'newclientid',
+            clientSecret: 'newclientsecret',
+            expiresAt: '2024-11-14T04:05:45Z',
+        })
+
+        const actual = await sut.getSsoClientRegistration(clientName, ssoRegion, ssoStartUrl)
+
+        expect(actual).to.not.be.null.and.not.undefined
+        expect(actual?.clientId).to.equal('newclientid')
+        expect(actual?.clientSecret).to.equal('newclientsecret')
+        expect(actual?.expiresAt).to.equal('2024-11-14T04:05:45Z')
+        expect(actual).does.not.have.property('scopes')
+    })
+
+    it('setSsoClientRegistration returns without error on invalid registration', async () => {
+        setupTest()
+
+        await sut.setSsoClientRegistration(clientName, ssoRegion, ssoStartUrl, {} as SsoClientRegistration) // no throw
+    })
+
+    it('getSsoToken returns valid token', async () => {
+        setupTest()
+
+        const actual = await sut.getSsoToken(ssoSessionName)
+
+        expect(actual).to.not.be.null.and.not.undefined
+        expect(actual?.accessToken).to.equal('someaccesstoken')
+        expect(actual?.clientId).to.equal('someclientid')
+        expect(actual?.clientSecret).to.equal('someclientsecret')
+        expect(actual?.expiresAt).to.equal('2024-09-25T18:09:20.455Z')
+        expect(actual?.refreshToken).to.equal('somerefreshtoken')
+        expect(actual?.region).to.equal('us-east-1')
+        expect(actual?.registrationExpiresAt).to.equal('2024-12-09T19:59:06.000Z')
+        expect(actual?.startUrl).to.equal('https://nowhere')
+    })
+
+    it('getSsoToken returns undefined when file does not exist', async () => {
+        setupTest()
+
+        const actual = await sut.getSsoToken('does not exist')
+
+        expect(actual).to.be.undefined
+    })
+
+    it('getSsoToken returns undefined on invalid token', async () => {
+        setupTest({ ssoSessionName: 'invalid-token', ssoToken: {} as SSOToken })
+
+        const actual = await sut.getSsoToken('invalid-token')
+
+        expect(actual).to.be.undefined
+    })
+
+    it('setSsoToken writes new valid token', async () => {
+        setupTest()
+
+        await sut.setSsoToken('new-token', {
+            clientId: 'someclientid',
+            clientSecret: 'someclientsecret',
+            region: 'us-west-2',
+            startUrl: 'https://somewhere',
+            accessToken: 'newaccesstoken',
+            refreshToken: 'newrefreshtoken',
+            expiresAt: '2024-10-14T12:00:00.000Z',
+            registrationExpiresAt: '2024-12-14T12:00:00.000Z',
+        })
+
+        const actual = await sut.getSsoToken('new-token')
+
+        expect(actual).to.not.be.null.and.not.undefined
+        expect(actual?.accessToken).to.equal('newaccesstoken')
+        expect(actual?.clientId).to.equal('someclientid')
+        expect(actual?.clientSecret).to.equal('someclientsecret')
+        expect(actual?.expiresAt).to.equal('2024-10-14T12:00:00.000Z')
+        expect(actual?.refreshToken).to.equal('newrefreshtoken')
+        expect(actual?.region).to.equal('us-west-2')
+        expect(actual?.registrationExpiresAt).to.equal('2024-12-14T12:00:00.000Z')
+        expect(actual?.startUrl).to.equal('https://somewhere')
+    })
+
+    it('setSsoToken writes updated existing token', async () => {
+        setupTest()
+
+        await sut.setSsoToken(ssoSessionName, {
+            accessToken: 'newaccesstoken',
+            expiresAt: '2024-10-14T12:00:00.000Z',
+        })
+
+        const actual = await sut.getSsoToken(ssoSessionName)
+
+        expect(actual).to.not.be.null.and.not.undefined
+        expect(actual?.accessToken).to.equal('newaccesstoken')
+        expect(actual?.expiresAt).to.equal('2024-10-14T12:00:00.000Z')
+        expect(actual).does.not.have.property('clientId')
+        expect(actual).does.not.have.property('clientSecret')
+        expect(actual).does.not.have.property('refreshToken')
+        expect(actual).does.not.have.property('region')
+        expect(actual).does.not.have.property('registrationExpiresAt')
+        expect(actual).does.not.have.property('startUrl')
+    })
+
+    it('setSsoToken returns without error on invalid token', async () => {
+        setupTest()
+
+        await sut.setSsoToken(ssoSessionName, {} as SSOToken) // no throw
+    })
+})

--- a/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.ts
+++ b/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.ts
@@ -1,0 +1,107 @@
+import { getSSOTokenFilepath, getSSOTokenFromFile, SSOToken } from '@smithy/shared-ini-file-loader'
+import { SsoCache, SsoClientRegistration, ssoClientRegistrationDuckTyper, ssoTokenDuckTyper } from './ssoCache'
+import { readFile, writeFile } from 'fs/promises'
+import { AwsError, tryAsync } from '../../awsError'
+import { AwsErrorCodes } from '@aws/language-server-runtimes/protocol'
+
+// As this is a cache, we tend to swallow a lot of the errors as it is ok to just recreate the items each
+// time, though recreating the SSO token without a refresh token will be every hour.  This is a better
+// situation that failing to get an SSO token at all.
+
+export class FileSystemSsoCache implements SsoCache {
+    async getSsoClientRegistration(
+        clientName: string,
+        ssoRegion: string,
+        ssoStartUrl: string
+    ): Promise<SsoClientRegistration | undefined> {
+        const id = toSsoClientRegistrationCacheId(clientName, ssoRegion, ssoStartUrl)
+        return await tryGetAsync(async () => {
+            const registration = await getSsoClientRegistrationFromFile(id)
+            return ssoClientRegistrationDuckTyper.eval(registration) ? registration : undefined
+        })
+    }
+
+    async setSsoClientRegistration(
+        clientName: string,
+        ssoRegion: string,
+        ssoStartUrl: string,
+        clientRegistration: SsoClientRegistration
+    ): Promise<void> {
+        if (!clientName || !ssoRegion || !ssoStartUrl || !ssoClientRegistrationDuckTyper.eval(clientRegistration)) {
+            return
+        }
+
+        const id = toSsoClientRegistrationCacheId(clientName, ssoRegion, ssoStartUrl)
+        await tryAsync(
+            () => writeSsoObjectToFile(id, clientRegistration),
+            error => AwsError.wrap(error, AwsErrorCodes.E_CANNOT_WRITE_SSO_CACHE)
+        )
+    }
+
+    async getSsoToken(ssoSessionName: string): Promise<SSOToken | undefined> {
+        return await tryGetAsync(async () => {
+            const ssoToken = await getSSOTokenFromFile(ssoSessionName)
+            return ssoTokenDuckTyper.eval(ssoToken) ? ssoToken : undefined
+        })
+    }
+
+    async setSsoToken(ssoSessionName: string, ssoToken: SSOToken): Promise<void> {
+        if (!ssoSessionName || !ssoTokenDuckTyper.eval(ssoToken)) {
+            return
+        }
+
+        tryAsync(
+            () => writeSsoObjectToFile(ssoSessionName, ssoToken),
+            error => AwsError.wrap(error, AwsErrorCodes.E_CANNOT_WRITE_SSO_CACHE)
+        )
+    }
+}
+
+async function tryGetAsync<R>(tryIt: () => Promise<R | undefined>): Promise<R | undefined> {
+    try {
+        return await tryIt()
+    } catch (error) {
+        // Error codes are consistent across OSes (Windows is converted to libuv error codes)
+        // https://nodejs.org/api/errors.html#errorerrno
+        if ((error as SystemError)?.code === 'ENOENT') {
+            return Promise.resolve(undefined)
+        }
+
+        throw AwsError.wrap(error as Error, AwsErrorCodes.E_CANNOT_READ_SSO_CACHE)
+    }
+}
+
+function toSsoClientRegistrationCacheId(clientName: string, ssoRegion: string, ssoStartUrl: string): string {
+    return JSON.stringify({
+        region: ssoRegion,
+        startUrl: ssoStartUrl,
+        tool: clientName,
+    })
+}
+
+// Based on:
+// https://github.com/smithy-lang/smithy-typescript/blob/main/packages/shared-ini-file-loader/src/getSSOTokenFromFile.ts
+async function getSsoClientRegistrationFromFile(id: string): Promise<SsoClientRegistration> {
+    const filepath = getSSOTokenFilepath(id)
+    const json = await readFile(filepath, 'utf8')
+    return JSON.parse(json) as SsoClientRegistration
+}
+
+// Based on:
+// https://github.com/aws/aws-sdk-js-v3/blob/6e61f0e78ff7a9e3b1f2cd651bde5fc656d85ba9/packages/token-providers/src/writeSSOTokenToFile.ts
+async function writeSsoObjectToFile(id: string, ssoObject: SSOToken | SsoClientRegistration): Promise<void> {
+    try {
+        const filepath = getSSOTokenFilepath(id)
+        const json = JSON.stringify(ssoObject, null, 2)
+        return await writeFile(filepath, json)
+    } catch {
+        // Writing to cache is best effort, based on:
+        // https://github.com/aws/aws-sdk-js-v3/blob/main/packages/token-providers/src/fromSso.ts
+    }
+}
+
+// Minimal declaration of SystemError (no node type declaration for it) to access code property
+// https://nodejs.org/api/errors.html#class-systemerror
+interface SystemError {
+    code: string
+}

--- a/server/aws-lsp-identity/src/sso/cache/index.ts
+++ b/server/aws-lsp-identity/src/sso/cache/index.ts
@@ -1,0 +1,2 @@
+export * from './fileSystemSsoCache'
+export * from './ssoCache'

--- a/server/aws-lsp-identity/src/sso/cache/ssoCache.ts
+++ b/server/aws-lsp-identity/src/sso/cache/ssoCache.ts
@@ -1,0 +1,52 @@
+import { SSOToken } from '@smithy/shared-ini-file-loader'
+import { DuckTyper } from '../../duckTyper'
+
+// https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_RegisterClient.html
+export interface SsoClientRegistration {
+    // The returned ClientId from the RegisterClient call.
+    clientId: string
+
+    // The returned ClientSecret from the RegisterClient call.
+    clientSecret: string
+
+    // The expiration time of the registration as an RFC 3339 formatted timestamp.
+    expiresAt: string
+
+    // If provided when generating the registration, the list of scopes should be cached alongside the token.
+    scopes?: string[]
+}
+
+export interface SsoCache {
+    getSsoClientRegistration(
+        clientName: string,
+        ssoRegion: string,
+        ssoStartUrl: string
+    ): Promise<SsoClientRegistration | undefined>
+
+    setSsoClientRegistration(
+        clientName: string,
+        ssoRegion: string,
+        ssoStartUrl: string,
+        clientRegistration: SsoClientRegistration
+    ): Promise<void>
+
+    getSsoToken(ssoSessionName: string): Promise<SSOToken | undefined>
+
+    setSsoToken(ssoSessionName: string, ssoToken: SSOToken): Promise<void>
+}
+
+export const ssoClientRegistrationDuckTyper = new DuckTyper()
+    .requireProperty('clientId')
+    .requireProperty('clientSecret')
+    .requireProperty('expiresAt')
+    .optionalProperty('scopes')
+
+export const ssoTokenDuckTyper = new DuckTyper()
+    .requireProperty('accessToken')
+    .requireProperty('expiresAt')
+    .optionalProperty('refreshToken')
+    .optionalProperty('clientId')
+    .optionalProperty('clientSecret')
+    .optionalProperty('registrationExpiresAt')
+    .optionalProperty('region')
+    .optionalProperty('startUrl')


### PR DESCRIPTION
Adds cache for client registration and sso token files stored in $USER/.aws/sso/cache.  Leverages existing smithy-type and AWS SDK for JavaScript code where possible.

ssoCache.ts contains the cache interface along with a few supporting classes (SSOToken is reused from smithy-types, SsoClientRegistration added here in similar manner).  

FileSystemSsoCache is implementation for standalone runtime.  If an when webworker runtime needs an SsoCache, the interface can be implemented for it at that time (e.g. BrowserStorageSsoCache).

The cache is very basic, it just gets and sets the sso tokens and client registrations.  As it is a cache, it tends to swallow many errors so as to just allow the object to be recreated and not break the user experience.  For sso tokens, they will expire each hour, but it's better that they work at all than fail.  

Logging throughout the identity server will be added in a future PR (IDE-14689).  This will notify users of cache issues without interrupting their work.

