### PR TITLE
Add 'netstandard2.0' to target framework map

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
@@ -32,6 +32,7 @@ export const targetFrameworkMap = new Map<string, string>([
     ['net7.0', 'NET_7_0'],
     ['net8.0', 'NET_8_0'],
     ['net9.0', 'NET_9_0'],
+    ['netstandard2.0', 'NET_STANDARD_2_0'],
 ])
 
 const dummyVersionIndex = 999


### PR DESCRIPTION
## Problem

The converter for .NET transformation currently does not support .NET Standard 2.0 as an option.

## Solution

A one-line addition to the `targetFrameworkMap` has been made that adds .NET Standard 2.0 as an option for transformation.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
