### PR TITLE
Amazon Q Server: Update service definition and types for bearer token service client

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
+++ b/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
@@ -18,14 +18,27 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "CreateUploadUrlRequest" },
-            "output": { "shape": "CreateUploadUrlResponse" },
+            "input": {
+                "shape": "CreateUploadUrlRequest"
+            },
+            "output": {
+                "shape": "CreateUploadUrlResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
             ],
+            "documentation": "<p>Creates a pre-signed, S3 write URL for uploading a repository zip archive.</p>",
             "idempotent": true
         },
         "CreateTaskAssistConversation": {
@@ -34,14 +47,30 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "CreateTaskAssistConversationRequest" },
-            "output": { "shape": "CreateTaskAssistConversationResponse" },
+            "input": {
+                "shape": "CreateTaskAssistConversationRequest"
+            },
+            "output": {
+                "shape": "CreateTaskAssistConversationResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ServiceQuotaExceededException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to create task assist conversation.</p>"
         },
         "CreateUploadUrl": {
             "name": "CreateUploadUrl",
@@ -49,16 +78,36 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "CreateUploadUrlRequest" },
-            "output": { "shape": "CreateUploadUrlResponse" },
+            "input": {
+                "shape": "CreateUploadUrlRequest"
+            },
+            "output": {
+                "shape": "CreateUploadUrlResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "ConflictException" },
-                { "shape": "ResourceNotFoundException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ServiceQuotaExceededException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
             ],
+            "documentation": "<p>Creates a pre-signed, S3 write URL for uploading a repository zip archive.</p>",
             "idempotent": true
         },
         "DeleteTaskAssistConversation": {
@@ -67,15 +116,30 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "DeleteTaskAssistConversationRequest" },
-            "output": { "shape": "DeleteTaskAssistConversationResponse" },
+            "input": {
+                "shape": "DeleteTaskAssistConversationRequest"
+            },
+            "output": {
+                "shape": "DeleteTaskAssistConversationResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "ResourceNotFoundException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to delete task assist conversation.</p>"
         },
         "GenerateCompletions": {
             "name": "GenerateCompletions",
@@ -83,14 +147,27 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "GenerateCompletionsRequest" },
-            "output": { "shape": "GenerateCompletionsResponse" },
+            "input": {
+                "shape": "GenerateCompletionsRequest"
+            },
+            "output": {
+                "shape": "GenerateCompletionsResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>Generate completions based on the provided file context in a paginated response.</p>"
         },
         "GetCodeAnalysis": {
             "name": "GetCodeAnalysis",
@@ -98,15 +175,30 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "GetCodeAnalysisRequest" },
-            "output": { "shape": "GetCodeAnalysisResponse" },
+            "input": {
+                "shape": "GetCodeAnalysisRequest"
+            },
+            "output": {
+                "shape": "GetCodeAnalysisResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "ResourceNotFoundException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>Gets the metadata of a code analysis job.</p>"
         },
         "GetTaskAssistCodeGeneration": {
             "name": "GetTaskAssistCodeGeneration",
@@ -114,16 +206,61 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "GetTaskAssistCodeGenerationRequest" },
-            "output": { "shape": "GetTaskAssistCodeGenerationResponse" },
+            "input": {
+                "shape": "GetTaskAssistCodeGenerationRequest"
+            },
+            "output": {
+                "shape": "GetTaskAssistCodeGenerationResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "ConflictException" },
-                { "shape": "ResourceNotFoundException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to get status of task assist code generation.</p>"
+        },
+        "GetTestGeneration": {
+            "name": "GetTestGeneration",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "GetTestGenerationRequest"
+            },
+            "output": {
+                "shape": "GetTestGenerationResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to get test generation job.</p>"
         },
         "GetTransformation": {
             "name": "GetTransformation",
@@ -131,14 +268,30 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "GetTransformationRequest" },
-            "output": { "shape": "GetTransformationResponse" },
+            "input": {
+                "shape": "GetTransformationRequest"
+            },
+            "output": {
+                "shape": "GetTransformationResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to get code transformation status.</p>"
         },
         "GetTransformationPlan": {
             "name": "GetTransformationPlan",
@@ -146,14 +299,30 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "GetTransformationPlanRequest" },
-            "output": { "shape": "GetTransformationPlanResponse" },
+            "input": {
+                "shape": "GetTransformationPlanRequest"
+            },
+            "output": {
+                "shape": "GetTransformationPlanResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to get code transformation status.</p>"
         },
         "ListAvailableCustomizations": {
             "name": "ListAvailableCustomizations",
@@ -161,13 +330,25 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "ListAvailableCustomizationsRequest" },
-            "output": { "shape": "ListAvailableCustomizationsResponse" },
+            "input": {
+                "shape": "ListAvailableCustomizationsRequest"
+            },
+            "output": {
+                "shape": "ListAvailableCustomizationsResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
             ]
         },
         "ListCodeAnalysisFindings": {
@@ -176,15 +357,30 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "ListCodeAnalysisFindingsRequest" },
-            "output": { "shape": "ListCodeAnalysisFindingsResponse" },
+            "input": {
+                "shape": "ListCodeAnalysisFindingsRequest"
+            },
+            "output": {
+                "shape": "ListCodeAnalysisFindingsResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "ResourceNotFoundException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>Lists the findings from a particular code analysis job.</p>"
         },
         "ListFeatureEvaluations": {
             "name": "ListFeatureEvaluations",
@@ -192,14 +388,58 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "ListFeatureEvaluationsRequest" },
-            "output": { "shape": "ListFeatureEvaluationsResponse" },
+            "input": {
+                "shape": "ListFeatureEvaluationsRequest"
+            },
+            "output": {
+                "shape": "ListFeatureEvaluationsResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>Return configruations for each feature that has been setup for A/B testing.</p>"
+        },
+        "ResumeTransformation": {
+            "name": "ResumeTransformation",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "ResumeTransformationRequest"
+            },
+            "output": {
+                "shape": "ResumeTransformationResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to resume transformation job.</p>"
         },
         "SendTelemetryEvent": {
             "name": "SendTelemetryEvent",
@@ -207,14 +447,27 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "SendTelemetryEventRequest" },
-            "output": { "shape": "SendTelemetryEventResponse" },
+            "input": {
+                "shape": "SendTelemetryEventRequest"
+            },
+            "output": {
+                "shape": "SendTelemetryEventResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
             ],
+            "documentation": "<p>API to record telemetry events.</p>",
             "idempotent": true
         },
         "StartCodeAnalysis": {
@@ -223,16 +476,33 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "StartCodeAnalysisRequest" },
-            "output": { "shape": "StartCodeAnalysisResponse" },
+            "input": {
+                "shape": "StartCodeAnalysisRequest"
+            },
+            "output": {
+                "shape": "StartCodeAnalysisResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "ConflictException" },
-                { "shape": "ResourceNotFoundException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
             ],
+            "documentation": "<p>Starts a code analysis job</p>",
             "idempotent": true
         },
         "StartTaskAssistCodeGeneration": {
@@ -241,16 +511,68 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "StartTaskAssistCodeGenerationRequest" },
-            "output": { "shape": "StartTaskAssistCodeGenerationResponse" },
+            "input": {
+                "shape": "StartTaskAssistCodeGenerationRequest"
+            },
+            "output": {
+                "shape": "StartTaskAssistCodeGenerationResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "ConflictException" },
-                { "shape": "ResourceNotFoundException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ServiceQuotaExceededException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to start task assist code generation.</p>"
+        },
+        "StartTestGeneration": {
+            "name": "StartTestGeneration",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "StartTestGenerationRequest"
+            },
+            "output": {
+                "shape": "StartTestGenerationResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to start test generation.</p>",
+            "idempotent": true
         },
         "StartTransformation": {
             "name": "StartTransformation",
@@ -258,14 +580,30 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "StartTransformationRequest" },
-            "output": { "shape": "StartTransformationResponse" },
+            "input": {
+                "shape": "StartTransformationRequest"
+            },
+            "output": {
+                "shape": "StartTransformationResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to start code translation.</p>"
         },
         "StopTransformation": {
             "name": "StopTransformation",
@@ -273,14 +611,30 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "StopTransformationRequest" },
-            "output": { "shape": "StopTransformationResponse" },
+            "input": {
+                "shape": "StopTransformationRequest"
+            },
+            "output": {
+                "shape": "StopTransformationResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
-            ]
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to stop code transformation status.</p>"
         }
     },
     "shapes": {
@@ -288,14 +642,82 @@
             "type": "structure",
             "required": ["message"],
             "members": {
-                "message": { "shape": "String" }
+                "message": {
+                    "shape": "String"
+                },
+                "reason": {
+                    "shape": "AccessDeniedExceptionReason"
+                }
             },
+            "documentation": "<p>This exception is thrown when the user does not have sufficient access to perform this action.</p>",
             "exception": true
+        },
+        "AccessDeniedExceptionReason": {
+            "type": "string",
+            "documentation": "<p>Reason for AccessDeniedException</p>",
+            "enum": ["UNAUTHORIZED_CUSTOMIZATION_RESOURCE_ACCESS"]
+        },
+        "AppStudioState": {
+            "type": "structure",
+            "required": ["namespace", "propertyName", "propertyContext"],
+            "members": {
+                "namespace": {
+                    "shape": "AppStudioStateNamespaceString",
+                    "documentation": "<p>The namespace of the context. Examples: 'ui.Button', 'ui.Table.DataSource', 'ui.Table.RowActions.Button', 'logic.invokeAWS', 'logic.JavaScript'</p>"
+                },
+                "propertyName": {
+                    "shape": "AppStudioStatePropertyNameString",
+                    "documentation": "<p>The name of the property. Examples: 'visibility', 'disability', 'value', 'code'</p>"
+                },
+                "propertyValue": {
+                    "shape": "AppStudioStatePropertyValueString",
+                    "documentation": "<p>The value of the property.</p>"
+                },
+                "propertyContext": {
+                    "shape": "AppStudioStatePropertyContextString",
+                    "documentation": "<p>Context about how the property is used</p>"
+                }
+            },
+            "documentation": "<p>Description of a user's context when they are calling Q Chat from AppStudio</p>"
+        },
+        "AppStudioStateNamespaceString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
+        },
+        "AppStudioStatePropertyContextString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
+        },
+        "AppStudioStatePropertyNameString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
+        },
+        "AppStudioStatePropertyValueString": {
+            "type": "string",
+            "max": 10240,
+            "min": 0,
+            "sensitive": true
+        },
+        "ArtifactId": {
+            "type": "string",
+            "max": 126,
+            "min": 1,
+            "pattern": "[a-zA-Z0-9-_]+"
         },
         "ArtifactMap": {
             "type": "map",
-            "key": { "shape": "ArtifactType" },
-            "value": { "shape": "UploadId" },
+            "key": {
+                "shape": "ArtifactType"
+            },
+            "value": {
+                "shape": "UploadId"
+            },
             "max": 64,
             "min": 1
         },
@@ -307,12 +729,27 @@
             "type": "structure",
             "required": ["content"],
             "members": {
-                "messageId": { "shape": "MessageId" },
-                "content": { "shape": "AssistantResponseMessageContentString" },
-                "supplementaryWebLinks": { "shape": "SupplementaryWebLinks" },
-                "references": { "shape": "References" },
-                "followupPrompt": { "shape": "FollowupPrompt" }
-            }
+                "messageId": {
+                    "shape": "MessageId"
+                },
+                "content": {
+                    "shape": "AssistantResponseMessageContentString",
+                    "documentation": "<p>The content of the text message in markdown format.</p>"
+                },
+                "supplementaryWebLinks": {
+                    "shape": "SupplementaryWebLinks",
+                    "documentation": "<p>Web References</p>"
+                },
+                "references": {
+                    "shape": "References",
+                    "documentation": "<p>Code References</p>"
+                },
+                "followupPrompt": {
+                    "shape": "FollowupPrompt",
+                    "documentation": "<p>Followup Prompt</p>"
+                }
+            },
+            "documentation": "<p>Markdown text message.</p>"
         },
         "AssistantResponseMessageContentString": {
             "type": "string",
@@ -334,22 +771,56 @@
             "type": "structure",
             "required": ["conversationId", "messageId"],
             "members": {
-                "conversationId": { "shape": "ConversationId" },
-                "messageId": { "shape": "MessageId" },
-                "userIntent": { "shape": "UserIntent" },
-                "hasCodeSnippet": { "shape": "Boolean" },
-                "programmingLanguage": { "shape": "ProgrammingLanguage" },
-                "activeEditorTotalCharacters": { "shape": "Integer" },
-                "timeToFirstChunkMilliseconds": { "shape": "Double" },
-                "timeBetweenChunks": { "shape": "TimeBetweenChunks" },
-                "fullResponselatency": { "shape": "Double" },
-                "requestLength": { "shape": "Integer" },
-                "responseLength": { "shape": "Integer" }
+                "conversationId": {
+                    "shape": "ConversationId"
+                },
+                "messageId": {
+                    "shape": "MessageId"
+                },
+                "customizationArn": {
+                    "shape": "CustomizationArn"
+                },
+                "userIntent": {
+                    "shape": "UserIntent"
+                },
+                "hasCodeSnippet": {
+                    "shape": "Boolean"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                },
+                "activeEditorTotalCharacters": {
+                    "shape": "Integer"
+                },
+                "timeToFirstChunkMilliseconds": {
+                    "shape": "Double"
+                },
+                "timeBetweenChunks": {
+                    "shape": "timeBetweenChunks"
+                },
+                "fullResponselatency": {
+                    "shape": "Double"
+                },
+                "requestLength": {
+                    "shape": "Integer"
+                },
+                "responseLength": {
+                    "shape": "Integer"
+                },
+                "numberOfCodeBlocks": {
+                    "shape": "Integer"
+                },
+                "hasProjectLevelContext": {
+                    "shape": "Boolean"
+                }
             }
         },
         "ChatHistory": {
             "type": "list",
-            "member": { "shape": "ChatMessage" },
+            "member": {
+                "shape": "ChatMessage"
+            },
+            "documentation": "<p>Indicates Participant in Chat conversation</p>",
             "max": 10,
             "min": 0
         },
@@ -357,24 +828,58 @@
             "type": "structure",
             "required": ["conversationId", "messageId"],
             "members": {
-                "conversationId": { "shape": "ConversationId" },
-                "messageId": { "shape": "MessageId" },
-                "interactionType": { "shape": "ChatMessageInteractionType" },
-                "interactionTarget": { "shape": "String" },
-                "acceptedCharacterCount": { "shape": "Integer" },
-                "acceptedSnippetHasReference": { "shape": "Boolean" }
+                "conversationId": {
+                    "shape": "ConversationId"
+                },
+                "messageId": {
+                    "shape": "MessageId"
+                },
+                "customizationArn": {
+                    "shape": "CustomizationArn"
+                },
+                "interactionType": {
+                    "shape": "ChatMessageInteractionType"
+                },
+                "interactionTarget": {
+                    "shape": "ChatInteractWithMessageEventInteractionTargetString"
+                },
+                "acceptedCharacterCount": {
+                    "shape": "Integer"
+                },
+                "acceptedLineCount": {
+                    "shape": "Integer"
+                },
+                "acceptedSnippetHasReference": {
+                    "shape": "Boolean"
+                },
+                "hasProjectLevelContext": {
+                    "shape": "Boolean"
+                },
+                "userIntent": {
+                    "shape": "UserIntent"
+                }
             }
+        },
+        "ChatInteractWithMessageEventInteractionTargetString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1
         },
         "ChatMessage": {
             "type": "structure",
             "members": {
-                "userInputMessage": { "shape": "UserInputMessage" },
-                "assistantResponseMessage": { "shape": "AssistantResponseMessage" }
+                "userInputMessage": {
+                    "shape": "UserInputMessage"
+                },
+                "assistantResponseMessage": {
+                    "shape": "AssistantResponseMessage"
+                }
             },
             "union": true
         },
         "ChatMessageInteractionType": {
             "type": "string",
+            "documentation": "<p>Chat Message Interaction Type</p>",
             "enum": [
                 "INSERT_AT_CURSOR",
                 "COPY_SNIPPET",
@@ -387,42 +892,83 @@
                 "DOWNVOTE"
             ]
         },
+        "ChatTriggerType": {
+            "type": "string",
+            "documentation": "<p>Trigger Reason for Chat</p>",
+            "enum": ["MANUAL", "DIAGNOSTIC", "INLINE_CHAT"]
+        },
         "ChatUserModificationEvent": {
             "type": "structure",
             "required": ["conversationId", "messageId", "modificationPercentage"],
             "members": {
-                "conversationId": { "shape": "ConversationId" },
-                "messageId": { "shape": "MessageId" },
-                "programmingLanguage": { "shape": "ProgrammingLanguage" },
-                "modificationPercentage": { "shape": "Double" }
+                "conversationId": {
+                    "shape": "ConversationId"
+                },
+                "customizationArn": {
+                    "shape": "CustomizationArn"
+                },
+                "messageId": {
+                    "shape": "MessageId"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                },
+                "modificationPercentage": {
+                    "shape": "Double"
+                },
+                "hasProjectLevelContext": {
+                    "shape": "Boolean"
+                }
             }
-        },
-        "ChatTriggerType": {
-            "type": "string",
-            "enum": ["MANUAL", "DIAGNOSTIC"]
         },
         "CodeAnalysisFindingsSchema": {
             "type": "string",
             "enum": ["codeanalysis/findings/1.0"]
         },
+        "CodeAnalysisScope": {
+            "type": "string",
+            "enum": ["FILE", "PROJECT"]
+        },
         "CodeAnalysisStatus": {
             "type": "string",
             "enum": ["Completed", "Pending", "Failed"]
+        },
+        "CodeAnalysisUploadContext": {
+            "type": "structure",
+            "required": ["codeScanName"],
+            "members": {
+                "codeScanName": {
+                    "shape": "CodeScanName"
+                }
+            }
         },
         "CodeCoverageEvent": {
             "type": "structure",
             "required": ["programmingLanguage", "acceptedCharacterCount", "totalCharacterCount", "timestamp"],
             "members": {
-                "customizationArn": { "shape": "CustomizationArn" },
-                "programmingLanguage": { "shape": "ProgrammingLanguage" },
-                "acceptedCharacterCount": { "shape": "PrimitiveInteger" },
-                "totalCharacterCount": { "shape": "PrimitiveInteger" },
-                "timestamp": { "shape": "Timestamp" },
-                "unmodifiedAcceptedCharacterCount": { "shape": "PrimitiveInteger" }
+                "customizationArn": {
+                    "shape": "CustomizationArn"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                },
+                "acceptedCharacterCount": {
+                    "shape": "PrimitiveInteger"
+                },
+                "totalCharacterCount": {
+                    "shape": "PrimitiveInteger"
+                },
+                "timestamp": {
+                    "shape": "Timestamp"
+                },
+                "unmodifiedAcceptedCharacterCount": {
+                    "shape": "PrimitiveInteger"
+                }
             }
         },
         "CodeGenerationId": {
             "type": "string",
+            "documentation": "<p>ID which represents a single code generation in a conversation</p>",
             "max": 128,
             "min": 1
         },
@@ -430,9 +976,18 @@
             "type": "structure",
             "required": ["status", "currentStage"],
             "members": {
-                "status": { "shape": "CodeGenerationWorkflowStatus" },
-                "currentStage": { "shape": "CodeGenerationWorkflowStage" }
+                "status": {
+                    "shape": "CodeGenerationWorkflowStatus"
+                },
+                "currentStage": {
+                    "shape": "CodeGenerationWorkflowStage"
+                }
             }
+        },
+        "CodeGenerationStatusDetail": {
+            "type": "string",
+            "documentation": "<p>Detailed message about the code generation status</p>",
+            "sensitive": true
         },
         "CodeGenerationWorkflowStage": {
             "type": "string",
@@ -446,9 +1001,18 @@
             "type": "structure",
             "required": ["programmingLanguage", "codeScanJobId", "timestamp"],
             "members": {
-                "programmingLanguage": { "shape": "ProgrammingLanguage" },
-                "codeScanJobId": { "shape": "CodeScanJobId" },
-                "timestamp": { "shape": "Timestamp" }
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                },
+                "codeScanJobId": {
+                    "shape": "CodeScanJobId"
+                },
+                "timestamp": {
+                    "shape": "Timestamp"
+                },
+                "codeAnalysisScope": {
+                    "shape": "CodeAnalysisScope"
+                }
             }
         },
         "CodeScanJobId": {
@@ -456,13 +1020,65 @@
             "max": 128,
             "min": 1
         },
+        "CodeScanName": {
+            "type": "string",
+            "documentation": "<p>Code analysis scan name</p>",
+            "max": 128,
+            "min": 1
+        },
+        "CodeScanRemediationsEvent": {
+            "type": "structure",
+            "members": {
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                },
+                "CodeScanRemediationsEventType": {
+                    "shape": "CodeScanRemediationsEventType"
+                },
+                "timestamp": {
+                    "shape": "Timestamp"
+                },
+                "detectorId": {
+                    "shape": "String"
+                },
+                "findingId": {
+                    "shape": "String"
+                },
+                "ruleId": {
+                    "shape": "String"
+                },
+                "component": {
+                    "shape": "String"
+                },
+                "reason": {
+                    "shape": "String"
+                },
+                "result": {
+                    "shape": "String"
+                },
+                "includesFix": {
+                    "shape": "Boolean"
+                }
+            }
+        },
+        "CodeScanRemediationsEventType": {
+            "type": "string",
+            "documentation": "<p>Code Scan Remediations Interaction Type</p>",
+            "enum": ["CODESCAN_ISSUE_HOVER", "CODESCAN_ISSUE_APPLY_FIX", "CODESCAN_ISSUE_VIEW_DETAILS"]
+        },
         "Completion": {
             "type": "structure",
             "required": ["content"],
             "members": {
-                "content": { "shape": "CompletionContentString" },
-                "references": { "shape": "References" },
-                "mostRelevantMissingImports": { "shape": "Imports" }
+                "content": {
+                    "shape": "CompletionContentString"
+                },
+                "references": {
+                    "shape": "References"
+                },
+                "mostRelevantMissingImports": {
+                    "shape": "Imports"
+                }
             }
         },
         "CompletionContentString": {
@@ -477,7 +1093,9 @@
         },
         "Completions": {
             "type": "list",
-            "member": { "shape": "Completion" },
+            "member": {
+                "shape": "Completion"
+            },
             "max": 10,
             "min": 0
         },
@@ -485,9 +1103,44 @@
             "type": "structure",
             "required": ["message"],
             "members": {
-                "message": { "shape": "String" }
+                "message": {
+                    "shape": "String"
+                },
+                "reason": {
+                    "shape": "ConflictExceptionReason"
+                }
             },
+            "documentation": "<p>This exception is thrown when the action to perform could not be completed because the resource is in a conflicting state.</p>",
             "exception": true
+        },
+        "ConflictExceptionReason": {
+            "type": "string",
+            "documentation": "<p>Reason for ConflictException</p>",
+            "enum": ["CUSTOMER_KMS_KEY_INVALID_KEY_POLICY", "CUSTOMER_KMS_KEY_DISABLED", "MISMATCHED_KMS_KEY"]
+        },
+        "ConsoleState": {
+            "type": "structure",
+            "members": {
+                "region": {
+                    "shape": "String"
+                },
+                "consoleUrl": {
+                    "shape": "SensitiveString"
+                },
+                "serviceId": {
+                    "shape": "String"
+                },
+                "serviceConsolePage": {
+                    "shape": "String"
+                },
+                "serviceSubconsolePage": {
+                    "shape": "String"
+                },
+                "taskName": {
+                    "shape": "SensitiveString"
+                }
+            },
+            "documentation": "<p>Information about the state of the AWS management console page from which the user is calling</p>"
         },
         "ContentChecksumType": {
             "type": "string",
@@ -495,10 +1148,12 @@
         },
         "ContextTruncationScheme": {
             "type": "string",
+            "documentation": "<p>Workspace context truncation schemes based on usecase</p>",
             "enum": ["ANALYSIS", "GUMBY"]
         },
         "ConversationId": {
             "type": "string",
+            "documentation": "<p>ID which represents a multi-turn conversation</p>",
             "max": 128,
             "min": 1
         },
@@ -506,33 +1161,70 @@
             "type": "structure",
             "required": ["currentMessage", "chatTriggerType"],
             "members": {
-                "conversationId": { "shape": "ConversationId" },
-                "history": { "shape": "ChatHistory" },
-                "currentMessage": { "shape": "ChatMessage" },
-                "chatTriggerType": { "shape": "ChatTriggerType" }
-            }
+                "conversationId": {
+                    "shape": "ConversationId",
+                    "documentation": "<p>Unique identifier for the chat conversation stream</p>"
+                },
+                "history": {
+                    "shape": "ChatHistory",
+                    "documentation": "<p>Holds the history of chat messages.</p>"
+                },
+                "currentMessage": {
+                    "shape": "ChatMessage",
+                    "documentation": "<p>Holds the current message being processed or displayed.</p>"
+                },
+                "chatTriggerType": {
+                    "shape": "ChatTriggerType",
+                    "documentation": "<p>Trigger Reason for Chat</p>"
+                },
+                "customizationArn": {
+                    "shape": "ResourceArn"
+                }
+            },
+            "documentation": "<p>Structure to represent the current state of a chat conversation.</p>"
         },
         "CreateTaskAssistConversationRequest": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "documentation": "<p>Structure to represent bootstrap conversation request.</p>"
         },
         "CreateTaskAssistConversationResponse": {
             "type": "structure",
             "required": ["conversationId"],
             "members": {
-                "conversationId": { "shape": "ConversationId" }
-            }
+                "conversationId": {
+                    "shape": "ConversationId"
+                }
+            },
+            "documentation": "<p>Structure to represent bootstrap conversation response.</p>"
         },
         "CreateUploadUrlRequest": {
             "type": "structure",
             "members": {
-                "contentMd5": { "shape": "CreateUploadUrlRequestContentMd5String" },
-                "contentChecksum": { "shape": "CreateUploadUrlRequestContentChecksumString" },
-                "contentChecksumType": { "shape": "ContentChecksumType" },
-                "contentLength": { "shape": "CreateUploadUrlRequestContentLengthLong" },
-                "artifactType": { "shape": "ArtifactType" },
-                "uploadIntent": { "shape": "UploadIntent" },
-                "uploadContext": { "shape": "UploadContext" }
+                "contentMd5": {
+                    "shape": "CreateUploadUrlRequestContentMd5String"
+                },
+                "contentChecksum": {
+                    "shape": "CreateUploadUrlRequestContentChecksumString"
+                },
+                "contentChecksumType": {
+                    "shape": "ContentChecksumType"
+                },
+                "contentLength": {
+                    "shape": "CreateUploadUrlRequestContentLengthLong"
+                },
+                "artifactType": {
+                    "shape": "ArtifactType"
+                },
+                "uploadIntent": {
+                    "shape": "UploadIntent"
+                },
+                "uploadContext": {
+                    "shape": "UploadContext"
+                },
+                "uploadId": {
+                    "shape": "UploadId"
+                }
             }
         },
         "CreateUploadUrlRequestContentChecksumString": {
@@ -556,26 +1248,48 @@
             "type": "structure",
             "required": ["uploadId", "uploadUrl"],
             "members": {
-                "uploadId": { "shape": "UploadId" },
-                "uploadUrl": { "shape": "PreSignedUrl" },
-                "kmsKeyArn": { "shape": "ResourceArn" }
+                "uploadId": {
+                    "shape": "UploadId"
+                },
+                "uploadUrl": {
+                    "shape": "PreSignedUrl"
+                },
+                "kmsKeyArn": {
+                    "shape": "ResourceArn"
+                },
+                "requestHeaders": {
+                    "shape": "RequestHeaders"
+                }
             }
         },
         "CursorState": {
             "type": "structure",
             "members": {
-                "position": { "shape": "Position" },
-                "range": { "shape": "Range" }
+                "position": {
+                    "shape": "Position",
+                    "documentation": "<p>Represents a cursor position in a Text Document</p>"
+                },
+                "range": {
+                    "shape": "Range",
+                    "documentation": "<p>Represents a text selection in a Text Document</p>"
+                }
             },
+            "documentation": "<p>Represents the state of the Cursor in an Editor</p>",
             "union": true
         },
         "Customization": {
             "type": "structure",
             "required": ["arn"],
             "members": {
-                "arn": { "shape": "CustomizationArn" },
-                "name": { "shape": "CustomizationName" },
-                "description": { "shape": "Description" }
+                "arn": {
+                    "shape": "CustomizationArn"
+                },
+                "name": {
+                    "shape": "CustomizationName"
+                },
+                "description": {
+                    "shape": "Description"
+                }
             }
         },
         "CustomizationArn": {
@@ -592,21 +1306,29 @@
         },
         "Customizations": {
             "type": "list",
-            "member": { "shape": "Customization" }
+            "member": {
+                "shape": "Customization"
+            }
         },
         "DeleteTaskAssistConversationRequest": {
             "type": "structure",
             "required": ["conversationId"],
             "members": {
-                "conversationId": { "shape": "ConversationId" }
-            }
+                "conversationId": {
+                    "shape": "ConversationId"
+                }
+            },
+            "documentation": "<p>Structure to represent bootstrap conversation request.</p>"
         },
         "DeleteTaskAssistConversationResponse": {
             "type": "structure",
             "required": ["conversationId"],
             "members": {
-                "conversationId": { "shape": "ConversationId" }
-            }
+                "conversationId": {
+                    "shape": "ConversationId"
+                }
+            },
+            "documentation": "<p>Structure to represent bootstrap conversation response.</p>"
         },
         "Description": {
             "type": "string",
@@ -617,25 +1339,39 @@
         "Diagnostic": {
             "type": "structure",
             "members": {
-                "textDocumentDiagnostic": { "shape": "TextDocumentDiagnostic" },
-                "runtimeDiagnostic": { "shape": "RuntimeDiagnostic" }
+                "textDocumentDiagnostic": {
+                    "shape": "TextDocumentDiagnostic",
+                    "documentation": "<p>Diagnostics originating from a TextDocument</p>"
+                },
+                "runtimeDiagnostic": {
+                    "shape": "RuntimeDiagnostic",
+                    "documentation": "<p>Diagnostics originating from a Runtime</p>"
+                }
             },
+            "documentation": "<p>Represents a Diagnostic message</p>",
             "union": true
         },
         "DiagnosticSeverity": {
             "type": "string",
+            "documentation": "<p>Diagnostic Error types</p>",
             "enum": ["ERROR", "WARNING", "INFORMATION", "HINT"]
         },
         "Dimension": {
             "type": "structure",
             "members": {
-                "name": { "shape": "DimensionNameString" },
-                "value": { "shape": "DimensionValueString" }
+                "name": {
+                    "shape": "DimensionNameString"
+                },
+                "value": {
+                    "shape": "DimensionValueString"
+                }
             }
         },
         "DimensionList": {
             "type": "list",
-            "member": { "shape": "Dimension" },
+            "member": {
+                "shape": "Dimension"
+            },
             "max": 30,
             "min": 0
         },
@@ -655,9 +1391,18 @@
             "type": "structure",
             "required": ["name", "type"],
             "members": {
-                "name": { "shape": "DocumentSymbolNameString" },
-                "type": { "shape": "SymbolType" },
-                "source": { "shape": "DocumentSymbolSourceString" }
+                "name": {
+                    "shape": "DocumentSymbolNameString",
+                    "documentation": "<p>Name of the Document Symbol</p>"
+                },
+                "type": {
+                    "shape": "SymbolType",
+                    "documentation": "<p>Symbol type - DECLARATION / USAGE</p>"
+                },
+                "source": {
+                    "shape": "DocumentSymbolSourceString",
+                    "documentation": "<p>Symbol package / source for FullyQualified names</p>"
+                }
             }
         },
         "DocumentSymbolNameString": {
@@ -672,9 +1417,27 @@
         },
         "DocumentSymbols": {
             "type": "list",
-            "member": { "shape": "DocumentSymbol" },
+            "member": {
+                "shape": "DocumentSymbol"
+            },
             "max": 1000,
             "min": 0
+        },
+        "DocumentationIntentContext": {
+            "type": "structure",
+            "required": ["type"],
+            "members": {
+                "scope": {
+                    "shape": "String"
+                },
+                "type": {
+                    "shape": "DocumentationType"
+                }
+            }
+        },
+        "DocumentationType": {
+            "type": "string",
+            "enum": ["README"]
         },
         "Double": {
             "type": "double",
@@ -683,22 +1446,119 @@
         "EditorState": {
             "type": "structure",
             "members": {
-                "document": { "shape": "TextDocument" },
-                "cursorState": { "shape": "CursorState" }
+                "document": {
+                    "shape": "TextDocument",
+                    "documentation": "<p>Represents currently edited file</p>"
+                },
+                "cursorState": {
+                    "shape": "CursorState",
+                    "documentation": "<p>Position of the cursor</p>"
+                },
+                "relevantDocuments": {
+                    "shape": "RelevantDocumentList",
+                    "documentation": "<p>Represents IDE provided relevant files</p>"
+                },
+                "useRelevantDocuments": {
+                    "shape": "Boolean",
+                    "documentation": "<p>Whether service should use relevant document in prompt</p>"
+                }
+            },
+            "documentation": "<p>Represents the state of an Editor</p>"
+        },
+        "EnvState": {
+            "type": "structure",
+            "members": {
+                "operatingSystem": {
+                    "shape": "EnvStateOperatingSystemString",
+                    "documentation": "<p>The name of the operating system in use</p>"
+                },
+                "currentWorkingDirectory": {
+                    "shape": "EnvStateCurrentWorkingDirectoryString",
+                    "documentation": "<p>The current working directory of the environment</p>"
+                },
+                "environmentVariables": {
+                    "shape": "EnvironmentVariables",
+                    "documentation": "<p>The environment variables set in the current environment</p>"
+                }
+            },
+            "documentation": "<p>State related to the user's environment</p>"
+        },
+        "EnvStateCurrentWorkingDirectoryString": {
+            "type": "string",
+            "max": 256,
+            "min": 1,
+            "sensitive": true
+        },
+        "EnvStateOperatingSystemString": {
+            "type": "string",
+            "max": 32,
+            "min": 1,
+            "pattern": "(macos|linux|windows)"
+        },
+        "EnvironmentVariable": {
+            "type": "structure",
+            "members": {
+                "key": {
+                    "shape": "EnvironmentVariableKeyString",
+                    "documentation": "<p>The key of an environment variable</p>"
+                },
+                "value": {
+                    "shape": "EnvironmentVariableValueString",
+                    "documentation": "<p>The value of an environment variable</p>"
+                }
+            },
+            "documentation": "<p>An environment variable</p>"
+        },
+        "EnvironmentVariableKeyString": {
+            "type": "string",
+            "max": 256,
+            "min": 1,
+            "sensitive": true
+        },
+        "EnvironmentVariableValueString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
+        },
+        "EnvironmentVariables": {
+            "type": "list",
+            "member": {
+                "shape": "EnvironmentVariable"
+            },
+            "documentation": "<p>A list of environment variables</p>",
+            "max": 100,
+            "min": 0
+        },
+        "FeatureDevEvent": {
+            "type": "structure",
+            "required": ["conversationId"],
+            "members": {
+                "conversationId": {
+                    "shape": "ConversationId"
+                }
             }
         },
         "FeatureEvaluation": {
             "type": "structure",
             "required": ["feature", "variation", "value"],
             "members": {
-                "feature": { "shape": "FeatureName" },
-                "variation": { "shape": "FeatureVariation" },
-                "value": { "shape": "FeatureValue" }
+                "feature": {
+                    "shape": "FeatureName"
+                },
+                "variation": {
+                    "shape": "FeatureVariation"
+                },
+                "value": {
+                    "shape": "FeatureValue"
+                }
             }
         },
         "FeatureEvaluationsList": {
             "type": "list",
-            "member": { "shape": "FeatureEvaluation" },
+            "member": {
+                "shape": "FeatureEvaluation"
+            },
             "max": 50,
             "min": 0
         },
@@ -711,10 +1571,18 @@
         "FeatureValue": {
             "type": "structure",
             "members": {
-                "boolValue": { "shape": "Boolean" },
-                "doubleValue": { "shape": "Double" },
-                "longValue": { "shape": "Long" },
-                "stringValue": { "shape": "FeatureValueStringType" }
+                "boolValue": {
+                    "shape": "Boolean"
+                },
+                "doubleValue": {
+                    "shape": "Double"
+                },
+                "longValue": {
+                    "shape": "Long"
+                },
+                "stringValue": {
+                    "shape": "FeatureValueStringType"
+                }
             },
             "union": true
         },
@@ -733,10 +1601,18 @@
             "type": "structure",
             "required": ["leftFileContent", "rightFileContent", "filename", "programmingLanguage"],
             "members": {
-                "leftFileContent": { "shape": "FileContextLeftFileContentString" },
-                "rightFileContent": { "shape": "FileContextRightFileContentString" },
-                "filename": { "shape": "FileContextFilenameString" },
-                "programmingLanguage": { "shape": "ProgrammingLanguage" }
+                "leftFileContent": {
+                    "shape": "FileContextLeftFileContentString"
+                },
+                "rightFileContent": {
+                    "shape": "FileContextRightFileContentString"
+                },
+                "filename": {
+                    "shape": "FileContextFilenameString"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                }
             }
         },
         "FileContextFilenameString": {
@@ -761,9 +1637,16 @@
             "type": "structure",
             "required": ["content"],
             "members": {
-                "content": { "shape": "FollowupPromptContentString" },
-                "userIntent": { "shape": "UserIntent" }
-            }
+                "content": {
+                    "shape": "FollowupPromptContentString",
+                    "documentation": "<p>The content of the text message in markdown format.</p>"
+                },
+                "userIntent": {
+                    "shape": "UserIntent",
+                    "documentation": "<p>User Intent</p>"
+                }
+            },
+            "documentation": "<p>Followup Prompt for the Assistant Response</p>"
         },
         "FollowupPromptContentString": {
             "type": "string",
@@ -775,14 +1658,33 @@
             "type": "structure",
             "required": ["fileContext"],
             "members": {
-                "fileContext": { "shape": "FileContext" },
-                "maxResults": { "shape": "GenerateCompletionsRequestMaxResultsInteger" },
-                "nextToken": { "shape": "GenerateCompletionsRequestNextTokenString" },
-                "referenceTrackerConfiguration": { "shape": "ReferenceTrackerConfiguration" },
-                "supplementalContexts": { "shape": "SupplementalContextList" },
-                "customizationArn": { "shape": "CustomizationArn" },
-                "optOutPreference": { "shape": "OptOutPreference" },
-                "userContext": { "shape": "UserContext" }
+                "fileContext": {
+                    "shape": "FileContext"
+                },
+                "maxResults": {
+                    "shape": "GenerateCompletionsRequestMaxResultsInteger"
+                },
+                "nextToken": {
+                    "shape": "GenerateCompletionsRequestNextTokenString"
+                },
+                "referenceTrackerConfiguration": {
+                    "shape": "ReferenceTrackerConfiguration"
+                },
+                "supplementalContexts": {
+                    "shape": "SupplementalContextList"
+                },
+                "customizationArn": {
+                    "shape": "CustomizationArn"
+                },
+                "optOutPreference": {
+                    "shape": "OptOutPreference"
+                },
+                "userContext": {
+                    "shape": "UserContext"
+                },
+                "profileArn": {
+                    "shape": "ProfileArn"
+                }
             }
         },
         "GenerateCompletionsRequestMaxResultsInteger": {
@@ -801,15 +1703,21 @@
         "GenerateCompletionsResponse": {
             "type": "structure",
             "members": {
-                "completions": { "shape": "Completions" },
-                "nextToken": { "shape": "SensitiveString" }
+                "completions": {
+                    "shape": "Completions"
+                },
+                "nextToken": {
+                    "shape": "SensitiveString"
+                }
             }
         },
         "GetCodeAnalysisRequest": {
             "type": "structure",
             "required": ["jobId"],
             "members": {
-                "jobId": { "shape": "GetCodeAnalysisRequestJobIdString" }
+                "jobId": {
+                    "shape": "GetCodeAnalysisRequestJobIdString"
+                }
             }
         },
         "GetCodeAnalysisRequestJobIdString": {
@@ -821,57 +1729,130 @@
             "type": "structure",
             "required": ["status"],
             "members": {
-                "status": { "shape": "CodeAnalysisStatus" },
-                "errorMessage": { "shape": "SensitiveString" }
+                "status": {
+                    "shape": "CodeAnalysisStatus"
+                },
+                "errorMessage": {
+                    "shape": "SensitiveString"
+                }
             }
         },
         "GetTaskAssistCodeGenerationRequest": {
             "type": "structure",
             "required": ["conversationId", "codeGenerationId"],
             "members": {
-                "conversationId": { "shape": "ConversationId" },
-                "codeGenerationId": { "shape": "CodeGenerationId" }
-            }
+                "conversationId": {
+                    "shape": "ConversationId"
+                },
+                "codeGenerationId": {
+                    "shape": "CodeGenerationId"
+                }
+            },
+            "documentation": "<p>Request for getting task assist code generation.</p>"
         },
         "GetTaskAssistCodeGenerationResponse": {
             "type": "structure",
             "required": ["conversationId", "codeGenerationStatus"],
             "members": {
-                "conversationId": { "shape": "ConversationId" },
-                "codeGenerationStatus": { "shape": "CodeGenerationStatus" }
-            }
+                "conversationId": {
+                    "shape": "ConversationId"
+                },
+                "codeGenerationStatus": {
+                    "shape": "CodeGenerationStatus"
+                },
+                "codeGenerationStatusDetail": {
+                    "shape": "CodeGenerationStatusDetail"
+                },
+                "codeGenerationRemainingIterationCount": {
+                    "shape": "Integer"
+                },
+                "codeGenerationTotalIterationCount": {
+                    "shape": "Integer"
+                }
+            },
+            "documentation": "<p>Response for getting task assist code generation status.</p>"
+        },
+        "GetTestGenerationRequest": {
+            "type": "structure",
+            "required": ["testGenerationJobGroupName", "testGenerationJobId"],
+            "members": {
+                "testGenerationJobGroupName": {
+                    "shape": "TestGenerationJobGroupName"
+                },
+                "testGenerationJobId": {
+                    "shape": "UUID"
+                }
+            },
+            "documentation": "<p>Structure to represent get test generation request.</p>"
+        },
+        "GetTestGenerationResponse": {
+            "type": "structure",
+            "members": {
+                "testGenerationJob": {
+                    "shape": "TestGenerationJob"
+                }
+            },
+            "documentation": "<p>Structure to represent get test generation response.</p>"
         },
         "GetTransformationPlanRequest": {
             "type": "structure",
             "required": ["transformationJobId"],
             "members": {
-                "transformationJobId": { "shape": "TransformationJobId" }
-            }
+                "transformationJobId": {
+                    "shape": "TransformationJobId"
+                }
+            },
+            "documentation": "<p>Structure to represent get code transformation plan request.</p>"
         },
         "GetTransformationPlanResponse": {
             "type": "structure",
             "required": ["transformationPlan"],
             "members": {
-                "transformationPlan": { "shape": "TransformationPlan" }
-            }
+                "transformationPlan": {
+                    "shape": "TransformationPlan"
+                }
+            },
+            "documentation": "<p>Structure to represent get code transformation plan response.</p>"
         },
         "GetTransformationRequest": {
             "type": "structure",
             "required": ["transformationJobId"],
             "members": {
-                "transformationJobId": { "shape": "TransformationJobId" }
-            }
+                "transformationJobId": {
+                    "shape": "TransformationJobId"
+                }
+            },
+            "documentation": "<p>Structure to represent get code transformation request.</p>"
         },
         "GetTransformationResponse": {
             "type": "structure",
             "required": ["transformationJob"],
             "members": {
-                "transformationJob": { "shape": "TransformationJob" }
-            }
+                "transformationJob": {
+                    "shape": "TransformationJob"
+                }
+            },
+            "documentation": "<p>Structure to represent get code transformation response.</p>"
+        },
+        "GitState": {
+            "type": "structure",
+            "members": {
+                "status": {
+                    "shape": "GitStateStatusString",
+                    "documentation": "<p>The output of the command <code>git status --porcelain=v1 -b</code></p>"
+                }
+            },
+            "documentation": "<p>State related to the Git VSC</p>"
+        },
+        "GitStateStatusString": {
+            "type": "string",
+            "max": 4096,
+            "min": 0,
+            "sensitive": true
         },
         "IdeCategory": {
             "type": "string",
-            "enum": ["JETBRAINS", "VSCODE"],
+            "enum": ["JETBRAINS", "VSCODE", "CLI", "JUPYTER_MD", "JUPYTER_SM", "ECLIPSE", "VISUAL_STUDIO"],
             "max": 64,
             "min": 1
         },
@@ -883,7 +1864,9 @@
         "Import": {
             "type": "structure",
             "members": {
-                "statement": { "shape": "ImportStatementString" }
+                "statement": {
+                    "shape": "ImportStatementString"
+                }
             }
         },
         "ImportStatementString": {
@@ -894,29 +1877,111 @@
         },
         "Imports": {
             "type": "list",
-            "member": { "shape": "Import" },
+            "member": {
+                "shape": "Import"
+            },
             "max": 10,
             "min": 0
+        },
+        "InlineChatEvent": {
+            "type": "structure",
+            "required": ["requestId", "timestamp"],
+            "members": {
+                "requestId": {
+                    "shape": "UUID"
+                },
+                "timestamp": {
+                    "shape": "Timestamp"
+                },
+                "inputLength": {
+                    "shape": "PrimitiveInteger"
+                },
+                "numSelectedLines": {
+                    "shape": "PrimitiveInteger"
+                },
+                "numSuggestionAddChars": {
+                    "shape": "PrimitiveInteger"
+                },
+                "numSuggestionAddLines": {
+                    "shape": "PrimitiveInteger"
+                },
+                "numSuggestionDelChars": {
+                    "shape": "PrimitiveInteger"
+                },
+                "numSuggestionDelLines": {
+                    "shape": "PrimitiveInteger"
+                },
+                "codeIntent": {
+                    "shape": "Boolean"
+                },
+                "userDecision": {
+                    "shape": "InlineChatUserDecision"
+                },
+                "responseStartLatency": {
+                    "shape": "Double"
+                },
+                "responseEndLatency": {
+                    "shape": "Double"
+                },
+                "charactersAdded": {
+                    "shape": "PrimitiveInteger"
+                },
+                "charactersRemoved": {
+                    "shape": "PrimitiveInteger"
+                }
+            }
+        },
+        "InlineChatUserDecision": {
+            "type": "string",
+            "enum": ["ACCEPT", "REJECT", "DISMISS"]
         },
         "Integer": {
             "type": "integer",
             "box": true
         },
+        "Intent": {
+            "type": "string",
+            "enum": ["DEV", "DOC"]
+        },
+        "IntentContext": {
+            "type": "structure",
+            "members": {
+                "documentation": {
+                    "shape": "DocumentationIntentContext"
+                }
+            },
+            "union": true
+        },
         "InternalServerException": {
             "type": "structure",
             "required": ["message"],
             "members": {
-                "message": { "shape": "String" }
+                "message": {
+                    "shape": "String"
+                }
             },
+            "documentation": "<p>This exception is thrown when an unexpected error occurred during the processing of a request.</p>",
             "exception": true,
             "fault": true,
-            "retryable": { "throttling": false }
+            "retryable": {
+                "throttling": false
+            }
+        },
+        "LineRangeList": {
+            "type": "list",
+            "member": {
+                "shape": "Range"
+            }
         },
         "ListAvailableCustomizationsRequest": {
             "type": "structure",
             "members": {
-                "maxResults": { "shape": "ListAvailableCustomizationsRequestMaxResultsInteger" },
-                "nextToken": { "shape": "Base64EncodedPaginationToken" }
+                "maxResults": {
+                    "shape": "ListAvailableCustomizationsRequestMaxResultsInteger"
+                },
+                "nextToken": {
+                    "shape": "Base64EncodedPaginationToken"
+                }
             }
         },
         "ListAvailableCustomizationsRequestMaxResultsInteger": {
@@ -929,17 +1994,27 @@
             "type": "structure",
             "required": ["customizations"],
             "members": {
-                "customizations": { "shape": "Customizations" },
-                "nextToken": { "shape": "Base64EncodedPaginationToken" }
+                "customizations": {
+                    "shape": "Customizations"
+                },
+                "nextToken": {
+                    "shape": "Base64EncodedPaginationToken"
+                }
             }
         },
         "ListCodeAnalysisFindingsRequest": {
             "type": "structure",
             "required": ["jobId", "codeAnalysisFindingsSchema"],
             "members": {
-                "jobId": { "shape": "ListCodeAnalysisFindingsRequestJobIdString" },
-                "nextToken": { "shape": "PaginationToken" },
-                "codeAnalysisFindingsSchema": { "shape": "CodeAnalysisFindingsSchema" }
+                "jobId": {
+                    "shape": "ListCodeAnalysisFindingsRequestJobIdString"
+                },
+                "nextToken": {
+                    "shape": "PaginationToken"
+                },
+                "codeAnalysisFindingsSchema": {
+                    "shape": "CodeAnalysisFindingsSchema"
+                }
             }
         },
         "ListCodeAnalysisFindingsRequestJobIdString": {
@@ -951,22 +2026,30 @@
             "type": "structure",
             "required": ["codeAnalysisFindings"],
             "members": {
-                "nextToken": { "shape": "PaginationToken" },
-                "codeAnalysisFindings": { "shape": "SensitiveString" }
+                "nextToken": {
+                    "shape": "PaginationToken"
+                },
+                "codeAnalysisFindings": {
+                    "shape": "SensitiveString"
+                }
             }
         },
         "ListFeatureEvaluationsRequest": {
             "type": "structure",
             "required": ["userContext"],
             "members": {
-                "userContext": { "shape": "UserContext" }
+                "userContext": {
+                    "shape": "UserContext"
+                }
             }
         },
         "ListFeatureEvaluationsResponse": {
             "type": "structure",
             "required": ["featureEvaluations"],
             "members": {
-                "featureEvaluations": { "shape": "FeatureEvaluationsList" }
+                "featureEvaluations": {
+                    "shape": "FeatureEvaluationsList"
+                }
             }
         },
         "Long": {
@@ -975,22 +2058,40 @@
         },
         "MessageId": {
             "type": "string",
+            "documentation": "<p>Unique identifier for the chat message</p>",
             "max": 128,
             "min": 0
         },
         "MetricData": {
             "type": "structure",
-            "required": ["metricName", "metricValue", "timestamp"],
+            "required": ["metricName", "metricValue", "timestamp", "product"],
             "members": {
-                "metricName": { "shape": "MetricDataMetricNameString" },
-                "metricValue": { "shape": "Double" },
-                "timestamp": { "shape": "Timestamp" },
-                "dimensions": { "shape": "DimensionList" }
+                "metricName": {
+                    "shape": "MetricDataMetricNameString"
+                },
+                "metricValue": {
+                    "shape": "Double"
+                },
+                "timestamp": {
+                    "shape": "Timestamp"
+                },
+                "product": {
+                    "shape": "MetricDataProductString"
+                },
+                "dimensions": {
+                    "shape": "DimensionList"
+                }
             }
         },
         "MetricDataMetricNameString": {
             "type": "string",
             "max": 1024,
+            "min": 1,
+            "pattern": "[-a-zA-Z0-9._]*"
+        },
+        "MetricDataProductString": {
+            "type": "string",
+            "max": 128,
             "min": 1,
             "pattern": "[-a-zA-Z0-9._]*"
         },
@@ -1014,9 +2115,16 @@
             "type": "structure",
             "required": ["line", "character"],
             "members": {
-                "line": { "shape": "Integer" },
-                "character": { "shape": "Integer" }
-            }
+                "line": {
+                    "shape": "Integer",
+                    "documentation": "<p>Line position in a document.</p>"
+                },
+                "character": {
+                    "shape": "Integer",
+                    "documentation": "<p>Character offset on a line in a document (zero-based)</p>"
+                }
+            },
+            "documentation": "<p>Indicates Cursor postion in a Text Document</p>"
         },
         "PreSignedUrl": {
             "type": "string",
@@ -1024,44 +2132,78 @@
             "min": 1,
             "sensitive": true
         },
-        "PrimitiveInteger": { "type": "integer" },
+        "PrimitiveInteger": {
+            "type": "integer"
+        },
+        "ProfileArn": {
+            "type": "string",
+            "max": 950,
+            "min": 0,
+            "pattern": "arn:aws:codewhisperer:[-.a-z0-9]{1,63}:\\d{12}:profile/([a-zA-Z0-9]){12}"
+        },
         "ProgrammingLanguage": {
             "type": "structure",
             "required": ["languageName"],
             "members": {
-                "languageName": { "shape": "ProgrammingLanguageLanguageNameString" }
-            }
+                "languageName": {
+                    "shape": "ProgrammingLanguageLanguageNameString"
+                }
+            },
+            "documentation": "<p>Programming Languages supported by CodeWhisperer</p>"
         },
         "ProgrammingLanguageLanguageNameString": {
             "type": "string",
             "max": 128,
             "min": 1,
-            "pattern": "(python|javascript|java|csharp|typescript|c|cpp|go|kotlin|php|ruby|rust|scala|shell|sql|json|yaml|vue|tf|tsx|jsx)"
+            "pattern": "(python|javascript|java|csharp|typescript|c|cpp|go|kotlin|php|ruby|rust|scala|shell|sql|json|yaml|vue|tf|tsx|jsx|plaintext|systemverilog|dart|lua|swift|powershell|r)"
         },
         "ProgressUpdates": {
             "type": "list",
-            "member": { "shape": "TransformationProgressUpdate" }
+            "member": {
+                "shape": "TransformationProgressUpdate"
+            }
         },
         "Range": {
             "type": "structure",
             "required": ["start", "end"],
             "members": {
-                "start": { "shape": "Position" },
-                "end": { "shape": "Position" }
-            }
+                "start": {
+                    "shape": "Position",
+                    "documentation": "<p>The range's start position.</p>"
+                },
+                "end": {
+                    "shape": "Position",
+                    "documentation": "<p>The range's end position.</p>"
+                }
+            },
+            "documentation": "<p>Indicates Range / Span in a Text Document</p>"
         },
         "RecommendationsWithReferencesPreference": {
             "type": "string",
+            "documentation": "<p>Recommendations with references setting for CodeWhisperer</p>",
             "enum": ["BLOCK", "ALLOW"]
         },
         "Reference": {
             "type": "structure",
             "members": {
-                "licenseName": { "shape": "ReferenceLicenseNameString" },
-                "repository": { "shape": "ReferenceRepositoryString" },
-                "url": { "shape": "ReferenceUrlString" },
-                "recommendationContentSpan": { "shape": "Span" }
-            }
+                "licenseName": {
+                    "shape": "ReferenceLicenseNameString",
+                    "documentation": "<p>License name</p>"
+                },
+                "repository": {
+                    "shape": "ReferenceRepositoryString",
+                    "documentation": "<p>Code Repsitory for the associated reference</p>"
+                },
+                "url": {
+                    "shape": "ReferenceUrlString",
+                    "documentation": "<p>Respository URL</p>"
+                },
+                "recommendationContentSpan": {
+                    "shape": "Span",
+                    "documentation": "<p>Span / Range for the Reference</p>"
+                }
+            },
+            "documentation": "<p>Code Reference / Repository details</p>"
         },
         "ReferenceLicenseNameString": {
             "type": "string",
@@ -1077,7 +2219,9 @@
             "type": "structure",
             "required": ["recommendationsWithReferences"],
             "members": {
-                "recommendationsWithReferences": { "shape": "RecommendationsWithReferencesPreference" }
+                "recommendationsWithReferences": {
+                    "shape": "RecommendationsWithReferencesPreference"
+                }
             }
         },
         "ReferenceUrlString": {
@@ -1087,9 +2231,76 @@
         },
         "References": {
             "type": "list",
-            "member": { "shape": "Reference" },
+            "member": {
+                "shape": "Reference"
+            },
             "max": 10,
             "min": 0
+        },
+        "RelevantDocumentList": {
+            "type": "list",
+            "member": {
+                "shape": "RelevantTextDocument"
+            },
+            "max": 5,
+            "min": 0
+        },
+        "RelevantTextDocument": {
+            "type": "structure",
+            "required": ["relativeFilePath"],
+            "members": {
+                "relativeFilePath": {
+                    "shape": "RelevantTextDocumentRelativeFilePathString",
+                    "documentation": "<p>Filepath relative to the root of the workspace</p>"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage",
+                    "documentation": "<p>The text document's language identifier.</p>"
+                },
+                "text": {
+                    "shape": "RelevantTextDocumentTextString",
+                    "documentation": "<p>Content of the text document</p>"
+                },
+                "documentSymbols": {
+                    "shape": "DocumentSymbols",
+                    "documentation": "<p>DocumentSymbols parsed from a text document</p>"
+                }
+            },
+            "documentation": "<p>Represents an IDE retrieved relevant Text Document / File</p>"
+        },
+        "RelevantTextDocumentRelativeFilePathString": {
+            "type": "string",
+            "max": 4096,
+            "min": 1,
+            "sensitive": true
+        },
+        "RelevantTextDocumentTextString": {
+            "type": "string",
+            "max": 10240,
+            "min": 0,
+            "sensitive": true
+        },
+        "RequestHeaderKey": {
+            "type": "string",
+            "max": 64,
+            "min": 1
+        },
+        "RequestHeaderValue": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+        },
+        "RequestHeaders": {
+            "type": "map",
+            "key": {
+                "shape": "RequestHeaderKey"
+            },
+            "value": {
+                "shape": "RequestHeaderValue"
+            },
+            "max": 16,
+            "min": 1,
+            "sensitive": true
         },
         "ResourceArn": {
             "type": "string",
@@ -1101,18 +2312,54 @@
             "type": "structure",
             "required": ["message"],
             "members": {
-                "message": { "shape": "String" }
+                "message": {
+                    "shape": "String"
+                }
             },
+            "documentation": "<p>This exception is thrown when describing a resource that does not exist.</p>",
             "exception": true
+        },
+        "ResumeTransformationRequest": {
+            "type": "structure",
+            "required": ["transformationJobId"],
+            "members": {
+                "transformationJobId": {
+                    "shape": "TransformationJobId"
+                },
+                "userActionStatus": {
+                    "shape": "TransformationUserActionStatus"
+                }
+            },
+            "documentation": "<p>Structure to represent stop code transformation request.</p>"
+        },
+        "ResumeTransformationResponse": {
+            "type": "structure",
+            "required": ["transformationStatus"],
+            "members": {
+                "transformationStatus": {
+                    "shape": "TransformationStatus"
+                }
+            },
+            "documentation": "<p>Structure to represent stop code transformation response.</p>"
         },
         "RuntimeDiagnostic": {
             "type": "structure",
             "required": ["source", "severity", "message"],
             "members": {
-                "source": { "shape": "RuntimeDiagnosticSourceString" },
-                "severity": { "shape": "DiagnosticSeverity" },
-                "message": { "shape": "RuntimeDiagnosticMessageString" }
-            }
+                "source": {
+                    "shape": "RuntimeDiagnosticSourceString",
+                    "documentation": "<p>A human-readable string describing the source of the diagnostic</p>"
+                },
+                "severity": {
+                    "shape": "DiagnosticSeverity",
+                    "documentation": "<p>Diagnostic Error type</p>"
+                },
+                "message": {
+                    "shape": "RuntimeDiagnosticMessageString",
+                    "documentation": "<p>The diagnostic's message.</p>"
+                }
+            },
+            "documentation": "<p>Structure to represent metadata about a Runtime Diagnostics</p>"
         },
         "RuntimeDiagnosticMessageString": {
             "type": "string",
@@ -1134,9 +2381,18 @@
                     "shape": "IdempotencyToken",
                     "idempotencyToken": true
                 },
-                "telemetryEvent": { "shape": "TelemetryEvent" },
-                "optOutPreference": { "shape": "OptOutPreference" },
-                "userContext": { "shape": "UserContext" }
+                "telemetryEvent": {
+                    "shape": "TelemetryEvent"
+                },
+                "optOutPreference": {
+                    "shape": "OptOutPreference"
+                },
+                "userContext": {
+                    "shape": "UserContext"
+                },
+                "profileArn": {
+                    "shape": "ProfileArn"
+                }
             }
         },
         "SendTelemetryEventResponse": {
@@ -1147,12 +2403,109 @@
             "type": "string",
             "sensitive": true
         },
+        "ServiceQuotaExceededException": {
+            "type": "structure",
+            "required": ["message"],
+            "members": {
+                "message": {
+                    "shape": "String"
+                }
+            },
+            "documentation": "<p>This exception is thrown when request was denied due to caller exceeding their usage limits</p>",
+            "exception": true
+        },
+        "ShellHistory": {
+            "type": "list",
+            "member": {
+                "shape": "ShellHistoryEntry"
+            },
+            "documentation": "<p>A list of shell history entries</p>",
+            "max": 20,
+            "min": 0
+        },
+        "ShellHistoryEntry": {
+            "type": "structure",
+            "required": ["command"],
+            "members": {
+                "command": {
+                    "shape": "ShellHistoryEntryCommandString",
+                    "documentation": "<p>The shell command that was run</p>"
+                },
+                "directory": {
+                    "shape": "ShellHistoryEntryDirectoryString",
+                    "documentation": "<p>The directory the command was ran in</p>"
+                },
+                "exitCode": {
+                    "shape": "Integer",
+                    "documentation": "<p>The exit code of the command after it finished</p>"
+                },
+                "stdout": {
+                    "shape": "ShellHistoryEntryStdoutString",
+                    "documentation": "<p>The stdout from the command</p>"
+                },
+                "stderr": {
+                    "shape": "ShellHistoryEntryStderrString",
+                    "documentation": "<p>The stderr from the command</p>"
+                }
+            },
+            "documentation": "<p>An single entry in the shell history</p>"
+        },
+        "ShellHistoryEntryCommandString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
+        },
+        "ShellHistoryEntryDirectoryString": {
+            "type": "string",
+            "max": 256,
+            "min": 1,
+            "sensitive": true
+        },
+        "ShellHistoryEntryStderrString": {
+            "type": "string",
+            "max": 4096,
+            "min": 0,
+            "sensitive": true
+        },
+        "ShellHistoryEntryStdoutString": {
+            "type": "string",
+            "max": 4096,
+            "min": 0,
+            "sensitive": true
+        },
+        "ShellState": {
+            "type": "structure",
+            "required": ["shellName"],
+            "members": {
+                "shellName": {
+                    "shape": "ShellStateShellNameString",
+                    "documentation": "<p>The name of the current shell</p>"
+                },
+                "shellHistory": {
+                    "shape": "ShellHistory",
+                    "documentation": "<p>The history previous shell commands for the current shell</p>"
+                }
+            },
+            "documentation": "<p>Represents the state of a shell</p>"
+        },
+        "ShellStateShellNameString": {
+            "type": "string",
+            "max": 32,
+            "min": 1,
+            "pattern": "(zsh|bash|fish|pwsh|nu)"
+        },
         "Span": {
             "type": "structure",
             "members": {
-                "start": { "shape": "SpanStartInteger" },
-                "end": { "shape": "SpanEndInteger" }
-            }
+                "start": {
+                    "shape": "SpanStartInteger"
+                },
+                "end": {
+                    "shape": "SpanEndInteger"
+                }
+            },
+            "documentation": "<p>Represents span in a text</p>"
         },
         "SpanEndInteger": {
             "type": "integer",
@@ -1168,11 +2521,21 @@
             "type": "structure",
             "required": ["artifacts", "programmingLanguage"],
             "members": {
-                "artifacts": { "shape": "ArtifactMap" },
-                "programmingLanguage": { "shape": "ProgrammingLanguage" },
+                "artifacts": {
+                    "shape": "ArtifactMap"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                },
                 "clientToken": {
                     "shape": "StartCodeAnalysisRequestClientTokenString",
                     "idempotencyToken": true
+                },
+                "scope": {
+                    "shape": "CodeAnalysisScope"
+                },
+                "codeScanName": {
+                    "shape": "CodeScanName"
                 }
             }
         },
@@ -1185,9 +2548,15 @@
             "type": "structure",
             "required": ["jobId", "status"],
             "members": {
-                "jobId": { "shape": "StartCodeAnalysisResponseJobIdString" },
-                "status": { "shape": "CodeAnalysisStatus" },
-                "errorMessage": { "shape": "SensitiveString" }
+                "jobId": {
+                    "shape": "StartCodeAnalysisResponseJobIdString"
+                },
+                "status": {
+                    "shape": "CodeAnalysisStatus"
+                },
+                "errorMessage": {
+                    "shape": "SensitiveString"
+                }
             }
         },
         "StartCodeAnalysisResponseJobIdString": {
@@ -1199,32 +2568,109 @@
             "type": "structure",
             "required": ["conversationState", "workspaceState"],
             "members": {
-                "conversationState": { "shape": "ConversationState" },
-                "workspaceState": { "shape": "WorkspaceState" }
-            }
+                "conversationState": {
+                    "shape": "ConversationState"
+                },
+                "workspaceState": {
+                    "shape": "WorkspaceState"
+                },
+                "taskAssistPlan": {
+                    "shape": "TaskAssistPlan"
+                },
+                "codeGenerationId": {
+                    "shape": "CodeGenerationId"
+                },
+                "currentCodeGenerationId": {
+                    "shape": "CodeGenerationId"
+                },
+                "intent": {
+                    "shape": "Intent"
+                },
+                "intentContext": {
+                    "shape": "IntentContext"
+                }
+            },
+            "documentation": "<p>Structure to represent start code generation request.</p>"
         },
         "StartTaskAssistCodeGenerationResponse": {
             "type": "structure",
             "required": ["conversationId", "codeGenerationId"],
             "members": {
-                "conversationId": { "shape": "ConversationId" },
-                "codeGenerationId": { "shape": "CodeGenerationId" }
-            }
+                "conversationId": {
+                    "shape": "ConversationId"
+                },
+                "codeGenerationId": {
+                    "shape": "CodeGenerationId"
+                }
+            },
+            "documentation": "<p>Structure to represent start code generation response.</p>"
+        },
+        "StartTestGenerationRequest": {
+            "type": "structure",
+            "required": ["uploadId", "targetCodeList", "userInput"],
+            "members": {
+                "uploadId": {
+                    "shape": "UploadId"
+                },
+                "targetCodeList": {
+                    "shape": "TargetCodeList"
+                },
+                "userInput": {
+                    "shape": "StartTestGenerationRequestUserInputString",
+                    "documentation": "<p>The content of user input.</p>"
+                },
+                "testGenerationJobGroupName": {
+                    "shape": "TestGenerationJobGroupName"
+                },
+                "clientToken": {
+                    "shape": "StartTestGenerationRequestClientTokenString",
+                    "idempotencyToken": true
+                }
+            },
+            "documentation": "<p>Structure to represent test generation request.</p>"
+        },
+        "StartTestGenerationRequestClientTokenString": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+        },
+        "StartTestGenerationRequestUserInputString": {
+            "type": "string",
+            "max": 4096,
+            "min": 0,
+            "sensitive": true
+        },
+        "StartTestGenerationResponse": {
+            "type": "structure",
+            "members": {
+                "testGenerationJob": {
+                    "shape": "TestGenerationJob"
+                }
+            },
+            "documentation": "<p>Structure to represent code transformation response.</p>"
         },
         "StartTransformationRequest": {
             "type": "structure",
             "required": ["workspaceState", "transformationSpec"],
             "members": {
-                "workspaceState": { "shape": "WorkspaceState" },
-                "transformationSpec": { "shape": "TransformationSpec" }
-            }
+                "workspaceState": {
+                    "shape": "WorkspaceState"
+                },
+                "transformationSpec": {
+                    "shape": "TransformationSpec"
+                }
+            },
+            "documentation": "<p>Structure to represent code transformation request.</p>"
         },
         "StartTransformationResponse": {
             "type": "structure",
             "required": ["transformationJobId"],
             "members": {
-                "transformationJobId": { "shape": "TransformationJobId" }
-            }
+                "transformationJobId": {
+                    "shape": "TransformationJobId"
+                }
+            },
+            "documentation": "<p>Structure to represent code transformation response.</p>"
         },
         "StepId": {
             "type": "string",
@@ -1235,17 +2681,25 @@
             "type": "structure",
             "required": ["transformationJobId"],
             "members": {
-                "transformationJobId": { "shape": "TransformationJobId" }
-            }
+                "transformationJobId": {
+                    "shape": "TransformationJobId"
+                }
+            },
+            "documentation": "<p>Structure to represent stop code transformation request.</p>"
         },
         "StopTransformationResponse": {
             "type": "structure",
             "required": ["transformationStatus"],
             "members": {
-                "transformationStatus": { "shape": "TransformationStatus" }
-            }
+                "transformationStatus": {
+                    "shape": "TransformationStatus"
+                }
+            },
+            "documentation": "<p>Structure to represent stop code transformation response.</p>"
         },
-        "String": { "type": "string" },
+        "String": {
+            "type": "string"
+        },
         "SuggestionState": {
             "type": "string",
             "enum": ["ACCEPT", "REJECT", "DISCARD", "EMPTY"]
@@ -1254,8 +2708,12 @@
             "type": "structure",
             "required": ["filePath", "content"],
             "members": {
-                "filePath": { "shape": "SupplementalContextFilePathString" },
-                "content": { "shape": "SupplementalContextContentString" }
+                "filePath": {
+                    "shape": "SupplementalContextFilePathString"
+                },
+                "content": {
+                    "shape": "SupplementalContextContentString"
+                }
             }
         },
         "SupplementalContextContentString": {
@@ -1272,7 +2730,9 @@
         },
         "SupplementalContextList": {
             "type": "list",
-            "member": { "shape": "SupplementalContext" },
+            "member": {
+                "shape": "SupplementalContext"
+            },
             "max": 5,
             "min": 0
         },
@@ -1280,10 +2740,20 @@
             "type": "structure",
             "required": ["url", "title"],
             "members": {
-                "url": { "shape": "SupplementaryWebLinkUrlString" },
-                "title": { "shape": "SupplementaryWebLinkTitleString" },
-                "snippet": { "shape": "SupplementaryWebLinkSnippetString" }
-            }
+                "url": {
+                    "shape": "SupplementaryWebLinkUrlString",
+                    "documentation": "<p>URL of the web reference link</p>"
+                },
+                "title": {
+                    "shape": "SupplementaryWebLinkTitleString",
+                    "documentation": "<p>Title of the web reference link</p>"
+                },
+                "snippet": {
+                    "shape": "SupplementaryWebLinkSnippetString",
+                    "documentation": "<p>Relevant text snippet from the link</p>"
+                }
+            },
+            "documentation": "<p>Represents an additional reference link retured with the Chat message</p>"
         },
         "SupplementaryWebLinkSnippetString": {
             "type": "string",
@@ -1305,7 +2775,9 @@
         },
         "SupplementaryWebLinks": {
             "type": "list",
-            "member": { "shape": "SupplementaryWebLink" },
+            "member": {
+                "shape": "SupplementaryWebLink"
+            },
             "max": 10,
             "min": 0
         },
@@ -1313,47 +2785,270 @@
             "type": "string",
             "enum": ["DECLARATION", "USAGE"]
         },
+        "TargetCode": {
+            "type": "structure",
+            "required": ["relativeTargetPath"],
+            "members": {
+                "relativeTargetPath": {
+                    "shape": "TargetCodeRelativeTargetPathString",
+                    "documentation": "<p>The file path relative to the root of the workspace, could be a single file or a folder.</p>"
+                },
+                "targetLineRangeList": {
+                    "shape": "LineRangeList"
+                }
+            }
+        },
+        "TargetCodeList": {
+            "type": "list",
+            "member": {
+                "shape": "TargetCode"
+            },
+            "min": 1
+        },
+        "TargetCodeRelativeTargetPathString": {
+            "type": "string",
+            "max": 4096,
+            "min": 1,
+            "sensitive": true
+        },
+        "TaskAssistPlan": {
+            "type": "list",
+            "member": {
+                "shape": "TaskAssistPlanStep"
+            },
+            "min": 0
+        },
+        "TaskAssistPlanStep": {
+            "type": "structure",
+            "required": ["filePath", "description"],
+            "members": {
+                "filePath": {
+                    "shape": "TaskAssistPlanStepFilePathString",
+                    "documentation": "<p>File path on which the step is working on.</p>"
+                },
+                "description": {
+                    "shape": "TaskAssistPlanStepDescriptionString",
+                    "documentation": "<p>Description on the step.</p>"
+                },
+                "startLine": {
+                    "shape": "TaskAssistPlanStepStartLineInteger",
+                    "documentation": "<p>Start line number of the related changes.</p>"
+                },
+                "endLine": {
+                    "shape": "TaskAssistPlanStepEndLineInteger",
+                    "documentation": "<p>End line number of the related changes.</p>"
+                },
+                "action": {
+                    "shape": "TaskAssistPlanStepAction",
+                    "documentation": "<p>Type of the action.</p>"
+                }
+            },
+            "documentation": "<p>Structured plan step for a task assist plan.</p>"
+        },
+        "TaskAssistPlanStepAction": {
+            "type": "string",
+            "documentation": "<p>Action for task assist plan step</p>",
+            "enum": ["MODIFY", "CREATE", "DELETE", "UNKNOWN"]
+        },
+        "TaskAssistPlanStepDescriptionString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1
+        },
+        "TaskAssistPlanStepEndLineInteger": {
+            "type": "integer",
+            "box": true,
+            "min": 0
+        },
+        "TaskAssistPlanStepFilePathString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1
+        },
+        "TaskAssistPlanStepStartLineInteger": {
+            "type": "integer",
+            "box": true,
+            "min": 0
+        },
         "TaskAssistPlanningUploadContext": {
             "type": "structure",
             "required": ["conversationId"],
             "members": {
-                "conversationId": { "shape": "ConversationId" }
+                "conversationId": {
+                    "shape": "ConversationId"
+                }
             }
         },
         "TelemetryEvent": {
             "type": "structure",
             "members": {
-                "userTriggerDecisionEvent": { "shape": "UserTriggerDecisionEvent" },
-                "codeCoverageEvent": { "shape": "CodeCoverageEvent" },
-                "userModificationEvent": { "shape": "UserModificationEvent" },
-                "codeScanEvent": { "shape": "CodeScanEvent" },
-                "metricData": { "shape": "MetricData" },
-                "chatAddMessageEvent": { "shape": "ChatAddMessageEvent" },
-                "chatInteractWithMessageEvent": { "shape": "ChatInteractWithMessageEvent" },
-                "chatUserModificationEvent": { "shape": "ChatUserModificationEvent" }
+                "userTriggerDecisionEvent": {
+                    "shape": "UserTriggerDecisionEvent"
+                },
+                "codeCoverageEvent": {
+                    "shape": "CodeCoverageEvent"
+                },
+                "userModificationEvent": {
+                    "shape": "UserModificationEvent"
+                },
+                "codeScanEvent": {
+                    "shape": "CodeScanEvent"
+                },
+                "codeScanRemediationsEvent": {
+                    "shape": "CodeScanRemediationsEvent"
+                },
+                "metricData": {
+                    "shape": "MetricData"
+                },
+                "chatAddMessageEvent": {
+                    "shape": "ChatAddMessageEvent"
+                },
+                "chatInteractWithMessageEvent": {
+                    "shape": "ChatInteractWithMessageEvent"
+                },
+                "chatUserModificationEvent": {
+                    "shape": "ChatUserModificationEvent"
+                },
+                "terminalUserInteractionEvent": {
+                    "shape": "TerminalUserInteractionEvent"
+                },
+                "featureDevEvent": {
+                    "shape": "FeatureDevEvent"
+                },
+                "inlineChatEvent": {
+                    "shape": "InlineChatEvent"
+                }
             },
             "union": true
+        },
+        "TerminalUserInteractionEvent": {
+            "type": "structure",
+            "members": {
+                "terminalUserInteractionEventType": {
+                    "shape": "TerminalUserInteractionEventType"
+                },
+                "terminal": {
+                    "shape": "String"
+                },
+                "terminalVersion": {
+                    "shape": "String"
+                },
+                "shell": {
+                    "shape": "String"
+                },
+                "shellVersion": {
+                    "shape": "String"
+                },
+                "duration": {
+                    "shape": "Integer"
+                },
+                "timeToSuggestion": {
+                    "shape": "Integer"
+                },
+                "isCompletionAccepted": {
+                    "shape": "Boolean"
+                },
+                "cliToolCommand": {
+                    "shape": "String"
+                }
+            }
+        },
+        "TerminalUserInteractionEventType": {
+            "type": "string",
+            "documentation": "<p>CodeWhisperer terminal Interaction Type</p>",
+            "enum": ["CODEWHISPERER_TERMINAL_TRANSLATION_ACTION", "CODEWHISPERER_TERMINAL_COMPLETION_INSERTED"]
+        },
+        "TestGenerationJob": {
+            "type": "structure",
+            "required": ["testGenerationJobId", "testGenerationJobGroupName", "status", "creationTime"],
+            "members": {
+                "testGenerationJobId": {
+                    "shape": "UUID"
+                },
+                "testGenerationJobGroupName": {
+                    "shape": "TestGenerationJobGroupName"
+                },
+                "status": {
+                    "shape": "TestGenerationJobStatus"
+                },
+                "shortAnswer": {
+                    "shape": "SensitiveString"
+                },
+                "creationTime": {
+                    "shape": "Timestamp"
+                },
+                "progressRate": {
+                    "shape": "TestGenerationJobProgressRateInteger"
+                }
+            },
+            "documentation": "<p>Represents a test generation job</p>"
+        },
+        "TestGenerationJobGroupName": {
+            "type": "string",
+            "documentation": "<p>Test generation job group name</p>",
+            "max": 128,
+            "min": 1,
+            "pattern": "[a-zA-Z0-9-_]+"
+        },
+        "TestGenerationJobProgressRateInteger": {
+            "type": "integer",
+            "box": true,
+            "max": 100,
+            "min": 0
+        },
+        "TestGenerationJobStatus": {
+            "type": "string",
+            "enum": ["IN_PROGRESS", "FAILED", "COMPLETED"]
         },
         "TextDocument": {
             "type": "structure",
             "required": ["relativeFilePath"],
             "members": {
-                "relativeFilePath": { "shape": "TextDocumentRelativeFilePathString" },
-                "programmingLanguage": { "shape": "ProgrammingLanguage" },
-                "text": { "shape": "TextDocumentTextString" },
-                "documentSymbols": { "shape": "DocumentSymbols" }
-            }
+                "relativeFilePath": {
+                    "shape": "TextDocumentRelativeFilePathString",
+                    "documentation": "<p>Filepath relative to the root of the workspace</p>"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage",
+                    "documentation": "<p>The text document's language identifier.</p>"
+                },
+                "text": {
+                    "shape": "TextDocumentTextString",
+                    "documentation": "<p>Content of the text document</p>"
+                },
+                "documentSymbols": {
+                    "shape": "DocumentSymbols",
+                    "documentation": "<p>DocumentSymbols parsed from a text document</p>"
+                }
+            },
+            "documentation": "<p>Represents a Text Document / File</p>"
         },
         "TextDocumentDiagnostic": {
             "type": "structure",
             "required": ["document", "range", "source", "severity", "message"],
             "members": {
-                "document": { "shape": "TextDocument" },
-                "range": { "shape": "Range" },
-                "source": { "shape": "SensitiveString" },
-                "severity": { "shape": "DiagnosticSeverity" },
-                "message": { "shape": "TextDocumentDiagnosticMessageString" }
-            }
+                "document": {
+                    "shape": "TextDocument",
+                    "documentation": "<p>Represents a Text Document associated with Diagnostic</p>"
+                },
+                "range": {
+                    "shape": "Range",
+                    "documentation": "<p>The range at which the message applies.</p>"
+                },
+                "source": {
+                    "shape": "SensitiveString",
+                    "documentation": "<p>A human-readable string describing the source of the diagnostic</p>"
+                },
+                "severity": {
+                    "shape": "DiagnosticSeverity",
+                    "documentation": "<p>Diagnostic Error type</p>"
+                },
+                "message": {
+                    "shape": "TextDocumentDiagnosticMessageString",
+                    "documentation": "<p>The diagnostic's message.</p>"
+                }
+            },
+            "documentation": "<p>Structure to represent metadata about a TextDocument Diagnostic</p>"
         },
         "TextDocumentDiagnosticMessageString": {
             "type": "string",
@@ -1377,18 +3072,19 @@
             "type": "structure",
             "required": ["message"],
             "members": {
-                "message": { "shape": "String" }
+                "message": {
+                    "shape": "String"
+                }
             },
+            "documentation": "<p>This exception is thrown when request was denied due to request throttling.</p>",
             "exception": true,
-            "retryable": { "throttling": true }
+            "retryable": {
+                "throttling": true
+            }
         },
-        "TimeBetweenChunks": {
-            "type": "list",
-            "member": { "shape": "Double" },
-            "max": 100,
-            "min": 0
+        "Timestamp": {
+            "type": "timestamp"
         },
-        "Timestamp": { "type": "timestamp" },
         "TransformationDotNetRuntimeEnv": {
             "type": "string",
             "enum": [
@@ -1418,6 +3114,29 @@
                 "NET_8_0"
             ]
         },
+        "TransformationDownloadArtifact": {
+            "type": "structure",
+            "members": {
+                "downloadArtifactType": {
+                    "shape": "TransformationDownloadArtifactType"
+                },
+                "downloadArtifactId": {
+                    "shape": "ArtifactId"
+                }
+            }
+        },
+        "TransformationDownloadArtifactType": {
+            "type": "string",
+            "enum": ["ClientInstructions", "Logs", "GeneratedCode"]
+        },
+        "TransformationDownloadArtifacts": {
+            "type": "list",
+            "member": {
+                "shape": "TransformationDownloadArtifact"
+            },
+            "max": 10,
+            "min": 0
+        },
         "TransformationJavaRuntimeEnv": {
             "type": "string",
             "enum": ["JVM_8", "JVM_11", "JVM_17"]
@@ -1425,23 +3144,49 @@
         "TransformationJob": {
             "type": "structure",
             "members": {
-                "jobId": { "shape": "TransformationJobId" },
-                "transformationSpec": { "shape": "TransformationSpec" },
-                "status": { "shape": "TransformationStatus" },
-                "reason": { "shape": "String" },
-                "creationTime": { "shape": "Timestamp" },
-                "startExecutionTime": { "shape": "Timestamp" },
-                "endExecutionTime": { "shape": "Timestamp" }
-            }
+                "jobId": {
+                    "shape": "TransformationJobId"
+                },
+                "transformationSpec": {
+                    "shape": "TransformationSpec"
+                },
+                "status": {
+                    "shape": "TransformationStatus"
+                },
+                "reason": {
+                    "shape": "String"
+                },
+                "creationTime": {
+                    "shape": "Timestamp"
+                },
+                "startExecutionTime": {
+                    "shape": "Timestamp"
+                },
+                "endExecutionTime": {
+                    "shape": "Timestamp"
+                }
+            },
+            "documentation": "<p>Represent a Transformation Job</p>"
         },
         "TransformationJobId": {
             "type": "string",
+            "documentation": "<p>Identifier for the Transformation Job</p>",
             "max": 128,
             "min": 1
         },
         "TransformationLanguage": {
             "type": "string",
-            "enum": ["JAVA_8", "JAVA_11", "JAVA_17", "C_SHARP"]
+            "enum": ["JAVA_8", "JAVA_11", "JAVA_17", "C_SHARP", "COBOL", "PL_I", "JCL"]
+        },
+        "TransformationLanguages": {
+            "type": "list",
+            "member": {
+                "shape": "TransformationLanguage"
+            }
+        },
+        "TransformationMainframeRuntimeEnv": {
+            "type": "string",
+            "enum": ["MAINFRAME"]
         },
         "TransformationOperatingSystemFamily": {
             "type": "string",
@@ -1451,52 +3196,111 @@
             "type": "structure",
             "required": ["transformationSteps"],
             "members": {
-                "transformationSteps": { "shape": "TransformationSteps" }
+                "transformationSteps": {
+                    "shape": "TransformationSteps"
+                }
             }
         },
         "TransformationPlatformConfig": {
             "type": "structure",
             "members": {
-                "operatingSystemFamily": { "shape": "TransformationOperatingSystemFamily" }
+                "operatingSystemFamily": {
+                    "shape": "TransformationOperatingSystemFamily"
+                }
             }
         },
         "TransformationProgressUpdate": {
             "type": "structure",
             "required": ["name", "status"],
             "members": {
-                "name": { "shape": "String" },
-                "status": { "shape": "TransformationProgressUpdateStatus" },
-                "description": { "shape": "String" },
-                "startTime": { "shape": "Timestamp" },
-                "endTime": { "shape": "Timestamp" }
+                "name": {
+                    "shape": "String"
+                },
+                "status": {
+                    "shape": "TransformationProgressUpdateStatus"
+                },
+                "description": {
+                    "shape": "String"
+                },
+                "startTime": {
+                    "shape": "Timestamp"
+                },
+                "endTime": {
+                    "shape": "Timestamp"
+                },
+                "downloadArtifacts": {
+                    "shape": "TransformationDownloadArtifacts"
+                }
             }
         },
         "TransformationProgressUpdateStatus": {
             "type": "string",
-            "enum": ["IN_PROGRESS", "COMPLETED", "FAILED"]
+            "enum": ["IN_PROGRESS", "COMPLETED", "FAILED", "PAUSED", "AWAITING_CLIENT_ACTION"]
+        },
+        "TransformationProjectArtifactDescriptor": {
+            "type": "structure",
+            "members": {
+                "sourceCodeArtifact": {
+                    "shape": "TransformationSourceCodeArtifactDescriptor"
+                }
+            },
+            "union": true
         },
         "TransformationProjectState": {
             "type": "structure",
             "members": {
-                "language": { "shape": "TransformationLanguage" },
-                "runtimeEnv": { "shape": "TransformationRuntimeEnv" },
-                "platformConfig": { "shape": "TransformationPlatformConfig" }
+                "language": {
+                    "shape": "TransformationLanguage"
+                },
+                "runtimeEnv": {
+                    "shape": "TransformationRuntimeEnv"
+                },
+                "platformConfig": {
+                    "shape": "TransformationPlatformConfig"
+                },
+                "projectArtifact": {
+                    "shape": "TransformationProjectArtifactDescriptor"
+                }
             }
         },
         "TransformationRuntimeEnv": {
             "type": "structure",
             "members": {
-                "java": { "shape": "TransformationJavaRuntimeEnv" },
-                "dotNet": { "shape": "TransformationDotNetRuntimeEnv" }
+                "java": {
+                    "shape": "TransformationJavaRuntimeEnv"
+                },
+                "dotNet": {
+                    "shape": "TransformationDotNetRuntimeEnv"
+                },
+                "mainframe": {
+                    "shape": "TransformationMainframeRuntimeEnv"
+                }
             },
             "union": true
+        },
+        "TransformationSourceCodeArtifactDescriptor": {
+            "type": "structure",
+            "members": {
+                "languages": {
+                    "shape": "TransformationLanguages"
+                },
+                "runtimeEnv": {
+                    "shape": "TransformationRuntimeEnv"
+                }
+            }
         },
         "TransformationSpec": {
             "type": "structure",
             "members": {
-                "transformationType": { "shape": "TransformationType" },
-                "source": { "shape": "TransformationProjectState" },
-                "target": { "shape": "TransformationProjectState" }
+                "transformationType": {
+                    "shape": "TransformationType"
+                },
+                "source": {
+                    "shape": "TransformationProjectState"
+                },
+                "target": {
+                    "shape": "TransformationProjectState"
+                }
             }
         },
         "TransformationStatus": {
@@ -1516,33 +3320,71 @@
                 "COMPLETED",
                 "PARTIALLY_COMPLETED",
                 "STOPPING",
-                "STOPPED"
+                "STOPPED",
+                "PAUSED",
+                "RESUMED"
             ]
         },
         "TransformationStep": {
             "type": "structure",
             "required": ["id", "name", "description", "status"],
             "members": {
-                "id": { "shape": "StepId" },
-                "name": { "shape": "String" },
-                "description": { "shape": "String" },
-                "status": { "shape": "TransformationStepStatus" },
-                "progressUpdates": { "shape": "ProgressUpdates" },
-                "startTime": { "shape": "Timestamp" },
-                "endTime": { "shape": "Timestamp" }
+                "id": {
+                    "shape": "StepId"
+                },
+                "name": {
+                    "shape": "String"
+                },
+                "description": {
+                    "shape": "String"
+                },
+                "status": {
+                    "shape": "TransformationStepStatus"
+                },
+                "progressUpdates": {
+                    "shape": "ProgressUpdates"
+                },
+                "startTime": {
+                    "shape": "Timestamp"
+                },
+                "endTime": {
+                    "shape": "Timestamp"
+                }
             }
         },
         "TransformationStepStatus": {
             "type": "string",
-            "enum": ["CREATED", "COMPLETED", "PARTIALLY_COMPLETED", "STOPPED", "FAILED"]
+            "enum": ["CREATED", "COMPLETED", "PARTIALLY_COMPLETED", "STOPPED", "FAILED", "PAUSED"]
         },
         "TransformationSteps": {
             "type": "list",
-            "member": { "shape": "TransformationStep" }
+            "member": {
+                "shape": "TransformationStep"
+            }
         },
         "TransformationType": {
             "type": "string",
-            "enum": ["LANGUAGE_UPGRADE"]
+            "enum": ["LANGUAGE_UPGRADE", "DOCUMENT_GENERATION"]
+        },
+        "TransformationUploadArtifactType": {
+            "type": "string",
+            "enum": ["Dependencies", "ClientBuildResult"]
+        },
+        "TransformationUploadContext": {
+            "type": "structure",
+            "required": ["jobId", "uploadArtifactType"],
+            "members": {
+                "jobId": {
+                    "shape": "TransformationJobId"
+                },
+                "uploadArtifactType": {
+                    "shape": "TransformationUploadArtifactType"
+                }
+            }
+        },
+        "TransformationUserActionStatus": {
+            "type": "string",
+            "enum": ["COMPLETED", "REJECTED"]
         },
         "UUID": {
             "type": "string",
@@ -1552,28 +3394,54 @@
         "UploadContext": {
             "type": "structure",
             "members": {
-                "taskAssistPlanningUploadContext": { "shape": "TaskAssistPlanningUploadContext" }
+                "taskAssistPlanningUploadContext": {
+                    "shape": "TaskAssistPlanningUploadContext"
+                },
+                "transformationUploadContext": {
+                    "shape": "TransformationUploadContext"
+                },
+                "codeAnalysisUploadContext": {
+                    "shape": "CodeAnalysisUploadContext"
+                }
             },
             "union": true
         },
         "UploadId": {
             "type": "string",
+            "documentation": "<p>Upload ID returned by CreateUploadUrl API</p>",
             "max": 128,
             "min": 1
         },
         "UploadIntent": {
             "type": "string",
-            "enum": ["TRANSFORMATION", "TASK_ASSIST_PLANNING"]
+            "documentation": "<p>Upload Intent</p>",
+            "enum": [
+                "TRANSFORMATION",
+                "TASK_ASSIST_PLANNING",
+                "AUTOMATIC_FILE_SECURITY_SCAN",
+                "FULL_PROJECT_SECURITY_SCAN",
+                "UNIT_TESTS_GENERATION"
+            ]
         },
         "UserContext": {
             "type": "structure",
             "required": ["ideCategory", "operatingSystem", "product"],
             "members": {
-                "ideCategory": { "shape": "IdeCategory" },
-                "operatingSystem": { "shape": "OperatingSystem" },
-                "product": { "shape": "UserContextProductString" },
-                "clientId": { "shape": "UUID" },
-                "ideVersion": { "shape": "String" }
+                "ideCategory": {
+                    "shape": "IdeCategory"
+                },
+                "operatingSystem": {
+                    "shape": "OperatingSystem"
+                },
+                "product": {
+                    "shape": "UserContextProductString"
+                },
+                "clientId": {
+                    "shape": "UUID"
+                },
+                "ideVersion": {
+                    "shape": "String"
+                }
             }
         },
         "UserContextProductString": {
@@ -1586,10 +3454,20 @@
             "type": "structure",
             "required": ["content"],
             "members": {
-                "content": { "shape": "UserInputMessageContentString" },
-                "userInputMessageContext": { "shape": "UserInputMessageContext" },
-                "userIntent": { "shape": "UserIntent" }
-            }
+                "content": {
+                    "shape": "UserInputMessageContentString",
+                    "documentation": "<p>The content of the chat message.</p>"
+                },
+                "userInputMessageContext": {
+                    "shape": "UserInputMessageContext",
+                    "documentation": "<p>Chat message context associated with the Chat Message</p>"
+                },
+                "userIntent": {
+                    "shape": "UserIntent",
+                    "documentation": "<p>User Intent</p>"
+                }
+            },
+            "documentation": "<p>Structure to represent a chat input message from User</p>"
         },
         "UserInputMessageContentString": {
             "type": "string",
@@ -1600,12 +3478,44 @@
         "UserInputMessageContext": {
             "type": "structure",
             "members": {
-                "editorState": { "shape": "EditorState" },
-                "diagnostic": { "shape": "Diagnostic" }
-            }
+                "editorState": {
+                    "shape": "EditorState",
+                    "documentation": "<p>Editor state chat message context.</p>"
+                },
+                "shellState": {
+                    "shape": "ShellState",
+                    "documentation": "<p>Shell state chat message context.</p>"
+                },
+                "gitState": {
+                    "shape": "GitState",
+                    "documentation": "<p>Git state chat message context.</p>"
+                },
+                "envState": {
+                    "shape": "EnvState",
+                    "documentation": "<p>Environment state chat message context.</p>"
+                },
+                "appStudioContext": {
+                    "shape": "AppStudioState",
+                    "documentation": "<p>The state of a user's AppStudio UI when sending a message.</p>"
+                },
+                "diagnostic": {
+                    "shape": "Diagnostic",
+                    "documentation": "<p>Diagnostic chat message context.</p>"
+                },
+                "consoleState": {
+                    "shape": "ConsoleState",
+                    "documentation": "<p>Contextual information about the environment from which the user is calling.</p>"
+                },
+                "userSettings": {
+                    "shape": "UserSettings",
+                    "documentation": "<p>Settings information, e.g., whether the user has enabled cross-region API calls.</p>"
+                }
+            },
+            "documentation": "<p>Additional Chat message context associated with the Chat Message</p>"
         },
         "UserIntent": {
             "type": "string",
+            "documentation": "<p>User Intent</p>",
             "enum": [
                 "SUGGEST_ALTERNATE_IMPLEMENTATION",
                 "APPLY_COMMON_BEST_PRACTICES",
@@ -1613,20 +3523,58 @@
                 "SHOW_EXAMPLES",
                 "CITE_SOURCES",
                 "EXPLAIN_LINE_BY_LINE",
-                "EXPLAIN_CODE_SELECTION"
+                "EXPLAIN_CODE_SELECTION",
+                "GENERATE_CLOUDFORMATION_TEMPLATE",
+                "GENERATE_UNIT_TESTS",
+                "CODE_GENERATION"
             ]
         },
         "UserModificationEvent": {
             "type": "structure",
-            "required": ["sessionId", "requestId", "programmingLanguage", "modificationPercentage", "timestamp"],
+            "required": [
+                "sessionId",
+                "requestId",
+                "programmingLanguage",
+                "modificationPercentage",
+                "timestamp",
+                "acceptedCharacterCount",
+                "unmodifiedAcceptedCharacterCount"
+            ],
             "members": {
-                "sessionId": { "shape": "UUID" },
-                "requestId": { "shape": "UUID" },
-                "programmingLanguage": { "shape": "ProgrammingLanguage" },
-                "modificationPercentage": { "shape": "Double" },
-                "customizationArn": { "shape": "CustomizationArn" },
-                "timestamp": { "shape": "Timestamp" }
+                "sessionId": {
+                    "shape": "UUID"
+                },
+                "requestId": {
+                    "shape": "UUID"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                },
+                "modificationPercentage": {
+                    "shape": "Double"
+                },
+                "customizationArn": {
+                    "shape": "CustomizationArn"
+                },
+                "timestamp": {
+                    "shape": "Timestamp"
+                },
+                "acceptedCharacterCount": {
+                    "shape": "PrimitiveInteger"
+                },
+                "unmodifiedAcceptedCharacterCount": {
+                    "shape": "PrimitiveInteger"
+                }
             }
+        },
+        "UserSettings": {
+            "type": "structure",
+            "members": {
+                "hasConsentedToCrossRegionCalls": {
+                    "shape": "Boolean"
+                }
+            },
+            "documentation": "<p>Settings information passed by the Q widget</p>"
         },
         "UserTriggerDecisionEvent": {
             "type": "structure",
@@ -1640,41 +3588,95 @@
                 "timestamp"
             ],
             "members": {
-                "sessionId": { "shape": "UUID" },
-                "requestId": { "shape": "UUID" },
-                "customizationArn": { "shape": "CustomizationArn" },
-                "programmingLanguage": { "shape": "ProgrammingLanguage" },
-                "completionType": { "shape": "CompletionType" },
-                "suggestionState": { "shape": "SuggestionState" },
-                "recommendationLatencyMilliseconds": { "shape": "Double" },
-                "timestamp": { "shape": "Timestamp" },
-                "triggerToResponseLatencyMilliseconds": { "shape": "Double" },
-                "suggestionReferenceCount": { "shape": "PrimitiveInteger" },
-                "generatedLine": { "shape": "PrimitiveInteger" },
-                "numberOfRecommendations": { "shape": "PrimitiveInteger" }
+                "sessionId": {
+                    "shape": "UUID"
+                },
+                "requestId": {
+                    "shape": "UUID"
+                },
+                "customizationArn": {
+                    "shape": "CustomizationArn"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                },
+                "completionType": {
+                    "shape": "CompletionType"
+                },
+                "suggestionState": {
+                    "shape": "SuggestionState"
+                },
+                "recommendationLatencyMilliseconds": {
+                    "shape": "Double"
+                },
+                "timestamp": {
+                    "shape": "Timestamp"
+                },
+                "triggerToResponseLatencyMilliseconds": {
+                    "shape": "Double"
+                },
+                "suggestionReferenceCount": {
+                    "shape": "PrimitiveInteger"
+                },
+                "generatedLine": {
+                    "shape": "PrimitiveInteger"
+                },
+                "numberOfRecommendations": {
+                    "shape": "PrimitiveInteger"
+                },
+                "perceivedLatencyMilliseconds": {
+                    "shape": "Double"
+                },
+                "acceptedCharacterCount": {
+                    "shape": "PrimitiveInteger"
+                }
             }
         },
         "ValidationException": {
             "type": "structure",
             "required": ["message"],
             "members": {
-                "message": { "shape": "String" },
-                "reason": { "shape": "ValidationExceptionReason" }
+                "message": {
+                    "shape": "String"
+                },
+                "reason": {
+                    "shape": "ValidationExceptionReason"
+                }
             },
+            "documentation": "<p>This exception is thrown when the input fails to satisfy the constraints specified by the service.</p>",
             "exception": true
         },
         "ValidationExceptionReason": {
             "type": "string",
-            "enum": ["INVALID_CONVERSATION_ID"]
+            "documentation": "<p>Reason for ValidationException</p>",
+            "enum": ["INVALID_CONVERSATION_ID", "CONTENT_LENGTH_EXCEEDS_THRESHOLD", "INVALID_KMS_GRANT"]
         },
         "WorkspaceState": {
             "type": "structure",
             "required": ["uploadId", "programmingLanguage"],
             "members": {
-                "uploadId": { "shape": "UploadId" },
-                "programmingLanguage": { "shape": "ProgrammingLanguage" },
-                "contextTruncationScheme": { "shape": "ContextTruncationScheme" }
-            }
+                "uploadId": {
+                    "shape": "UploadId",
+                    "documentation": "<p>Upload ID representing an Upload using a PreSigned URL</p>"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage",
+                    "documentation": "<p>Primary programming language of the Workspace</p>"
+                },
+                "contextTruncationScheme": {
+                    "shape": "ContextTruncationScheme",
+                    "documentation": "<p>Workspace context truncation schemes based on usecase</p>"
+                }
+            },
+            "documentation": "<p>Represents a Workspace state uploaded to S3 for Async Code Actions</p>"
+        },
+        "timeBetweenChunks": {
+            "type": "list",
+            "member": {
+                "shape": "Double"
+            },
+            "max": 100,
+            "min": 0
         }
     }
 }

--- a/server/aws-lsp-codewhisperer/src/client/token/codewhispererbearertokenclient.d.ts
+++ b/server/aws-lsp-codewhisperer/src/client/token/codewhispererbearertokenclient.d.ts
@@ -18,75 +18,83 @@ declare class CodeWhispererBearerTokenClient extends Service {
   constructor(options?: CodeWhispererBearerTokenClient.Types.ClientConfiguration)
   config: Config & CodeWhispererBearerTokenClient.Types.ClientConfiguration;
   /**
-   * 
+   * Creates a pre-signed, S3 write URL for uploading a repository zip archive.
    */
   createArtifactUploadUrl(params: CodeWhispererBearerTokenClient.Types.CreateUploadUrlRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse, AWSError>;
   /**
-   * 
+   * Creates a pre-signed, S3 write URL for uploading a repository zip archive.
    */
   createArtifactUploadUrl(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse, AWSError>;
   /**
-   * 
+   * API to create task assist conversation.
    */
   createTaskAssistConversation(params: CodeWhispererBearerTokenClient.Types.CreateTaskAssistConversationRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateTaskAssistConversationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateTaskAssistConversationResponse, AWSError>;
   /**
-   * 
+   * API to create task assist conversation.
    */
   createTaskAssistConversation(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateTaskAssistConversationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateTaskAssistConversationResponse, AWSError>;
   /**
-   * 
+   * Creates a pre-signed, S3 write URL for uploading a repository zip archive.
    */
   createUploadUrl(params: CodeWhispererBearerTokenClient.Types.CreateUploadUrlRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse, AWSError>;
   /**
-   * 
+   * Creates a pre-signed, S3 write URL for uploading a repository zip archive.
    */
   createUploadUrl(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse, AWSError>;
   /**
-   * 
+   * API to delete task assist conversation.
    */
   deleteTaskAssistConversation(params: CodeWhispererBearerTokenClient.Types.DeleteTaskAssistConversationRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.DeleteTaskAssistConversationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.DeleteTaskAssistConversationResponse, AWSError>;
   /**
-   * 
+   * API to delete task assist conversation.
    */
   deleteTaskAssistConversation(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.DeleteTaskAssistConversationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.DeleteTaskAssistConversationResponse, AWSError>;
   /**
-   * 
+   * Generate completions based on the provided file context in a paginated response.
    */
   generateCompletions(params: CodeWhispererBearerTokenClient.Types.GenerateCompletionsRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GenerateCompletionsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GenerateCompletionsResponse, AWSError>;
   /**
-   * 
+   * Generate completions based on the provided file context in a paginated response.
    */
   generateCompletions(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GenerateCompletionsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GenerateCompletionsResponse, AWSError>;
   /**
-   * 
+   * Gets the metadata of a code analysis job.
    */
   getCodeAnalysis(params: CodeWhispererBearerTokenClient.Types.GetCodeAnalysisRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetCodeAnalysisResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetCodeAnalysisResponse, AWSError>;
   /**
-   * 
+   * Gets the metadata of a code analysis job.
    */
   getCodeAnalysis(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetCodeAnalysisResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetCodeAnalysisResponse, AWSError>;
   /**
-   * 
+   * API to get status of task assist code generation.
    */
   getTaskAssistCodeGeneration(params: CodeWhispererBearerTokenClient.Types.GetTaskAssistCodeGenerationRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetTaskAssistCodeGenerationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetTaskAssistCodeGenerationResponse, AWSError>;
   /**
-   * 
+   * API to get status of task assist code generation.
    */
   getTaskAssistCodeGeneration(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetTaskAssistCodeGenerationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetTaskAssistCodeGenerationResponse, AWSError>;
   /**
-   * 
+   * API to get test generation job.
+   */
+  getTestGeneration(params: CodeWhispererBearerTokenClient.Types.GetTestGenerationRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetTestGenerationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetTestGenerationResponse, AWSError>;
+  /**
+   * API to get test generation job.
+   */
+  getTestGeneration(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetTestGenerationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetTestGenerationResponse, AWSError>;
+  /**
+   * API to get code transformation status.
    */
   getTransformation(params: CodeWhispererBearerTokenClient.Types.GetTransformationRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetTransformationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetTransformationResponse, AWSError>;
   /**
-   * 
+   * API to get code transformation status.
    */
   getTransformation(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetTransformationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetTransformationResponse, AWSError>;
   /**
-   * 
+   * API to get code transformation status.
    */
   getTransformationPlan(params: CodeWhispererBearerTokenClient.Types.GetTransformationPlanRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetTransformationPlanResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetTransformationPlanResponse, AWSError>;
   /**
-   * 
+   * API to get code transformation status.
    */
   getTransformationPlan(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetTransformationPlanResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetTransformationPlanResponse, AWSError>;
   /**
@@ -98,70 +106,121 @@ declare class CodeWhispererBearerTokenClient extends Service {
    */
   listAvailableCustomizations(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListAvailableCustomizationsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListAvailableCustomizationsResponse, AWSError>;
   /**
-   * 
+   * Lists the findings from a particular code analysis job.
    */
   listCodeAnalysisFindings(params: CodeWhispererBearerTokenClient.Types.ListCodeAnalysisFindingsRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListCodeAnalysisFindingsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListCodeAnalysisFindingsResponse, AWSError>;
   /**
-   * 
+   * Lists the findings from a particular code analysis job.
    */
   listCodeAnalysisFindings(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListCodeAnalysisFindingsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListCodeAnalysisFindingsResponse, AWSError>;
   /**
-   * 
+   * Return configruations for each feature that has been setup for A/B testing.
    */
   listFeatureEvaluations(params: CodeWhispererBearerTokenClient.Types.ListFeatureEvaluationsRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListFeatureEvaluationsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListFeatureEvaluationsResponse, AWSError>;
   /**
-   * 
+   * Return configruations for each feature that has been setup for A/B testing.
    */
   listFeatureEvaluations(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListFeatureEvaluationsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListFeatureEvaluationsResponse, AWSError>;
   /**
-   * 
+   * API to resume transformation job.
+   */
+  resumeTransformation(params: CodeWhispererBearerTokenClient.Types.ResumeTransformationRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ResumeTransformationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ResumeTransformationResponse, AWSError>;
+  /**
+   * API to resume transformation job.
+   */
+  resumeTransformation(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ResumeTransformationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ResumeTransformationResponse, AWSError>;
+  /**
+   * API to record telemetry events.
    */
   sendTelemetryEvent(params: CodeWhispererBearerTokenClient.Types.SendTelemetryEventRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.SendTelemetryEventResponse) => void): Request<CodeWhispererBearerTokenClient.Types.SendTelemetryEventResponse, AWSError>;
   /**
-   * 
+   * API to record telemetry events.
    */
   sendTelemetryEvent(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.SendTelemetryEventResponse) => void): Request<CodeWhispererBearerTokenClient.Types.SendTelemetryEventResponse, AWSError>;
   /**
-   * 
+   * Starts a code analysis job
    */
   startCodeAnalysis(params: CodeWhispererBearerTokenClient.Types.StartCodeAnalysisRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartCodeAnalysisResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartCodeAnalysisResponse, AWSError>;
   /**
-   * 
+   * Starts a code analysis job
    */
   startCodeAnalysis(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartCodeAnalysisResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartCodeAnalysisResponse, AWSError>;
   /**
-   * 
+   * API to start task assist code generation.
    */
   startTaskAssistCodeGeneration(params: CodeWhispererBearerTokenClient.Types.StartTaskAssistCodeGenerationRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartTaskAssistCodeGenerationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartTaskAssistCodeGenerationResponse, AWSError>;
   /**
-   * 
+   * API to start task assist code generation.
    */
   startTaskAssistCodeGeneration(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartTaskAssistCodeGenerationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartTaskAssistCodeGenerationResponse, AWSError>;
   /**
-   * 
+   * API to start test generation.
+   */
+  startTestGeneration(params: CodeWhispererBearerTokenClient.Types.StartTestGenerationRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartTestGenerationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartTestGenerationResponse, AWSError>;
+  /**
+   * API to start test generation.
+   */
+  startTestGeneration(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartTestGenerationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartTestGenerationResponse, AWSError>;
+  /**
+   * API to start code translation.
    */
   startTransformation(params: CodeWhispererBearerTokenClient.Types.StartTransformationRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartTransformationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartTransformationResponse, AWSError>;
   /**
-   * 
+   * API to start code translation.
    */
   startTransformation(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartTransformationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartTransformationResponse, AWSError>;
   /**
-   * 
+   * API to stop code transformation status.
    */
   stopTransformation(params: CodeWhispererBearerTokenClient.Types.StopTransformationRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StopTransformationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StopTransformationResponse, AWSError>;
   /**
-   * 
+   * API to stop code transformation status.
    */
   stopTransformation(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StopTransformationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StopTransformationResponse, AWSError>;
 }
 declare namespace CodeWhispererBearerTokenClient {
+  export interface AppStudioState {
+    /**
+     * The namespace of the context. Examples: 'ui.Button', 'ui.Table.DataSource', 'ui.Table.RowActions.Button', 'logic.invokeAWS', 'logic.JavaScript'
+     */
+    namespace: AppStudioStateNamespaceString;
+    /**
+     * The name of the property. Examples: 'visibility', 'disability', 'value', 'code'
+     */
+    propertyName: AppStudioStatePropertyNameString;
+    /**
+     * The value of the property.
+     */
+    propertyValue?: AppStudioStatePropertyValueString;
+    /**
+     * Context about how the property is used
+     */
+    propertyContext: AppStudioStatePropertyContextString;
+  }
+  export type AppStudioStateNamespaceString = string;
+  export type AppStudioStatePropertyContextString = string;
+  export type AppStudioStatePropertyNameString = string;
+  export type AppStudioStatePropertyValueString = string;
+  export type ArtifactId = string;
   export type ArtifactMap = {[key: string]: UploadId};
   export type ArtifactType = "SourceCode"|"BuiltJars"|string;
   export interface AssistantResponseMessage {
     messageId?: MessageId;
+    /**
+     * The content of the text message in markdown format.
+     */
     content: AssistantResponseMessageContentString;
+    /**
+     * Web References
+     */
     supplementaryWebLinks?: SupplementaryWebLinks;
+    /**
+     * Code References
+     */
     references?: References;
+    /**
+     * Followup Prompt
+     */
     followupPrompt?: FollowupPrompt;
   }
   export type AssistantResponseMessageContentString = string;
@@ -170,39 +229,53 @@ declare namespace CodeWhispererBearerTokenClient {
   export interface ChatAddMessageEvent {
     conversationId: ConversationId;
     messageId: MessageId;
+    customizationArn?: CustomizationArn;
     userIntent?: UserIntent;
     hasCodeSnippet?: Boolean;
     programmingLanguage?: ProgrammingLanguage;
     activeEditorTotalCharacters?: Integer;
     timeToFirstChunkMilliseconds?: Double;
-    timeBetweenChunks?: TimeBetweenChunks;
+    timeBetweenChunks?: timeBetweenChunks;
     fullResponselatency?: Double;
     requestLength?: Integer;
     responseLength?: Integer;
+    numberOfCodeBlocks?: Integer;
+    hasProjectLevelContext?: Boolean;
   }
   export type ChatHistory = ChatMessage[];
   export interface ChatInteractWithMessageEvent {
     conversationId: ConversationId;
     messageId: MessageId;
+    customizationArn?: CustomizationArn;
     interactionType?: ChatMessageInteractionType;
-    interactionTarget?: String;
+    interactionTarget?: ChatInteractWithMessageEventInteractionTargetString;
     acceptedCharacterCount?: Integer;
+    acceptedLineCount?: Integer;
     acceptedSnippetHasReference?: Boolean;
+    hasProjectLevelContext?: Boolean;
+    userIntent?: UserIntent;
   }
+  export type ChatInteractWithMessageEventInteractionTargetString = string;
   export interface ChatMessage {
     userInputMessage?: UserInputMessage;
     assistantResponseMessage?: AssistantResponseMessage;
   }
   export type ChatMessageInteractionType = "INSERT_AT_CURSOR"|"COPY_SNIPPET"|"COPY"|"CLICK_LINK"|"CLICK_BODY_LINK"|"CLICK_FOLLOW_UP"|"HOVER_REFERENCE"|"UPVOTE"|"DOWNVOTE"|string;
+  export type ChatTriggerType = "MANUAL"|"DIAGNOSTIC"|"INLINE_CHAT"|string;
   export interface ChatUserModificationEvent {
     conversationId: ConversationId;
+    customizationArn?: CustomizationArn;
     messageId: MessageId;
     programmingLanguage?: ProgrammingLanguage;
     modificationPercentage: Double;
+    hasProjectLevelContext?: Boolean;
   }
-  export type ChatTriggerType = "MANUAL"|"DIAGNOSTIC"|string;
   export type CodeAnalysisFindingsSchema = "codeanalysis/findings/1.0"|string;
+  export type CodeAnalysisScope = "FILE"|"PROJECT"|string;
   export type CodeAnalysisStatus = "Completed"|"Pending"|"Failed"|string;
+  export interface CodeAnalysisUploadContext {
+    codeScanName: CodeScanName;
+  }
   export interface CodeCoverageEvent {
     customizationArn?: CustomizationArn;
     programmingLanguage: ProgrammingLanguage;
@@ -216,14 +289,30 @@ declare namespace CodeWhispererBearerTokenClient {
     status: CodeGenerationWorkflowStatus;
     currentStage: CodeGenerationWorkflowStage;
   }
+  export type CodeGenerationStatusDetail = string;
   export type CodeGenerationWorkflowStage = "InitialCodeGeneration"|"CodeRefinement"|string;
   export type CodeGenerationWorkflowStatus = "InProgress"|"Complete"|"Failed"|string;
   export interface CodeScanEvent {
     programmingLanguage: ProgrammingLanguage;
     codeScanJobId: CodeScanJobId;
     timestamp: Timestamp;
+    codeAnalysisScope?: CodeAnalysisScope;
   }
   export type CodeScanJobId = string;
+  export type CodeScanName = string;
+  export interface CodeScanRemediationsEvent {
+    programmingLanguage?: ProgrammingLanguage;
+    CodeScanRemediationsEventType?: CodeScanRemediationsEventType;
+    timestamp?: Timestamp;
+    detectorId?: String;
+    findingId?: String;
+    ruleId?: String;
+    component?: String;
+    reason?: String;
+    result?: String;
+    includesFix?: Boolean;
+  }
+  export type CodeScanRemediationsEventType = "CODESCAN_ISSUE_HOVER"|"CODESCAN_ISSUE_APPLY_FIX"|"CODESCAN_ISSUE_VIEW_DETAILS"|string;
   export interface Completion {
     content: CompletionContentString;
     references?: References;
@@ -232,14 +321,35 @@ declare namespace CodeWhispererBearerTokenClient {
   export type CompletionContentString = string;
   export type CompletionType = "BLOCK"|"LINE"|string;
   export type Completions = Completion[];
+  export interface ConsoleState {
+    region?: String;
+    consoleUrl?: SensitiveString;
+    serviceId?: String;
+    serviceConsolePage?: String;
+    serviceSubconsolePage?: String;
+    taskName?: SensitiveString;
+  }
   export type ContentChecksumType = "SHA_256"|string;
   export type ContextTruncationScheme = "ANALYSIS"|"GUMBY"|string;
   export type ConversationId = string;
   export interface ConversationState {
+    /**
+     * Unique identifier for the chat conversation stream
+     */
     conversationId?: ConversationId;
+    /**
+     * Holds the history of chat messages.
+     */
     history?: ChatHistory;
+    /**
+     * Holds the current message being processed or displayed.
+     */
     currentMessage: ChatMessage;
+    /**
+     * Trigger Reason for Chat
+     */
     chatTriggerType: ChatTriggerType;
+    customizationArn?: ResourceArn;
   }
   export interface CreateTaskAssistConversationRequest {
   }
@@ -254,6 +364,7 @@ declare namespace CodeWhispererBearerTokenClient {
     artifactType?: ArtifactType;
     uploadIntent?: UploadIntent;
     uploadContext?: UploadContext;
+    uploadId?: UploadId;
   }
   export type CreateUploadUrlRequestContentChecksumString = string;
   export type CreateUploadUrlRequestContentLengthLong = number;
@@ -262,9 +373,16 @@ declare namespace CodeWhispererBearerTokenClient {
     uploadId: UploadId;
     uploadUrl: PreSignedUrl;
     kmsKeyArn?: ResourceArn;
+    requestHeaders?: RequestHeaders;
   }
   export interface CursorState {
+    /**
+     * Represents a cursor position in a Text Document
+     */
     position?: Position;
+    /**
+     * Represents a text selection in a Text Document
+     */
     range?: Range;
   }
   export interface Customization {
@@ -283,7 +401,13 @@ declare namespace CodeWhispererBearerTokenClient {
   }
   export type Description = string;
   export interface Diagnostic {
+    /**
+     * Diagnostics originating from a TextDocument
+     */
     textDocumentDiagnostic?: TextDocumentDiagnostic;
+    /**
+     * Diagnostics originating from a Runtime
+     */
     runtimeDiagnostic?: RuntimeDiagnostic;
   }
   export type DiagnosticSeverity = "ERROR"|"WARNING"|"INFORMATION"|"HINT"|string;
@@ -295,17 +419,77 @@ declare namespace CodeWhispererBearerTokenClient {
   export type DimensionNameString = string;
   export type DimensionValueString = string;
   export interface DocumentSymbol {
+    /**
+     * Name of the Document Symbol
+     */
     name: DocumentSymbolNameString;
+    /**
+     * Symbol type - DECLARATION / USAGE
+     */
     type: SymbolType;
+    /**
+     * Symbol package / source for FullyQualified names
+     */
     source?: DocumentSymbolSourceString;
   }
   export type DocumentSymbolNameString = string;
   export type DocumentSymbolSourceString = string;
   export type DocumentSymbols = DocumentSymbol[];
+  export interface DocumentationIntentContext {
+    scope?: String;
+    type: DocumentationType;
+  }
+  export type DocumentationType = "README"|string;
   export type Double = number;
   export interface EditorState {
+    /**
+     * Represents currently edited file
+     */
     document?: TextDocument;
+    /**
+     * Position of the cursor
+     */
     cursorState?: CursorState;
+    /**
+     * Represents IDE provided relevant files
+     */
+    relevantDocuments?: RelevantDocumentList;
+    /**
+     * Whether service should use relevant document in prompt
+     */
+    useRelevantDocuments?: Boolean;
+  }
+  export interface EnvState {
+    /**
+     * The name of the operating system in use
+     */
+    operatingSystem?: EnvStateOperatingSystemString;
+    /**
+     * The current working directory of the environment
+     */
+    currentWorkingDirectory?: EnvStateCurrentWorkingDirectoryString;
+    /**
+     * The environment variables set in the current environment
+     */
+    environmentVariables?: EnvironmentVariables;
+  }
+  export type EnvStateCurrentWorkingDirectoryString = string;
+  export type EnvStateOperatingSystemString = string;
+  export interface EnvironmentVariable {
+    /**
+     * The key of an environment variable
+     */
+    key?: EnvironmentVariableKeyString;
+    /**
+     * The value of an environment variable
+     */
+    value?: EnvironmentVariableValueString;
+  }
+  export type EnvironmentVariableKeyString = string;
+  export type EnvironmentVariableValueString = string;
+  export type EnvironmentVariables = EnvironmentVariable[];
+  export interface FeatureDevEvent {
+    conversationId: ConversationId;
   }
   export interface FeatureEvaluation {
     feature: FeatureName;
@@ -332,7 +516,13 @@ declare namespace CodeWhispererBearerTokenClient {
   export type FileContextLeftFileContentString = string;
   export type FileContextRightFileContentString = string;
   export interface FollowupPrompt {
+    /**
+     * The content of the text message in markdown format.
+     */
     content: FollowupPromptContentString;
+    /**
+     * User Intent
+     */
     userIntent?: UserIntent;
   }
   export type FollowupPromptContentString = string;
@@ -345,6 +535,7 @@ declare namespace CodeWhispererBearerTokenClient {
     customizationArn?: CustomizationArn;
     optOutPreference?: OptOutPreference;
     userContext?: UserContext;
+    profileArn?: ProfileArn;
   }
   export type GenerateCompletionsRequestMaxResultsInteger = number;
   export type GenerateCompletionsRequestNextTokenString = string;
@@ -367,6 +558,16 @@ declare namespace CodeWhispererBearerTokenClient {
   export interface GetTaskAssistCodeGenerationResponse {
     conversationId: ConversationId;
     codeGenerationStatus: CodeGenerationStatus;
+    codeGenerationStatusDetail?: CodeGenerationStatusDetail;
+    codeGenerationRemainingIterationCount?: Integer;
+    codeGenerationTotalIterationCount?: Integer;
+  }
+  export interface GetTestGenerationRequest {
+    testGenerationJobGroupName: TestGenerationJobGroupName;
+    testGenerationJobId: UUID;
+  }
+  export interface GetTestGenerationResponse {
+    testGenerationJob?: TestGenerationJob;
   }
   export interface GetTransformationPlanRequest {
     transformationJobId: TransformationJobId;
@@ -380,14 +581,43 @@ declare namespace CodeWhispererBearerTokenClient {
   export interface GetTransformationResponse {
     transformationJob: TransformationJob;
   }
-  export type IdeCategory = "JETBRAINS"|"VSCODE"|string;
+  export interface GitState {
+    /**
+     * The output of the command git status --porcelain=v1 -b
+     */
+    status?: GitStateStatusString;
+  }
+  export type GitStateStatusString = string;
+  export type IdeCategory = "JETBRAINS"|"VSCODE"|"CLI"|"JUPYTER_MD"|"JUPYTER_SM"|"ECLIPSE"|"VISUAL_STUDIO"|string;
   export type IdempotencyToken = string;
   export interface Import {
     statement?: ImportStatementString;
   }
   export type ImportStatementString = string;
   export type Imports = Import[];
+  export interface InlineChatEvent {
+    requestId: UUID;
+    timestamp: Timestamp;
+    inputLength?: PrimitiveInteger;
+    numSelectedLines?: PrimitiveInteger;
+    numSuggestionAddChars?: PrimitiveInteger;
+    numSuggestionAddLines?: PrimitiveInteger;
+    numSuggestionDelChars?: PrimitiveInteger;
+    numSuggestionDelLines?: PrimitiveInteger;
+    codeIntent?: Boolean;
+    userDecision?: InlineChatUserDecision;
+    responseStartLatency?: Double;
+    responseEndLatency?: Double;
+    charactersAdded?: PrimitiveInteger;
+    charactersRemoved?: PrimitiveInteger;
+  }
+  export type InlineChatUserDecision = "ACCEPT"|"REJECT"|"DISMISS"|string;
   export type Integer = number;
+  export type Intent = "DEV"|"DOC"|string;
+  export interface IntentContext {
+    documentation?: DocumentationIntentContext;
+  }
+  export type LineRangeList = Range[];
   export interface ListAvailableCustomizationsRequest {
     maxResults?: ListAvailableCustomizationsRequestMaxResultsInteger;
     nextToken?: Base64EncodedPaginationToken;
@@ -419,32 +649,59 @@ declare namespace CodeWhispererBearerTokenClient {
     metricName: MetricDataMetricNameString;
     metricValue: Double;
     timestamp: Timestamp;
+    product: MetricDataProductString;
     dimensions?: DimensionList;
   }
   export type MetricDataMetricNameString = string;
+  export type MetricDataProductString = string;
   export type OperatingSystem = "MAC"|"WINDOWS"|"LINUX"|string;
   export type OptOutPreference = "OPTIN"|"OPTOUT"|string;
   export type PaginationToken = string;
   export interface Position {
+    /**
+     * Line position in a document.
+     */
     line: Integer;
+    /**
+     * Character offset on a line in a document (zero-based)
+     */
     character: Integer;
   }
   export type PreSignedUrl = string;
   export type PrimitiveInteger = number;
+  export type ProfileArn = string;
   export interface ProgrammingLanguage {
     languageName: ProgrammingLanguageLanguageNameString;
   }
   export type ProgrammingLanguageLanguageNameString = string;
   export type ProgressUpdates = TransformationProgressUpdate[];
   export interface Range {
+    /**
+     * The range's start position.
+     */
     start: Position;
+    /**
+     * The range's end position.
+     */
     end: Position;
   }
   export type RecommendationsWithReferencesPreference = "BLOCK"|"ALLOW"|string;
   export interface Reference {
+    /**
+     * License name
+     */
     licenseName?: ReferenceLicenseNameString;
+    /**
+     * Code Repsitory for the associated reference
+     */
     repository?: ReferenceRepositoryString;
+    /**
+     * Respository URL
+     */
     url?: ReferenceUrlString;
+    /**
+     * Span / Range for the Reference
+     */
     recommendationContentSpan?: Span;
   }
   export type ReferenceLicenseNameString = string;
@@ -454,10 +711,50 @@ declare namespace CodeWhispererBearerTokenClient {
   }
   export type ReferenceUrlString = string;
   export type References = Reference[];
+  export type RelevantDocumentList = RelevantTextDocument[];
+  export interface RelevantTextDocument {
+    /**
+     * Filepath relative to the root of the workspace
+     */
+    relativeFilePath: RelevantTextDocumentRelativeFilePathString;
+    /**
+     * The text document's language identifier.
+     */
+    programmingLanguage?: ProgrammingLanguage;
+    /**
+     * Content of the text document
+     */
+    text?: RelevantTextDocumentTextString;
+    /**
+     * DocumentSymbols parsed from a text document
+     */
+    documentSymbols?: DocumentSymbols;
+  }
+  export type RelevantTextDocumentRelativeFilePathString = string;
+  export type RelevantTextDocumentTextString = string;
+  export type RequestHeaderKey = string;
+  export type RequestHeaderValue = string;
+  export type RequestHeaders = {[key: string]: RequestHeaderValue};
   export type ResourceArn = string;
+  export interface ResumeTransformationRequest {
+    transformationJobId: TransformationJobId;
+    userActionStatus?: TransformationUserActionStatus;
+  }
+  export interface ResumeTransformationResponse {
+    transformationStatus: TransformationStatus;
+  }
   export interface RuntimeDiagnostic {
+    /**
+     * A human-readable string describing the source of the diagnostic
+     */
     source: RuntimeDiagnosticSourceString;
+    /**
+     * Diagnostic Error type
+     */
     severity: DiagnosticSeverity;
+    /**
+     * The diagnostic's message.
+     */
     message: RuntimeDiagnosticMessageString;
   }
   export type RuntimeDiagnosticMessageString = string;
@@ -467,10 +764,49 @@ declare namespace CodeWhispererBearerTokenClient {
     telemetryEvent: TelemetryEvent;
     optOutPreference?: OptOutPreference;
     userContext?: UserContext;
+    profileArn?: ProfileArn;
   }
   export interface SendTelemetryEventResponse {
   }
   export type SensitiveString = string;
+  export type ShellHistory = ShellHistoryEntry[];
+  export interface ShellHistoryEntry {
+    /**
+     * The shell command that was run
+     */
+    command: ShellHistoryEntryCommandString;
+    /**
+     * The directory the command was ran in
+     */
+    directory?: ShellHistoryEntryDirectoryString;
+    /**
+     * The exit code of the command after it finished
+     */
+    exitCode?: Integer;
+    /**
+     * The stdout from the command
+     */
+    stdout?: ShellHistoryEntryStdoutString;
+    /**
+     * The stderr from the command
+     */
+    stderr?: ShellHistoryEntryStderrString;
+  }
+  export type ShellHistoryEntryCommandString = string;
+  export type ShellHistoryEntryDirectoryString = string;
+  export type ShellHistoryEntryStderrString = string;
+  export type ShellHistoryEntryStdoutString = string;
+  export interface ShellState {
+    /**
+     * The name of the current shell
+     */
+    shellName: ShellStateShellNameString;
+    /**
+     * The history previous shell commands for the current shell
+     */
+    shellHistory?: ShellHistory;
+  }
+  export type ShellStateShellNameString = string;
   export interface Span {
     start?: SpanStartInteger;
     end?: SpanEndInteger;
@@ -481,6 +817,8 @@ declare namespace CodeWhispererBearerTokenClient {
     artifacts: ArtifactMap;
     programmingLanguage: ProgrammingLanguage;
     clientToken?: StartCodeAnalysisRequestClientTokenString;
+    scope?: CodeAnalysisScope;
+    codeScanName?: CodeScanName;
   }
   export type StartCodeAnalysisRequestClientTokenString = string;
   export interface StartCodeAnalysisResponse {
@@ -492,10 +830,30 @@ declare namespace CodeWhispererBearerTokenClient {
   export interface StartTaskAssistCodeGenerationRequest {
     conversationState: ConversationState;
     workspaceState: WorkspaceState;
+    taskAssistPlan?: TaskAssistPlan;
+    codeGenerationId?: CodeGenerationId;
+    currentCodeGenerationId?: CodeGenerationId;
+    intent?: Intent;
+    intentContext?: IntentContext;
   }
   export interface StartTaskAssistCodeGenerationResponse {
     conversationId: ConversationId;
     codeGenerationId: CodeGenerationId;
+  }
+  export interface StartTestGenerationRequest {
+    uploadId: UploadId;
+    targetCodeList: TargetCodeList;
+    /**
+     * The content of user input.
+     */
+    userInput: StartTestGenerationRequestUserInputString;
+    testGenerationJobGroupName?: TestGenerationJobGroupName;
+    clientToken?: StartTestGenerationRequestClientTokenString;
+  }
+  export type StartTestGenerationRequestClientTokenString = string;
+  export type StartTestGenerationRequestUserInputString = string;
+  export interface StartTestGenerationResponse {
+    testGenerationJob?: TestGenerationJob;
   }
   export interface StartTransformationRequest {
     workspaceState: WorkspaceState;
@@ -521,8 +879,17 @@ declare namespace CodeWhispererBearerTokenClient {
   export type SupplementalContextFilePathString = string;
   export type SupplementalContextList = SupplementalContext[];
   export interface SupplementaryWebLink {
+    /**
+     * URL of the web reference link
+     */
     url: SupplementaryWebLinkUrlString;
+    /**
+     * Title of the web reference link
+     */
     title: SupplementaryWebLinkTitleString;
+    /**
+     * Relevant text snippet from the link
+     */
     snippet?: SupplementaryWebLinkSnippetString;
   }
   export type SupplementaryWebLinkSnippetString = string;
@@ -530,6 +897,43 @@ declare namespace CodeWhispererBearerTokenClient {
   export type SupplementaryWebLinkUrlString = string;
   export type SupplementaryWebLinks = SupplementaryWebLink[];
   export type SymbolType = "DECLARATION"|"USAGE"|string;
+  export interface TargetCode {
+    /**
+     * The file path relative to the root of the workspace, could be a single file or a folder.
+     */
+    relativeTargetPath: TargetCodeRelativeTargetPathString;
+    targetLineRangeList?: LineRangeList;
+  }
+  export type TargetCodeList = TargetCode[];
+  export type TargetCodeRelativeTargetPathString = string;
+  export type TaskAssistPlan = TaskAssistPlanStep[];
+  export interface TaskAssistPlanStep {
+    /**
+     * File path on which the step is working on.
+     */
+    filePath: TaskAssistPlanStepFilePathString;
+    /**
+     * Description on the step.
+     */
+    description: TaskAssistPlanStepDescriptionString;
+    /**
+     * Start line number of the related changes.
+     */
+    startLine?: TaskAssistPlanStepStartLineInteger;
+    /**
+     * End line number of the related changes.
+     */
+    endLine?: TaskAssistPlanStepEndLineInteger;
+    /**
+     * Type of the action.
+     */
+    action?: TaskAssistPlanStepAction;
+  }
+  export type TaskAssistPlanStepAction = "MODIFY"|"CREATE"|"DELETE"|"UNKNOWN"|string;
+  export type TaskAssistPlanStepDescriptionString = string;
+  export type TaskAssistPlanStepEndLineInteger = number;
+  export type TaskAssistPlanStepFilePathString = string;
+  export type TaskAssistPlanStepStartLineInteger = number;
   export interface TaskAssistPlanningUploadContext {
     conversationId: ConversationId;
   }
@@ -538,30 +942,89 @@ declare namespace CodeWhispererBearerTokenClient {
     codeCoverageEvent?: CodeCoverageEvent;
     userModificationEvent?: UserModificationEvent;
     codeScanEvent?: CodeScanEvent;
+    codeScanRemediationsEvent?: CodeScanRemediationsEvent;
     metricData?: MetricData;
     chatAddMessageEvent?: ChatAddMessageEvent;
     chatInteractWithMessageEvent?: ChatInteractWithMessageEvent;
     chatUserModificationEvent?: ChatUserModificationEvent;
+    terminalUserInteractionEvent?: TerminalUserInteractionEvent;
+    featureDevEvent?: FeatureDevEvent;
+    inlineChatEvent?: InlineChatEvent;
   }
+  export interface TerminalUserInteractionEvent {
+    terminalUserInteractionEventType?: TerminalUserInteractionEventType;
+    terminal?: String;
+    terminalVersion?: String;
+    shell?: String;
+    shellVersion?: String;
+    duration?: Integer;
+    timeToSuggestion?: Integer;
+    isCompletionAccepted?: Boolean;
+    cliToolCommand?: String;
+  }
+  export type TerminalUserInteractionEventType = "CODEWHISPERER_TERMINAL_TRANSLATION_ACTION"|"CODEWHISPERER_TERMINAL_COMPLETION_INSERTED"|string;
+  export interface TestGenerationJob {
+    testGenerationJobId: UUID;
+    testGenerationJobGroupName: TestGenerationJobGroupName;
+    status: TestGenerationJobStatus;
+    shortAnswer?: SensitiveString;
+    creationTime: Timestamp;
+    progressRate?: TestGenerationJobProgressRateInteger;
+  }
+  export type TestGenerationJobGroupName = string;
+  export type TestGenerationJobProgressRateInteger = number;
+  export type TestGenerationJobStatus = "IN_PROGRESS"|"FAILED"|"COMPLETED"|string;
   export interface TextDocument {
+    /**
+     * Filepath relative to the root of the workspace
+     */
     relativeFilePath: TextDocumentRelativeFilePathString;
+    /**
+     * The text document's language identifier.
+     */
     programmingLanguage?: ProgrammingLanguage;
+    /**
+     * Content of the text document
+     */
     text?: TextDocumentTextString;
+    /**
+     * DocumentSymbols parsed from a text document
+     */
     documentSymbols?: DocumentSymbols;
   }
   export interface TextDocumentDiagnostic {
+    /**
+     * Represents a Text Document associated with Diagnostic
+     */
     document: TextDocument;
+    /**
+     * The range at which the message applies.
+     */
     range: Range;
+    /**
+     * A human-readable string describing the source of the diagnostic
+     */
     source: SensitiveString;
+    /**
+     * Diagnostic Error type
+     */
     severity: DiagnosticSeverity;
+    /**
+     * The diagnostic's message.
+     */
     message: TextDocumentDiagnosticMessageString;
   }
   export type TextDocumentDiagnosticMessageString = string;
   export type TextDocumentRelativeFilePathString = string;
   export type TextDocumentTextString = string;
-  export type TimeBetweenChunks = Double[];
   export type Timestamp = Date;
   export type TransformationDotNetRuntimeEnv = "NET_FRAMEWORK_V_3_5"|"NET_FRAMEWORK_V_4_0"|"NET_FRAMEWORK_V_4_5"|"NET_FRAMEWORK_V_4_5_1"|"NET_FRAMEWORK_V_4_5_2"|"NET_FRAMEWORK_V_4_6"|"NET_FRAMEWORK_V_4_6_1"|"NET_FRAMEWORK_V_4_6_2"|"NET_FRAMEWORK_V_4_7"|"NET_FRAMEWORK_V_4_7_1"|"NET_FRAMEWORK_V_4_7_2"|"NET_FRAMEWORK_V_4_8"|"NET_FRAMEWORK_V_4_8_1"|"NET_CORE_APP_1_0"|"NET_CORE_APP_1_1"|"NET_CORE_APP_2_0"|"NET_CORE_APP_2_1"|"NET_CORE_APP_2_2"|"NET_CORE_APP_3_0"|"NET_CORE_APP_3_1"|"NET_5_0"|"NET_6_0"|"NET_7_0"|"NET_8_0"|string;
+  export interface TransformationDownloadArtifact {
+    downloadArtifactType?: TransformationDownloadArtifactType;
+    downloadArtifactId?: ArtifactId;
+  }
+  export type TransformationDownloadArtifactType = "ClientInstructions"|"Logs"|"GeneratedCode"|string;
+  export type TransformationDownloadArtifacts = TransformationDownloadArtifact[];
   export type TransformationJavaRuntimeEnv = "JVM_8"|"JVM_11"|"JVM_17"|string;
   export interface TransformationJob {
     jobId?: TransformationJobId;
@@ -573,7 +1036,9 @@ declare namespace CodeWhispererBearerTokenClient {
     endExecutionTime?: Timestamp;
   }
   export type TransformationJobId = string;
-  export type TransformationLanguage = "JAVA_8"|"JAVA_11"|"JAVA_17"|"C_SHARP"|string;
+  export type TransformationLanguage = "JAVA_8"|"JAVA_11"|"JAVA_17"|"C_SHARP"|"COBOL"|"PL_I"|"JCL"|string;
+  export type TransformationLanguages = TransformationLanguage[];
+  export type TransformationMainframeRuntimeEnv = "MAINFRAME"|string;
   export type TransformationOperatingSystemFamily = "WINDOWS"|"LINUX"|string;
   export interface TransformationPlan {
     transformationSteps: TransformationSteps;
@@ -587,23 +1052,33 @@ declare namespace CodeWhispererBearerTokenClient {
     description?: String;
     startTime?: Timestamp;
     endTime?: Timestamp;
+    downloadArtifacts?: TransformationDownloadArtifacts;
   }
-  export type TransformationProgressUpdateStatus = "IN_PROGRESS"|"COMPLETED"|"FAILED"|string;
+  export type TransformationProgressUpdateStatus = "IN_PROGRESS"|"COMPLETED"|"FAILED"|"PAUSED"|"AWAITING_CLIENT_ACTION"|string;
+  export interface TransformationProjectArtifactDescriptor {
+    sourceCodeArtifact?: TransformationSourceCodeArtifactDescriptor;
+  }
   export interface TransformationProjectState {
     language?: TransformationLanguage;
     runtimeEnv?: TransformationRuntimeEnv;
     platformConfig?: TransformationPlatformConfig;
+    projectArtifact?: TransformationProjectArtifactDescriptor;
   }
   export interface TransformationRuntimeEnv {
     java?: TransformationJavaRuntimeEnv;
     dotNet?: TransformationDotNetRuntimeEnv;
+    mainframe?: TransformationMainframeRuntimeEnv;
+  }
+  export interface TransformationSourceCodeArtifactDescriptor {
+    languages?: TransformationLanguages;
+    runtimeEnv?: TransformationRuntimeEnv;
   }
   export interface TransformationSpec {
     transformationType?: TransformationType;
     source?: TransformationProjectState;
     target?: TransformationProjectState;
   }
-  export type TransformationStatus = "CREATED"|"ACCEPTED"|"REJECTED"|"STARTED"|"PREPARING"|"PREPARED"|"PLANNING"|"PLANNED"|"TRANSFORMING"|"TRANSFORMED"|"FAILED"|"COMPLETED"|"PARTIALLY_COMPLETED"|"STOPPING"|"STOPPED"|string;
+  export type TransformationStatus = "CREATED"|"ACCEPTED"|"REJECTED"|"STARTED"|"PREPARING"|"PREPARED"|"PLANNING"|"PLANNED"|"TRANSFORMING"|"TRANSFORMED"|"FAILED"|"COMPLETED"|"PARTIALLY_COMPLETED"|"STOPPING"|"STOPPED"|"PAUSED"|"RESUMED"|string;
   export interface TransformationStep {
     id: StepId;
     name: String;
@@ -613,15 +1088,23 @@ declare namespace CodeWhispererBearerTokenClient {
     startTime?: Timestamp;
     endTime?: Timestamp;
   }
-  export type TransformationStepStatus = "CREATED"|"COMPLETED"|"PARTIALLY_COMPLETED"|"STOPPED"|"FAILED"|string;
+  export type TransformationStepStatus = "CREATED"|"COMPLETED"|"PARTIALLY_COMPLETED"|"STOPPED"|"FAILED"|"PAUSED"|string;
   export type TransformationSteps = TransformationStep[];
-  export type TransformationType = "LANGUAGE_UPGRADE"|string;
+  export type TransformationType = "LANGUAGE_UPGRADE"|"DOCUMENT_GENERATION"|string;
+  export type TransformationUploadArtifactType = "Dependencies"|"ClientBuildResult"|string;
+  export interface TransformationUploadContext {
+    jobId: TransformationJobId;
+    uploadArtifactType: TransformationUploadArtifactType;
+  }
+  export type TransformationUserActionStatus = "COMPLETED"|"REJECTED"|string;
   export type UUID = string;
   export interface UploadContext {
     taskAssistPlanningUploadContext?: TaskAssistPlanningUploadContext;
+    transformationUploadContext?: TransformationUploadContext;
+    codeAnalysisUploadContext?: CodeAnalysisUploadContext;
   }
   export type UploadId = string;
-  export type UploadIntent = "TRANSFORMATION"|"TASK_ASSIST_PLANNING"|string;
+  export type UploadIntent = "TRANSFORMATION"|"TASK_ASSIST_PLANNING"|"AUTOMATIC_FILE_SECURITY_SCAN"|"FULL_PROJECT_SECURITY_SCAN"|"UNIT_TESTS_GENERATION"|string;
   export interface UserContext {
     ideCategory: IdeCategory;
     operatingSystem: OperatingSystem;
@@ -631,16 +1114,55 @@ declare namespace CodeWhispererBearerTokenClient {
   }
   export type UserContextProductString = string;
   export interface UserInputMessage {
+    /**
+     * The content of the chat message.
+     */
     content: UserInputMessageContentString;
+    /**
+     * Chat message context associated with the Chat Message
+     */
     userInputMessageContext?: UserInputMessageContext;
+    /**
+     * User Intent
+     */
     userIntent?: UserIntent;
   }
   export type UserInputMessageContentString = string;
   export interface UserInputMessageContext {
+    /**
+     * Editor state chat message context.
+     */
     editorState?: EditorState;
+    /**
+     * Shell state chat message context.
+     */
+    shellState?: ShellState;
+    /**
+     * Git state chat message context.
+     */
+    gitState?: GitState;
+    /**
+     * Environment state chat message context.
+     */
+    envState?: EnvState;
+    /**
+     * The state of a user's AppStudio UI when sending a message.
+     */
+    appStudioContext?: AppStudioState;
+    /**
+     * Diagnostic chat message context.
+     */
     diagnostic?: Diagnostic;
+    /**
+     * Contextual information about the environment from which the user is calling.
+     */
+    consoleState?: ConsoleState;
+    /**
+     * Settings information, e.g., whether the user has enabled cross-region API calls.
+     */
+    userSettings?: UserSettings;
   }
-  export type UserIntent = "SUGGEST_ALTERNATE_IMPLEMENTATION"|"APPLY_COMMON_BEST_PRACTICES"|"IMPROVE_CODE"|"SHOW_EXAMPLES"|"CITE_SOURCES"|"EXPLAIN_LINE_BY_LINE"|"EXPLAIN_CODE_SELECTION"|string;
+  export type UserIntent = "SUGGEST_ALTERNATE_IMPLEMENTATION"|"APPLY_COMMON_BEST_PRACTICES"|"IMPROVE_CODE"|"SHOW_EXAMPLES"|"CITE_SOURCES"|"EXPLAIN_LINE_BY_LINE"|"EXPLAIN_CODE_SELECTION"|"GENERATE_CLOUDFORMATION_TEMPLATE"|"GENERATE_UNIT_TESTS"|"CODE_GENERATION"|string;
   export interface UserModificationEvent {
     sessionId: UUID;
     requestId: UUID;
@@ -648,6 +1170,11 @@ declare namespace CodeWhispererBearerTokenClient {
     modificationPercentage: Double;
     customizationArn?: CustomizationArn;
     timestamp: Timestamp;
+    acceptedCharacterCount: PrimitiveInteger;
+    unmodifiedAcceptedCharacterCount: PrimitiveInteger;
+  }
+  export interface UserSettings {
+    hasConsentedToCrossRegionCalls?: Boolean;
   }
   export interface UserTriggerDecisionEvent {
     sessionId: UUID;
@@ -662,12 +1189,24 @@ declare namespace CodeWhispererBearerTokenClient {
     suggestionReferenceCount?: PrimitiveInteger;
     generatedLine?: PrimitiveInteger;
     numberOfRecommendations?: PrimitiveInteger;
+    perceivedLatencyMilliseconds?: Double;
+    acceptedCharacterCount?: PrimitiveInteger;
   }
   export interface WorkspaceState {
+    /**
+     * Upload ID representing an Upload using a PreSigned URL
+     */
     uploadId: UploadId;
+    /**
+     * Primary programming language of the Workspace
+     */
     programmingLanguage: ProgrammingLanguage;
+    /**
+     * Workspace context truncation schemes based on usecase
+     */
     contextTruncationScheme?: ContextTruncationScheme;
   }
+  export type timeBetweenChunks = Double[];
   /**
    * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
    */


### PR DESCRIPTION
## Problem
Service definition .json file for bearer-token based Amazon Q server is outdated

## Solution
* Updated service definition and generated Typescript definition file using script from VSCode Toolkit https://github.com/aws/aws-toolkit-vscode/blob/1ca150164b6a88be6130d09876433b7330b4f1de/CONTRIBUTING.md#aws-sdk-generator
* Tested that Amazon Q server compiles and InlineCompletions and Chat work with updated client

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
