### PR TITLE
Amazon Q: fix proxy server configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10102,8 +10102,9 @@
         },
         "node_modules/https-proxy-agent": {
             "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.0.2",
                 "debug": "4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2995,8 +2995,6 @@
         },
         "node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.654.0.tgz",
-            "integrity": "sha512-ydGOrXJxj3x0sJhsXyTmvJVLAE0xxuTWFJihTl67RtaO7VRNtd82I3P3bwoMMaDn5WpmV5mPo8fEUDRlBm3fPg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.654.0",
@@ -3012,8 +3010,6 @@
         },
         "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/node-config-provider": {
             "version": "3.1.9",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
-            "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/property-provider": "^3.1.8",
@@ -3147,8 +3143,7 @@
         },
         "node_modules/@aws/chat-client-ui-types": {
             "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.0.8.tgz",
-            "integrity": "sha512-aU8r0FaCKIhMiTWvr/yuWYZmVWPgE2vBAPsVcafhlu7ucubiH/+YodqDw+0Owk0R0kxxZDdjdZghPZSyy0G84A==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.7"
             }
@@ -3188,8 +3183,7 @@
         },
         "node_modules/@aws/language-server-runtimes-types": {
             "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.0.7.tgz",
-            "integrity": "sha512-P83YkgWITcUGHaZvYFI0N487nWErgRpejALKNm/xs8jEcHooDfjigOpliN8TgzfF9BGvGeQnnAzIG16UBXc9ig==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"
@@ -4900,8 +4894,6 @@
         },
         "node_modules/@smithy/abort-controller": {
             "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
-            "integrity": "sha512-0XuhuHQlEqbNQZp7QxxrFTdVWdwxch4vjxYgfInF91hZFkPxf9QDrdQka0KfxFMPqLNzSw0b95uGTrLliQUavQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -4962,8 +4954,6 @@
         },
         "node_modules/@smithy/core": {
             "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.1.tgz",
-            "integrity": "sha512-DujtuDA7BGEKExJ05W5OdxCoyekcKT3Rhg1ZGeiUWaz2BJIWXjZmsG/DIP4W48GHno7AQwRsaCb8NcBgH3QZpg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/middleware-serde": "^3.0.8",
@@ -4981,8 +4971,6 @@
         },
         "node_modules/@smithy/core/node_modules/@smithy/middleware-serde": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.8.tgz",
-            "integrity": "sha512-Xg2jK9Wc/1g/MBMP/EUn2DLspN8LNt+GMe7cgF+Ty3vl+Zvu+VeZU5nmhveU+H8pxyTsjrAkci8NqY6OuvZnjA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -5023,8 +5011,6 @@
         },
         "node_modules/@smithy/credential-provider-imds": {
             "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.5.tgz",
-            "integrity": "sha512-4FTQGAsuwqTzVMmiRVTn0RR9GrbRfkP0wfu/tXWVHd2LgNpTY0uglQpIScXK4NaEyXbB3JmZt8gfVqO50lP8wg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/node-config-provider": "^3.1.9",
@@ -5039,8 +5025,6 @@
         },
         "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/node-config-provider": {
             "version": "3.1.9",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
-            "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/property-provider": "^3.1.8",
@@ -5054,8 +5038,6 @@
         },
         "node_modules/@smithy/eventstream-codec": {
             "version": "3.1.7",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.7.tgz",
-            "integrity": "sha512-kVSXScIiRN7q+s1x7BrQtZ1Aa9hvvP9FeCqCdBxv37GimIHgBCOnZ5Ip80HLt0DhnAKpiobFdGqTFgbaJNrazA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/crc32": "5.2.0",
@@ -5066,8 +5048,6 @@
         },
         "node_modules/@smithy/eventstream-codec/node_modules/@smithy/util-hex-encoding": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-            "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -5078,8 +5058,6 @@
         },
         "node_modules/@smithy/eventstream-serde-browser": {
             "version": "3.0.11",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.11.tgz",
-            "integrity": "sha512-Pd1Wnq3CQ/v2SxRifDUihvpXzirJYbbtXfEnnLV/z0OGCTx/btVX74P86IgrZkjOydOASBGXdPpupYQI+iO/6A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/eventstream-serde-universal": "^3.0.10",
@@ -5103,8 +5081,6 @@
         },
         "node_modules/@smithy/eventstream-serde-node": {
             "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.10.tgz",
-            "integrity": "sha512-hjpU1tIsJ9qpcoZq9zGHBJPBOeBGYt+n8vfhDwnITPhEre6APrvqq/y3XMDEGUT2cWQ4ramNqBPRbx3qn55rhw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/eventstream-serde-universal": "^3.0.10",
@@ -5117,8 +5093,6 @@
         },
         "node_modules/@smithy/eventstream-serde-universal": {
             "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.10.tgz",
-            "integrity": "sha512-ewG1GHbbqsFZ4asaq40KmxCmXO+AFSM1b+DcO2C03dyJj/ZH71CiTg853FSE/3SHK9q3jiYQIFjlGSwfxQ9kww==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/eventstream-codec": "^3.1.7",
@@ -5224,8 +5198,6 @@
         },
         "node_modules/@smithy/middleware-endpoint": {
             "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.1.tgz",
-            "integrity": "sha512-wWO3xYmFm6WRW8VsEJ5oU6h7aosFXfszlz3Dj176pTij6o21oZnzkCLzShfmRaaCHDkBXWBdO0c4sQAvLFP6zA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/core": "^2.5.1",
@@ -5243,8 +5215,6 @@
         },
         "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/middleware-serde": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.8.tgz",
-            "integrity": "sha512-Xg2jK9Wc/1g/MBMP/EUn2DLspN8LNt+GMe7cgF+Ty3vl+Zvu+VeZU5nmhveU+H8pxyTsjrAkci8NqY6OuvZnjA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -5256,8 +5226,6 @@
         },
         "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/node-config-provider": {
             "version": "3.1.9",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
-            "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/property-provider": "^3.1.8",
@@ -5271,8 +5239,6 @@
         },
         "node_modules/@smithy/middleware-stack": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.8.tgz",
-            "integrity": "sha512-d7ZuwvYgp1+3682Nx0MD3D/HtkmZd49N3JUndYWQXfRZrYEnCWYc8BHcNmVsPAp9gKvlurdg/mubE6b/rPS9MA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -5284,8 +5250,6 @@
         },
         "node_modules/@smithy/node-http-handler": {
             "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
-            "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/abort-controller": "^3.1.6",
@@ -5300,8 +5264,6 @@
         },
         "node_modules/@smithy/property-provider": {
             "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.8.tgz",
-            "integrity": "sha512-ukNUyo6rHmusG64lmkjFeXemwYuKge1BJ8CtpVKmrxQxc6rhUX0vebcptFA9MmrGsnLhwnnqeH83VTU9hwOpjA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -5313,8 +5275,6 @@
         },
         "node_modules/@smithy/protocol-http": {
             "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
-            "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -5326,8 +5286,6 @@
         },
         "node_modules/@smithy/querystring-builder": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.8.tgz",
-            "integrity": "sha512-btYxGVqFUARbUrN6VhL9c3dnSviIwBYD9Rz1jHuN1hgh28Fpv2xjU1HeCeDJX68xctz7r4l1PBnFhGg1WBBPuA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -5340,8 +5298,6 @@
         },
         "node_modules/@smithy/querystring-parser": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.8.tgz",
-            "integrity": "sha512-BtEk3FG7Ks64GAbt+JnKqwuobJNX8VmFLBsKIwWr1D60T426fGrV2L3YS5siOcUhhp6/Y6yhBw1PSPxA5p7qGg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -5353,8 +5309,6 @@
         },
         "node_modules/@smithy/shared-ini-file-loader": {
             "version": "3.1.9",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
-            "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -5415,8 +5369,6 @@
         },
         "node_modules/@smithy/types": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
-            "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -5427,8 +5379,6 @@
         },
         "node_modules/@smithy/url-parser": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.8.tgz",
-            "integrity": "sha512-4FdOhwpTW7jtSFWm7SpfLGKIBC9ZaTKG5nBF0wK24aoQKQyDIKUw3+KFWCQ9maMzrgTJIuOvOnsV2lLGW5XjTg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/querystring-parser": "^3.0.8",
@@ -5494,8 +5444,6 @@
         },
         "node_modules/@smithy/util-middleware": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.8.tgz",
-            "integrity": "sha512-p7iYAPaQjoeM+AKABpYWeDdtwQNxasr4aXQEA/OmbOaug9V0odRVDy3Wx4ci8soljE/JXQo+abV0qZpW8NX0yA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -5507,8 +5455,6 @@
         },
         "node_modules/@smithy/util-stream": {
             "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.2.1.tgz",
-            "integrity": "sha512-R3ufuzJRxSJbE58K9AEnL/uSZyVdHzud9wLS8tIbXclxKzoe09CRohj2xV8wpx5tj7ZbiJaKYcutMm1eYgz/0A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/fetch-http-handler": "^4.0.0",
@@ -5526,8 +5472,6 @@
         },
         "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
-            "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/protocol-http": "^4.1.5",
@@ -5539,8 +5483,6 @@
         },
         "node_modules/@smithy/util-stream/node_modules/@smithy/util-base64": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
-            "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-buffer-from": "^3.0.0",
@@ -5553,8 +5495,6 @@
         },
         "node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^3.0.0",
@@ -5576,8 +5516,6 @@
         },
         "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-buffer-from": "^3.0.0",
@@ -5589,8 +5527,6 @@
         },
         "node_modules/@smithy/util-uri-escape": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-            "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -5921,8 +5857,6 @@
         },
         "node_modules/@types/node": {
             "version": "22.8.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.2.tgz",
-            "integrity": "sha512-NzaRNFV+FZkvK/KLCsNdTvID0SThyrs5SHB6tsD/lajr22FGC73N2QeDPM2wHtVde8mgcXuSsHQkH5cX1pbPLw==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.19.8"
@@ -7854,9 +7788,8 @@
         },
         "node_modules/cookie": {
             "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -9233,9 +9166,8 @@
         },
         "node_modules/express": {
             "version": "4.21.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-            "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
@@ -10067,9 +9999,8 @@
         },
         "node_modules/http-proxy-middleware": {
             "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-            "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/http-proxy": "^1.17.8",
                 "http-proxy": "^1.18.1",
@@ -10102,9 +10033,8 @@
         },
         "node_modules/https-proxy-agent": {
             "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.0.2",
                 "debug": "4"
@@ -17391,8 +17321,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/sha256-browser": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-js": "^5.2.0",
@@ -17406,8 +17334,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/sha256-js": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/util": "^5.2.0",
@@ -17420,8 +17346,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/supports-web-crypto": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -17429,8 +17353,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/util": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
@@ -17440,8 +17362,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.654.0.tgz",
-            "integrity": "sha512-rxGgVHWKp8U2ubMv+t+vlIk7QYUaRCHaVpmUlJv0Wv6Q0KeO9a42T9FxHphjOTlCGQOLcjCreL9CF8Qhtb4mdQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.654.0",
@@ -17455,8 +17375,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/middleware-logger": {
             "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.654.0.tgz",
-            "integrity": "sha512-OQYb+nWlmASyXfRb989pwkJ9EVUMP1CrKn2eyTk3usl20JZmKo2Vjis6I0tLUkMSxMhnBJJlQKyWkRpD/u1FVg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.654.0",
@@ -17469,8 +17387,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/middleware-recursion-detection": {
             "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.654.0.tgz",
-            "integrity": "sha512-gKSomgltKVmsT8sC6W7CrADZ4GHwX9epk3GcH6QhebVO3LA9LRbkL3TwOPUXakxxOLLUTYdOZLIOtFf7iH00lg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.654.0",
@@ -17484,8 +17400,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/middleware-user-agent": {
             "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.654.0.tgz",
-            "integrity": "sha512-liCcqPAyRsr53cy2tYu4qeH4MMN0eh9g6k56XzI5xd4SghXH5YWh4qOYAlQ8T66ZV4nPMtD8GLtLXGzsH8moFg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.654.0",
@@ -17500,8 +17414,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/util-user-agent-browser": {
             "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.654.0.tgz",
-            "integrity": "sha512-ykYAJqvnxLt7wfrqya28wuH3/7NdrwzfiFd7NqEVQf7dXVxL5RPEpD7DxjcyQo3DsHvvdUvGZVaQhozycn1pzA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.654.0",
@@ -17512,8 +17424,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/util-user-agent-node": {
             "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.654.0.tgz",
-            "integrity": "sha512-a0ojjdBN6pqv6gB4H/QPPSfhs7mFtlVwnmKCM/QrTaFzN0U810PJ1BST3lBx5sa23I5jWHGaoFY+5q65C3clLQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.654.0",
@@ -17535,8 +17445,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/config-resolver": {
             "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.10.tgz",
-            "integrity": "sha512-Uh0Sz9gdUuz538nvkPiyv1DZRX9+D15EKDtnQP5rYVAzM/dnYk3P8cg73jcxyOitPgT3mE3OVj7ky7sibzHWkw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/node-config-provider": "^3.1.9",
@@ -17551,8 +17459,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/fetch-http-handler": {
             "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
-            "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/protocol-http": "^4.1.4",
@@ -17564,8 +17470,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/hash-node": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.8.tgz",
-            "integrity": "sha512-tlNQYbfpWXHimHqrvgo14DrMAgUBua/cNoz9fMYcDmYej7MAmUcjav/QKQbFc3NrcPxeJ7QClER4tWZmfwoPng==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -17579,8 +17483,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-buffer-from": "^3.0.0",
@@ -17592,8 +17494,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-content-length": {
             "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.10.tgz",
-            "integrity": "sha512-T4dIdCs1d/+/qMpwhJ1DzOhxCZjZHbHazEPJWdB4GDi2HjIZllVzeBEcdJUN0fomV8DURsgOyrbEUzg3vzTaOg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/protocol-http": "^4.1.5",
@@ -17606,8 +17506,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-retry": {
             "version": "3.0.25",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.25.tgz",
-            "integrity": "sha512-m1F70cPaMBML4HiTgCw5I+jFNtjgz5z5UdGnUbG37vw6kh4UvizFYjqJGHvicfgKMkDL6mXwyPp5mhZg02g5sg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/node-config-provider": "^3.1.9",
@@ -17626,8 +17524,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-serde": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.8.tgz",
-            "integrity": "sha512-Xg2jK9Wc/1g/MBMP/EUn2DLspN8LNt+GMe7cgF+Ty3vl+Zvu+VeZU5nmhveU+H8pxyTsjrAkci8NqY6OuvZnjA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0",
@@ -17639,8 +17535,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/node-config-provider": {
             "version": "3.1.9",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
-            "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/property-provider": "^3.1.8",
@@ -17654,8 +17548,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/service-error-classification": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.8.tgz",
-            "integrity": "sha512-uEC/kCCFto83bz5ZzapcrgGqHOh/0r69sZ2ZuHlgoD5kYgXJEThCoTuw/y1Ub3cE7aaKdznb+jD9xRPIfIwD7g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^3.6.0"
@@ -17666,8 +17558,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/smithy-client": {
             "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.2.tgz",
-            "integrity": "sha512-dxw1BDxJiY9/zI3cBqfVrInij6ShjpV4fmGHesGZZUiP9OSE/EVfdwdRz0PgvkEvrZHpsj2htRaHJfftE8giBA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/core": "^2.5.1",
@@ -17684,8 +17574,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/util-base64": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
-            "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-buffer-from": "^3.0.0",
@@ -17698,8 +17586,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-buffer-from": "^3.0.0",
@@ -17711,8 +17597,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/util-body-length-browser": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
-            "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -17720,8 +17604,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/util-body-length-node": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
-            "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -17732,8 +17614,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/util-buffer-from": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^3.0.0",
@@ -17745,8 +17625,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/util-defaults-mode-browser": {
             "version": "3.0.25",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.25.tgz",
-            "integrity": "sha512-fRw7zymjIDt6XxIsLwfJfYUfbGoO9CmCJk6rjJ/X5cd20+d2Is7xjU5Kt/AiDt6hX8DAf5dztmfP5O82gR9emA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/property-provider": "^3.1.8",
@@ -17761,8 +17639,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/util-defaults-mode-node": {
             "version": "3.0.25",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.25.tgz",
-            "integrity": "sha512-H3BSZdBDiVZGzt8TG51Pd2FvFO0PAx/A0mJ0EH8a13KJ6iUCdYnw/Dk/MdC1kTd0eUuUGisDFaxXVXo4HHFL1g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/config-resolver": "^3.0.10",
@@ -17779,8 +17655,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/util-retry": {
             "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.8.tgz",
-            "integrity": "sha512-TCEhLnY581YJ+g1x0hapPz13JFqzmh/pMWL2KEFASC51qCfw3+Y47MrTmea4bUE5vsdxQ4F6/KFbUeSz22Q1ow==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/service-error-classification": "^3.0.8",
@@ -17793,8 +17667,6 @@
         },
         "server/aws-lsp-codewhisperer/node_modules/@tsconfig/node16": {
             "version": "16.1.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.3.tgz",
-            "integrity": "sha512-9nTOUBn+EMKO6rtSZJk+DcqsfgtlERGT9XPJ5PRj/HNENPCBY1yu/JEj5wT6GLtbCLBO2k46SeXDaY0pjMqypw==",
             "dev": true,
             "license": "MIT"
         },
@@ -17871,27 +17743,12 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
             "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-buffer-from": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
-            }
-        },
-        "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/node_modules/@types/uuid": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-            "dev": true
-        },
-        "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "server/aws-lsp-identity": {
@@ -17928,9 +17785,8 @@
         },
         "server/aws-lsp-identity/node_modules/@types/sinon": {
             "version": "17.0.3",
-            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
-            "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/sinonjs__fake-timers": "*"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6033,13 +6033,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/tunnel": {
-            "version": "0.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/uuid": {
             "version": "9.0.8",
             "dev": true,
@@ -14032,14 +14025,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/proxy-http-agent": {
-            "version": "1.0.1",
-            "license": "ISC",
-            "dependencies": {
-                "@types/tunnel": "0.0.1",
-                "tunnel": "0.0.6"
-            }
-        },
         "node_modules/psl": {
             "version": "1.9.0",
             "dev": true,
@@ -16101,13 +16086,6 @@
                 "fsevents": "~2.3.3"
             }
         },
-        "node_modules/tunnel": {
-            "version": "0.0.6",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-            }
-        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "dev": true,
@@ -17389,7 +17367,6 @@
                 "got": "^11.8.5",
                 "hpagent": "^1.2.0",
                 "js-md5": "^0.8.3",
-                "proxy-http-agent": "^1.0.1",
                 "uuid": "^9.0.1",
                 "vscode-uri": "^3.0.8"
             },

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -47,7 +47,6 @@
         "got": "^11.8.5",
         "hpagent": "^1.2.0",
         "js-md5": "^0.8.3",
-        "proxy-http-agent": "^1.0.1",
         "uuid": "^9.0.1",
         "vscode-uri": "^3.0.8"
     },

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -8,6 +8,7 @@ import { QChatServer } from './qChatServer'
 import { QConfigurationServerToken } from './configuration/qConfigurationServer'
 import { readFileSync } from 'fs'
 import { ConfigurationOptions } from 'aws-sdk'
+import { HttpsProxyAgent } from 'hpagent'
 
 const makeProxyConfig = () => {
     let additionalAwsConfig: ConfigurationOptions = {}
@@ -15,7 +16,6 @@ const makeProxyConfig = () => {
 
     if (proxyUrl) {
         const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
-        const { HttpsProxyAgent } = require('hpagent')
         const agent = new HttpsProxyAgent({
             proxy: proxyUrl,
             ca: certs,
@@ -61,17 +61,6 @@ export const QChatServerProxy = QChatServer(credentialsProvider => {
     if (proxyUrl) {
         const { NodeHttpHandler } = require('@smithy/node-http-handler')
 
-        /**
-         * TODO: consolidate the libraries we need for http proxy
-         *
-         * proxy-http-agent is not compatible with smithy's node-http-handler,
-         *  so we will use hpagent to create a new http handler
-         *
-         * At the same time, hpagent is not compatible with v2 sdk
-         */
-        const { HttpsProxyAgent } = require('hpagent')
-
-        // passing client options as a function so a new http handler can be created
         clientOptions = () => {
             // this mimics aws-sdk-v3-js-proxy
             const agent = new HttpsProxyAgent({

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -7,76 +7,48 @@ import { QNetTransformServerToken } from './netTransformServer'
 import { QChatServer } from './qChatServer'
 import { QConfigurationServerToken } from './configuration/qConfigurationServer'
 import { readFileSync } from 'fs'
+import { ConfigurationOptions } from 'aws-sdk'
 
-export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credentialsProvider => {
-    let additionalAwsConfig = {}
+const makeProxyConfig = () => {
+    let additionalAwsConfig: ConfigurationOptions = {}
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
 
     if (proxyUrl) {
-        const { getProxyHttpAgent } = require('proxy-http-agent')
-        const proxyAgent = getProxyHttpAgent({
+        const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
+        const { HttpsProxyAgent } = require('hpagent')
+        const agent = new HttpsProxyAgent({
             proxy: proxyUrl,
             ca: certs,
         })
+
         additionalAwsConfig = {
-            httpOptions: proxyAgent,
+            httpOptions: {
+                agent: agent,
+            },
         }
     }
+
+    return additionalAwsConfig
+}
+
+export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credentialsProvider => {
+    const additionalAwsConfig = makeProxyConfig()
+
     return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
 })
 
 export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(credentialsProvider => {
-    let additionalAwsConfig = {}
-    const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
-
-    if (proxyUrl) {
-        const { getProxyHttpAgent } = require('proxy-http-agent')
-        const proxyAgent = getProxyHttpAgent({
-            proxy: proxyUrl,
-            ca: certs,
-        })
-        additionalAwsConfig = {
-            httpOptions: proxyAgent,
-        }
-    }
+    const additionalAwsConfig = makeProxyConfig()
     return new CodeWhispererServiceIAM(credentialsProvider, additionalAwsConfig)
 })
 
 export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken(credentialsProvider => {
-    let additionalAwsConfig = {}
-    const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
-
-    if (proxyUrl) {
-        const { getProxyHttpAgent } = require('proxy-http-agent')
-        const proxyAgent = getProxyHttpAgent({
-            proxy: proxyUrl,
-            ca: certs,
-        })
-        additionalAwsConfig = {
-            httpOptions: proxyAgent,
-        }
-    }
+    const additionalAwsConfig = makeProxyConfig()
     return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
 })
 
 export const QNetTransformServerTokenProxy = QNetTransformServerToken(credentialsProvider => {
-    let additionalAwsConfig = {}
-    const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
-
-    if (proxyUrl) {
-        const { getProxyHttpAgent } = require('proxy-http-agent')
-        const proxyAgent = getProxyHttpAgent({
-            proxy: proxyUrl,
-            ca: certs,
-        })
-        additionalAwsConfig = {
-            httpOptions: proxyAgent,
-        }
-    }
+    const additionalAwsConfig = makeProxyConfig()
     return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
 })
 
@@ -122,19 +94,6 @@ export const QChatServerProxy = QChatServer(credentialsProvider => {
 })
 
 export const QConfigurationServerTokenProxy = QConfigurationServerToken(credentialsProvider => {
-    let additionalAwsConfig = {}
-    const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-    const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
-
-    if (proxyUrl) {
-        const { getProxyHttpAgent } = require('proxy-http-agent')
-        const proxyAgent = getProxyHttpAgent({
-            proxy: proxyUrl,
-            ca: certs,
-        })
-        additionalAwsConfig = {
-            httpOptions: proxyAgent,
-        }
-    }
+    const additionalAwsConfig = makeProxyConfig()
     return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
 })


### PR DESCRIPTION
## Problem
HTTP proxy setup does not work for CodeWhisperer capabilities except Q Chat.

## Solution
* Fixed bug in `httpOptions` AWS Configuration passed to `CodewhispererService` in `proxy-servers` versions of capabilities: proxy agent object was not passed in correct field expected (https://github.com/aws/language-servers/pull/579/files#diff-6f77316cd6785df25fcc13badc7a24b9fa77b4e594455d07011c4ccc817d0be2R25-R27)
* Switched to `hpagent` package for all proxies. `proxy-http-agent` that was used originally was also misconfigured - arguments passed were not in correct shape.

Tested with local proxy setup using Charles and Sample VSCode extension on my Macbook. Verified that with setting `HTTPS_PROXY` and `AWS_CA_BUNDLE` in https://github.com/aws/language-servers/blob/main/.vscode/launch.json#L90-L91 result in calls for `InlineCompletion` and `QConfigurationServer` to go through proxy.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
