### PR TITLE
Update @aws/chat-client-ui-types to 0.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,14 +194,6 @@
                 "webpack-cli": "^5.1.4"
             }
         },
-        "chat-client/node_modules/@aws/chat-client-ui-types": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.0.7.tgz",
-            "integrity": "sha512-lZbMxeguLvRALvvzr70YcrjbFRsIJ6tE19WfDIyVxDFiGn4De0wo2eiLssMwle8AwmvYTF0ZQzbZNlS1cyfVmg==",
-            "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.0.6"
-            }
-        },
         "client/vscode": {
             "name": "awsdocuments-ls-client",
             "version": "0.1.0",
@@ -219,15 +211,6 @@
             },
             "engines": {
                 "vscode": "^1.74.0"
-            }
-        },
-        "client/vscode/node_modules/@aws/chat-client-ui-types": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.0.7.tgz",
-            "integrity": "sha512-lZbMxeguLvRALvvzr70YcrjbFRsIJ6tE19WfDIyVxDFiGn4De0wo2eiLssMwle8AwmvYTF0ZQzbZNlS1cyfVmg==",
-            "dev": true,
-            "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.0.6"
             }
         },
         "core/aws-lsp-core": {
@@ -5032,9 +5015,9 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.0.6.tgz",
-            "integrity": "sha512-M0mRCDT2hfgeSUWP/jXDUiVBjrJ2JmZhLogACj4hHHZNmcpgjY60nABgDrPumm1Y55rKuuvAgrZ0lOV2R1f9Jg==",
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.0.7.tgz",
+            "integrity": "sha512-lZbMxeguLvRALvvzr70YcrjbFRsIJ6tE19WfDIyVxDFiGn4De0wo2eiLssMwle8AwmvYTF0ZQzbZNlS1cyfVmg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.6"
@@ -23125,7 +23108,7 @@
             "dependencies": {
                 "@amzn/codewhisperer-streaming": "*",
                 "@aws-sdk/util-retry": "^3.374.0",
-                "@aws/chat-client-ui-types": "^0.0.6",
+                "@aws/chat-client-ui-types": "^0.0.7",
                 "@aws/language-server-runtimes": "^0.2.20",
                 "@aws/lsp-fqn": "^0.0.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@amzn/codewhisperer-streaming": "*",
         "@aws-sdk/util-retry": "^3.374.0",
-        "@aws/chat-client-ui-types": "^0.0.6",
+        "@aws/chat-client-ui-types": "^0.0.7",
         "@aws/language-server-runtimes": "^0.2.20",
         "@aws/lsp-fqn": "^0.0.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",


### PR DESCRIPTION
## Problem
In https://github.com/aws/language-servers/pull/499/files the dependency on @aws/chat-client-ui-types wasn't updated in aws-lsp-codewhisperer

And `^0.0.6` cannot be resolved to `0.0.7` because in semantic versioning it's a major version bump. That is because a major version is the leftmost non-zero number. 

## Solution
Updating the dependency to 0.0.7

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
