### PR TITLE
Handle insertToCursorPosition event in the chat server

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,6 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "compile",
             "type": "npm",
             "script": "compile",
             "group": "build",
@@ -26,12 +25,6 @@
                 "reveal": "never"
             },
             "problemMatcher": ["$tsc-watch"]
-        },
-        {
-            "label": "pkgCompress",
-            "type": "shell",
-            "command": "pkg --compress GZip --no-bytecode --out-path dist .",
-            "problemMatcher": []
         }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5047,12 +5047,11 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.20",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.20.tgz",
-            "integrity": "sha512-Q28yvQ3hA1Nl4GHru5YwP5dojbP12DwZFB+n1TWHvJ1QjIFBnERjBEp3UIU0FJigscTXoTO+mATftY55WEYWEA==",
-            "license": "Apache-2.0",
+            "version": "0.2.21",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.21.tgz",
+            "integrity": "sha512-x4nruWTyYYFrcmDD9GSq2hxGIFuguAOybAuNpDBmCfSz15gvXP9yDeC/Ko3yERvs5RqBMSTu2eQDRmLuFfhGvA==",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.0.6",
+                "@aws/language-server-runtimes-types": "^0.0.7",
                 "jose": "^5.9.3",
                 "rxjs": "^7.8.1",
                 "vscode-languageserver": "^9.0.1",
@@ -5069,6 +5068,15 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-languageserver-types": "^3.17.5"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/@aws/language-server-runtimes-types": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.7.tgz",
+            "integrity": "sha512-P83YkgWITcUGHaZvYFI0N487nWErgRpejALKNm/xs8jEcHooDfjigOpliN8TgzfF9BGvGeQnnAzIG16UBXc9ig==",
+            "dependencies": {
+                "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"
             }
         },
@@ -23109,7 +23117,7 @@
                 "@amzn/codewhisperer-streaming": "*",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.0.7",
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.21",
                 "@aws/lsp-fqn": "^0.0.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -35,7 +35,7 @@
         "@amzn/codewhisperer-streaming": "*",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.0.7",
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.21",
         "@aws/lsp-fqn": "^0.0.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -2,7 +2,15 @@ import {
     GenerateAssistantResponseCommandInput,
     GenerateAssistantResponseCommandOutput,
 } from '@amzn/codewhisperer-streaming'
-import { ErrorCodes, FeedbackParams, chatRequestType } from '@aws/language-server-runtimes/protocol'
+import {
+    ApplyWorkspaceEditParams,
+    ErrorCodes,
+    FeedbackParams,
+    InsertToCursorPositionParams,
+    TextDocumentEdit,
+    TextEdit,
+    chatRequestType,
+} from '@aws/language-server-runtimes/protocol'
 import {
     CancellationToken,
     Chat,
@@ -169,7 +177,63 @@ export class ChatController implements ChatHandlers {
         }
     }
 
-    onCodeInsertToCursorPosition() {}
+    async onCodeInsertToCursorPosition(params: InsertToCursorPositionParams) {
+        // Implementation based on https://github.com/aws/aws-toolkit-vscode/blob/1814cc84228d4bf20270574c5980b91b227f31cf/packages/core/src/amazonq/commons/controllers/contentController.ts#L38
+        if (!params.textDocument || !params.cursorPosition || !params.code) {
+            const missingParams = []
+
+            if (!params.textDocument) missingParams.push('textDocument')
+            if (!params.cursorPosition) missingParams.push('cursorPosition')
+            if (!params.code) missingParams.push('code')
+
+            this.#log(
+                `Q Chat server failed to insert code. Missing required parameters for insert code: ${missingParams.join(', ')}`
+            )
+
+            return
+        }
+
+        const cursorPosition = params.cursorPosition
+
+        const indentRange = {
+            start: { line: cursorPosition.line, character: 0 },
+            end: cursorPosition,
+        }
+        const documentContent = await this.#features.workspace.getTextDocument(params.textDocument.uri)
+        let indent = documentContent?.getText(indentRange)
+        if (indent && indent.trim().length !== 0) {
+            indent = ' '.repeat(indent.length - indent.trimStart().length)
+        }
+
+        let textWithIndent = ''
+        params.code.split('\n').forEach((line, index) => {
+            if (index === 0) {
+                textWithIndent += line
+            } else {
+                textWithIndent += '\n' + indent + line
+            }
+        })
+
+        const workspaceEdit: ApplyWorkspaceEditParams = {
+            edit: {
+                documentChanges: [
+                    TextDocumentEdit.create({ uri: params.textDocument.uri, version: 0 }, [
+                        TextEdit.insert(cursorPosition, textWithIndent),
+                    ]),
+                ],
+            },
+        }
+        const applyResult = await this.#features.lsp.workspace.applyWorkspaceEdit(workspaceEdit)
+
+        if (applyResult.applied) {
+            this.#log(`Q Chat server inserted code successfully`)
+            this.#telemetryController.enqueueCodeDiffEntry({ ...params, code: textWithIndent })
+        } else {
+            this.#log(
+                `Q Chat server failed to insert code: ${applyResult.failureReason ?? 'No failure reason provided'}`
+            )
+        }
+    }
     onCopyCodeToClipboard() {}
 
     onEndChat(params: EndChatParams, _token: CancellationToken): boolean {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/clientTelemetry.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/clientTelemetry.ts
@@ -75,7 +75,6 @@ export type SourceLinkClickParams = ServerInterface.SourceLinkClickParams &
 export type InsertToCursorPositionParams = ServerInterface.InsertToCursorPositionParams &
     BaseClientTelemetryParams<ChatUIEventName.InsertToCursorPosition> & {
         cursorState?: ServerInterface.CursorState[]
-        textDocument?: ServerInterface.TextDocumentIdentifier
     }
 
 export type ClientTelemetryEvent =

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/csharpDependencyGraph.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/csharpDependencyGraph.test.ts
@@ -1,4 +1,4 @@
-import { Logging } from '@aws/language-server-runtimes/server-interface'
+import { Logging, Workspace } from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import * as path from 'path'
 import * as Sinon from 'sinon'
@@ -11,17 +11,11 @@ describe('Test CsharpDependencyGraph', () => {
     let mockedLogging: StubbedInstance<Logging>
     const projectPathUri = path.resolve(path.join(__dirname, 'sampleWs'))
     const tempDirPath = path.resolve('\\Temp')
-    const mockedFs = {
-        copy: Sinon.mock(),
-        exists: Sinon.mock(),
-        getFileSize: Sinon.mock(),
-        getTempDirPath: () => tempDirPath,
-        readdir: Sinon.stub(),
-        readFile: Sinon.stub(),
-        isFile: Sinon.mock(),
-        remove: Sinon.mock(),
-    }
-    const mockedWorkspace = {
+
+    const mockedFs: StubbedInstance<Workspace['fs']> = stubInterface<Workspace['fs']>()
+    mockedFs.getTempDirPath.returns(tempDirPath)
+
+    const mockedWorkspace: Workspace = {
         getTextDocument: Sinon.mock(),
         getAllTextDocuments: Sinon.mock(),
         getWorkspaceFolder: mockedGetWorkspaceFolder,
@@ -152,6 +146,8 @@ describe('Test CsharpDependencyGraph', () => {
                 if (filePath === path.join(projectPathUri, 'src', 'model.cs')) {
                     return `namespace Amazon.Cw.Model {}`
                 }
+
+                return 'defaultReadFileResult'
             })
             await csharpDependencyGraph.createNamespaceFilenameMapper(projectPathUri)
             assert.deepStrictEqual(
@@ -171,6 +167,8 @@ describe('Test CsharpDependencyGraph', () => {
                 if (filePath === path.join(projectPathUri, 'src', 'model.cs')) {
                     return ``
                 }
+
+                return 'defaultReadFileResult'
             })
             await csharpDependencyGraph.createNamespaceFilenameMapper(projectPathUri)
             assert.deepStrictEqual(csharpDependencyGraph.namespaceToFilepathDirectory, new Map([]))
@@ -204,13 +202,14 @@ describe('Test CsharpDependencyGraph', () => {
         })
 
         it("should return source file with its dependecies' file path", async () => {
-            mockedFs.getFileSize.atLeast(1).resolves({ size: 1000 })
+            mockedFs.getFileSize.resolves({ size: 1000 })
 
             mockedFs.readFile.onFirstCall().resolves(
                 `using Amazon.Cw.Props;
         var total = 5 + 4;`
             )
             const pickedSourceFiles = await csharpDependencyGraph.searchDependency(path.join(projectPathUri, 'main.cs'))
+            Sinon.assert.called(mockedFs.getFileSize)
             assert.deepStrictEqual(
                 pickedSourceFiles,
                 new Set([
@@ -314,13 +313,15 @@ describe('Test CsharpDependencyGraph', () => {
             assert.strictEqual(mockedFs.readFile.calledWith(projectPathUri), false)
         })
         it('should traverse through files until it reaches payload size limit', async () => {
-            mockedFs.getFileSize.atLeast(1).resolves({ size: Math.pow(2, 19) })
+            mockedFs.getFileSize.resolves({ size: Math.pow(2, 19) })
             await csharpDependencyGraph.traverseDir(projectPathUri)
+            Sinon.assert.called(mockedFs.getFileSize)
             assert.strictEqual(csharpDependencyGraph.isProjectTruncated, true)
         })
         it('should traverse through all files', async () => {
-            mockedFs.getFileSize.atLeast(1).resolves({ size: Math.pow(2, 10) })
+            mockedFs.getFileSize.resolves({ size: Math.pow(2, 10) })
             await csharpDependencyGraph.traverseDir(projectPathUri)
+            Sinon.assert.called(mockedFs.getFileSize)
             assert.strictEqual(csharpDependencyGraph.isProjectTruncated, false)
         })
     })
@@ -390,7 +391,8 @@ namespace Amazon.Toolkit.Demo {
         it('should call zip dir', async () => {
             const zipSize = Math.pow(2, 19)
             const zipFileBuffer = 'dummy-zip-data'
-            mockedFs.getFileSize.atLeast(1).resolves({ size: zipSize })
+            mockedFs.getFileSize.resolves({ size: zipSize })
+
             csharpDependencyGraph.createZip = Sinon.stub().returns({
                 zipFileBuffer,
                 zipFileSize: zipSize,
@@ -407,6 +409,7 @@ namespace Amazon.Toolkit.Demo {
 
             const trucation = await csharpDependencyGraph.generateTruncation(path.join(projectPathUri, 'main.cs'))
 
+            Sinon.assert.called(mockedFs.getFileSize)
             assert.deepStrictEqual(trucation, expectedResult)
         })
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -68,6 +68,10 @@ export const QChatServer =
             return chatController.onSendFeedback(params)
         })
 
+        chat.onCodeInsertToCursorPosition(params => {
+            return chatController.onCodeInsertToCursorPosition(params)
+        })
+
         lsp.onInitialized(chatController.updateConfiguration)
         lsp.didChangeConfiguration(chatController.updateConfiguration)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
@@ -94,6 +94,11 @@ export class CodeDiffTracker<T extends AcceptedSuggestionEntry = AcceptedSuggest
         }
     }
 
+    // Used for accessing the codeDiffTracker eventQueue in unit tests
+    public get eventQueue() {
+        return this.#eventQueue
+    }
+
     private async flush() {
         const newEventQueue: T[] = []
 


### PR DESCRIPTION
## Description

Currently the chat server is not capable of handling insertToCursor position event. With the recent addition of `applyWorkspaceEdit` functionality to the runtimes (https://github.com/aws/language-server-runtimes/pull/233) the server becomes capable of handling the event. This PR enables the chat server to handle `insertToCursorPosition` event

This PR accommodates for existing usages of the chat server and won't cause breaking changes for existing destinations

In addition: 
- Updated the sample extension to test the server handling the insert event 
- Minor: Updated `cSharpDependencyGraph` test file to prevent the tests from breaking whenever there are changes to the runtimes package
- Minor: Also updated the tasks.json file: removed unused task and removed the label from compile task because it was breaking the launch.json tasks 



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
