### PR TITLE
Ignore streaming client from dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,48 @@
 version: 2
 updates:
     - package-ecosystem: 'npm'
-      directory: '/'
-      target-branch: 'main' # Avoid updates to "staging".
+      directory: '/server/aws-lsp-buildspec'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/server/aws-lsp-cloudformation'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/server/aws-lsp-codewhisperer'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/server/aws-lsp-identity'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/server/aws-lsp-json'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/server/aws-lsp-partiql'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/server/aws-lsp-s3'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/server/aws-lsp-yaml'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/server/aws-lsp-device-sso-auth-lsp'
+      target-branch: 'main'
       schedule:
           interval: 'weekly'
     - package-ecosystem: 'npm'
@@ -15,3 +55,28 @@ updates:
           interval: 'weekly'
       ignore:
           - dependency-name: '*'
+    - package-ecosystem: 'npm'
+      directory: '/'
+      target-branch: 'main' # Avoid updates to "staging".
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/app'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/chat-client'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/client'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/core'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
       target-branch: 'main' # Avoid updates to "staging".
       schedule:
           interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/server/aws-lsp-codewhisperer/src.gen'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+      ignore:
+          - dependency-name: '*'


### PR DESCRIPTION
## Problem
The streaming client is not to be manually updated, this means any dependabot PRs pointing to that directory should be ignored. Currently we still get those PRs

## Solution
There currently is no option to exclude the entire subdirectory from the scan, but there is a workaround to autoclose the PRs that only targets the streaming client https://github.com/dependabot/dependabot-core/issues/4364#issuecomment-2006542987. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
