### PR TITLE
Update language-server-runtimes to 0.2.22

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1"
     },

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
-        "@aws/aws-lsp-identity": "^0.0.1"
+        "@aws/aws-lsp-identity": "^0.0.1",
+        "@aws/language-server-runtimes": "^0.2.22"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "@aws/lsp-partiql": "^0.0.4"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.20"
+        "@aws/language-server-runtimes": "^0.2.22"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -214,7 +214,7 @@
         "@aws-sdk/credential-providers": "^3.614.0",
         "@aws-sdk/types": "^3.535.0",
         "@aws/chat-client-ui-types": "^0.0.7",
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.88.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1"
             },
@@ -65,14 +65,14 @@
             "version": "0.1.0",
             "dependencies": {
                 "@aws/aws-lsp-identity": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.20"
+                "@aws/language-server-runtimes": "^0.2.22"
             }
         },
         "app/aws-lsp-json-runtimes": {
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -92,7 +92,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "@aws/lsp-partiql": "^0.0.4"
             },
             "devDependencies": {
@@ -116,7 +116,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -136,7 +136,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -158,7 +158,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.20"
+                "@aws/language-server-runtimes": "^0.2.22"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -202,7 +202,7 @@
                 "@aws-sdk/credential-providers": "^3.614.0",
                 "@aws-sdk/types": "^3.535.0",
                 "@aws/chat-client-ui-types": "^0.0.7",
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",
@@ -5047,12 +5047,12 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.20",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.20.tgz",
-            "integrity": "sha512-Q28yvQ3hA1Nl4GHru5YwP5dojbP12DwZFB+n1TWHvJ1QjIFBnERjBEp3UIU0FJigscTXoTO+mATftY55WEYWEA==",
+            "version": "0.2.22",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.22.tgz",
+            "integrity": "sha512-UJD90NvJdsVK6CCsp2wjgc5L/mYMgVTeVVLu+M1OzHJg/jeDVnOa12iAwp74KQCRQfNAh2YvUB0I6ms/Mq4x5w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.0.6",
+                "@aws/language-server-runtimes-types": "^0.0.7",
                 "jose": "^5.9.3",
                 "rxjs": "^7.8.1",
                 "vscode-languageserver": "^9.0.1",
@@ -5069,6 +5069,16 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-languageserver-types": "^3.17.5"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/@aws/language-server-runtimes-types": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.7.tgz",
+            "integrity": "sha512-P83YkgWITcUGHaZvYFI0N487nWErgRpejALKNm/xs8jEcHooDfjigOpliN8TgzfF9BGvGeQnnAzIG16UBXc9ig==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"
             }
         },
@@ -23075,7 +23085,7 @@
                 "@amzn/codewhisperer-streaming": "*",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.0.7",
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "@aws/lsp-fqn": "^0.0.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@smithy/node-http-handler": "^2.5.0",
@@ -23270,7 +23280,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.614.0",
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "@smithy/shared-ini-file-loader": "^3.1.5",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -23311,7 +23321,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -23325,7 +23335,7 @@
             "version": "0.0.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4",
                 "web-tree-sitter": "0.22.6"
@@ -23358,7 +23368,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -23372,7 +23382,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -23383,7 +23393,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.20",
+                "@aws/language-server-runtimes": "^0.2.22",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -35,7 +35,7 @@
         "@amzn/codewhisperer-streaming": "*",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.0.7",
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "@aws/lsp-fqn": "^0.0.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.614.0",
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "@smithy/shared-ini-file-loader": "^3.1.5",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.20",
+        "@aws/language-server-runtimes": "^0.2.22",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem

Changes from https://github.com/aws/language-servers/pull/531 require updating language-server-runtimes to 0.2.22

## Solution

Updated the package to 0.2.22

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
