### PR TITLE
Add return type to getRuntimeConfig function definition

### DIFF
--- a/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/runtimeConfig.ts
+++ b/server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/src/runtimeConfig.ts
@@ -38,7 +38,7 @@ import { emitWarningIfUnsupportedVersion } from "@smithy/smithy-client";
 /**
  * @internal
  */
-export const getRuntimeConfig = (config: CodeWhispererStreamingClientConfig) => {
+export const getRuntimeConfig: any = (config: CodeWhispererStreamingClientConfig) => {
   emitWarningIfUnsupportedVersion(process.version);
   const defaultsMode = resolveDefaultsModeConfig(config);
   const defaultConfigProvider = () => defaultsMode().then(loadConfigsForDefaultMode);


### PR DESCRIPTION
## Problem
The function not having a return type was causing problems

## Solution

Let's add any as a return type to suppress the problems

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
