### PR TITLE
VSCode Client: attach textDocument context to chat requests

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -23,6 +23,7 @@
         "onLanguage:java",
         "onLanguage:python",
         "onLanguage:partiql",
+        "onLanguage:csharp",
         "onCommand:aws.sample-vscode-ext-amazonq.accept"
     ],
     "contributes": {

--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -95,6 +95,8 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
             // typescript is illustrative of code-handling language servers
             { scheme: 'file', language: 'typescript' },
             { scheme: 'untitled', language: 'typescript' },
+            { scheme: 'file', language: 'javascript' },
+            { scheme: 'untitled', language: 'javascript' },
             // java is illustrative of code-handling language servers
             { scheme: 'file', language: 'java' },
             { scheme: 'untitled', language: 'java' },
@@ -131,6 +133,8 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
             { scheme: 'untitled', language: 'systemverilog' },
             { scheme: 'file', language: 'vue' },
             { scheme: 'untitled', language: 'vue' },
+            { scheme: 'file', language: 'csharp' },
+            { scheme: 'untitled', language: 'csharp' },
         ],
         initializationOptions: {
             aws: {

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -84,6 +84,14 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri, 
                     handlePartialResult<ChatResult>(partialResult, encryptionKey, panel, message.params.tabId)
                 )
 
+                const editor =
+                    window.activeTextEditor ||
+                    window.visibleTextEditors.find(editor => editor.document.languageId != 'Log')
+                if (editor) {
+                    message.params.cursorPosition = [editor.selection.active]
+                    message.params.textDocument = { uri: editor.document.uri.toString() }
+                }
+
                 const chatRequest = await encryptRequest<ChatParams>(message.params, encryptionKey)
                 const chatResult = await languageClient.sendRequest(chatRequestType, {
                     ...chatRequest,

--- a/client/vscode/src/inlineCompletionActivation.ts
+++ b/client/vscode/src/inlineCompletionActivation.ts
@@ -21,6 +21,7 @@ import {
 
 export const CodewhispererInlineCompletionLanguages = [
     { scheme: 'file', language: 'typescript' },
+    { scheme: 'file', language: 'javascript' },
     { scheme: 'file', language: 'json' },
     { scheme: 'file', language: 'yaml' },
     { scheme: 'file', language: 'java' },
@@ -39,6 +40,7 @@ export const CodewhispererInlineCompletionLanguages = [
     { scheme: 'file', language: 'systemverilog' },
     { scheme: 'file', language: 'scala' },
     { scheme: 'file', language: 'vue' },
+    { scheme: 'file', language: 'csharp' },
 ]
 
 export function registerInlineCompletion(languageClient: LanguageClient) {


### PR DESCRIPTION
## Problem
Chat integration in sample VSCode extension does not pass active text document as context for requests. We can't fully test context collection in Language Servers.

## Solution
Add active text document or first visible non-log document as parameter for chat prompt requests from the client VSCode extension.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
