### PR TITLE
Remove conditional requires and convert to top level import

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
+++ b/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
@@ -2,6 +2,8 @@ import { CodeWhispererStreaming, CodeWhispererStreamingClientConfig } from '@amz
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { readFileSync } from 'fs'
 import { AWS_Q_REGION, AWS_Q_ENDPOINT_URL } from '../../constants'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
+import { HttpsProxyAgent } from 'hpagent'
 
 export class StreamingClient {
     public async getStreamingClient(credentialsProvider: any, config?: CodeWhispererStreamingClientConfig) {
@@ -19,9 +21,6 @@ export async function createStreamingClient(
     const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
 
     if (proxyUrl) {
-        const { NodeHttpHandler } = require('@smithy/node-http-handler')
-        const { HttpsProxyAgent } = require('hpagent')
-
         const agent = new HttpsProxyAgent({
             proxy: proxyUrl,
             ca: certs,

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -9,6 +9,7 @@ import { QConfigurationServerToken } from './configuration/qConfigurationServer'
 import { readFileSync } from 'fs'
 import { ConfigurationOptions } from 'aws-sdk'
 import { HttpsProxyAgent } from 'hpagent'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
 
 const makeProxyConfig = () => {
     let additionalAwsConfig: ConfigurationOptions = {}
@@ -59,8 +60,6 @@ export const QChatServerProxy = QChatServer(credentialsProvider => {
     const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
 
     if (proxyUrl) {
-        const { NodeHttpHandler } = require('@smithy/node-http-handler')
-
         clientOptions = () => {
             // this mimics aws-sdk-v3-js-proxy
             const agent = new HttpsProxyAgent({


### PR DESCRIPTION
## Description

Let's not mix require and import statements in the same file. The benefits of conditional require can be discussed as a followup 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
