### PR TITLE
Fix file does not exist bugs and add tests

### DIFF
--- a/client/vscode/src/identityActivation.ts
+++ b/client/vscode/src/identityActivation.ts
@@ -1,14 +1,11 @@
 import { commands, window } from 'vscode'
 import {
     AwsResponseError,
-    GetSsoTokenParams,
-    getSsoTokenRequestType,
-    IamIdentityCenterSsoTokenSource,
-    InvalidateSsoTokenParams,
-    invalidateSsoTokenRequestType,
+    ProfileKind,
     SsoTokenChangedParams,
     ssoTokenChangedRequestType,
-    SsoTokenSourceKind,
+    UpdateProfileParams,
+    updateProfileRequestType,
 } from '@aws/language-server-runtimes/protocol'
 
 import { LanguageClient } from 'vscode-languageclient/node'
@@ -31,30 +28,30 @@ function ssoTokenChangedHandler(params: SsoTokenChangedParams): void {
 // Consider the code in this function a scratchpad, do not put anything you want to keep here.
 // Put whatever calls to the aws-lsp-identity server you want to experiment with/debug here
 async function execTestCommand(client: LanguageClient): Promise<void> {
-    // try {
-    //     const result = await client.sendRequest(updateProfileRequestType.method, {
-    //         profile: {
-    //             kinds: [ProfileKind.SsoTokenProfile],
-    //             name: 'codecatalyst',
-    //             settings: {
-    //                 region: 'us-west-2',
-    //                 sso_session: 'codecatalyst2',
-    //             },
-    //         },
-    //         ssoSession: {
-    //             name: 'codecatalyst2',
-    //             settings: {
-    //                 sso_region: 'us-east-1',
-    //                 sso_start_url: 'https://view.awsapps.com/start',
-    //                 sso_registration_scopes: ['codecatalyst:read_write'],
-    //             },
-    //         },
-    //     } satisfies UpdateProfileParams)
-    //     window.showInformationMessage(`UpdateProfile: ${JSON.stringify(result)}`)
-    // } catch (e) {
-    //     const are = e as AwsResponseError
-    //     window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
-    // }
+    try {
+        const result = await client.sendRequest(updateProfileRequestType.method, {
+            profile: {
+                kinds: [ProfileKind.SsoTokenProfile],
+                name: 'codecatalyst',
+                settings: {
+                    region: 'us-west-2',
+                    sso_session: 'codecatalyst2',
+                },
+            },
+            ssoSession: {
+                name: 'codecatalyst2',
+                settings: {
+                    sso_region: 'us-east-1',
+                    sso_start_url: 'https://view.awsapps.com/start',
+                    sso_registration_scopes: ['codecatalyst:read_write'],
+                },
+            },
+        } satisfies UpdateProfileParams)
+        window.showInformationMessage(`UpdateProfile: ${JSON.stringify(result)}`)
+    } catch (e) {
+        const are = e as AwsResponseError
+        window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
+    }
 
     // try {
     //     const result = await client.sendRequest(listProfilesRequestType.method, {} satisfies ListProfilesParams)
@@ -64,31 +61,31 @@ async function execTestCommand(client: LanguageClient): Promise<void> {
     //     window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
     // }
 
-    try {
-        const result = await client.sendRequest(getSsoTokenRequestType.method, {
-            clientName: 'Flare test client',
-            // source: {
-            //     kind: SsoTokenSourceKind.AwsBuilderId,
-            //     ssoRegistrationScopes: ['sso:account:access'],
-            // } satisfies AwsBuilderIdSsoTokenSource,
-            source: {
-                kind: SsoTokenSourceKind.IamIdentityCenter,
-                profileName: 'my-idc-q',
-            } satisfies IamIdentityCenterSsoTokenSource,
-        } satisfies GetSsoTokenParams)
-        window.showInformationMessage(`GetSsoToken: ${JSON.stringify(result)}`)
-    } catch (e) {
-        const are = e as AwsResponseError
-        window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
-    }
+    // try {
+    //     const result = await client.sendRequest(getSsoTokenRequestType.method, {
+    //         clientName: 'Flare test client',
+    //         // source: {
+    //         //     kind: SsoTokenSourceKind.AwsBuilderId,
+    //         //     ssoRegistrationScopes: ['sso:account:access'],
+    //         // } satisfies AwsBuilderIdSsoTokenSource,
+    //         source: {
+    //             kind: SsoTokenSourceKind.IamIdentityCenter,
+    //             profileName: 'my-idc-q',
+    //         } satisfies IamIdentityCenterSsoTokenSource,
+    //     } satisfies GetSsoTokenParams)
+    //     window.showInformationMessage(`GetSsoToken: ${JSON.stringify(result)}`)
+    // } catch (e) {
+    //     const are = e as AwsResponseError
+    //     window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
+    // }
 
-    try {
-        await client.sendRequest(invalidateSsoTokenRequestType.method, {
-            ssoTokenId: 'my-idc-q-NOPE',
-        } satisfies InvalidateSsoTokenParams)
-        window.showInformationMessage(`InvalidateSsoToken: successful`)
-    } catch (e) {
-        const are = e as AwsResponseError
-        window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
-    }
+    // try {
+    //     await client.sendRequest(invalidateSsoTokenRequestType.method, {
+    //         ssoTokenId: 'my-idc-q-NOPE',
+    //     } satisfies InvalidateSsoTokenParams)
+    //     window.showInformationMessage(`InvalidateSsoToken: successful`)
+    // } catch (e) {
+    //     const are = e as AwsResponseError
+    //     window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
+    // }
 }

--- a/server/aws-lsp-identity/src/sharedConfig/saveSharedConfigFile.test.ts
+++ b/server/aws-lsp-identity/src/sharedConfig/saveSharedConfigFile.test.ts
@@ -64,6 +64,7 @@ async function setupTest(config: string): Promise<ParsedIniData> {
     const mockConfig: DirectoryItems = {}
     mockConfig[dir] = {
         config,
+        'config~': config,
     }
 
     mock(mockConfig)
@@ -242,5 +243,35 @@ sso_session = test-sso-session`
         assert.equal(input[0], '# Config comment 1')
         assert.equal(input[1], "[default] # Section's trailing comment")
         assert.equal(input[2], "region = us-east-1   ; Setting's trailing comment")
+    })
+
+    it('Can create new when ~/.aws does not exist', async () => {
+        mock.restore()
+        mock({})
+
+        const data = { default: { region: 'us-west-2' } }
+
+        await saveSharedConfigFile(init.configFilepath!, IniFileType.config, data)
+
+        const { configFile } = await loadSharedConfigFiles(init)
+        normalizeParsedIniData(configFile)
+
+        assert.equal(Object.hasOwn(configFile, 'default'), true)
+    })
+
+    it('Can create new when ~/.aws exists, but file does not exist', async () => {
+        mock.restore()
+        const mockConfig: DirectoryItems = {}
+        mockConfig[dir] = {}
+        mock(mockConfig)
+
+        const data = { default: { region: 'us-west-2' } }
+
+        await saveSharedConfigFile(init.configFilepath!, IniFileType.config, data)
+
+        const { configFile } = await loadSharedConfigFiles(init)
+        normalizeParsedIniData(configFile)
+
+        assert.equal(Object.hasOwn(configFile, 'default'), true)
     })
 })

--- a/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.test.ts
+++ b/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.test.ts
@@ -133,6 +133,26 @@ describe('FileSystemSsoCache', () => {
         expect(actual?.scopes).to.deep.equal(['sso:account:access', 'codewhisperer:analysis'])
     })
 
+    it('setSsoClientRegistration writes new valid registration when ~/.aws does not exist', async () => {
+        mock.restore()
+        mock({})
+
+        await sut.setSsoClientRegistration('new', ssoSession, {
+            clientId: 'someclientid',
+            clientSecret: 'someclientsecret',
+            expiresAt: '2024-10-14T12:00:00.000Z',
+            scopes: ['sso:account:access', 'codewhisperer:analysis'],
+        })
+
+        const actual = await sut.getSsoClientRegistration('new', ssoSession)
+
+        expect(actual).to.not.be.null.and.not.undefined
+        expect(actual?.clientId).to.equal('someclientid')
+        expect(actual?.clientSecret).to.equal('someclientsecret')
+        expect(actual?.expiresAt).to.equal('2024-10-14T12:00:00.000Z')
+        expect(actual?.scopes).to.deep.equal(['sso:account:access', 'codewhisperer:analysis'])
+    })
+
     it('setSsoClientRegistration writes updated existing registration', async () => {
         setupTest()
 
@@ -217,6 +237,36 @@ describe('FileSystemSsoCache', () => {
 
     it('setSsoToken writes new valid token', async () => {
         setupTest()
+        const ssoSession = createSsoSession('new-token')
+
+        await sut.setSsoToken(clientName, ssoSession, {
+            clientId: 'someclientid',
+            clientSecret: 'someclientsecret',
+            region: 'us-west-2',
+            startUrl: 'https://somewhere',
+            accessToken: 'newaccesstoken',
+            refreshToken: 'newrefreshtoken',
+            expiresAt: '2024-10-14T12:00:00.000Z',
+            registrationExpiresAt: '2024-12-14T12:00:00.000Z',
+        })
+
+        const actual = await sut.getSsoToken(clientName, ssoSession)
+
+        expect(actual).to.not.be.null.and.not.undefined
+        expect(actual?.accessToken).to.equal('newaccesstoken')
+        expect(actual?.clientId).to.equal('someclientid')
+        expect(actual?.clientSecret).to.equal('someclientsecret')
+        expect(actual?.expiresAt).to.equal('2024-10-14T12:00:00.000Z')
+        expect(actual?.refreshToken).to.equal('newrefreshtoken')
+        expect(actual?.region).to.equal('us-west-2')
+        expect(actual?.registrationExpiresAt).to.equal('2024-12-14T12:00:00.000Z')
+        expect(actual?.startUrl).to.equal('https://somewhere')
+    })
+
+    it('setSsoToken writes new valid token when ~/.aws does not exist', async () => {
+        mock.restore()
+        mock({})
+
         const ssoSession = createSsoSession('new-token')
 
         await sut.setSsoToken(clientName, ssoSession, {


### PR DESCRIPTION
This PR fixes error on file write when the file and/or directory does not exist.  identityActiviation.ts updated only for the purposes of developing/verifying fixes.  Unit tests added for build-time validation.  

1. Majority of saveSharedConfig file was just wrapping the readFile followed by a large for-loop in a filepathExists check.  The for-loop was not changed otherwise.  
2. No longer swallowing error in fileSystemSsoCache.writeSsoObjectToFile, ensuring directory exists and errors will bubble up to caller now.