### PR TITLE
Ignore streaming client dependency update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
       target-branch: 'main' # Avoid updates to "staging".
       schedule:
           interval: 'weekly'
+    - package-ecosystem: 'npm'
+      directory: '/server/aws-lsp-codewhisperer/src.gen'
+      target-branch: 'main'
+      schedule:
+          interval: 'weekly'
+      ignore:
+          - dependency-name: '*'


### PR DESCRIPTION
## Problem
The streaming client is not to be manually updated, this means any dependabot PRs pointing to that directory should be ignored. Currently we still get those PRs

## Solution
Simple version of https://github.com/aws/language-servers/pull/507

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
