### PR TITLE
Update workspace fs interface to use expected defaults

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1"
     },

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-partiql": "^0.0.4"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.23"
+        "@aws/language-server-runtimes": "^0.2.24"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -247,7 +247,7 @@
         "@aws-sdk/credential-providers": "^3.614.0",
         "@aws-sdk/types": "^3.535.0",
         "@aws/chat-client-ui-types": "^0.0.8",
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.88.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1"
             },
@@ -64,7 +64,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -72,7 +72,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -92,7 +92,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-partiql": "^0.0.4"
             },
             "devDependencies": {
@@ -116,7 +116,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -136,7 +136,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -158,7 +158,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.23"
+                "@aws/language-server-runtimes": "^0.2.24"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -202,7 +202,7 @@
                 "@aws-sdk/credential-providers": "^3.614.0",
                 "@aws-sdk/types": "^3.535.0",
                 "@aws/chat-client-ui-types": "^0.0.8",
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",
@@ -4393,7 +4393,7 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.23",
+            "version": "0.2.24",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.7",
@@ -19318,7 +19318,7 @@
                 "@amzn/codewhisperer-streaming": "*",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.0.8",
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-fqn": "^0.0.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@smithy/node-http-handler": "^2.5.0",
@@ -19499,7 +19499,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.614.0",
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@smithy/shared-ini-file-loader": "^3.1.5",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -19549,7 +19549,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -19563,7 +19563,7 @@
             "version": "0.0.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4",
                 "web-tree-sitter": "0.22.6"
@@ -19596,7 +19596,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -19610,7 +19610,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -19621,7 +19621,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.23",
+                "@aws/language-server-runtimes": "^0.2.24",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -35,7 +35,7 @@
         "@amzn/codewhisperer-streaming": "*",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.0.8",
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-fqn": "^0.0.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/csharpDependencyGraph.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/csharpDependencyGraph.test.ts
@@ -12,7 +12,7 @@ describe('Test CsharpDependencyGraph', () => {
     const projectPathUri = path.resolve(path.join(__dirname, 'sampleWs'))
     const tempDirPath = path.resolve('\\Temp')
     const mockedFs = {
-        copy: Sinon.mock(),
+        copyFile: Sinon.mock(),
         getFileSize: Sinon.mock(),
         getTempDirPath: () => tempDirPath,
         readdir: Sinon.stub(),

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraph.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraph.ts
@@ -186,7 +186,7 @@ export abstract class DependencyGraph {
      */
     protected async removeDir(dir: string) {
         if (await this.workspace.fs.exists(dir)) {
-            await this.workspace.fs.remove(dir)
+            await this.workspace.fs.rm(dir, { recursive: true, force: true })
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraph.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraph.ts
@@ -160,7 +160,7 @@ export abstract class DependencyGraph {
         const sourceWorkspacePath = await this.getProjectPath(srcFilePath)
         const fileRelativePath = path.relative(sourceWorkspacePath, srcFilePath)
         const destinationFileAbsolutePath = path.join(destDir, fileRelativePath)
-        await this.workspace.fs.copy(srcFilePath, destinationFileAbsolutePath)
+        await this.workspace.fs.copyFile(srcFilePath, destinationFileAbsolutePath)
     }
 
     /**
@@ -186,7 +186,7 @@ export abstract class DependencyGraph {
      */
     protected async removeDir(dir: string) {
         if (await this.workspace.fs.exists(dir)) {
-            await this.workspace.fs.rm(dir, { recursive: true, force: true })
+            await this.workspace.fs.rm(dir, { force: true })
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraph.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/dependencyGraph/dependencyGraph.ts
@@ -160,7 +160,7 @@ export abstract class DependencyGraph {
         const sourceWorkspacePath = await this.getProjectPath(srcFilePath)
         const fileRelativePath = path.relative(sourceWorkspacePath, srcFilePath)
         const destinationFileAbsolutePath = path.join(destDir, fileRelativePath)
-        await this.workspace.fs.copyFile(srcFilePath, destinationFileAbsolutePath)
+        await this.workspace.fs.copyFile(srcFilePath, destinationFileAbsolutePath, { ensureDir: true })
     }
 
     /**

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -26,7 +26,7 @@ export class ArtifactManager {
     }
     async removeDir(dir: string) {
         if (await this.workspace.fs.exists(dir)) {
-            await this.workspace.fs.remove(dir)
+            await this.workspace.fs.rm(dir, { recursive: true, force: true })
         }
     }
     cleanup() {

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.614.0",
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@smithy/shared-ini-file-loader": "^3.1.5",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.23",
+        "@aws/language-server-runtimes": "^0.2.24",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem
Currently, in the standalone Workspace file system, there are some unreasonable default options passed to the Node.js fs functions, which can be confusing to the developers and produce unexpected results.
## Solution
Updated interface in the language-server-runtimes repo: https://github.com/aws/language-server-runtimes/pull/247. 
Applied the necessary changes in the language servers to use the modified workspace interface.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
