### PR TITLE
Add logging to identity server

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "check:formatting": "prettier --check .",
         "format": "prettier --write .",
         "format-staged": "npx pretty-quick --staged",
-        "clean": "ts-node ./script/clean.ts",
+        "clean": "ts-node ./script/clean.ts && npm run clean --workspaces --if-present",
         "precompile": "npm run precompile --workspaces --if-present",
         "compile": "tsc --build --verbose && npm run compile:servers && npm run compile --workspaces --if-present",
         "compile:servers": "npm run compile --workspace=server --if-present",

--- a/server/aws-lsp-identity/src/language-server/identityServer.ts
+++ b/server/aws-lsp-identity/src/language-server/identityServer.ts
@@ -26,6 +26,7 @@ export class IdentityServer extends ServerBase {
     }
 
     static create(features: ServerFeatures): () => void {
+        features.logging.log('Creating identity server.')
         return new IdentityServer(features)[Symbol.dispose]
     }
 
@@ -62,6 +63,7 @@ export class IdentityServer extends ServerBase {
         this.features.identityManagement.onGetSsoToken(
             async (params: GetSsoTokenParams, token: CancellationToken) =>
                 await identityService.getSsoToken(params, token).catch(reason => {
+                    this.observability.logging.log(`GetSsoToken failed. ${reason}`)
                     throw awsResponseErrorWrap(reason)
                 })
         )
@@ -69,6 +71,7 @@ export class IdentityServer extends ServerBase {
         this.features.identityManagement.onInvalidateSsoToken(
             async (params: InvalidateSsoTokenParams, token: CancellationToken) =>
                 await identityService.invalidateSsoToken(params, token).catch(reason => {
+                    this.observability.logging.log(`InvalidateSsoToken failed. ${reason}`)
                     throw awsResponseErrorWrap(reason)
                 })
         )
@@ -76,6 +79,7 @@ export class IdentityServer extends ServerBase {
         this.features.identityManagement.onListProfiles(
             async (params: ListProfilesParams, token: CancellationToken) =>
                 await profileService.listProfiles(params, token).catch(reason => {
+                    this.observability.logging.log(`ListProfiles failed. ${reason}`)
                     throw awsResponseErrorWrap(reason)
                 })
         )
@@ -83,6 +87,7 @@ export class IdentityServer extends ServerBase {
         this.features.identityManagement.onUpdateProfile(
             async (params: UpdateProfileParams, token: CancellationToken) =>
                 await profileService.updateProfile(params, token).catch(reason => {
+                    this.observability.logging.log(`UpdateProfile failed. ${reason}`)
                     throw awsResponseErrorWrap(reason)
                 })
         )

--- a/server/aws-lsp-identity/src/language-server/identityService.test.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.test.ts
@@ -9,6 +9,7 @@ import { createStubInstance, restore, stub } from 'sinon'
 import { CancellationToken, ProfileKind, SsoTokenSourceKind } from '@aws/language-server-runtimes/protocol'
 import { SSOToken } from '@smithy/shared-ini-file-loader'
 import { Observability } from './utils'
+import { Logging, Telemetry } from '@aws/language-server-runtimes/server-interface'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
@@ -69,6 +70,10 @@ describe('IdentityService', () => {
                 expiresAt: new Date(Date.now() + 10 * 1000).toISOString(),
             } satisfies SSOToken)
         )
+
+        observability = stubInterface<Observability>()
+        observability.logging = stubInterface<Logging>()
+        observability.telemetry = stubInterface<Telemetry>()
 
         sut = new IdentityService(profileStore, ssoCache, autoRefresher, _ => {}, 'My Client', observability)
     })

--- a/server/aws-lsp-identity/src/language-server/profiles/profileService.test.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/profileService.test.ts
@@ -1,9 +1,11 @@
 import { ProfileData, profileDuckTypers, ProfileService, ProfileStore, ssoSessionDuckTyper } from './profileService'
 import {
     AwsErrorCodes,
+    Logging,
     Profile,
     ProfileKind,
     SsoSession,
+    Telemetry,
     UpdateProfileParams,
 } from '@aws/language-server-runtimes/server-interface'
 import { normalizeParsedIniData } from '../../sharedConfig/saveKnownFiles'
@@ -77,6 +79,8 @@ describe('ProfileService', async () => {
         })
 
         observability = stubInterface<Observability>()
+        observability.logging = stubInterface<Logging>()
+        observability.telemetry = stubInterface<Telemetry>()
 
         sut = new ProfileService(store, observability)
     })

--- a/server/aws-lsp-identity/src/language-server/profiles/profileService.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/profileService.ts
@@ -126,10 +126,12 @@ export class ProfileService {
 
         // Enforce options
         if (!options.createNonexistentProfile && !profiles.some(p => p.name === profile.name)) {
+            this.observability.logging.log(`Cannot create profile. options: ${JSON.stringify(options)}`)
             throw new AwsError('Cannot create profile.', AwsErrorCodes.E_CANNOT_CREATE_PROFILE)
         }
 
         if (!options.createNonexistentSsoSession && !ssoSessions.some(s => s.name === ssoSession.name)) {
+            this.observability.logging.log(`Cannot create sso-session. options: ${JSON.stringify(options)}`)
             throw new AwsError('Cannot create sso-session.', AwsErrorCodes.E_CANNOT_CREATE_SSO_SESSION)
         }
 
@@ -138,6 +140,7 @@ export class ProfileService {
             this.isSharedSsoSession(ssoSession.name, profiles, profile.name) &&
             this.willUpdateExistingSsoSession(ssoSession, ssoSessions)
         ) {
+            this.observability.logging.log(`Cannot update shared sso-session. options: ${JSON.stringify(options)}`)
             throw new AwsError('Cannot update shared sso-session.', AwsErrorCodes.E_CANNOT_OVERWRITE_SSO_SESSION)
         }
 
@@ -195,6 +198,7 @@ export class ProfileService {
 
     private throwOnInvalid(expr: boolean, message: string, awsErrorCode: string): void {
         if (expr) {
+            this.observability.logging.log(message)
             throw new AwsError(message, awsErrorCode)
         }
     }

--- a/server/aws-lsp-identity/src/language-server/profiles/sharedConfigProfileStore.test.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/sharedConfigProfileStore.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import { SharedConfigProfileStore } from './sharedConfigProfileStore'
 import { expect, use } from 'chai'
 import { ProfileData } from './profileService'
-import { ProfileKind } from '@aws/language-server-runtimes/server-interface'
+import { Logging, ProfileKind, Telemetry } from '@aws/language-server-runtimes/server-interface'
 import { StubbedInstance, stubInterface } from 'ts-sinon'
 import { Observability } from '../utils'
 
@@ -70,6 +70,8 @@ function setupTest(config: string, credentials: string): void {
 describe('SharedConfigProfileStore', async () => {
     beforeEach(() => {
         observability = stubInterface<Observability>()
+        observability.logging = stubInterface<Logging>()
+        observability.telemetry = stubInterface<Telemetry>()
 
         sut = new SharedConfigProfileStore(observability)
     })

--- a/server/aws-lsp-identity/src/language-server/profiles/sharedConfigProfileStore.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/sharedConfigProfileStore.ts
@@ -37,6 +37,7 @@ export class SharedConfigProfileStore implements ProfileStore {
 
         const parsedIni = normalizeParsedIniData(
             await parseKnownFiles(this.getSharedConfigInit(init)).catch(reason => {
+                this.observability.logging.log(`Unable to load shared config. ${reason}`)
                 throw AwsError.wrap(reason, AwsErrorCodes.E_CANNOT_READ_SHARED_CONFIG)
             })
         )
@@ -87,6 +88,7 @@ export class SharedConfigProfileStore implements ProfileStore {
             }
         }
 
+        this.observability.logging.log('Loaded shared config.')
         return result
     }
 
@@ -103,6 +105,7 @@ export class SharedConfigProfileStore implements ProfileStore {
         init = this.getSharedConfigInit(init)
         const parsedKnownFiles = normalizeParsedIniData(
             await parseKnownFiles(this.getSharedConfigInit(init)).catch(reason => {
+                this.observability.logging.log(`Unable to load shared config for saving. ${reason}`)
                 throw AwsError.wrap(reason, AwsErrorCodes.E_CANNOT_READ_SHARED_CONFIG)
             })
         )
@@ -128,8 +131,11 @@ export class SharedConfigProfileStore implements ProfileStore {
         }
 
         await saveKnownFiles(parsedKnownFiles, init).catch(reason => {
+            this.observability.logging.log(`Unable to save shared config. ${reason}`)
             throw AwsError.wrap(reason, AwsErrorCodes.E_CANNOT_WRITE_SHARED_CONFIG)
         })
+
+        this.observability.logging.log('Saved shared config.')
     }
 
     private applySectionsToParsedIni<T extends Section>(

--- a/server/aws-lsp-identity/src/language-server/ssoTokenAutoRefresher.test.ts
+++ b/server/aws-lsp-identity/src/language-server/ssoTokenAutoRefresher.test.ts
@@ -5,6 +5,7 @@ import { StubbedInstance, stubInterface } from 'ts-sinon'
 import { SsoClientRegistration, RefreshingSsoCache } from '../sso'
 import { restore, spy } from 'sinon'
 import { Observability } from './utils'
+import { Logging, Telemetry } from '@aws/language-server-runtimes/server-interface'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
@@ -52,6 +53,8 @@ function stubSsoCache(clientRegistration?: SsoClientRegistration, ssoToken?: SSO
 describe('SsoTokenAutoRefresher', () => {
     beforeEach(() => {
         observability = stubInterface<Observability>()
+        observability.logging = stubInterface<Logging>()
+        observability.telemetry = stubInterface<Telemetry>()
     })
 
     afterEach(() => {

--- a/server/aws-lsp-identity/src/language-server/ssoTokenAutoRefresher.ts
+++ b/server/aws-lsp-identity/src/language-server/ssoTokenAutoRefresher.ts
@@ -34,6 +34,9 @@ export class SsoTokenAutoRefresher implements Disposable {
 
         // Token doesn't exist, was invalidated by another process, or has expired
         if (!ssoToken) {
+            this.observability.logging.log(
+                'SSO token does not exist, was invalidated, or has expired and will not be auto-refreshed.'
+            )
             return
         }
 
@@ -51,9 +54,11 @@ export class SsoTokenAutoRefresher implements Disposable {
             delayMillis += Math.random() * maxRetryJitterMillis // Jitter to mitigate race conditions
         } else {
             // Otherwise, expired
+            this.observability.logging.log('SSO token has expired and will not be auto-refreshed.')
             return
         }
 
+        this.observability.logging.log(`Auto-refreshing SSO token in ${delayMillis} milliseconds.`)
         this.timeouts[ssoSession.name] = setTimeout(this.watch.bind(this, clientName, ssoSession), delayMillis)
     }
 
@@ -64,6 +69,7 @@ export class SsoTokenAutoRefresher implements Disposable {
         if (timeout) {
             clearTimeout(timeout)
             delete this.timeouts[ssoSessionName]
+            this.observability.logging.log('SSO token unwatched and will not be auto-refreshed.')
         }
     }
 }

--- a/server/aws-lsp-identity/src/language-server/utils.ts
+++ b/server/aws-lsp-identity/src/language-server/utils.ts
@@ -9,8 +9,10 @@ import {
     Workspace,
     PartialInitializeResult,
     Telemetry,
+    InitializeParams,
+    HandlerResult,
+    InitializeError,
 } from '@aws/language-server-runtimes/server-interface'
-import { InitializeParams, HandlerResult, InitializeError } from 'vscode-languageserver'
 
 export function ensureSsoAccountAccessScope(scopes?: string[]): string[] {
     const ssoAccountAccessScope = 'sso:account:access'

--- a/server/aws-lsp-identity/src/sso/authorizationCodePkce/authorizationCodePkceFlow.test.ts
+++ b/server/aws-lsp-identity/src/sso/authorizationCodePkce/authorizationCodePkceFlow.test.ts
@@ -8,6 +8,7 @@ import { CancellationToken, SsoSession } from '@aws/language-server-runtimes/pro
 import * as ssoUtils from '../utils'
 import { authorizationCodePkceFlow } from './authorizationCodePkceFlow'
 import { Observability } from '../../language-server/utils'
+import { Logging, Telemetry } from '@aws/language-server-runtimes/server-interface'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
@@ -56,6 +57,8 @@ describe('authorizationCodePkceFlow', () => {
         stub(ssoUtils, 'getSsoOidc').returns(ssoOidc)
 
         observability = stubInterface<Observability>()
+        observability.logging = stubInterface<Logging>()
+        observability.telemetry = stubInterface<Telemetry>()
     })
 
     afterEach(() => {

--- a/server/aws-lsp-identity/src/sso/authorizationCodePkce/authorizationCodePkceFlow.ts
+++ b/server/aws-lsp-identity/src/sso/authorizationCodePkce/authorizationCodePkceFlow.ts
@@ -43,12 +43,17 @@ export async function authorizationCodePkceFlow(
     }).toString()
 
     // Wait for user in browser flow
+    observability.logging.log(`Requesting ${clientName} to open SSO OIDC authorization login website.`)
     showUrl(authorizeUrl)
+
+    observability.logging.log('Waiting for authorization code...')
     const authorizationCode = await authServer.authorizationCode()
+    observability.logging.log('Authorization code returned.')
 
     // If success, call CreateToken
     using oidc = getSsoOidc(ssoSession.settings.sso_region)
 
+    observability.logging.log('Calling SSO OIDC to create SSO token.')
     const result = await oidc.createToken({
         clientId: clientRegistration.clientId,
         clientSecret: clientRegistration.clientSecret,
@@ -58,6 +63,7 @@ export async function authorizationCodePkceFlow(
         code: authorizationCode,
     })
 
+    observability.logging.log('Storing and returning created SSO token.')
     return UpdateSsoTokenFromCreateToken(result, clientRegistration, ssoSession)
 }
 

--- a/server/aws-lsp-identity/src/sso/authorizationCodePkce/authorizationServer.test.ts
+++ b/server/aws-lsp-identity/src/sso/authorizationCodePkce/authorizationServer.test.ts
@@ -3,6 +3,7 @@ import { AuthorizationServer } from './authorizationServer'
 import * as http from 'http'
 import { stubInterface } from 'ts-sinon'
 import { Observability } from '../../language-server/utils'
+import { Logging, Telemetry } from '@aws/language-server-runtimes/server-interface'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
@@ -27,6 +28,8 @@ async function httpGet(options: string | URL): Promise<{ data: string; statusCod
 
 function startAuthorizationServer(): Promise<AuthorizationServer> {
     const observability = stubInterface<Observability>()
+    observability.logging = stubInterface<Logging>()
+    observability.telemetry = stubInterface<Telemetry>()
 
     return AuthorizationServer.start('My Client', observability)
 }

--- a/server/aws-lsp-identity/src/sso/authorizationCodePkce/authorizationServer.ts
+++ b/server/aws-lsp-identity/src/sso/authorizationCodePkce/authorizationServer.ts
@@ -41,15 +41,18 @@ export class AuthorizationServer implements Disposable {
             !Object.hasOwn(address, 'address') ||
             !Object.hasOwn(address, 'port')
         ) {
-            throw new AwsError('Local server address not found.', AwsErrorCodes.E_CANNOT_CREATE_SSO_TOKEN)
+            this.observability.logging.log('Local authorization web server address not found.')
+            throw new AwsError(
+                'Local authorization web server address not found.',
+                AwsErrorCodes.E_CANNOT_CREATE_SSO_TOKEN
+            )
         }
 
         this.origin = `http://${address.address}:${address.port}`
         this.#redirectUri = `${this.origin}${AuthorizationServer.authorizationPath}`
 
         // Set up authorization code promise
-        let authResolve,
-            authReject = undefined
+        let authResolve, authReject
         this.authPromise = new Promise<string>((resolve, reject) => {
             authResolve = resolve
             authReject = reject
@@ -63,6 +66,7 @@ export class AuthorizationServer implements Disposable {
     }
 
     async [Symbol.dispose]() {
+        this.observability.logging.log('Disposing of local authorization web server.')
         this.httpServer.closeAllConnections()
         this.httpServer.close()
     }
@@ -73,12 +77,14 @@ export class AuthorizationServer implements Disposable {
         httpServer?: Server,
         token?: CancellationToken
     ): Promise<AuthorizationServer> {
+        observability.logging.log('Starting local authorization web server...')
         httpServer ||= http.createServer()
 
         // Wait for server to start listening
         await new Promise<void>(resolve => {
             httpServer!.once('listening', resolve)
             httpServer!.listen(0, '127.0.0.1')
+            observability.logging.log('Local authorization web server started.')
         })
 
         return new AuthorizationServer(clientName, observability, httpServer, token)
@@ -89,6 +95,7 @@ export class AuthorizationServer implements Disposable {
     }
 
     private async requesterListener(req: IncomingMessage, res: ServerResponse): Promise<void> {
+        this.observability.logging.log('Web request received on local authorization web server.')
         if (!req.url) {
             return
         }
@@ -103,6 +110,7 @@ export class AuthorizationServer implements Disposable {
     }
 
     private authorizationRequest(req: IncomingMessage, res: ServerResponse) {
+        this.observability.logging.log('Authorization web request received on local authorization web server.')
         if (!req.url) {
             return
         }
@@ -112,40 +120,48 @@ export class AuthorizationServer implements Disposable {
 
             const error = searchParams.get('error')
             if (error) {
+                this.observability.logging.log(`Error on authorization redirect: ${error}`)
                 throw new Error(`${error}: ${searchParams.get('error_description') ?? 'No description'}`)
             }
 
             const code = searchParams.get('code')
             if (!code) {
+                this.observability.logging.log('Authorization code not found.')
                 throw new Error('Authorization code not found.')
             }
 
             const state = searchParams.get('state')
             if (!state) {
+                this.observability.logging.log('CSRF state not found.')
                 throw new Error('CSRF state not found.')
             }
 
             if (state !== this.csrfState) {
+                this.observability.logging.log('CSRF state is invalid.')
                 throw new Error('CSRF state is invalid.')
             }
 
             try {
                 this.redirect(res)
             } finally {
+                this.observability.logging.log('Authorization code returned.')
                 this.authResolve(code)
             }
         } catch (error) {
             try {
                 this.redirect(res, error?.toString())
             } finally {
+                this.observability.logging.log('Authorization redirect failed.')
                 this.authReject(error)
             }
         }
     }
 
     private redirect(res: ServerResponse, error?: string) {
+        this.observability.logging.log('Redirecting to local web page.')
         let redirectUri = `${this.origin}/index.html?clientName=${this.clientName}`
         if (error) {
+            this.observability.logging.log(`Redirecting to local web page with error: ${error}.`)
             redirectUri += `?${new URLSearchParams({ error })}`
         }
 

--- a/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.test.ts
+++ b/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.test.ts
@@ -4,7 +4,7 @@ import { expect, use } from 'chai'
 import { DirectoryItems } from 'mock-fs/lib/filesystem'
 import { getSSOTokenFilepath, SSOToken } from '@smithy/shared-ini-file-loader'
 import { SsoClientRegistration } from './ssoCache'
-import { SsoSession } from '@aws/language-server-runtimes/server-interface'
+import { Logging, SsoSession, Telemetry } from '@aws/language-server-runtimes/server-interface'
 import { access } from 'fs/promises'
 import * as fs from 'fs'
 import { Observability } from '../../language-server/utils'
@@ -88,6 +88,8 @@ function expectFileExists(filename: string): Chai.Assertion {
 describe('FileSystemSsoCache', () => {
     beforeEach(() => {
         observability = stubInterface<Observability>()
+        observability.logging = stubInterface<Logging>()
+        observability.telemetry = stubInterface<Telemetry>()
 
         sut = new FileSystemSsoCache(observability)
     })

--- a/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.ts
+++ b/server/aws-lsp-identity/src/sso/cache/fileSystemSsoCache.ts
@@ -7,10 +7,6 @@ import { throwOnInvalidClientName, throwOnInvalidSsoSession, throwOnInvalidSsoSe
 import path from 'path'
 import { Observability } from '../../language-server/utils'
 
-// As this is a cache, we tend to swallow a lot of the errors as it is ok to just recreate the items each
-// time, though recreating the SSO token without a refresh token will be every hour.  This is a better
-// situation that failing to get an SSO token at all.
-
 export class FileSystemSsoCache implements SsoCache {
     constructor(private readonly observability: Observability) {}
 
@@ -18,11 +14,11 @@ export class FileSystemSsoCache implements SsoCache {
         clientName: string,
         ssoSession: SsoSession
     ): Promise<SsoClientRegistration | undefined> {
-        const id = toSsoClientRegistrationCacheId(clientName, ssoSession)
+        const id = this.toSsoClientRegistrationCacheId(clientName, ssoSession)
 
-        return await await getSsoClientRegistrationFromFile(id)
+        return await getSsoClientRegistrationFromFile(id)
             .then(registration => (ssoClientRegistrationDuckTyper.eval(registration) ? registration : undefined))
-            .catch(reason => ignoreDoesNotExistOrThrow(reason))
+            .catch(reason => this.ignoreDoesNotExistOrThrow(reason))
     }
 
     async setSsoClientRegistration(
@@ -30,9 +26,10 @@ export class FileSystemSsoCache implements SsoCache {
         ssoSession: SsoSession,
         clientRegistration: SsoClientRegistration
     ): Promise<void> {
-        const id = toSsoClientRegistrationCacheId(clientName, ssoSession)
+        const id = this.toSsoClientRegistrationCacheId(clientName, ssoSession)
 
         await writeSsoObjectToFile(id, clientRegistration).catch(reason => {
+            this.observability.logging.log('Cannot write to SSO cache.')
             throw AwsError.wrap(reason, AwsErrorCodes.E_CANNOT_WRITE_SSO_CACHE)
         })
     }
@@ -40,7 +37,7 @@ export class FileSystemSsoCache implements SsoCache {
     async removeSsoToken(ssoSessionName: string): Promise<void> {
         throwOnInvalidSsoSessionName(ssoSessionName)
 
-        await unlink(getSSOTokenFilepath(ssoSessionName)).catch(reason => ignoreDoesNotExistOrThrow(reason))
+        await unlink(getSSOTokenFilepath(ssoSessionName)).catch(reason => this.ignoreDoesNotExistOrThrow(reason))
     }
 
     async getSsoToken(clientName: string, ssoSession: SsoSession): Promise<SSOToken | undefined> {
@@ -48,13 +45,14 @@ export class FileSystemSsoCache implements SsoCache {
 
         return await getSSOTokenFromFile(ssoSession.name)
             .then(ssoToken => (ssoTokenDuckTyper.eval(ssoToken) ? ssoToken : undefined))
-            .catch(reason => ignoreDoesNotExistOrThrow(reason))
+            .catch(reason => this.ignoreDoesNotExistOrThrow(reason))
     }
 
     async setSsoToken(clientName: string, ssoSession: SsoSession, ssoToken: SSOToken): Promise<void> {
         throwOnInvalidSsoSession(ssoSession)
 
         if (!ssoTokenDuckTyper.eval(ssoToken)) {
+            this.observability.logging.log('File read from SSO cache is not an SSO token.')
             return
         }
 
@@ -62,27 +60,28 @@ export class FileSystemSsoCache implements SsoCache {
             throw AwsError.wrap(reason, AwsErrorCodes.E_CANNOT_WRITE_SSO_CACHE)
         })
     }
-}
 
-function ignoreDoesNotExistOrThrow(error: unknown): Promise<undefined> {
-    // Error codes are consistent across OSes (Windows is converted to libuv error codes)
-    // https://nodejs.org/api/errors.html#errorerrno
-    if ((error as SystemError)?.code === 'ENOENT') {
-        return Promise.resolve(undefined)
+    private ignoreDoesNotExistOrThrow(error: unknown): Promise<undefined> {
+        // Error codes are consistent across OSes (Windows is converted to libuv error codes)
+        // https://nodejs.org/api/errors.html#errorerrno
+        if ((error as SystemError)?.code === 'ENOENT') {
+            return Promise.resolve(undefined)
+        }
+
+        this.observability.logging.log('Cannot read SSO cache.')
+        throw AwsError.wrap(error as Error, AwsErrorCodes.E_CANNOT_READ_SSO_CACHE)
     }
 
-    throw AwsError.wrap(error as Error, AwsErrorCodes.E_CANNOT_READ_SSO_CACHE)
-}
+    private toSsoClientRegistrationCacheId(clientName: string, ssoSession: SsoSession): string {
+        throwOnInvalidClientName(clientName)
+        throwOnInvalidSsoSession(ssoSession)
 
-function toSsoClientRegistrationCacheId(clientName: string, ssoSession: SsoSession): string {
-    throwOnInvalidClientName(clientName)
-    throwOnInvalidSsoSession(ssoSession)
-
-    return JSON.stringify({
-        region: ssoSession.settings.sso_region,
-        startUrl: ssoSession.settings.sso_start_url,
-        tool: clientName,
-    })
+        return JSON.stringify({
+            region: ssoSession.settings.sso_region,
+            startUrl: ssoSession.settings.sso_start_url,
+            tool: clientName,
+        })
+    }
 }
 
 // Based on:

--- a/server/aws-lsp-identity/src/sso/cache/refreshingSsoCache.test.ts
+++ b/server/aws-lsp-identity/src/sso/cache/refreshingSsoCache.test.ts
@@ -7,6 +7,7 @@ import { RefreshingSsoCache } from './refreshingSsoCache'
 import { SSOOIDC } from '@aws-sdk/client-sso-oidc'
 import { SSOToken } from '@smithy/shared-ini-file-loader'
 import { Observability } from '../../language-server/utils'
+import { Logging, Telemetry } from '@aws/language-server-runtimes/server-interface'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 use(require('chai-as-promised'))
@@ -74,6 +75,8 @@ describe('RefreshingSsoCache', () => {
         stub(ssoUtils, 'getSsoOidc').returns(ssoOidc)
 
         observability = stubInterface<Observability>()
+        observability.logging = stubInterface<Logging>()
+        observability.telemetry = stubInterface<Telemetry>()
     })
 
     afterEach(() => {


### PR DESCRIPTION
Added logging throughout the aws-lsp-identity server.

Moved a couple of functions to methods in fileSystemSsoCache.ts to make logging easier.  These functions did not need to be separate as they're used exclusively by the FileSystemSsoCache class.