### PR TITLE
Simplify csharpDependencyGraph unit test to make it more resilient to runtimes changes

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/csharpDependencyGraph.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/csharpDependencyGraph.test.ts
@@ -13,21 +13,18 @@ describe('Test CsharpDependencyGraph', () => {
     const tempDirPath = path.resolve('\\Temp')
     const mockedFs = {
         copy: Sinon.mock(),
-        exists: Sinon.mock(),
         getFileSize: Sinon.mock(),
         getTempDirPath: () => tempDirPath,
         readdir: Sinon.stub(),
         readFile: Sinon.stub(),
         isFile: Sinon.mock(),
-        remove: Sinon.mock(),
-        writeFile: Sinon.stub(),
-        appendFile: Sinon.stub(),
-        mkdir: Sinon.stub(),
     }
+
     const mockedWorkspace: Workspace = {
         getTextDocument: Sinon.mock(),
         getAllTextDocuments: Sinon.mock(),
         getWorkspaceFolder: mockedGetWorkspaceFolder,
+        // @ts-ignore mockedFs doesn't need to mock every fs function for this test to work
         fs: mockedFs,
     }
 


### PR DESCRIPTION
## Problem
Currently we have to update csharpDependencyGraph any time there is a new version runtimes that updates the `workspace.fs` interface when in practice, we don't need a complete mock of `fs` for this test suite

## Solution
We can use `ts-ignore` to ignore the fact that `mockedFs` is not a complete mock of `fs` and the tests will continue to work  without needing modifications every time there is a change to `fs` interface


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
