### PR TITLE
Autotrigger parameters for additional languages

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/auto-trigger/coefficients.json
+++ b/server/aws-lsp-codewhisperer/src/language-server/auto-trigger/coefficients.json
@@ -362,7 +362,10 @@
         "csharp": -0.3475,
         "go": -0.3504,
         "scala": -0.534,
-        "cpp": -0.1734
+        "cpp": -0.1734,
+        "json": 0,
+        "yaml": -0.3,
+        "tf": -0.55
     },
 
     "triggerTypeCoefficient": {

--- a/server/aws-lsp-codewhisperer/src/language-server/auto-trigger/coefficients.json
+++ b/server/aws-lsp-codewhisperer/src/language-server/auto-trigger/coefficients.json
@@ -366,13 +366,13 @@
         "json": 0,
         "yaml": -0.3,
         "tf": -0.55,
-        "systemverilog": -0.43,
-        "dart": -0.43,
-        "lua": -0.43,
-        "swift": -0.43,
-        "vue": -0.43,
-        "powershell": -0.43,
-        "r": -0.43
+        "systemverilog": -0.4302,
+        "dart": -0.4302,
+        "lua": -0.4302,
+        "swift": -0.4302,
+        "vue": -0.4302,
+        "powershell": -0.4302,
+        "r": -0.4302
     },
 
     "triggerTypeCoefficient": {

--- a/server/aws-lsp-codewhisperer/src/language-server/auto-trigger/coefficients.json
+++ b/server/aws-lsp-codewhisperer/src/language-server/auto-trigger/coefficients.json
@@ -365,7 +365,14 @@
         "cpp": -0.1734,
         "json": 0,
         "yaml": -0.3,
-        "tf": -0.55
+        "tf": -0.55,
+        "systemverilog": -0.43,
+        "dart": -0.43,
+        "lua": -0.43,
+        "swift": -0.43,
+        "vue": -0.43,
+        "powershell": -0.43,
+        "r": -0.43
     },
 
     "triggerTypeCoefficient": {

--- a/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/languageDetection.ts
@@ -23,6 +23,12 @@ export type CodewhispererLanguage =
     | 'typescript'
     | 'vue'
     | 'yaml'
+    | 'systemverilog'
+    | 'dart'
+    | 'lua'
+    | 'swift'
+    | 'powershell'
+    | 'r'
 
 // This will be extended as more language features
 // are integrated into the language server and clients.
@@ -107,6 +113,13 @@ export const qLanguageIdByDocumentLanguageId: { [key: string]: CodewhispererLang
     typescriptreact: 'tsx',
     vue: 'vue',
     yaml: 'yaml',
+    yml: 'yaml',
+    systemverilog: 'systemverilog',
+    dart: 'dart',
+    lua: 'lua',
+    swift: 'swift',
+    powershell: 'powershell',
+    r: 'r',
 }
 
 export const getSupportedLanguageId = (


### PR DESCRIPTION
## Problem
We need to add autotrigger parameters for additional supported languages. 

## Solution

- IaC languages' parameters are taken from here: https://github.com/aws/aws-toolkit-vscode/commit/eedf096547260af56a26db5379e1df238bed837c

- For the parameters of the other new languages for now we are using an average of all the other languages:

average:  `((-0,4622) + (-0,4688) + (-0,3052) + (-0,6084) +  (-0,6084) + (-0,4688) + (-0,4718) + (-0,7356) + (-0,4937) + (-0,4309) + (-0,4739) + (-0,3917) + (-0,3475) + (-0,3504) + (-0,534) + (-0,1734) + (0) + (-0,3) + (-0,55)) / 19 = -0.4302`

The value  (`-0,4302`) is **hardcoded**, and not computed programmatically.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
