### PR TITLE
Pass .NET Standard flag to requirement.json

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -111,7 +111,7 @@ export class ArtifactManager {
         return {
             EntryPath: this.normalizeSourceFileRelativePath(request.SolutionRootPath, request.SelectedProjectPath),
             Projects: projects,
-            TransformNetStandardProjects: request.TransformNetStandardProjects
+            TransformNetStandardProjects: request.TransformNetStandardProjects,
         } as RequirementJson
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -111,6 +111,7 @@ export class ArtifactManager {
         return {
             EntryPath: this.normalizeSourceFileRelativePath(request.SolutionRootPath, request.SelectedProjectPath),
             Projects: projects,
+            TransformNetStandardProjects: request.TransformNetStandardProjects
         } as RequirementJson
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -7,7 +7,8 @@ export interface StartTransformRequest extends ExecuteCommandParams {
     ProgramLanguage: string
     TargetFramework: string
     SolutionConfigPaths: string[]
-    ProjectMetadata: TransformProjectMetadata[]
+    ProjectMetadata: TransformProjectMetadata[],
+    TransformNetStandardProjects: boolean
 }
 
 export interface StartTransformResponse {
@@ -71,7 +72,8 @@ export interface DownloadArtifactsResponse {
 
 export interface RequirementJson {
     EntryPath: string
-    Projects: Project[]
+    Projects: Project[],
+    TransformNetStandardProjects: boolean
 }
 
 export interface ExternalReference {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -7,7 +7,7 @@ export interface StartTransformRequest extends ExecuteCommandParams {
     ProgramLanguage: string
     TargetFramework: string
     SolutionConfigPaths: string[]
-    ProjectMetadata: TransformProjectMetadata[],
+    ProjectMetadata: TransformProjectMetadata[]
     TransformNetStandardProjects: boolean
 }
 
@@ -72,7 +72,7 @@ export interface DownloadArtifactsResponse {
 
 export interface RequirementJson {
     EntryPath: string
-    Projects: Project[],
+    Projects: Project[]
     TransformNetStandardProjects: boolean
 }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
@@ -63,6 +63,7 @@ const sampleUserInputRequest: StartTransformRequest = {
             SourceCodeFilePaths: [],
         },
     ],
+    TransformNetStandardProjects: false,
     command: '',
 }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
@@ -11,6 +11,7 @@ const sampleStartTransformRequest: StartTransformRequest = {
     TargetFramework: '',
     SolutionConfigPaths: [],
     ProjectMetadata: [],
+    TransformNetStandardProjects: false,
     command: '',
 }
 


### PR DESCRIPTION
## Problem
We need to give customers control of whether they want to transform their .NET Standard projects.

## Solution
We pass a flag from the UI and write it to the requirement.json so the CLI in the service backend will know whether to leave .NET Standard projects or try to transform.

## Testing
Test older IDE UI code against LSP changes and verified no exception when flag is not passed in the request.

## Checklist
- [x] Pull request title describes the changes without ambiguity
- [x] Added screenshots of visual/UI changes 
- [ ] Added Unit test coverage
- [x] Removed all developer references (internal URLs, etc)
- [x] Removed unused code, comments, references, namespaces
- [x] Used constants/readonly where needed
- [x] Used appropriate data structures
- [x] Used consistent naming convention
- [x] Used predefined Toolkit themes for UI elements
- [x] Used appropriate method and property access levels (private vs public)
- [x] Avoided global and singleton references where possible
- [x] Enforced DRY principles (Do not Repeat Yourself)
- [x] All TODOs have an internal tracking reference ID (e.g. SIM ID)
- [x] Resolved merge conflicts with destination branch
- [x] Add SIM ticket numbers for feature/ bugs from QCT.NET folder
- [ ] Reviewed by Huawen
- [x] Optional: Reviewed by Pranav, Sunwoo, Ke, Jiayu

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
