### PR TITLE
Bug fixes and preparing for observability additions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -138,6 +138,7 @@
             "name": "Identity Server + VSCode Extension",
             "type": "extensionHost",
             "request": "launch",
+            "preLaunchTask": "watch",
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}/client/vscode", "--disable-extensions"],
             "env": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,7 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "compile",
             "type": "npm",
             "script": "compile",
             "group": "build",

--- a/app/aws-lsp-identity-runtimes/src/standalone.ts
+++ b/app/aws-lsp-identity-runtimes/src/standalone.ts
@@ -4,7 +4,7 @@ import { IdentityServer } from '@aws/lsp-identity'
 
 const props: RuntimeProps = {
     version: '0.1.0',
-    servers: [IdentityServer],
+    servers: [IdentityServer.create],
     name: 'Identity Server',
 }
 

--- a/client/vscode/src/identityActivation.ts
+++ b/client/vscode/src/identityActivation.ts
@@ -1,9 +1,18 @@
 import { commands, window } from 'vscode'
 import {
+    AwsBuilderIdSsoTokenSource,
     AwsResponseError,
+    GetSsoTokenParams,
+    getSsoTokenRequestType,
+    GetSsoTokenResult,
+    InvalidateSsoTokenParams,
+    invalidateSsoTokenRequestType,
+    ListProfilesParams,
+    listProfilesRequestType,
     ProfileKind,
     SsoTokenChangedParams,
     ssoTokenChangedRequestType,
+    SsoTokenSourceKind,
     UpdateProfileParams,
     updateProfileRequestType,
 } from '@aws/language-server-runtimes/protocol'
@@ -53,39 +62,41 @@ async function execTestCommand(client: LanguageClient): Promise<void> {
         window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
     }
 
-    // try {
-    //     const result = await client.sendRequest(listProfilesRequestType.method, {} satisfies ListProfilesParams)
-    //     window.showInformationMessage(`ListProfiles: ${JSON.stringify(result)}`)
-    // } catch (e) {
-    //     const are = e as AwsResponseError
-    //     window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
-    // }
+    try {
+        const result = await client.sendRequest(listProfilesRequestType.method, {} satisfies ListProfilesParams)
+        window.showInformationMessage(`ListProfiles: ${JSON.stringify(result)}`)
+    } catch (e) {
+        const are = e as AwsResponseError
+        window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
+    }
 
-    // try {
-    //     const result = await client.sendRequest(getSsoTokenRequestType.method, {
-    //         clientName: 'Flare test client',
-    //         // source: {
-    //         //     kind: SsoTokenSourceKind.AwsBuilderId,
-    //         //     ssoRegistrationScopes: ['sso:account:access'],
-    //         // } satisfies AwsBuilderIdSsoTokenSource,
-    //         source: {
-    //             kind: SsoTokenSourceKind.IamIdentityCenter,
-    //             profileName: 'my-idc-q',
-    //         } satisfies IamIdentityCenterSsoTokenSource,
-    //     } satisfies GetSsoTokenParams)
-    //     window.showInformationMessage(`GetSsoToken: ${JSON.stringify(result)}`)
-    // } catch (e) {
-    //     const are = e as AwsResponseError
-    //     window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
-    // }
+    let ssoToken
+    try {
+        const result: GetSsoTokenResult = await client.sendRequest(getSsoTokenRequestType.method, {
+            clientName: 'Flare test client',
+            source: {
+                kind: SsoTokenSourceKind.AwsBuilderId,
+                ssoRegistrationScopes: ['codewhisperer:analysis', 'codewhisperer:completions'],
+            } satisfies AwsBuilderIdSsoTokenSource,
+            // source: {
+            //     kind: SsoTokenSourceKind.IamIdentityCenter,
+            //     profileName: 'my-idc-q',
+            // } satisfies IamIdentityCenterSsoTokenSource,
+        } satisfies GetSsoTokenParams)
+        ssoToken = result.ssoToken
+        window.showInformationMessage(`GetSsoToken: ${JSON.stringify(result)}`)
+    } catch (e) {
+        const are = e as AwsResponseError
+        window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
+    }
 
-    // try {
-    //     await client.sendRequest(invalidateSsoTokenRequestType.method, {
-    //         ssoTokenId: 'my-idc-q-NOPE',
-    //     } satisfies InvalidateSsoTokenParams)
-    //     window.showInformationMessage(`InvalidateSsoToken: successful`)
-    // } catch (e) {
-    //     const are = e as AwsResponseError
-    //     window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
-    // }
+    try {
+        await client.sendRequest(invalidateSsoTokenRequestType.method, {
+            ssoTokenId: ssoToken?.id || 'my-idc-q',
+        } satisfies InvalidateSsoTokenParams)
+        window.showInformationMessage(`InvalidateSsoToken: successful`)
+    } catch (e) {
+        const are = e as AwsResponseError
+        window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
+    }
 }

--- a/server/aws-lsp-identity/src/language-server/identityService.test.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.test.ts
@@ -8,6 +8,7 @@ import { SsoTokenAutoRefresher } from './ssoTokenAutoRefresher'
 import { createStubInstance, restore, stub } from 'sinon'
 import { CancellationToken, ProfileKind, SsoTokenSourceKind } from '@aws/language-server-runtimes/protocol'
 import { SSOToken } from '@smithy/shared-ini-file-loader'
+import { Observability } from './utils'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
@@ -17,6 +18,7 @@ let sut: IdentityService
 let profileStore: StubbedInstance<ProfileStore>
 let ssoCache: StubbedInstance<SsoCache>
 let autoRefresher: StubbedInstance<SsoTokenAutoRefresher>
+let observability: StubbedInstance<Observability>
 
 describe('IdentityService', () => {
     beforeEach(() => {
@@ -67,6 +69,8 @@ describe('IdentityService', () => {
                 expiresAt: new Date(Date.now() + 10 * 1000).toISOString(),
             } satisfies SSOToken)
         )
+
+        sut = new IdentityService(profileStore, ssoCache, autoRefresher, _ => {}, 'My Client', observability)
     })
 
     afterEach(() => {
@@ -75,8 +79,6 @@ describe('IdentityService', () => {
 
     describe('getSsoToken', () => {
         it('Can login with AWS Builder ID.', async () => {
-            sut = new IdentityService(profileStore, ssoCache, autoRefresher, _ => {})
-
             const actual = await sut.getSsoToken(
                 {
                     clientName: 'my-client',
@@ -91,8 +93,6 @@ describe('IdentityService', () => {
         })
 
         it('Can login with IAM Identity Center.', async () => {
-            sut = new IdentityService(profileStore, ssoCache, autoRefresher, _ => {})
-
             const actual = await sut.getSsoToken(
                 {
                     clientName: 'my-client',
@@ -107,8 +107,6 @@ describe('IdentityService', () => {
         })
 
         it('Throws when no SSO token cached and loginOnInvalidToken is false.', async () => {
-            sut = new IdentityService(profileStore, ssoCache, autoRefresher, _ => {})
-
             const error = await expect(
                 sut.getSsoToken(
                     {
@@ -130,16 +128,12 @@ describe('IdentityService', () => {
 
     describe('invalidateSsoToken', () => {
         it('removeToken removes on valid SSO session name', async () => {
-            sut = new IdentityService(profileStore, ssoCache, autoRefresher, _ => {})
-
             await sut.invalidateSsoToken({ ssoTokenId: 'my-sso-session' }, CancellationToken.None)
 
             expect(ssoCache.removeSsoToken.called).is.true
         })
 
         it('removeToken throws on invalid SSO session name', async () => {
-            sut = new IdentityService(profileStore, ssoCache, autoRefresher, _ => {})
-
             await expect(sut.invalidateSsoToken({ ssoTokenId: '   ' }, CancellationToken.None)).to.be.rejectedWith()
 
             expect(ssoCache.removeSsoToken.notCalled).is.true

--- a/server/aws-lsp-identity/src/language-server/profiles/profileService.test.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/profileService.test.ts
@@ -10,12 +10,15 @@ import { normalizeParsedIniData } from '../../sharedConfig/saveKnownFiles'
 import { StubbedInstance, stubInterface } from 'ts-sinon'
 import { expect, use } from 'chai'
 import { AwsError } from '../../awsError'
+import { Observability } from '../utils'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
 
 let sut: ProfileService
+
 let store: StubbedInstance<ProfileStore>
+let observability: StubbedInstance<Observability>
 let profile1: Profile
 let profile2: Profile
 let profile3: Profile
@@ -73,7 +76,9 @@ describe('ProfileService', async () => {
             save: Promise.resolve(),
         })
 
-        sut = new ProfileService(store)
+        observability = stubInterface<Observability>()
+
+        sut = new ProfileService(store, observability)
     })
 
     it('listProfiles return profiles and sso-sessions', async () => {

--- a/server/aws-lsp-identity/src/language-server/profiles/sharedConfigProfileStore.test.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/sharedConfigProfileStore.test.ts
@@ -6,11 +6,15 @@ import { SharedConfigProfileStore } from './sharedConfigProfileStore'
 import { expect, use } from 'chai'
 import { ProfileData } from './profileService'
 import { ProfileKind } from '@aws/language-server-runtimes/server-interface'
+import { StubbedInstance, stubInterface } from 'ts-sinon'
+import { Observability } from '../utils'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
 
-const sut = new SharedConfigProfileStore()
+let sut: SharedConfigProfileStore
+
+let observability: StubbedInstance<Observability>
 
 const config = `
 [default]
@@ -64,6 +68,12 @@ function setupTest(config: string, credentials: string): void {
 }
 
 describe('SharedConfigProfileStore', async () => {
+    beforeEach(() => {
+        observability = stubInterface<Observability>()
+
+        sut = new SharedConfigProfileStore(observability)
+    })
+
     afterEach(() => {
         mock.restore()
     })

--- a/server/aws-lsp-identity/src/language-server/ssoTokenAutoRefresher.test.ts
+++ b/server/aws-lsp-identity/src/language-server/ssoTokenAutoRefresher.test.ts
@@ -1,12 +1,15 @@
 import { expect, use } from 'chai'
 import { SsoTokenAutoRefresher } from './ssoTokenAutoRefresher'
 import { SSOToken } from '@smithy/shared-ini-file-loader'
-import { stubInterface } from 'ts-sinon'
+import { StubbedInstance, stubInterface } from 'ts-sinon'
 import { SsoClientRegistration, RefreshingSsoCache } from '../sso'
 import { restore, spy } from 'sinon'
+import { Observability } from './utils'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
+
+let observability: StubbedInstance<Observability>
 
 const clientName = 'my-test-client'
 const now = Date.now()
@@ -47,13 +50,17 @@ function stubSsoCache(clientRegistration?: SsoClientRegistration, ssoToken?: SSO
 }
 
 describe('SsoTokenAutoRefresher', () => {
+    beforeEach(() => {
+        observability = stubInterface<Observability>()
+    })
+
     afterEach(() => {
         restore()
     })
 
     it('watch does nothing if SSO token is not loaded from cache.', async () => {
         const ssoCache = stubSsoCache(clientRegistration)
-        using sut = new SsoTokenAutoRefresher(ssoCache)
+        using sut = new SsoTokenAutoRefresher(ssoCache, observability)
 
         expect(Object.keys(sut['timeouts']).length).to.equal(0)
 
@@ -64,7 +71,7 @@ describe('SsoTokenAutoRefresher', () => {
 
     it('watch does nothing if SSO token is expired.', async () => {
         const ssoCache = stubSsoCache(clientRegistration, createSsoToken(-10000))
-        using sut = new SsoTokenAutoRefresher(ssoCache)
+        using sut = new SsoTokenAutoRefresher(ssoCache, observability)
 
         expect(Object.keys(sut['timeouts']).length).to.equal(0)
 
@@ -78,7 +85,7 @@ describe('SsoTokenAutoRefresher', () => {
 
         // Before the refresh window
         const ssoCache = stubSsoCache(clientRegistration, createSsoToken(60 * 60 * 1000))
-        using sut = new SsoTokenAutoRefresher(ssoCache)
+        using sut = new SsoTokenAutoRefresher(ssoCache, observability)
 
         expect(Object.keys(sut['timeouts']).length).to.equal(0)
 
@@ -97,7 +104,7 @@ describe('SsoTokenAutoRefresher', () => {
 
         // In the refresh window
         const ssoCache = stubSsoCache(clientRegistration, createSsoToken(4 * 60 * 1000))
-        using sut = new SsoTokenAutoRefresher(ssoCache)
+        using sut = new SsoTokenAutoRefresher(ssoCache, observability)
 
         expect(Object.keys(sut['timeouts']).length).to.equal(0)
 
@@ -113,7 +120,7 @@ describe('SsoTokenAutoRefresher', () => {
 
     it('unwatch does nothing if ssoSessionName is not watched.', () => {
         const ssoCache = stubSsoCache(clientRegistration)
-        using sut = new SsoTokenAutoRefresher(ssoCache)
+        using sut = new SsoTokenAutoRefresher(ssoCache, observability)
 
         expect(Object.keys(sut['timeouts']).length).to.equal(0)
 

--- a/server/aws-lsp-identity/src/language-server/ssoTokenAutoRefresher.ts
+++ b/server/aws-lsp-identity/src/language-server/ssoTokenAutoRefresher.ts
@@ -1,6 +1,7 @@
 import { SsoSession, SsoTokenChangedParams } from '@aws/language-server-runtimes/protocol'
 import { RefreshingSsoCache, refreshWindowMillis, retryWindowMillis } from '../sso/cache/refreshingSsoCache'
 import { throwOnInvalidClientName, throwOnInvalidSsoSession, throwOnInvalidSsoSessionName } from '../sso/utils'
+import { Observability } from './utils'
 
 const bufferedRefreshWindowMillis = refreshWindowMillis * 0.95
 const bufferedRetryWindowMillis = retryWindowMillis * 1.05
@@ -12,7 +13,10 @@ export type RaiseSsoTokenChanged = (params: SsoTokenChangedParams) => void
 export class SsoTokenAutoRefresher implements Disposable {
     private readonly timeouts: Record<string, NodeJS.Timeout> = {}
 
-    constructor(private readonly ssoCache: RefreshingSsoCache) {}
+    constructor(
+        private readonly ssoCache: RefreshingSsoCache,
+        private readonly observability: Observability
+    ) {}
 
     [Symbol.dispose](): void {
         for (const ssoSessionName of Object.keys(this.timeouts)) {

--- a/server/aws-lsp-identity/src/language-server/utils.test.ts
+++ b/server/aws-lsp-identity/src/language-server/utils.test.ts
@@ -1,0 +1,34 @@
+import { expect, use } from 'chai'
+import { ensureSsoAccountAccessScope } from './utils'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+use(require('chai-as-promised'))
+
+describe('utils', () => {
+    describe('ensureSsoAccountAccessScope', () => {
+        it('Returns an array with sso:account:access if no scopes passed in', () => {
+            const actual = ensureSsoAccountAccessScope(undefined)
+
+            expect(actual).to.deep.equal(['sso:account:access'])
+        })
+
+        it('Returns an array with sso:account:access if empty scopes array passed in', () => {
+            const actual = ensureSsoAccountAccessScope([])
+
+            expect(actual).to.deep.equal(['sso:account:access'])
+        })
+
+        it('Returns an array with sso:account:access added if scopes passed in', () => {
+            const actual = ensureSsoAccountAccessScope(['this', 'that'])
+
+            expect(actual).to.deep.equal(['this', 'that', 'sso:account:access'])
+        })
+
+        it('Returns same array containing sso:account:access added if scopes with sso:account:access passed in', () => {
+            const scopes = ['this', 'that', 'sso:account:access']
+            const actual = ensureSsoAccountAccessScope(scopes)
+
+            expect(actual).to.deep.equal(scopes)
+        })
+    })
+})

--- a/server/aws-lsp-identity/src/language-server/utils.ts
+++ b/server/aws-lsp-identity/src/language-server/utils.ts
@@ -1,0 +1,67 @@
+import {
+    Chat,
+    CredentialsProvider,
+    IdentityManagement,
+    Logging,
+    Lsp,
+    Notification,
+    Runtime,
+    Workspace,
+    PartialInitializeResult,
+    Telemetry,
+} from '@aws/language-server-runtimes/server-interface'
+import { InitializeParams, HandlerResult, InitializeError } from 'vscode-languageserver'
+
+export function ensureSsoAccountAccessScope(scopes?: string[]): string[] {
+    const ssoAccountAccessScope = 'sso:account:access'
+
+    if (!scopes) {
+        scopes = [ssoAccountAccessScope]
+    } else if (!scopes.includes(ssoAccountAccessScope)) {
+        scopes.push(ssoAccountAccessScope)
+    }
+
+    return scopes
+}
+
+export interface ServerFeatures {
+    chat: Chat
+    credentialsProvider: CredentialsProvider
+    identityManagement: IdentityManagement
+    logging: Logging
+    lsp: Lsp
+    notification: Notification
+    runtime: Runtime
+    telemetry: Telemetry
+    workspace: Workspace
+}
+
+export interface Observability {
+    logging: Logging
+    telemetry: Telemetry
+}
+
+export abstract class ServerBase implements Disposable {
+    protected readonly observability: Observability
+    protected readonly disposables: (Disposable | (() => void))[] = []
+
+    constructor(protected readonly features: ServerFeatures) {
+        this.features.lsp.addInitializer(params => this.initialize(params))
+        this.observability = { logging: this.features.logging, telemetry: this.features.telemetry }
+    }
+
+    [Symbol.dispose]() {
+        let disposable
+        while ((disposable = this.disposables.pop())) {
+            if (disposable instanceof Function) {
+                disposable()
+            } else if (Object.hasOwn(disposable, Symbol.dispose)) {
+                disposable[Symbol.dispose]()
+            }
+        }
+    }
+
+    protected abstract initialize(
+        params: InitializeParams
+    ): HandlerResult<PartialInitializeResult<any>, InitializeError>
+}

--- a/server/aws-lsp-identity/src/language-server/utils.ts
+++ b/server/aws-lsp-identity/src/language-server/utils.ts
@@ -24,6 +24,8 @@ export function ensureSsoAccountAccessScope(scopes?: string[]): string[] {
     return scopes
 }
 
+// TODO In a future PR when schedule permits, migrate this to language-server-runtimes/server-interface/server
+// for reuse in Server type parameter
 export interface ServerFeatures {
     chat: Chat
     credentialsProvider: CredentialsProvider

--- a/server/aws-lsp-identity/src/sso/authorizationCodePkce/resources/auth.css
+++ b/server/aws-lsp-identity/src/sso/authorizationCodePkce/resources/auth.css
@@ -11,7 +11,7 @@ body {
     padding: 15px 30px;
     display: flex;
     flex-direction: column;
-    font-family: Verdana, Geneva, Tahoma, sans-serif;
+    font-family: 'Amazon Ember', 'Helvetica Neue', Roboto, Arial, sans-serif;
     font-size: 0.9rem;
     background-color: #f2f3f3;
     justify-content: center;
@@ -84,7 +84,7 @@ body {
 }
 
 .hint {
-    color: #545b64;
+    color: #16191f;
 }
 
 .aws-icon {

--- a/server/aws-lsp-identity/src/sso/authorizationCodePkce/resources/index.html
+++ b/server/aws-lsp-identity/src/sso/authorizationCodePkce/resources/index.html
@@ -56,7 +56,7 @@
                             <p id="errorMessage" class="hint"></p>
                         </div>
                     </div>
-                    <p class="hint">You can close this window and re-start the authorization flow</p>
+                    <p class="hint">You can close this window.</p>
                 </div>
             </div>
         </div>
@@ -70,11 +70,10 @@
                     return
                 }
 
-                const productName = 'AWS IDE Extensions for VS Code'
+                const clientName = params.get('clientName') || 'AWS Development Tools'
                 document.getElementById('approvalMessage').innerText =
-                    `${productName} have been given requested permissions`
-                document.getElementById('footerText').innerText =
-                    `You can close this window and start using ${productName}`
+                    `${clientName} has been given the requested permissions.`
+                document.getElementById('footerText').innerText = `You can close this window.`
 
                 function showErrorMessage(errorText) {
                     document.getElementById('approved-auth').classList.add('hidden')

--- a/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.test.ts
+++ b/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.test.ts
@@ -7,11 +7,15 @@ import { SsoClientRegistration } from './ssoCache'
 import { SsoSession } from '@aws/language-server-runtimes/server-interface'
 import { access } from 'fs/promises'
 import * as fs from 'fs'
+import { Observability } from '../../language-server/utils'
+import { StubbedInstance, stubInterface } from 'ts-sinon'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
 
-const sut = new FileSystemSsoCache()
+let sut: FileSystemSsoCache
+
+let observability: StubbedInstance<Observability>
 
 const ssoRegion = 'us-east-1'
 const ssoStartUrl = 'https://nowhere'
@@ -82,6 +86,12 @@ function expectFileExists(filename: string): Chai.Assertion {
 }
 
 describe('FileSystemSsoCache', () => {
+    beforeEach(() => {
+        observability = stubInterface<Observability>()
+
+        sut = new FileSystemSsoCache(observability)
+    })
+
     afterEach(() => {
         mock.restore()
     })

--- a/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.ts
+++ b/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.ts
@@ -5,12 +5,15 @@ import { AwsError } from '../../awsError'
 import { AwsErrorCodes, SsoSession } from '@aws/language-server-runtimes/server-interface'
 import { throwOnInvalidClientName, throwOnInvalidSsoSession, throwOnInvalidSsoSessionName } from '../utils'
 import path from 'path'
+import { Observability } from '../../language-server/utils'
 
 // As this is a cache, we tend to swallow a lot of the errors as it is ok to just recreate the items each
 // time, though recreating the SSO token without a refresh token will be every hour.  This is a better
 // situation that failing to get an SSO token at all.
 
 export class FileSystemSsoCache implements SsoCache {
+    constructor(private readonly observability: Observability) {}
+
     async getSsoClientRegistration(
         clientName: string,
         ssoSession: SsoSession

--- a/server/aws-lsp-identity/src/sso/cache/refreshingSsoCache.test.ts
+++ b/server/aws-lsp-identity/src/sso/cache/refreshingSsoCache.test.ts
@@ -6,11 +6,13 @@ import * as ssoUtils from '../utils'
 import { RefreshingSsoCache } from './refreshingSsoCache'
 import { SSOOIDC } from '@aws-sdk/client-sso-oidc'
 import { SSOToken } from '@smithy/shared-ini-file-loader'
+import { Observability } from '../../language-server/utils'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
 
 let ssoOidc: SSOOIDC & Disposable
+let observability: Observability
 
 const ssoSession = {
     name: 'my-sso-session',
@@ -70,6 +72,8 @@ describe('RefreshingSsoCache', () => {
         } as unknown as SSOOIDC & Disposable
 
         stub(ssoUtils, 'getSsoOidc').returns(ssoOidc)
+
+        observability = stubInterface<Observability>()
     })
 
     afterEach(() => {
@@ -79,7 +83,7 @@ describe('RefreshingSsoCache', () => {
     describe('getSsoClientRegistration', () => {
         it('Creates a new SSO client registration.', async () => {
             const ssoCache = stubSsoCache()
-            const sut = new RefreshingSsoCache(ssoCache, _ => {})
+            const sut = new RefreshingSsoCache(ssoCache, _ => {}, observability)
 
             const actual = await sut.getSsoClientRegistration('my-client-name', ssoSession)
 
@@ -93,7 +97,7 @@ describe('RefreshingSsoCache', () => {
         it('Updates an expired SSO client registration.', async () => {
             const clientRegistration = createSsoClientRegistration(-10000 /* expired */)
             const ssoCache = stubSsoCache(clientRegistration)
-            const sut = new RefreshingSsoCache(ssoCache, _ => {})
+            const sut = new RefreshingSsoCache(ssoCache, _ => {}, observability)
 
             const actual = await sut.getSsoClientRegistration('my-client-name', ssoSession)
 
@@ -109,7 +113,7 @@ describe('RefreshingSsoCache', () => {
     describe('getSsoToken', () => {
         it('Returns nothing on no cached SSO token.', async () => {
             const ssoCache = stubSsoCache()
-            const sut = new RefreshingSsoCache(ssoCache, _ => {})
+            const sut = new RefreshingSsoCache(ssoCache, _ => {}, observability)
 
             const actual = await sut.getSsoToken('my-client-name', ssoSession)
 
@@ -118,7 +122,7 @@ describe('RefreshingSsoCache', () => {
 
         it('Returns nothing on expired SSO token.', async () => {
             const ssoCache = stubSsoCache(createSsoClientRegistration(10000), createSsoToken(-10000))
-            const sut = new RefreshingSsoCache(ssoCache, _ => {})
+            const sut = new RefreshingSsoCache(ssoCache, _ => {}, observability)
 
             const actual = await sut.getSsoToken('my-client-name', ssoSession)
 
@@ -128,7 +132,7 @@ describe('RefreshingSsoCache', () => {
         it('Returns existing SSO token before refresh window (5 minutes before expiration).', async () => {
             const ssoToken = createSsoToken(6 * 60 * 1000 /* 6 minutes before */)
             const ssoCache = stubSsoCache(createSsoClientRegistration(10000), ssoToken)
-            const sut = new RefreshingSsoCache(ssoCache, _ => {})
+            const sut = new RefreshingSsoCache(ssoCache, _ => {}, observability)
 
             const actual = await sut.getSsoToken('my-client-name', ssoSession)
 
@@ -145,7 +149,7 @@ describe('RefreshingSsoCache', () => {
         it('Returns existing SSO token when refresh attempted recently (within 30 seconds).', async () => {
             const ssoToken = createSsoToken(3 * 60 * 1000 /* 3 minutes before */)
             const ssoCache = stubSsoCache(createSsoClientRegistration(10000), ssoToken)
-            const sut = new RefreshingSsoCache(ssoCache, _ => {})
+            const sut = new RefreshingSsoCache(ssoCache, _ => {}, observability)
             ;(sut as any).ssoTokenDetails[ssoSession.name] = {
                 lastRefreshMillis: Date.now() - 10000 /* 10 seconds ago */,
             }
@@ -166,7 +170,7 @@ describe('RefreshingSsoCache', () => {
             const ssoToken = createSsoToken(-10000)
             ssoToken.refreshToken = undefined
             const ssoCache = stubSsoCache(createSsoClientRegistration(10000), ssoToken)
-            const sut = new RefreshingSsoCache(ssoCache, _ => {})
+            const sut = new RefreshingSsoCache(ssoCache, _ => {}, observability)
 
             const actual = await sut.getSsoToken('my-client-name', ssoSession)
 
@@ -177,7 +181,7 @@ describe('RefreshingSsoCache', () => {
             const ssoToken = createSsoToken(4 * 60 * 1000 /* 4 minutes before */)
             const expiresAtMillis = Date.parse(ssoToken.expiresAt) // Save, token updated in-place
             const ssoCache = stubSsoCache(createSsoClientRegistration(10000), ssoToken)
-            const sut = new RefreshingSsoCache(ssoCache, _ => {})
+            const sut = new RefreshingSsoCache(ssoCache, _ => {}, observability)
 
             const actual = await sut.getSsoToken('my-client-name', ssoSession)
 

--- a/server/aws-lsp-identity/src/sso/cache/refreshingSsoCache.ts
+++ b/server/aws-lsp-identity/src/sso/cache/refreshingSsoCache.ts
@@ -10,6 +10,7 @@ import {
     throwOnInvalidSsoSessionName,
 } from '../utils'
 import { RaiseSsoTokenChanged } from '../../language-server/ssoTokenAutoRefresher'
+import { Observability } from '../../language-server/utils'
 
 export const refreshWindowMillis: number = 5 * 60 * 1000
 export const retryWindowMillis: number = 30000
@@ -22,8 +23,9 @@ export class RefreshingSsoCache implements SsoCache {
     private readonly ssoTokenDetails: Record<string, SsoTokenDetail> = {}
 
     constructor(
-        private next: SsoCache,
-        private readonly raiseSsoTokenChanged: RaiseSsoTokenChanged
+        private readonly next: SsoCache,
+        private readonly raiseSsoTokenChanged: RaiseSsoTokenChanged,
+        private readonly observability: Observability
     ) {}
 
     async getSsoClientRegistration(
@@ -145,11 +147,7 @@ export class RefreshingSsoCache implements SsoCache {
                 refreshToken: ssoToken.refreshToken,
             })
             .catch(reason => {
-                throw new AwsError(
-                    `Cannot refresh token [${ssoSession.name ?? 'null'}].`,
-                    AwsErrorCodes.E_CANNOT_REFRESH_SSO_TOKEN,
-                    { cause: reason }
-                )
+                throw new AwsError('Cannot refresh token.', AwsErrorCodes.E_CANNOT_REFRESH_SSO_TOKEN, { cause: reason })
             })
 
         UpdateSsoTokenFromCreateToken(result, clientRegistration, ssoSession, ssoToken)

--- a/server/aws-lsp-identity/src/sso/utils.ts
+++ b/server/aws-lsp-identity/src/sso/utils.ts
@@ -28,10 +28,7 @@ export function throwOnInvalidClientRegistration(
         !clientRegistration.scopes ||
         !clientRegistration.scopes.length
     ) {
-        throw new AwsError(
-            `Client registration [${clientRegistration?.clientId}] is invalid.`,
-            AwsErrorCodes.E_INVALID_SSO_CLIENT
-        )
+        throw new AwsError('Client registration is invalid.', AwsErrorCodes.E_INVALID_SSO_CLIENT)
     }
 }
 
@@ -51,7 +48,7 @@ export function throwOnInvalidSsoSession(
         !ssoSession.settings.sso_region?.trim() ||
         !ssoSession.settings.sso_start_url?.trim()
     ) {
-        throw new AwsError(`SSO session [${ssoSession?.name}] is invalid.`, AwsErrorCodes.E_INVALID_SSO_SESSION)
+        throw new AwsError('SSO session is invalid.', AwsErrorCodes.E_INVALID_SSO_SESSION)
     }
 }
 


### PR DESCRIPTION
identityActivation.ts only contains changes for validating during development.

Removed potential PII from error messages created by identity server.

ensureSsoAccountAccessScope added to ensure that sso:account:access scope is added to scopes if it doesn't exist before calls to registerClient and createToken.

Observability interface added that holds references to logging and telemetry features currently.  An instance of observability is plumbed through all aws-lsp-identity classes/functions that can emit logging/telemetry.  Actual log/emitMetric calls will be added in an upcoming PR.

Added a ServerBase and supporting types in language-server/utils.ts for making IdentityServer and future servers easier to write.

IdentityServer updated to be class extending ServerBase, IdentityServerFactory code moved into initialize() method almost verbatim.  Now retrieves clientName from InitializeParams.  Will remove clientName from protocol/identity-management in a future update.

Added support to cancel authorization webserver waiting if destination uses CancellationToken.

Minor style updates to success/failure web page (index.html) and now show client name instead of hard-coded VSC Toolkit as tool.


