### PR TITLE
Add HTTPS proxying to identity server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "type": "node",
             "request": "attach",
             "port": 6012, // Hard defined in the vscode client activation.ts
-            "outFiles": ["${workspaceFolder}/out/src/server/**/*.js", "${workspaceFolder}/out/src/service/**/*.js"],
+            "outFiles": ["${workspaceFolder}/**/out/**/*.js"],
             "restart": {
                 "maxAttempts": 10,
                 "delay": 1000

--- a/package-lock.json
+++ b/package-lock.json
@@ -6505,7 +6505,6 @@
         },
         "node_modules/agent-base": {
             "version": "7.1.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.4"
@@ -8149,7 +8148,6 @@
         },
         "node_modules/debug": {
             "version": "4.3.7",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -10109,7 +10107,8 @@
         },
         "node_modules/https-proxy-agent": {
             "version": "7.0.5",
-            "dev": true,
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.0.2",
@@ -13125,7 +13124,6 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/multicast-dns": {
@@ -17924,7 +17922,9 @@
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.614.0",
                 "@aws/language-server-runtimes": "^0.2.24",
+                "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^3.1.5",
+                "https-proxy-agent": "^7.0.5",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -24,7 +24,9 @@
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.614.0",
         "@aws/language-server-runtimes": "^0.2.24",
+        "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^3.1.5",
+        "https-proxy-agent": "^7.0.5",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Added HTTPS proxy to SSO OIDC client for identity server when HTTPS_PROXY is passed.  Optionally, AWS_CA_BUNDLE can be passed as well.  This is based on:

1. https://github.com/aws/language-servers/blob/main/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
1. https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-proxies.html
1. https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrate-client-constructors.html