### PR TITLE
Amazon Q: Emit CodeCoverageEvent to CodeWhisperer.SendTelemetryEvent API

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -321,7 +321,7 @@ export const CodewhispererServerFactory =
         // the context of a single response.
         let includeSuggestionsWithCodeReferences = false
 
-        const codePercentageTracker = new CodePercentageTracker(telemetry)
+        const codePercentageTracker = new CodePercentageTracker(telemetry, telemetryService)
 
         const onInlineCompletionHandler = async (
             params: InlineCompletionWithReferencesParams,
@@ -585,6 +585,7 @@ export const CodewhispererServerFactory =
                 const qConfig = await lsp.workspace.getConfiguration(Q_CONFIGURATION_SECTION)
                 if (qConfig) {
                     codeWhispererService.customizationArn = undefinedIfEmpty(qConfig.customization)
+                    codePercentageTracker.customizationArn = undefinedIfEmpty(qConfig.customization)
                     logging.log(
                         `Inline completion configuration updated to use ${codeWhispererService.customizationArn}`
                     )

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
@@ -112,7 +112,8 @@ class HelloWorld
                 data: {
                     codewhispererTotalTokens: totalInsertCharacters,
                     codewhispererLanguage: 'csharp',
-                    codewhispererAcceptedTokens: codeWhispererCharacters,
+                    codewhispererAcceptedTokens: undefined,
+                    codewhispererSuggestedTokens: codeWhispererCharacters,
                     codewhispererPercentage: codePercentage,
                     successCount: 1,
                 },

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry.test.ts
@@ -112,7 +112,6 @@ class HelloWorld
                 data: {
                     codewhispererTotalTokens: totalInsertCharacters,
                     codewhispererLanguage: 'csharp',
-                    codewhispererAcceptedTokens: undefined,
                     codewhispererSuggestedTokens: codeWhispererCharacters,
                     codewhispererPercentage: codePercentage,
                     successCount: 1,

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.test.ts
@@ -32,6 +32,7 @@ describe('CodePercentage', () => {
     it('does not send telemetry without edits', () => {
         clock.tick(5000 * 60)
         sinon.assert.notCalled(telemetry.emitMetric)
+        sinon.assert.notCalled(telemetryService.emitCodeCoverageEvent)
     })
 
     it('emits metrics every 5 minutes while editing', () => {
@@ -43,16 +44,11 @@ describe('CodePercentage', () => {
 
         clock.tick(5000 * 60)
 
-        sinon.assert.calledWith(telemetry.emitMetric, {
-            name: 'codewhisperer_codePercentage',
-            data: {
-                codewhispererTotalTokens: 20,
-                codewhispererLanguage: LANGUAGE_ID,
-                codewhispererAcceptedTokens: undefined,
-                codewhispererSuggestedTokens: 10,
-                codewhispererPercentage: 50.0,
-                successCount: 1,
-            },
+        sinon.assert.calledWith(telemetryService.emitCodeCoverageEvent, {
+            languageId: LANGUAGE_ID,
+            totalCharacterCount: 20,
+            acceptedCharacterCount: 10,
+            customizationArn: undefined,
         })
     })
 
@@ -62,6 +58,7 @@ describe('CodePercentage', () => {
         clock.tick(5000 * 60)
 
         sinon.assert.notCalled(telemetry.emitMetric)
+        sinon.assert.notCalled(telemetryService.emitCodeCoverageEvent)
     })
 
     it('emits separate metrics for different languages', () => {
@@ -80,16 +77,11 @@ describe('CodePercentage', () => {
 
         clock.tick(5000 * 60)
 
-        sinon.assert.calledWith(telemetry.emitMetric, {
-            name: 'codewhisperer_codePercentage',
-            data: {
-                codewhispererTotalTokens: 20,
-                codewhispererLanguage: LANGUAGE_ID,
-                codewhispererAcceptedTokens: undefined,
-                codewhispererSuggestedTokens: 10,
-                codewhispererPercentage: 50.0,
-                successCount: 1,
-            },
+        sinon.assert.calledWith(telemetryService.emitCodeCoverageEvent, {
+            languageId: LANGUAGE_ID,
+            totalCharacterCount: 20,
+            acceptedCharacterCount: 10,
+            customizationArn: undefined,
         })
 
         sinon.assert.calledWith(telemetry.emitMetric, {
@@ -97,11 +89,34 @@ describe('CodePercentage', () => {
             data: {
                 codewhispererTotalTokens: 30,
                 codewhispererLanguage: OTHER_LANGUAGE_ID,
-                codewhispererAcceptedTokens: undefined,
                 codewhispererSuggestedTokens: 10,
                 codewhispererPercentage: 33.33,
                 successCount: 1,
             },
+        })
+        sinon.assert.calledWith(telemetryService.emitCodeCoverageEvent, {
+            languageId: OTHER_LANGUAGE_ID,
+            totalCharacterCount: 30,
+            acceptedCharacterCount: 10,
+            customizationArn: undefined,
+        })
+    })
+
+    it('emits metrics with customizationArn value', () => {
+        tracker.countTokens(LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countAcceptedTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countInvocation(LANGUAGE_ID)
+        tracker.countSuccess(LANGUAGE_ID)
+        tracker.customizationArn = 'test-arn'
+
+        clock.tick(5000 * 60)
+
+        sinon.assert.calledWith(telemetryService.emitCodeCoverageEvent, {
+            languageId: LANGUAGE_ID,
+            totalCharacterCount: 20,
+            acceptedCharacterCount: 10,
+            customizationArn: 'test-arn',
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.test.ts
@@ -2,6 +2,7 @@ import { Telemetry } from '@aws/language-server-runtimes/server-interface'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
 import { CodePercentageTracker } from './codePercentage'
 import assert = require('assert')
+import { TelemetryService } from '../telemetryService'
 
 describe('CodePercentage', () => {
     const LANGUAGE_ID = 'python'
@@ -13,12 +14,14 @@ describe('CodePercentage', () => {
 
     let tracker: CodePercentageTracker
     let telemetry: StubbedInstance<Telemetry>
+    let telemetryService: StubbedInstance<TelemetryService>
     let clock: sinon.SinonFakeTimers
 
     beforeEach(() => {
         clock = sinon.useFakeTimers()
         telemetry = stubInterface<Telemetry>()
-        tracker = new CodePercentageTracker(telemetry)
+        telemetryService = stubInterface<TelemetryService>()
+        tracker = new CodePercentageTracker(telemetry, telemetryService)
     })
 
     afterEach(() => {
@@ -45,7 +48,8 @@ describe('CodePercentage', () => {
             data: {
                 codewhispererTotalTokens: 20,
                 codewhispererLanguage: LANGUAGE_ID,
-                codewhispererAcceptedTokens: 10,
+                codewhispererAcceptedTokens: undefined,
+                codewhispererSuggestedTokens: 10,
                 codewhispererPercentage: 50.0,
                 successCount: 1,
             },
@@ -81,7 +85,8 @@ describe('CodePercentage', () => {
             data: {
                 codewhispererTotalTokens: 20,
                 codewhispererLanguage: LANGUAGE_ID,
-                codewhispererAcceptedTokens: 10,
+                codewhispererAcceptedTokens: undefined,
+                codewhispererSuggestedTokens: 10,
                 codewhispererPercentage: 50.0,
                 successCount: 1,
             },
@@ -92,7 +97,8 @@ describe('CodePercentage', () => {
             data: {
                 codewhispererTotalTokens: 30,
                 codewhispererLanguage: OTHER_LANGUAGE_ID,
-                codewhispererAcceptedTokens: 10,
+                codewhispererAcceptedTokens: undefined,
+                codewhispererSuggestedTokens: 10,
                 codewhispererPercentage: 33.33,
                 successCount: 1,
             },

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.ts
@@ -11,8 +11,6 @@ type TelemetryBuckets = {
         totalTokens: number
         // The accepted characters without counting user modification
         acceptedTokens: number
-        // The accepted characters after calculating user modification
-        unmodifiedAcceptedTokens?: number
         invocationCount: number
         successCount: number
     }
@@ -43,10 +41,9 @@ export class CodePercentageTracker {
 
                 this.telemetryService.emitCodeCoverageEvent({
                     languageId: event.codewhispererLanguage as CodewhispererLanguage,
+                    customizationArn: this.customizationArn,
                     totalCharacterCount: event.codewhispererTotalTokens,
                     acceptedCharacterCount: event.codewhispererSuggestedTokens,
-                    unmodifiedAcceptedCharacterCount: event.codewhispererAcceptedTokens,
-                    customizationArn: this.customizationArn,
                 })
             })
         }, CODE_PERCENTAGE_INTERVAL)
@@ -62,7 +59,6 @@ export class CodePercentageTracker {
                 return {
                     codewhispererTotalTokens: bucket.totalTokens,
                     codewhispererLanguage: languageId,
-                    codewhispererAcceptedTokens: bucket.unmodifiedAcceptedTokens,
                     codewhispererSuggestedTokens: bucket.acceptedTokens,
                     codewhispererPercentage: percentage,
                     successCount: bucket.successCount,
@@ -86,7 +82,6 @@ export class CodePercentageTracker {
         if (!this.buckets[languageId]) {
             this.buckets[languageId] = {
                 totalTokens: 0,
-                unmodifiedAcceptedTokens: undefined,
                 acceptedTokens: 0,
                 invocationCount: 0,
                 successCount: 0,

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/types.ts
@@ -68,7 +68,8 @@ export interface CodeWhispererUserTriggerDecisionEvent {
 export interface CodeWhispererCodePercentageEvent {
     codewhispererTotalTokens: number
     codewhispererLanguage: string
-    codewhispererAcceptedTokens: number
+    codewhispererAcceptedTokens?: number
+    codewhispererSuggestedTokens: number
     codewhispererPercentage: number
     successCount: number
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
@@ -334,4 +334,39 @@ describe('TelemetryService', () => {
             expect(calledArg.telemetryEvent.chatInteractWithMessageEvent.acceptedLineCount).to.be.undefined
         })
     })
+
+    it('should emit CodeCoverageEvent event', () => {
+        const timestamp = new Date(Date.now())
+        const expectedEvent = {
+            codeCoverageEvent: {
+                customizationArn: 'test-arn',
+                programmingLanguage: { languageName: 'typescript' },
+                acceptedCharacterCount: 123,
+                totalCharacterCount: 456,
+                // timestamp,
+            },
+        }
+        mockCredentialsProvider.setConnectionMetadata({
+            sso: {
+                startUrl: 'idc-start-url',
+            },
+        })
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
+        const invokeSendTelemetryEventSpy: sinon.SinonSpy = sinon.spy(
+            telemetryService,
+            'invokeSendTelemetryEvent' as any
+        )
+        telemetryService.updateOptOutPreference('OPTIN')
+
+        telemetryService.emitCodeCoverageEvent({
+            languageId: 'typescript',
+            customizationArn: 'test-arn',
+            acceptedCharacterCount: 123,
+            totalCharacterCount: 456,
+        })
+
+        sinon.assert.calledOnce(invokeSendTelemetryEventSpy)
+        sinon.assert.calledWith(invokeSendTelemetryEventSpy, sinon.match(expectedEvent))
+        invokeSendTelemetryEventSpy.restore()
+    })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
@@ -198,19 +198,17 @@ export class TelemetryService extends CodeWhispererServiceToken {
         languageId: CodewhispererLanguage
         acceptedCharacterCount: number
         totalCharacterCount: number
-        unmodifiedAcceptedCharacterCount?: number
         customizationArn?: string
     }) {
         const event: CodeCoverageEvent = {
-            customizationArn: params.customizationArn,
             programmingLanguage: {
                 languageName: getRuntimeLanguage(params.languageId),
             },
             acceptedCharacterCount: params.acceptedCharacterCount,
             totalCharacterCount: params.totalCharacterCount,
             timestamp: new Date(Date.now()),
-            unmodifiedAcceptedCharacterCount: params.unmodifiedAcceptedCharacterCount,
         }
+        if (params.customizationArn) event.customizationArn = params.customizationArn
 
         this.invokeSendTelemetryEvent({
             codeCoverageEvent: event,

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
@@ -138,8 +138,8 @@ export class TelemetryService extends CodeWhispererServiceToken {
             acceptedSuggestion === undefined
                 ? 0
                 : acceptedSuggestion.references && acceptedSuggestion.references.length > 0
-                    ? 1
-                    : 0
+                  ? 1
+                  : 0
         const perceivedLatencyMilliseconds =
             session.triggerType === 'OnDemand' ? session.timeToFirstRecommendation : timeSinceLastUserModification
 


### PR DESCRIPTION
## Problem

We need to emit CodeCoverageEvent telemetry to Amazon Q SendTelemetry API.

## Solution

* Added new `emitCodeCoverageEvent` method to `TeleetryService`
* Extended `CodePercentageTracker` to track customization used and call `emitCodeCoverageEvent` at scheduled time
* Extended unit tests to cover new methods
* Bug fix: in existing telemetry sent over LSP channel, we used `codewhispererAcceptedTokens` to send length of all accepted recommendations. Per reference implementation in VSCode, we should use `codewhispererSuggestedTokens` for this. Switched to using `codewhispererSuggestedTokens` for this event

Reference implementation https://github.com/aws/aws-toolkit-vscode/blob/6c420c7f8c2f03fc1c6236669d701b2581cba6e0/packages/core/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts#L132-L146.

Difference with reference implementation is that we don't send `unmodifiedAcceptedCharacterCount` field. This field is optional, deprecated and will be removed from API.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

### TODO

* [x] Unit tests
* [x] Clarify requirements for `unmodifiedAcceptedCharacterCount`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
