### PR TITLE
Make AWS Q endpoint url configurable

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
+++ b/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
@@ -1,10 +1,7 @@
 import { CodeWhispererStreaming, CodeWhispererStreamingClientConfig } from '@amzn/codewhisperer-streaming'
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { readFileSync } from 'fs'
-
-const codeWhispererRegion = 'us-east-1'
-
-const codeWhispererEndpoint = process?.env.AWS_Q_ENDPOINT_URL ?? 'https://codewhisperer.us-east-1.amazonaws.com/'
+import { AWS_Q_REGION, AWS_Q_ENDPOINT_URL } from '../../constants'
 
 export class StreamingClient {
     public async getStreamingClient(credentialsProvider: any, config?: CodeWhispererStreamingClientConfig) {
@@ -39,8 +36,8 @@ export async function createStreamingClient(
     }
 
     const streamingClient = new CodeWhispererStreaming({
-        region: codeWhispererRegion,
-        endpoint: codeWhispererEndpoint,
+        region: AWS_Q_REGION,
+        endpoint: AWS_Q_ENDPOINT_URL,
         token: { token: creds.token },
         retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
         requestHandler: clientOptions?.requestHandler,

--- a/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
+++ b/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs'
 
 const codeWhispererRegion = 'us-east-1'
 
-const codeWhispererEndpoint = 'https://codewhisperer.us-east-1.amazonaws.com/'
+const codeWhispererEndpoint = process?.env.AWS_Q_ENDPOINT_URL ?? 'https://codewhisperer.us-east-1.amazonaws.com/'
 
 export class StreamingClient {
     public async getStreamingClient(credentialsProvider: any, config?: CodeWhispererStreamingClientConfig) {

--- a/server/aws-lsp-codewhisperer/src/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/constants.ts
@@ -1,0 +1,2 @@
+export const AWS_Q_ENDPOINT_URL = process?.env.AWS_Q_ENDPOINT_URL ?? 'https://codewhisperer.us-east-1.amazonaws.com/'
+export const AWS_Q_REGION = process?.env.AWS_Q_REGION ?? 'us-east-1'

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -12,7 +12,8 @@ export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
     readonly #codeWhispererRegion = 'us-east-1'
-    readonly #codeWhispererEndpoint = 'https://codewhisperer.us-east-1.amazonaws.com/'
+    readonly #codeWhispererEndpoint =
+        process?.env.AWS_Q_ENDPOINT_URL ?? 'https://codewhisperer.us-east-1.amazonaws.com/'
     #abortController?: AbortController
     #credentialsProvider: CredentialsProvider
     #config?: CodeWhispererStreamingClientConfig

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -7,13 +7,13 @@ import {
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
 import { getBearerTokenFromProvider } from '../utils'
+import { AWS_Q_REGION, AWS_Q_ENDPOINT_URL } from '../../constants'
 
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
-    readonly #codeWhispererRegion = 'us-east-1'
-    readonly #codeWhispererEndpoint =
-        process?.env.AWS_Q_ENDPOINT_URL ?? 'https://codewhisperer.us-east-1.amazonaws.com/'
+    readonly #codeWhispererRegion = AWS_Q_REGION
+    readonly #codeWhispererEndpoint = AWS_Q_ENDPOINT_URL
     #abortController?: AbortController
     #credentialsProvider: CredentialsProvider
     #config?: CodeWhispererStreamingClientConfig

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -42,13 +42,13 @@ export interface AWSConfig {
 import CodeWhispererSigv4Client = require('../client/sigv4/codewhisperersigv4client')
 import CodeWhispererTokenClient = require('../client/token/codewhispererbearertokenclient')
 import AWS = require('aws-sdk')
+import { AWS_Q_ENDPOINT_URL, AWS_Q_REGION } from '../constants'
 
 // Right now the only difference between the token client and the IAM client for codewhsiperer is the difference in function name
 // This abstract class can grow in the future to account for any additional changes across the clients
 export abstract class CodeWhispererServiceBase {
-    protected readonly codeWhispererRegion = 'us-east-1'
-    protected readonly codeWhispererEndpoint =
-        process?.env.AWS_Q_ENDPOINT_URL ?? 'https://codewhisperer.us-east-1.amazonaws.com/'
+    protected readonly codeWhispererRegion = AWS_Q_REGION
+    protected readonly codeWhispererEndpoint = AWS_Q_ENDPOINT_URL
     public shareCodeWhispererContentWithAWS = false
     public customizationArn?: string
     abstract client: CodeWhispererSigv4Client | CodeWhispererTokenClient

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -47,7 +47,8 @@ import AWS = require('aws-sdk')
 // This abstract class can grow in the future to account for any additional changes across the clients
 export abstract class CodeWhispererServiceBase {
     protected readonly codeWhispererRegion = 'us-east-1'
-    protected readonly codeWhispererEndpoint = 'https://codewhisperer.us-east-1.amazonaws.com/'
+    protected readonly codeWhispererEndpoint =
+        process?.env.AWS_Q_ENDPOINT_URL ?? 'https://codewhisperer.us-east-1.amazonaws.com/'
     public shareCodeWhispererContentWithAWS = false
     public customizationArn?: string
     abstract client: CodeWhispererSigv4Client | CodeWhispererTokenClient


### PR DESCRIPTION
## Notes
Making AWS Q endpoint url configurable. 
When `AWS_Q_ENDPOINT_URL` is set, sdk clients will use it instead of the default endpoint. 
The SDK clients will also honour `AWS_Q_REGION` but if the endpoint url already contains a region then it will be ignored based on my observations which is the desired behaviour. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
