### PR TITLE
Add InvalidateSsoToken and convert tryAsync to catch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -150,8 +150,7 @@
                 "${workspaceFolder}/app/aws-lsp-identity-runtimes/out/**/*.js",
                 "${workspaceFolder}/server/aws-lsp-identity/out/**/*.js"
             ],
-            "autoAttachChildProcesses": true,
-            "preLaunchTask": "npm: package"
+            "autoAttachChildProcesses": true
         },
         {
             "name": "Unit Tests",

--- a/client/vscode/src/identityActivation.ts
+++ b/client/vscode/src/identityActivation.ts
@@ -4,6 +4,8 @@ import {
     GetSsoTokenParams,
     getSsoTokenRequestType,
     IamIdentityCenterSsoTokenSource,
+    InvalidateSsoTokenParams,
+    invalidateSsoTokenRequestType,
     SsoTokenChangedParams,
     ssoTokenChangedRequestType,
     SsoTokenSourceKind,
@@ -75,6 +77,16 @@ async function execTestCommand(client: LanguageClient): Promise<void> {
             } satisfies IamIdentityCenterSsoTokenSource,
         } satisfies GetSsoTokenParams)
         window.showInformationMessage(`GetSsoToken: ${JSON.stringify(result)}`)
+    } catch (e) {
+        const are = e as AwsResponseError
+        window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
+    }
+
+    try {
+        await client.sendRequest(invalidateSsoTokenRequestType.method, {
+            ssoTokenId: 'my-idc-q-NOPE',
+        } satisfies InvalidateSsoTokenParams)
+        window.showInformationMessage(`InvalidateSsoToken: successful`)
     } catch (e) {
         const are = e as AwsResponseError
         window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)

--- a/server/aws-lsp-identity/src/language-server/identityService.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.ts
@@ -67,6 +67,8 @@ export class IdentityService {
     ): Promise<InvalidateSsoTokenResult> {
         throwOnInvalidSsoSessionName(params?.ssoTokenId)
 
+        this.autoRefresher.unwatch(params.ssoTokenId)
+
         await this.ssoCache.removeSsoToken(params.ssoTokenId)
 
         return {}

--- a/server/aws-lsp-identity/src/language-server/profiles/profileService.test.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/profileService.test.ts
@@ -7,8 +7,7 @@ import {
     UpdateProfileParams,
 } from '@aws/language-server-runtimes/server-interface'
 import { normalizeParsedIniData } from '../../sharedConfig/saveKnownFiles'
-import { stubInterface } from 'ts-sinon'
-import { SinonStubbedInstance } from 'sinon'
+import { StubbedInstance, stubInterface } from 'ts-sinon'
 import { expect, use } from 'chai'
 import { AwsError } from '../../awsError'
 
@@ -16,7 +15,7 @@ import { AwsError } from '../../awsError'
 use(require('chai-as-promised'))
 
 let sut: ProfileService
-let store: SinonStubbedInstance<ProfileStore>
+let store: StubbedInstance<ProfileStore>
 let profile1: Profile
 let profile2: Profile
 let profile3: Profile
@@ -25,8 +24,6 @@ let ssoSession2: SsoSession
 
 describe('ProfileService', async () => {
     beforeEach(() => {
-        store = stubInterface()
-
         profile1 = {
             kinds: [ProfileKind.SsoTokenProfile],
             name: 'profile1',
@@ -68,12 +65,13 @@ describe('ProfileService', async () => {
             },
         }
 
-        store.load.returns(
-            Promise.resolve({
+        store = stubInterface<ProfileStore>({
+            load: Promise.resolve({
                 profiles: [profile1, profile2, profile3],
                 ssoSessions: [ssoSession1, ssoSession2],
-            } satisfies ProfileData)
-        )
+            } satisfies ProfileData),
+            save: Promise.resolve(),
+        })
 
         sut = new ProfileService(store)
     })

--- a/server/aws-lsp-identity/src/language-server/profiles/profileService.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/profileService.ts
@@ -14,7 +14,6 @@ import {
 import { SharedConfigInit } from '@smithy/shared-ini-file-loader'
 import { DuckTyper } from '../../duckTyper'
 import { AwsError } from '../../awsError'
-import { tryAsync } from '../../sso/utils'
 
 export interface ProfileData {
     profiles: Profile[]
@@ -75,10 +74,9 @@ export class ProfileService {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async listProfiles(params: ListProfilesParams, token?: CancellationToken): Promise<ListProfilesResult> {
         // Currently only returns non-legacy sso-session profiles, will return more profile types in the future
-        return await tryAsync(
-            () => this.profileStore.load(),
-            error => new AwsResponseError(error.message, { awsErrorCode: AwsErrorCodes.E_CANNOT_READ_SHARED_CONFIG })
-        )
+        return await this.profileStore.load().catch(reason => {
+            throw new AwsResponseError(reason.message, { awsErrorCode: AwsErrorCodes.E_CANNOT_READ_SHARED_CONFIG })
+        })
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -118,10 +116,9 @@ export class ProfileService {
             'Profile sso-session name must be the same as provided sso-session.'
         )
 
-        const { profiles, ssoSessions } = await tryAsync(
-            () => this.profileStore.load(),
-            error => AwsError.wrap(error, AwsErrorCodes.E_CANNOT_READ_SHARED_CONFIG)
-        )
+        const { profiles, ssoSessions } = await this.profileStore.load().catch(reason => {
+            throw AwsError.wrap(reason, AwsErrorCodes.E_CANNOT_READ_SHARED_CONFIG)
+        })
 
         // Enforce options
         if (!options.createNonexistentProfile && !profiles.some(p => p.name === profile.name)) {
@@ -151,14 +148,14 @@ export class ProfileService {
             }
         }
 
-        await tryAsync(
-            () =>
-                this.profileStore.save({
-                    profiles: [params.profile],
-                    ssoSessions: params.ssoSession ? [params.ssoSession] : [],
-                }),
-            error => AwsError.wrap(error, AwsErrorCodes.E_CANNOT_WRITE_SHARED_CONFIG)
-        )
+        await this.profileStore
+            .save({
+                profiles: [params.profile],
+                ssoSessions: params.ssoSession ? [params.ssoSession] : [],
+            })
+            .catch(reason => {
+                throw AwsError.wrap(reason, AwsErrorCodes.E_CANNOT_WRITE_SHARED_CONFIG)
+            })
 
         return result
     }

--- a/server/aws-lsp-identity/src/sso/cache/ssoCache.ts
+++ b/server/aws-lsp-identity/src/sso/cache/ssoCache.ts
@@ -29,6 +29,8 @@ export interface SsoCache {
         clientRegistration: SsoClientRegistration
     ): Promise<void>
 
+    removeSsoToken(ssoSessionName: string): Promise<void>
+
     getSsoToken(clientName: string, ssoSession: SsoSession): Promise<SSOToken | undefined>
 
     setSsoToken(clientName: string, ssoSession: SsoSession, ssoToken: SSOToken): Promise<void>

--- a/server/aws-lsp-identity/src/sso/utils.test.ts
+++ b/server/aws-lsp-identity/src/sso/utils.test.ts
@@ -3,7 +3,6 @@ import {
     throwOnInvalidClientName,
     throwOnInvalidClientRegistration,
     throwOnInvalidSsoSession,
-    tryAsync,
     UpdateSsoTokenFromCreateToken,
 } from './utils'
 import { SsoClientRegistration } from './cache'
@@ -125,28 +124,6 @@ describe('utils', () => {
                 expect(() => throwOnInvalidSsoSession(ssoSession)).to.throw()
             })
         }
-    })
-
-    describe('tryAsync', () => {
-        it('tryAsync returns value on success', async () => {
-            const actual = await tryAsync(
-                () => Promise.resolve('success has been so easy for you'),
-                error => new Error('bad news')
-            )
-
-            expect(actual).to.equal('success has been so easy for you')
-        })
-
-        it('tryAsync throws error on failure', async () => {
-            await expect(
-                tryAsync(
-                    () => {
-                        throw new Error('and I can put you back down too')
-                    },
-                    error => error
-                )
-            ).to.be.rejectedWith('and I can put you back down too')
-        })
     })
 
     describe('UpdateSsoTokenFromCreateToken', () => {

--- a/server/aws-lsp-identity/src/sso/utils.ts
+++ b/server/aws-lsp-identity/src/sso/utils.ts
@@ -22,9 +22,9 @@ export function throwOnInvalidClientRegistration(
 ): asserts clientRegistration is SsoClientRegistration & { clientId: string; clientSecret: string; expiresAt: string } {
     if (
         !clientRegistration ||
-        !clientRegistration.clientId ||
-        !clientRegistration.clientSecret ||
-        !clientRegistration.expiresAt ||
+        !clientRegistration.clientId?.trim() ||
+        !clientRegistration.clientSecret?.trim() ||
+        !clientRegistration.expiresAt?.trim() ||
         !clientRegistration.scopes ||
         !clientRegistration.scopes.length
     ) {
@@ -35,27 +35,23 @@ export function throwOnInvalidClientRegistration(
     }
 }
 
+export function throwOnInvalidSsoSessionName(ssoSessionName?: string): asserts ssoSessionName is string {
+    if (!ssoSessionName?.trim()) {
+        throw new AwsError('SSO session name is invalid.', AwsErrorCodes.E_INVALID_SSO_SESSION)
+    }
+}
+
 export function throwOnInvalidSsoSession(
     ssoSession?: SsoSession
 ): asserts ssoSession is SsoSession & { name: string; settings: { sso_region: string; sso_start_url: string } } {
     if (
         !ssoSession ||
-        !ssoSession.name ||
+        throwOnInvalidClientName(ssoSession.name) ||
         !ssoSession.settings ||
-        !ssoSession.settings.sso_region ||
-        !ssoSession.settings.sso_start_url
+        !ssoSession.settings.sso_region?.trim() ||
+        !ssoSession.settings.sso_start_url?.trim()
     ) {
         throw new AwsError(`SSO session [${ssoSession?.name}] is invalid.`, AwsErrorCodes.E_INVALID_SSO_SESSION)
-    }
-}
-
-// A convenience function to reduce the amount of code need for one-liner try/catch blocks as well
-// as make declarations of consts for results of a call that must occur inside a try block.
-export async function tryAsync<R, E extends Error>(tryIt: () => Promise<R>, catchIt: (error: Error) => E): Promise<R> {
-    try {
-        return await tryIt()
-    } catch (error) {
-        throw catchIt(error instanceof Error ? error : new Error(error?.toString() ?? 'Unknown error'))
     }
 }
 


### PR DESCRIPTION
This PR adds InvalidateSsoToken to IdentityServer and IdentityService.  

SsoCache.removeSsoToken was added so that the SSO token cache file in ~/.aws/sso/cache could be deleted.  While passing null/undefined to the existing SsoCache.setSsoToken could've been used to perform the same function, a separate function name was chosen to make intent clear and avoid silent bugs where the SSO token should've been set, but was actually null/undefined.

tryAsync has been removed and replaced by idiomatic use of Promise.catch to perform the same function without an extra dependency.

identityActivation.ts in vscode sample client updated for purposes of validating InvalidateSsoToken during development.

