### PR TITLE
Temporarily disable the notification sample extension

### DIFF
--- a/client/vscode/src/notificationActivation.ts
+++ b/client/vscode/src/notificationActivation.ts
@@ -1,10 +1,5 @@
 import { commands, window } from 'vscode'
-import {
-    AwsResponseError,
-    notificationFollowupRequestType,
-    NotificationParams,
-    showNotificationRequestType,
-} from '@aws/language-server-runtimes/protocol'
+import { NotificationParams, showNotificationRequestType } from '@aws/language-server-runtimes/protocol'
 
 import { LanguageClient } from 'vscode-languageclient/node'
 
@@ -26,6 +21,8 @@ function showNotificationHandler(params: NotificationParams): void {
 // Consider the code in this function a scratchpad, do not put anything you want to keep here.
 // Put whatever calls to the aws-lsp-notification server you want to experiment with/debug here
 async function execTestCommand(client: LanguageClient): Promise<void> {
+    window.showInformationMessage('TODO, Re-enable the following section when new runtimes is released')
+    /*
     try {
         const result = await client.sendNotification(notificationFollowupRequestType, {
             id: 'someid',
@@ -36,4 +33,5 @@ async function execTestCommand(client: LanguageClient): Promise<void> {
         const are = e as AwsResponseError
         window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
     }
+    */
 }


### PR DESCRIPTION
## Description

Temporarily disabling the notification sample extension because it is causing issues when building against latest runtimes which has updated parameter structure for notifications

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
