### PR TITLE
Update @aws/language-server-runtimes-types dependency to 0.0.7

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.0.8",
-        "@aws/language-server-runtimes-types": "^0.0.6",
+        "@aws/language-server-runtimes-types": "^0.0.7",
         "@aws/mynah-ui": "^4.15.11"
     },
     "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,7 +179,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.0.8",
-                "@aws/language-server-runtimes-types": "^0.0.6",
+                "@aws/language-server-runtimes-types": "^0.0.7",
                 "@aws/mynah-ui": "^4.15.11"
             },
             "devDependencies": {
@@ -5015,16 +5015,6 @@
                 "@aws/language-server-runtimes-types": "^0.0.7"
             }
         },
-        "node_modules/@aws/chat-client-ui-types/node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.7.tgz",
-            "integrity": "sha512-P83YkgWITcUGHaZvYFI0N487nWErgRpejALKNm/xs8jEcHooDfjigOpliN8TgzfF9BGvGeQnnAzIG16UBXc9ig==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "vscode-languageserver-textdocument": "^1.0.12",
-                "vscode-languageserver-types": "^3.17.5"
-            }
-        },
         "node_modules/@aws/fully-qualified-names": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@aws/fully-qualified-names/-/fully-qualified-names-2.1.4.tgz",
@@ -5065,19 +5055,10 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.6.tgz",
-            "integrity": "sha512-z+j+iAhU3eK/Zmm+A9gSW0EOMIZxSAWHtf9QklLSqx4Hul7CiRu8NVxPTQFb6T38AG8hBCFlWWPpAcsqzQCyBA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "vscode-languageserver-textdocument": "^1.0.11",
-                "vscode-languageserver-types": "^3.17.5"
-            }
-        },
-        "node_modules/@aws/language-server-runtimes/node_modules/@aws/language-server-runtimes-types": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.7.tgz",
             "integrity": "sha512-P83YkgWITcUGHaZvYFI0N487nWErgRpejALKNm/xs8jEcHooDfjigOpliN8TgzfF9BGvGeQnnAzIG16UBXc9ig==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"


### PR DESCRIPTION
## Problem
chat-client still depended on @aws/language-server-runtimes-types@0.0.6
## Solution
updated the dependency to 0.0.7

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
