### PR TITLE
remove webforms from supported projects

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/resources/SupportedProjects.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/resources/SupportedProjects.ts
@@ -4,7 +4,6 @@ export const supportedProjects = [
     'AspNetCoreMvcRazorPage',
     'AspNetMvc',
     'AspNetWebApi',
-    'AspNetWebForms',
     'CoreWCFService',
     'CoreWCFServiceConfig',
     'WCFClient',


### PR DESCRIPTION
## Problem
- ASPNet Webforms is not a supported project type.

## Solution
- Remove ASPNet Webforms from supported project types.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
