### PR TITLE
Change sendRequest to sendNotification in the notification sample

### DIFF
--- a/client/vscode/src/notificationActivation.ts
+++ b/client/vscode/src/notificationActivation.ts
@@ -1,7 +1,6 @@
 import { commands, window } from 'vscode'
 import {
     AwsResponseError,
-    NotificationFollowupParams,
     notificationFollowupRequestType,
     NotificationParams,
     showNotificationRequestType,
@@ -28,10 +27,10 @@ function showNotificationHandler(params: NotificationParams): void {
 // Put whatever calls to the aws-lsp-notification server you want to experiment with/debug here
 async function execTestCommand(client: LanguageClient): Promise<void> {
     try {
-        const result = await client.sendRequest(notificationFollowupRequestType.method, {
+        const result = await client.sendNotification(notificationFollowupRequestType, {
             id: 'someid',
             actions: ['Acknowledge'],
-        } satisfies NotificationFollowupParams)
+        })
         window.showInformationMessage(`NotificationFollowup: ${JSON.stringify(result)}`)
     } catch (e) {
         const are = e as AwsResponseError


### PR DESCRIPTION
## Problem

This was causing build problems, because `notificationFollowupRequestType` is defined as a `ProtocolNotificationType` we shouldn't use `sendRequest` but rather use `sendNotification` when sending it 

` const notificationFollowupRequestType: ProtocolNotificationType<NotificationFollowupParams, void>;`

## Solution
Change `sendRequest` to `sendNotification` 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
