### PR TITLE
Downgrade @smithy/node-http-handler to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17303,7 +17303,7 @@
                 "@aws/language-server-runtimes": "^0.2.24",
                 "@aws/lsp-fqn": "^0.0.1",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
-                "@smithy/node-http-handler": "^3.2.3",
+                "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
                 "archiver": "^6.0.1",
                 "aws-sdk": "^2.1403.0",
@@ -17560,6 +17560,69 @@
                 "node": ">=16.0.0"
             }
         },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/node-http-handler": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+            "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+            "dependencies": {
+                "@smithy/abort-controller": "^2.2.0",
+                "@smithy/protocol-http": "^3.3.0",
+                "@smithy/querystring-builder": "^2.2.0",
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/node-http-handler/node_modules/@smithy/abort-controller": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+            "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/node-http-handler/node_modules/@smithy/protocol-http": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+            "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/node-http-handler/node_modules/@smithy/querystring-builder": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+            "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+            "dependencies": {
+                "@smithy/types": "^2.12.0",
+                "@smithy/util-uri-escape": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+            "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/service-error-classification": {
             "version": "3.0.8",
             "license": "Apache-2.0",
@@ -17679,6 +17742,17 @@
                 "node": ">=16.0.0"
             }
         },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-uri-escape": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+            "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "server/aws-lsp-codewhisperer/node_modules/@tsconfig/node16": {
             "version": "16.1.3",
             "dev": true,
@@ -17748,6 +17822,21 @@
                 "downlevel-dts": "0.10.1",
                 "rimraf": "^3.0.0",
                 "typescript": "~4.9.5"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/src.gen/@amzn/codewhisperer-streaming/node_modules/@smithy/node-http-handler": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
+            "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
+            "dependencies": {
+                "@smithy/abort-controller": "^3.1.6",
+                "@smithy/protocol-http": "^4.1.5",
+                "@smithy/querystring-builder": "^3.0.8",
+                "@smithy/types": "^3.6.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -38,7 +38,7 @@
         "@aws/language-server-runtimes": "^0.2.24",
         "@aws/lsp-fqn": "^0.0.1",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
-        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",
         "archiver": "^6.0.1",
         "aws-sdk": "^2.1403.0",


### PR DESCRIPTION
## Problem
The version bump is causing problems with builds

## Solution
Revert the version bump to fix builds

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
