### PR TITLE
Fixed build in another dependent environment for error TS2742

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -554,18 +554,6 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/abort-controller": {
-            "version": "3.1.5",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/config-resolver": {
             "version": "3.0.9",
             "dev": true,
@@ -677,46 +665,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-http-handler": {
-            "version": "3.2.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.1.5",
-                "@smithy/protocol-http": "^4.1.4",
-                "@smithy/querystring-builder": "^3.0.7",
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.7",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/service-error-classification": {
             "version": "3.0.7",
             "dev": true,
@@ -738,17 +686,6 @@
                 "@smithy/protocol-http": "^4.1.4",
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-stream": "^3.1.9",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -838,17 +775,6 @@
             "dependencies": {
                 "@smithy/service-error-classification": "^3.0.7",
                 "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1092,17 +1018,6 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/abort-controller": {
-            "version": "3.1.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-s3/node_modules/@smithy/config-resolver": {
             "version": "3.0.9",
             "license": "Apache-2.0",
@@ -1206,43 +1121,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/node-http-handler": {
-            "version": "3.2.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.1.5",
-                "@smithy/protocol-http": "^4.1.4",
-                "@smithy/querystring-builder": "^3.0.7",
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.7",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-s3/node_modules/@smithy/service-error-classification": {
             "version": "3.0.7",
             "license": "Apache-2.0",
@@ -1262,16 +1140,6 @@
                 "@smithy/protocol-http": "^4.1.4",
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-stream": "^3.1.9",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1354,16 +1222,6 @@
             "dependencies": {
                 "@smithy/service-error-classification": "^3.0.7",
                 "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1636,17 +1494,6 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/abort-controller": {
-            "version": "3.1.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/config-resolver": {
             "version": "3.0.9",
             "license": "Apache-2.0",
@@ -1750,43 +1597,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-http-handler": {
-            "version": "3.2.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.1.5",
-                "@smithy/protocol-http": "^4.1.4",
-                "@smithy/querystring-builder": "^3.0.7",
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.7",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/service-error-classification": {
             "version": "3.0.7",
             "license": "Apache-2.0",
@@ -1806,16 +1616,6 @@
                 "@smithy/protocol-http": "^4.1.4",
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-stream": "^3.1.9",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1898,16 +1698,6 @@
             "dependencies": {
                 "@smithy/service-error-classification": "^3.0.7",
                 "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2082,17 +1872,6 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/abort-controller": {
-            "version": "3.1.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-sso/node_modules/@smithy/config-resolver": {
             "version": "3.0.9",
             "license": "Apache-2.0",
@@ -2196,43 +1975,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-http-handler": {
-            "version": "3.2.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.1.5",
-                "@smithy/protocol-http": "^4.1.4",
-                "@smithy/querystring-builder": "^3.0.7",
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.7",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-sso/node_modules/@smithy/service-error-classification": {
             "version": "3.0.7",
             "license": "Apache-2.0",
@@ -2252,16 +1994,6 @@
                 "@smithy/protocol-http": "^4.1.4",
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-stream": "^3.1.9",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2344,16 +2076,6 @@
             "dependencies": {
                 "@smithy/service-error-classification": "^3.0.7",
                 "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2577,17 +2299,6 @@
                 }
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/abort-controller": {
-            "version": "3.1.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-sts/node_modules/@smithy/config-resolver": {
             "version": "3.0.9",
             "license": "Apache-2.0",
@@ -2691,43 +2402,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-http-handler": {
-            "version": "3.2.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.1.5",
-                "@smithy/protocol-http": "^4.1.4",
-                "@smithy/querystring-builder": "^3.0.7",
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.7",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-sts/node_modules/@smithy/service-error-classification": {
             "version": "3.0.7",
             "license": "Apache-2.0",
@@ -2747,16 +2421,6 @@
                 "@smithy/protocol-http": "^4.1.4",
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-stream": "^3.1.9",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2845,16 +2509,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
             "version": "3.0.0",
             "license": "Apache-2.0",
@@ -2909,17 +2563,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/core/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/core/node_modules/@smithy/smithy-client": {
             "version": "3.3.6",
             "license": "Apache-2.0",
@@ -2929,16 +2572,6 @@
                 "@smithy/protocol-http": "^4.1.4",
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-stream": "^3.1.9",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2960,17 +2593,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.654.0",
             "license": "Apache-2.0",
@@ -2978,16 +2600,6 @@
                 "@aws-sdk/types": "3.654.0",
                 "@smithy/property-provider": "^3.1.6",
                 "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3012,17 +2624,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/abort-controller": {
-            "version": "3.1.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/fetch-http-handler": {
             "version": "3.2.9",
             "license": "Apache-2.0",
@@ -3034,43 +2635,6 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-            "version": "3.2.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.1.5",
-                "@smithy/protocol-http": "^4.1.4",
-                "@smithy/querystring-builder": "^3.0.7",
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.7",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/smithy-client": {
             "version": "3.3.6",
             "license": "Apache-2.0",
@@ -3080,16 +2644,6 @@
                 "@smithy/protocol-http": "^4.1.4",
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-stream": "^3.1.9",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3113,16 +2667,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3163,16 +2707,6 @@
                 "@aws-sdk/client-sts": "^3.658.1"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-node": {
             "version": "3.658.1",
             "license": "Apache-2.0",
@@ -3194,16 +2728,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-process": {
             "version": "3.654.0",
             "license": "Apache-2.0",
@@ -3212,16 +2736,6 @@
                 "@smithy/property-provider": "^3.1.6",
                 "@smithy/shared-ini-file-loader": "^3.1.7",
                 "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3244,16 +2758,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
             "version": "3.654.0",
             "license": "Apache-2.0",
@@ -3268,16 +2772,6 @@
             },
             "peerDependencies": {
                 "@aws-sdk/client-sts": "^3.654.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-providers": {
@@ -3300,17 +2794,6 @@
                 "@smithy/credential-provider-imds": "^3.2.3",
                 "@smithy/property-provider": "^3.1.6",
                 "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3346,27 +2829,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-expect-continue": {
             "version": "3.654.0",
             "license": "Apache-2.0",
@@ -3374,27 +2836,6 @@
                 "@aws-sdk/types": "3.654.0",
                 "@smithy/protocol-http": "^4.1.3",
                 "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3433,27 +2874,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-buffer-from": {
             "version": "3.0.0",
             "license": "Apache-2.0",
@@ -3482,16 +2902,6 @@
             "dependencies": {
                 "@aws-sdk/types": "3.654.0",
                 "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3534,17 +2944,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/smithy-client": {
             "version": "3.3.6",
             "license": "Apache-2.0",
@@ -3554,16 +2953,6 @@
                 "@smithy/protocol-http": "^4.1.4",
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-stream": "^3.1.9",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3604,16 +2993,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-ssec/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.654.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.654.0.tgz",
@@ -3646,18 +3025,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
             "version": "3.658.1",
             "license": "Apache-2.0",
@@ -3667,27 +3034,6 @@
                 "@smithy/protocol-http": "^4.1.3",
                 "@smithy/signature-v4": "^4.1.4",
                 "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3711,31 +3057,11 @@
                 "@aws-sdk/client-sso-oidc": "^3.654.0"
             }
         },
-        "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/types": {
             "version": "3.654.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3759,16 +3085,6 @@
                 "@aws-sdk/types": "3.654.0",
                 "@smithy/types": "^3.4.2",
                 "@smithy/util-endpoints": "^2.1.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3819,16 +3135,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5593,14 +4899,16 @@
             "license": "(Unlicense OR Apache-2.0)"
         },
         "node_modules/@smithy/abort-controller": {
-            "version": "2.2.0",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
+            "integrity": "sha512-0XuhuHQlEqbNQZp7QxxrFTdVWdwxch4vjxYgfInF91hZFkPxf9QDrdQka0KfxFMPqLNzSw0b95uGTrLliQUavQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^2.12.0",
+                "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/chunked-blob-reader": {
@@ -5684,31 +4992,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/core/node_modules/@smithy/protocol-http": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
-            "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/core/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/core/node_modules/@smithy/util-body-length-browser": {
             "version": "3.0.0",
             "license": "Apache-2.0",
@@ -5769,18 +5052,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/eventstream-codec": {
             "version": "3.1.7",
             "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.7.tgz",
@@ -5791,18 +5062,6 @@
                 "@smithy/types": "^3.6.0",
                 "@smithy/util-hex-encoding": "^3.0.0",
                 "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@smithy/eventstream-codec/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/eventstream-codec/node_modules/@smithy/util-hex-encoding": {
@@ -5831,33 +5090,11 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/eventstream-serde-browser/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/eventstream-serde-config-resolver": {
             "version": "3.0.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5878,18 +5115,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/eventstream-serde-universal": {
             "version": "3.0.10",
             "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.10.tgz",
@@ -5898,18 +5123,6 @@
             "dependencies": {
                 "@smithy/eventstream-codec": "^3.1.7",
                 "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5926,32 +5139,12 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@smithy/hash-blob-browser/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/hash-stream-node": {
             "version": "3.1.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/hash-stream-node/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5988,16 +5181,6 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@smithy/invalid-dependency/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/is-array-buffer": {
             "version": "3.0.0",
             "license": "Apache-2.0",
@@ -6015,16 +5198,6 @@
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@smithy/md5-js/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/md5-js/node_modules/@smithy/util-buffer-from": {
@@ -6096,18 +5269,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/middleware-stack": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.8.tgz",
@@ -6121,30 +5282,20 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/middleware-stack/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
+        "node_modules/@smithy/node-http-handler": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
+            "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/abort-controller": "^3.1.6",
+                "@smithy/protocol-http": "^4.1.5",
+                "@smithy/querystring-builder": "^3.0.8",
+                "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/node-http-handler": {
-            "version": "2.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^2.2.0",
-                "@smithy/protocol-http": "^3.3.0",
-                "@smithy/querystring-builder": "^2.2.0",
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/property-provider": {
@@ -6160,45 +5311,10 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/property-provider/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/protocol-http": {
-            "version": "3.3.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/querystring-builder": {
-            "version": "2.2.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^2.12.0",
-                "@smithy/util-uri-escape": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/querystring-parser": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.8.tgz",
-            "integrity": "sha512-BtEk3FG7Ks64GAbt+JnKqwuobJNX8VmFLBsKIwWr1D60T426fGrV2L3YS5siOcUhhp6/Y6yhBw1PSPxA5p7qGg==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
+            "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -6208,12 +5324,27 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
+        "node_modules/@smithy/querystring-builder": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.8.tgz",
+            "integrity": "sha512-btYxGVqFUARbUrN6VhL9c3dnSviIwBYD9Rz1jHuN1hgh28Fpv2xjU1HeCeDJX68xctz7r4l1PBnFhGg1WBBPuA==",
             "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/types": "^3.6.0",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.8.tgz",
+            "integrity": "sha512-BtEk3FG7Ks64GAbt+JnKqwuobJNX8VmFLBsKIwWr1D60T426fGrV2L3YS5siOcUhhp6/Y6yhBw1PSPxA5p7qGg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6233,18 +5364,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/shared-ini-file-loader/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/signature-v4": {
             "version": "4.2.0",
             "license": "Apache-2.0",
@@ -6256,27 +5375,6 @@
                 "@smithy/util-middleware": "^3.0.7",
                 "@smithy/util-uri-escape": "^3.0.0",
                 "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/signature-v4/node_modules/@smithy/protocol-http": {
-            "version": "4.1.4",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6304,16 +5402,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/signature-v4/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
             "version": "3.0.0",
             "license": "Apache-2.0",
@@ -6326,13 +5414,15 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "2.12.0",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
+            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/url-parser": {
@@ -6344,18 +5434,6 @@
                 "@smithy/querystring-parser": "^3.0.8",
                 "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@smithy/url-parser/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-buffer-from": {
@@ -6414,16 +5492,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/util-endpoints/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/util-middleware": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.8.tgz",
@@ -6431,18 +5499,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6468,19 +5524,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/abort-controller": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
-            "integrity": "sha512-0XuhuHQlEqbNQZp7QxxrFTdVWdwxch4vjxYgfInF91hZFkPxf9QDrdQka0KfxFMPqLNzSw0b95uGTrLliQUavQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
@@ -6492,61 +5535,6 @@
                 "@smithy/types": "^3.6.0",
                 "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/node-http-handler": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
-            "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.1.6",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/querystring-builder": "^3.0.8",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/protocol-http": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
-            "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.8.tgz",
-            "integrity": "sha512-btYxGVqFUARbUrN6VhL9c3dnSviIwBYD9Rz1jHuN1hgh28Fpv2xjU1HeCeDJX68xctz7r4l1PBnFhGg1WBBPuA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-stream/node_modules/@smithy/util-base64": {
@@ -6586,18 +5574,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/util-stream/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-            "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
@@ -6612,13 +5588,15 @@
             }
         },
         "node_modules/@smithy/util-uri-escape": {
-            "version": "2.2.0",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+            "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-utf8": {
@@ -6638,27 +5616,6 @@
             "dependencies": {
                 "@smithy/abort-controller": "^3.1.5",
                 "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-waiter/node_modules/@smithy/abort-controller": {
-            "version": "3.1.5",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.5.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-waiter/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -18423,7 +17380,7 @@
                 "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-fqn": "^0.0.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
-                "@smithy/node-http-handler": "^2.5.0",
+                "@smithy/node-http-handler": "^3.2.3",
                 "adm-zip": "^0.5.10",
                 "archiver": "^6.0.1",
                 "aws-sdk": "^2.1403.0",
@@ -18598,19 +17555,6 @@
                 }
             }
         },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/abort-controller": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
-            "integrity": "sha512-0XuhuHQlEqbNQZp7QxxrFTdVWdwxch4vjxYgfInF91hZFkPxf9QDrdQka0KfxFMPqLNzSw0b95uGTrLliQUavQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/config-resolver": {
             "version": "3.0.10",
             "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.10.tgz",
@@ -18730,33 +17674,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/protocol-http": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
-            "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/querystring-builder": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.8.tgz",
-            "integrity": "sha512-btYxGVqFUARbUrN6VhL9c3dnSviIwBYD9Rz1jHuN1hgh28Fpv2xjU1HeCeDJX68xctz7r4l1PBnFhGg1WBBPuA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-uri-escape": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/service-error-classification": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.8.tgz",
@@ -18781,18 +17698,6 @@
                 "@smithy/protocol-http": "^4.1.5",
                 "@smithy/types": "^3.6.0",
                 "@smithy/util-stream": "^3.2.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/types": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
-            "license": "Apache-2.0",
-            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -18908,18 +17813,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-uri-escape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-            "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "server/aws-lsp-codewhisperer/node_modules/@tsconfig/node16": {
             "version": "16.1.3",
             "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.3.tgz",
@@ -18996,22 +17889,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/node-http-handler": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
-            "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/abort-controller": "^3.1.6",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/querystring-builder": "^3.0.8",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/util-utf8": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
@@ -19069,17 +17946,6 @@
             },
             "engines": {
                 "node": ">=18.0.0"
-            }
-        },
-        "server/aws-lsp-identity/node_modules/@smithy/types": {
-            "version": "3.5.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "server/aws-lsp-identity/node_modules/@types/sinon": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -38,7 +38,7 @@
         "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-fqn": "^0.0.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
-        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^3.2.3",
         "adm-zip": "^0.5.10",
         "archiver": "^6.0.1",
         "aws-sdk": "^2.1403.0",


### PR DESCRIPTION
## Problem

```[build:types] src/runtimeConfig.ts(41,14): error TS2742: The inferred type of 'getRuntimeConfig' cannot be named without a reference to '@smithy/node-http-handler/node_modules/@smithy/protocol-http'. This is likely not portable. A type annotation is necessary.```

## Solution

Ensure the same version for `@smithy/node-http-handler`. Based on https://stackoverflow.com/questions/63806168/need-help-fixing-or-suppressing-this-typescript-error-ts2742

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
