### PR TITLE
Add logging support in case of failures from STE call

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -6,6 +6,7 @@ import {
     TextDocument,
     CredentialsProvider,
     Telemetry,
+    Logging,
 } from '@aws/language-server-runtimes/server-interface'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as assert from 'assert'
@@ -62,6 +63,12 @@ describe('ChatController', () => {
         onCancellationRequested: () => ({ dispose: () => null }),
     }
 
+    const logging: Logging = {
+        log: (message: string) => {
+            console.log(message)
+        },
+    }
+
     let sendMessageStub: sinon.SinonStub
     let disposeStub: sinon.SinonStub
     let activeTabSpy: {
@@ -113,7 +120,7 @@ describe('ChatController', () => {
             }),
         }
 
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
         invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
         chatController = new ChatController(chatSessionManagementService, testFeatures, telemetryService)
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -299,6 +299,7 @@ export const CodewhispererServerFactory =
             credentialsProvider,
             codeWhispererService.getCredentialsType(),
             telemetry,
+            logging,
             {}
         )
 

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -11,7 +11,7 @@ export const QChatServer =
         const { chat, credentialsProvider, telemetry, logging, lsp, runtime } = features
 
         const chatSessionManagementService: ChatSessionManagementService = service(credentialsProvider)
-        const telemetryService = new TelemetryService(credentialsProvider, 'bearer', telemetry, {})
+        const telemetryService = new TelemetryService(credentialsProvider, 'bearer', telemetry, logging, {})
 
         const chatController = new ChatController(chatSessionManagementService, features, telemetryService)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
@@ -5,6 +5,7 @@ import {
     CredentialsProvider,
     CredentialsType,
     IamCredentials,
+    Logging,
     Telemetry,
 } from '@aws/language-server-runtimes/server-interface'
 import {
@@ -56,6 +57,11 @@ describe('TelemetryService', () => {
     let clock: sinon.SinonFakeTimers
     let telemetryService: TelemetryService
     let mockCredentialsProvider: MockCredentialsProvider
+    const logging: Logging = {
+        log: (message: string) => {
+            console.log(message)
+        },
+    }
     const mockSession: Partial<CodeWhispererSession> = {
         codewhispererSessionId: 'test-session-id',
         responseContext: {
@@ -97,7 +103,7 @@ describe('TelemetryService', () => {
     })
 
     it('updateUserContext updates the userContext property', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
         const mockUserContext: UserContext = {
             clientId: 'aaaabbbbccccdddd',
             ideCategory: 'ECLIPSE',
@@ -111,7 +117,7 @@ describe('TelemetryService', () => {
     })
 
     it('updateOptOutPreference updates the optOutPreference property', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
         const mockOptOutPreference: OptOutPreference = 'OPTIN'
         telemetryService.updateOptOutPreference(mockOptOutPreference)
 
@@ -119,14 +125,14 @@ describe('TelemetryService', () => {
     })
 
     it('updateEnableTelemetryEventsToDestination updates the enableTelemetryEventsToDestination property', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
         telemetryService.updateEnableTelemetryEventsToDestination(true)
 
         sinon.assert.match((telemetryService as any).enableTelemetryEventsToDestination, true)
     })
 
     it('getSuggestionState fetches the suggestion state from CodeWhispererSession', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
         const getSuggestionState = (telemetryService as any).getSuggestionState.bind(telemetryService)
         let session = {
             getAggregatedUserTriggerDecision: () => {
@@ -167,7 +173,7 @@ describe('TelemetryService', () => {
     })
 
     it('should not emit user trigger decision if login is invalid (IAM)', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', {} as Telemetry, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', {} as Telemetry, logging, {})
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
 
         telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
@@ -181,7 +187,7 @@ describe('TelemetryService', () => {
                 startUrl: BUILDER_ID_START_URL,
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
         telemetryService.updateOptOutPreference('OPTOUT')
 
@@ -191,8 +197,10 @@ describe('TelemetryService', () => {
     })
 
     it('should handle SSO connection type change at runtime', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
-        const sendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+        const sendTelemetryEventStub: sinon.SinonStub = sinon
+            .stub(telemetryService, 'sendTelemetryEvent' as any)
+            .returns(Promise.resolve())
         telemetryService.updateOptOutPreference('OPTOUT') // Disables telemetry for builderId startUrl
         mockCredentialsProvider.setConnectionMetadata({
             sso: {
@@ -245,8 +253,10 @@ describe('TelemetryService', () => {
                 startUrl: 'idc-start-url',
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
-        const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+        const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
+            .stub(telemetryService, 'sendTelemetryEvent' as any)
+            .returns(Promise.resolve())
         telemetryService.updateOptOutPreference('OPTIN')
 
         telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
@@ -266,8 +276,10 @@ describe('TelemetryService', () => {
                     startUrl: 'idc-start-url',
                 },
             })
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
-            invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+            invokeSendTelemetryEventStub = sinon
+                .stub(telemetryService, 'sendTelemetryEvent' as any)
+                .returns(Promise.resolve())
         })
 
         afterEach(() => {
@@ -324,7 +336,7 @@ describe('TelemetryService', () => {
         })
 
         it('should not send InteractWithMessage when credentialsType is IAM', () => {
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', {} as Telemetry, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', {} as Telemetry, logging, {})
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             const metric = {
                 cwsprChatMessageId: 'message123',
@@ -347,7 +359,7 @@ describe('TelemetryService', () => {
                     startUrl: BUILDER_ID_START_URL,
                 },
             })
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.updateOptOutPreference('OPTOUT')
             const metric = {
@@ -415,8 +427,10 @@ describe('TelemetryService', () => {
                 startUrl: 'idc-start-url',
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
-        const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+        const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
+            .stub(telemetryService, 'sendTelemetryEvent' as any)
+            .returns(Promise.resolve())
         telemetryService.updateOptOutPreference('OPTIN')
 
         telemetryService.emitCodeCoverageEvent({
@@ -441,8 +455,10 @@ describe('TelemetryService', () => {
                     startUrl: 'idc-start-url',
                 },
             })
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
-            invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+            invokeSendTelemetryEventStub = sinon
+                .stub(telemetryService, 'sendTelemetryEvent' as any)
+                .returns(Promise.resolve())
         })
 
         afterEach(() => {
@@ -487,6 +503,7 @@ describe('TelemetryService', () => {
                     },
                 },
             }
+
             sinon.assert.calledOnceWithExactly(invokeSendTelemetryEventStub, expectedEvent)
         })
 
@@ -507,7 +524,7 @@ describe('TelemetryService', () => {
         })
 
         it('should not send ChatAddMessage when credentialsType is IAM', () => {
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', {} as Telemetry, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', {} as Telemetry, logging, {})
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.emitChatAddMessage({
                 conversationId: 'conv123',
@@ -523,7 +540,7 @@ describe('TelemetryService', () => {
                     startUrl: BUILDER_ID_START_URL,
                 },
             })
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.updateOptOutPreference('OPTOUT')
             telemetryService.emitChatAddMessage({

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
@@ -1,5 +1,10 @@
 import { CodeWhispererServiceToken } from './codeWhispererService'
-import { CredentialsProvider, CredentialsType, Telemetry } from '@aws/language-server-runtimes/server-interface'
+import {
+    CredentialsProvider,
+    CredentialsType,
+    Logging,
+    Telemetry,
+} from '@aws/language-server-runtimes/server-interface'
 import { CodeWhispererSession } from './session/sessionManager'
 import {
     SuggestionState,
@@ -14,7 +19,7 @@ import {
     ChatAddMessageEvent,
     UserIntent,
 } from '../client/token/codewhispererbearertokenclient'
-import { getCompletionType, getSsoConnectionType, SsoConnectionType } from './utils'
+import { getCompletionType, getSsoConnectionType, isAwsError } from './utils'
 import { ChatInteractionType, InteractWithMessageEvent } from './telemetry/types'
 import { CodewhispererLanguage, getRuntimeLanguage } from './languageDetection'
 
@@ -25,6 +30,7 @@ export class TelemetryService extends CodeWhispererServiceToken {
     private telemetry: Telemetry
     private credentialsType: CredentialsType
     private credentialsProvider: CredentialsProvider
+    private logging: Logging
 
     private readonly cwInteractionTypeMap: Record<ChatInteractionType, ChatMessageInteractionType> = {
         [ChatInteractionType.InsertAtCursor]: 'INSERT_AT_CURSOR',
@@ -42,12 +48,14 @@ export class TelemetryService extends CodeWhispererServiceToken {
         credentialsProvider: CredentialsProvider,
         credentialsType: CredentialsType,
         telemetry: Telemetry,
+        logging: Logging,
         additionalAwsConfig: AWS.ConfigurationOptions = {}
     ) {
         super(credentialsProvider, additionalAwsConfig)
         this.credentialsProvider = credentialsProvider
         this.credentialsType = credentialsType
         this.telemetry = telemetry
+        this.logging = logging
     }
 
     public updateUserContext(userContext: UserContext | undefined): void {
@@ -90,6 +98,17 @@ export class TelemetryService extends CodeWhispererServiceToken {
         )
     }
 
+    private logSendTelemetryEventFailure(error: any) {
+        let requestId: string | undefined
+        if (isAwsError(error)) {
+            requestId = error.requestId
+        }
+
+        this.logging.log(
+            `Failed to sendTelemetryEvent to CodeWhisperer, requestId: ${requestId ?? ''}, message: ${error.message}`
+        )
+    }
+
     private invokeSendTelemetryEvent(event: TelemetryEvent) {
         if (!this.shouldSendTelemetry()) {
             return
@@ -104,7 +123,7 @@ export class TelemetryService extends CodeWhispererServiceToken {
             request.optOutPreference = this.optOutPreference
         }
 
-        this.sendTelemetryEvent(request)
+        this.sendTelemetryEvent(request).then().catch(this.logSendTelemetryEventFailure)
     }
 
     private getCWClientTelemetryInteractionType(interactionType: ChatInteractionType): ChatMessageInteractionType {


### PR DESCRIPTION
## Problem
Add logging support for error in case of failures from Send Telemetry Event API call. 

## Solution
The approach applies the same method of handling error as has been done for vscode. Reference: [link](https://github.com/aws/aws-toolkit-vscode/blob/77bd8a75539c7b1b7ba3c6489861babe4a986753/packages/core/src/codewhispererChat/controllers/chat/telemetryHelper.ts#L342)

It logs an error message with the requestId, if the error is of the type of AWS Error. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
