### PR TITLE
Bump lsp-codewhisperer version to 0.0.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23095,7 +23095,7 @@
         },
         "server/aws-lsp-codewhisperer": {
             "name": "@aws/lsp-codewhisperer",
-            "version": "0.0.15",
+            "version": "0.0.16",
             "bundleDependencies": [
                 "@amzn/codewhisperer-streaming",
                 "@aws/lsp-fqn"

--- a/server/aws-lsp-codewhisperer/CHANGELOG.md
+++ b/server/aws-lsp-codewhisperer/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.0.16] - 2024-10-15
+
+### Added
+- Amazon Q Inline Code Completions: The server now supports all languages supported by Q, including `go`, `php`, `rust`, `kotlin`, `terraform`, `ruby`, `shell`, `scala`
+
+### Changed
+- Amazon Q Inline Code Completions and Q Chat:  Extend Chat and Completion Telemetry with Customization (#493).
+- .Net Transform: Transform result is moved to the artifact location (#495).
+
 ## [0.0.15] - 2024-10-09
 
 ### Added

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/lsp-codewhisperer",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "description": "CodeWhisperer Language Server",
     "main": "out/index.js",
     "repository": {


### PR DESCRIPTION
## Description
Releasing @aws/lsp-codewhisperer@0.0.16

### Added
- Amazon Q Inline Code Completions: The server now supports all languages supported by Q, including `go`, `php`, `rust`, `kotlin`, `terraform`, `ruby`, `shell`, `scala`

### Changed
- Amazon Q Inline Code Completions and Q Chat:  Extend Chat and Completion Telemetry with Customization (#493).
- .Net Transform: Transform result is moved to the artifact location (#495).

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
