### PR TITLE
[Amazon Q] TelemetryService bugfix: recalculate connetionType in shouldSendTelemetry event from credentialsProvider at invocation

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
@@ -162,7 +162,9 @@ describe('TelemetryService', () => {
     it('should not emit user trigger decision if login is invalid (IAM)', () => {
         telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', {} as Telemetry, {})
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
+
         telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
+
         sinon.assert.notCalled(invokeSendTelemetryEventStub)
     })
 
@@ -173,10 +175,40 @@ describe('TelemetryService', () => {
             },
         })
         telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
-        telemetryService.updateOptOutPreference('OPTOUT')
-        telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
+        telemetryService.updateOptOutPreference('OPTOUT')
+
+        telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
+
         sinon.assert.notCalled(invokeSendTelemetryEventStub)
+    })
+
+    it('should handle SSO connection type change at runtime', () => {
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
+        const sendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
+        telemetryService.updateOptOutPreference('OPTOUT') // Disables telemetry for builderId startUrl
+        mockCredentialsProvider.setConnectionMetadata({
+            sso: {
+                startUrl: 'https://some-random-test-idc-directory.awsapps.com',
+            },
+        })
+
+        // Emitting event with IdC connection
+        telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
+
+        sinon.assert.calledOnce(sendTelemetryEventStub)
+
+        // Switch to BuilderId connection
+        mockCredentialsProvider.setConnectionMetadata({
+            sso: {
+                startUrl: BUILDER_ID_START_URL,
+            },
+        })
+        sendTelemetryEventStub.resetHistory()
+
+        // Should not emit event anymore with BuilderId
+        telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
+        sinon.assert.notCalled(sendTelemetryEventStub)
     })
 
     it('should emit userTriggerDecision event correctly', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
@@ -21,7 +21,6 @@ export class TelemetryService extends CodeWhispererServiceToken {
     private optOutPreference!: OptOutPreference
     private enableTelemetryEventsToDestination!: boolean
     private telemetry: Telemetry
-    private ssoConnectionType: SsoConnectionType
     private credentialsType: CredentialsType
     private credentialsProvider: CredentialsProvider
 
@@ -47,7 +46,6 @@ export class TelemetryService extends CodeWhispererServiceToken {
         this.credentialsProvider = credentialsProvider
         this.credentialsType = credentialsType
         this.telemetry = telemetry
-        this.ssoConnectionType = getSsoConnectionType(credentialsProvider)
     }
 
     public updateUserContext(userContext: UserContext | undefined): void {
@@ -81,10 +79,12 @@ export class TelemetryService extends CodeWhispererServiceToken {
     }
 
     private shouldSendTelemetry(): boolean {
+        const ssoConnectionType = getSsoConnectionType(this.credentialsProvider)
+
         return (
             this.credentialsType === 'bearer' &&
-            ((this.ssoConnectionType === 'builderId' && this.optOutPreference === 'OPTIN') ||
-                this.ssoConnectionType === 'identityCenter')
+            ((ssoConnectionType === 'builderId' && this.optOutPreference === 'OPTIN') ||
+                ssoConnectionType === 'identityCenter')
         )
     }
 


### PR DESCRIPTION
## Problem
Condition in `TelemetryService.shouldSendTelemetry` uses flag value computed at object creating time in constructor using values from `CredentialsProvider`. Tokens and metadata in `CredentialsProvider` may be not available at Language Server starttime, or can change in runtime, which results in `shouldSendTelemetry` value being computed incorrectly.

When language server starts, it does not have credentials set by client, which results in `shouldSendTelemetry` always being falsy and not sending telemetry.

## Solution
Calculate `ssoConnectionType` on each `sentTelemetryEvent` invocation to use up to date data from `CredentialsProvider`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
