### PR TITLE
Add 'net9.0' to target framework map

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
@@ -31,6 +31,7 @@ export const targetFrameworkMap = new Map<string, string>([
     ['net6.0', 'NET_6_0'],
     ['net7.0', 'NET_7_0'],
     ['net8.0', 'NET_8_0'],
+    ['net9.0', 'NET_9_0'],
 ])
 
 const dummyVersionIndex = 999


### PR DESCRIPTION
## Problem
The converter for .NET transformation currently does not support .NET 9 as an option.

## Solution
A one-line addition to the `targetFrameworkMap` has been made that adds .NET 9 as an option for transformation.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
