### PR TITLE
Trimming logs to not show steps

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -37,7 +37,7 @@ export class ArtifactManager {
             fs.unlinkSync(zipFile)
             fs.rmSync(this.workspacePath, { recursive: true, force: true })
         } catch (error) {
-            this.logging.log('failed to cleanup:' + error)
+            this.logging.log('Failed to cleanup:' + error)
         }
     }
 
@@ -45,7 +45,7 @@ export class ArtifactManager {
         const fileContent = await this.createRequirementJsonContent(request)
         const dir = this.getRequirementJsonPath()
         await this.writeRequirmentJsonAsync(dir, JSON.stringify(fileContent))
-        this.logging.log('generated requirement.json at: ' + dir)
+        this.logging.log('Generated requirement.json at: ' + dir)
     }
 
     async copySolutionConfigFiles(request: StartTransformRequest) {
@@ -78,7 +78,7 @@ export class ArtifactManager {
                         relativePath: relativePath,
                     })
                 } catch (error) {
-                    this.logging.log('failed to process file: ' + error + filePath)
+                    this.logging.log('Failed to process file: ' + error + filePath)
                 }
             })
 
@@ -97,7 +97,7 @@ export class ArtifactManager {
                         relativePath: relativePath,
                     })
                 } catch (error) {
-                    this.logging.log('failed to process file: ' + error + reference.AssemblyFullPath)
+                    this.logging.log('Failed to process file: ' + error + reference.AssemblyFullPath)
                 }
             })
             projects.push({
@@ -107,7 +107,7 @@ export class ArtifactManager {
                 references: references,
             })
         })
-        this.logging.log('total project reference:' + projects.length)
+        this.logging.log('Total project reference: ' + projects.length)
         return {
             EntryPath: this.normalizeSourceFileRelativePath(request.SolutionRootPath, request.SelectedProjectPath),
             Projects: projects,
@@ -117,11 +117,11 @@ export class ArtifactManager {
     async zipArtifact(): Promise<string> {
         const folderPath = path.join(this.workspacePath, artifactFolderName)
         if (!fs.existsSync(folderPath)) {
-            this.logging.log('cannot find artifact folder')
+            this.logging.log('Cannot find artifact folder')
             return ''
         }
         const zipPath = path.join(this.workspacePath, zipFileName)
-        this.logging.log('zipping files to ' + zipPath)
+        this.logging.log('Zipping files to ' + zipPath)
         await this.zipDirectory(folderPath, zipPath)
         return zipPath
     }
@@ -192,7 +192,7 @@ export class ArtifactManager {
         this.createFolderIfNotExist(dir)
         fs.copyFile(sourceFilePath, destFilePath, error => {
             if (error) {
-                this.logging.log('failed to copy: ' + sourceFilePath + error)
+                this.logging.log('Failed to copy: ' + sourceFilePath + error)
             }
         })
     }
@@ -203,7 +203,7 @@ export class ArtifactManager {
             const hash = crypto.createHash('md5').update(data)
             return hash.digest('hex')
         } catch (error) {
-            this.logging.log('failed to calculate hashcode: ' + filePath + error)
+            this.logging.log('Failed to calculate hashcode: ' + filePath + error)
             return ''
         }
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -121,7 +121,7 @@ export class ArtifactManager {
             return ''
         }
         const zipPath = path.join(this.workspacePath, zipFileName)
-        this.logging.log('zipping files to' + zipPath)
+        this.logging.log('zipping files to ' + zipPath)
         await this.zipDirectory(folderPath, zipPath)
         return zipPath
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -107,7 +107,7 @@ export class ArtifactManager {
                 references: references,
             })
         })
-        this.logging.log('Total project reference: ' + projects.length)
+        this.logging.log('Total project references: ' + projects.length)
         return {
             EntryPath: this.normalizeSourceFileRelativePath(request.SolutionRootPath, request.SelectedProjectPath),
             Projects: projects,
@@ -117,7 +117,7 @@ export class ArtifactManager {
     async zipArtifact(): Promise<string> {
         const folderPath = path.join(this.workspacePath, artifactFolderName)
         if (!fs.existsSync(folderPath)) {
-            this.logging.log('Cannot find artifact folder')
+            this.logging.log('Cannot find artifacts folder')
             return ''
         }
         const zipPath = path.join(this.workspacePath, zipFileName)

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -294,7 +294,9 @@ export class TransformHandler {
         } as GetTransformationRequest
         this.logging.log('poll : send request to get transform  api: ' + JSON.stringify(getCodeTransformationRequest))
         let response = await this.client.codeModernizerGetCodeTransformation(getCodeTransformationRequest)
-        this.logging.log('poll : received response from get transform api: ' + JSON.stringify(response))
+        this.logging.log(
+            'poll : received response from get transform api, the job status is ' + response.transformationJob?.status
+        )
         let status = response?.transformationJob?.status ?? PollTransformationStatus.NOT_FOUND
 
         this.logging.log('validExitStatus here are : ' + validExitStatus)
@@ -311,8 +313,10 @@ export class TransformHandler {
                     'poll : send request to get transform  api: ' + JSON.stringify(getCodeTransformationRequest)
                 )
                 response = await this.client.codeModernizerGetCodeTransformation(getCodeTransformationRequest)
-                this.logging.log('poll : received response from get transform api: ' + JSON.stringify(response))
-                this.logging.log('poll : job status here : ' + response.transformationJob.status)
+                this.logging.log(
+                    'poll : received response from get transform api, the job status is ' +
+                        response.transformationJob?.status
+                )
 
                 if (response.transformationJob?.status) {
                     this.logging.log(

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -235,10 +235,10 @@ export class TransformHandler {
                     transformationJobId: request.TransformationJobId,
                 } as StopTransformationRequest
                 this.logging.log(
-                    'Sending request to cancel transform plan api: ' + JSON.stringify(stopCodeTransformationRequest)
+                    'Sending CancelTransformRequest with job Id: ' + stopCodeTransformationRequest.transformationJobId
                 )
                 const response = await this.client.codeModernizerStopCodeTransformation(stopCodeTransformationRequest)
-                this.logging.log('Received response from cancel transform plan api: ' + JSON.stringify(response))
+                this.logging.log('Transformation status: ' + response.transformationStatus)
                 let status: CancellationJobStatus
                 switch (response.transformationStatus) {
                     case 'STOPPED':

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -309,7 +309,6 @@ export class TransformHandler {
                 status = response.transformationJob.status!
                 await this.sleep(10 * 1000)
                 timer += 10
-                this.logging.log('Current polling timer ' + timer)
 
                 if (timer > 24 * 3600 * 1000) {
                     status = PollTransformationStatus.TIMEOUT

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -182,9 +182,13 @@ export class TransformHandler {
             const getCodeTransformationRequest = {
                 transformationJobId: request.TransformationJobId,
             } as GetTransformationRequest
-            this.logging.log('send request to get transform api: ' + JSON.stringify(getCodeTransformationRequest))
             const response = await this.client.codeModernizerGetCodeTransformation(getCodeTransformationRequest)
-            this.logging.log('response received from get transform api: ' + JSON.stringify(response))
+            this.logging.log(
+                'response received from get transform api, the job status for ' +
+                    response.transformationJob.jobId +
+                    ' is ' +
+                    response.transformationJob.status
+            )
             return {
                 TransformationJob: response.transformationJob,
             } as GetTransformResponse
@@ -202,13 +206,9 @@ export class TransformHandler {
                 const getCodeTransformationPlanRequest = {
                     transformationJobId: request.TransformationJobId,
                 } as GetTransformationRequest
-                this.logging.log(
-                    'send request to get transform plan api: ' + JSON.stringify(getCodeTransformationPlanRequest)
-                )
                 const response = await this.client.codeModernizerGetCodeTransformationPlan(
                     getCodeTransformationPlanRequest
                 )
-                this.logging.log('received response from get transform plan api: ' + JSON.stringify(response))
                 return {
                     TransformationPlan: response.transformationPlan,
                 } as GetTransformPlanResponse
@@ -294,7 +294,7 @@ export class TransformHandler {
         } as GetTransformationRequest
         this.logging.log('poll : send request to get transform  api: ' + JSON.stringify(getCodeTransformationRequest))
         let response = await this.client.codeModernizerGetCodeTransformation(getCodeTransformationRequest)
-        this.logging.log('poll : received response from get transform  api: ' + JSON.stringify(response))
+        this.logging.log('poll : received response from get transform api: ' + JSON.stringify(response))
         let status = response?.transformationJob?.status ?? PollTransformationStatus.NOT_FOUND
 
         this.logging.log('validExitStatus here are : ' + validExitStatus)
@@ -311,7 +311,7 @@ export class TransformHandler {
                     'poll : send request to get transform  api: ' + JSON.stringify(getCodeTransformationRequest)
                 )
                 response = await this.client.codeModernizerGetCodeTransformation(getCodeTransformationRequest)
-                this.logging.log('poll : received response from get transform  api: ' + JSON.stringify(response))
+                this.logging.log('poll : received response from get transform api: ' + JSON.stringify(response))
                 this.logging.log('poll : job status here : ' + response.transformationJob.status)
 
                 if (response.transformationJob?.status) {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -71,13 +71,13 @@ export class TransformHandler {
         )
         try {
             const payloadFilePath = await this.zipCodeAsync(userInputrequest, artifactManager)
-            this.logging.log('payload path: ' + payloadFilePath)
+            this.logging.log('Payload path: ' + payloadFilePath)
 
             const uploadId = await this.preTransformationUploadCode(payloadFilePath)
             const request = getCWStartTransformRequest(userInputrequest, uploadId, this.logging)
-            this.logging.log('send request to start transform api: ' + JSON.stringify(request))
+            this.logging.log('Sending request to start transform api: ' + JSON.stringify(request))
             const response = await this.client.codeModernizerStartCodeTransformation(request)
-            this.logging.log('response start transform api: ' + JSON.stringify(response))
+            this.logging.log('Received transformation job Id: ' + response?.transformationJobId)
             return getCWStartTransformResponse(
                 response,
                 uploadId,
@@ -101,7 +101,7 @@ export class TransformHandler {
     async preTransformationUploadCode(payloadFilePath: string): Promise<string> {
         try {
             const uploadId = await this.uploadPayloadAsync(payloadFilePath)
-            this.logging.log('artifact successfully uploaded. upload tracking id: ' + uploadId)
+            this.logging.log('Artifact was successfully uploaded. Upload tracking id: ' + uploadId)
             return uploadId
         } catch (error) {
             const errorMessage = (error as Error).message ?? 'Failed to upload zip file'
@@ -120,7 +120,7 @@ export class TransformHandler {
             })
         } catch (e: any) {
             const errorMessage = (e as Error).message ?? 'Error in CreateUploadUrl API call'
-            this.logging.log('Error when creating Upload url: ' + errorMessage)
+            this.logging.log('Error when creating upload url: ' + errorMessage)
             throw new Error(errorMessage)
         }
 
@@ -183,12 +183,7 @@ export class TransformHandler {
                 transformationJobId: request.TransformationJobId,
             } as GetTransformationRequest
             const response = await this.client.codeModernizerGetCodeTransformation(getCodeTransformationRequest)
-            this.logging.log(
-                'response received from get transform api, the job status for ' +
-                    response.transformationJob.jobId +
-                    ' is ' +
-                    response.transformationJob.status
-            )
+            this.logging.log('Transformation status: ' + response.transformationJob?.status)
             return {
                 TransformationJob: response.transformationJob,
             } as GetTransformResponse
@@ -218,15 +213,13 @@ export class TransformHandler {
 
                 getTransformationPlanAttempt += 1
                 if (getTransformationPlanAttempt >= getTransformationPlanMaxAttempts) {
-                    this.logging.log(
-                        `CodeTransformation: GetTransformationPlan failed after ${getTransformationPlanMaxAttempts} attempts.`
-                    )
+                    this.logging.log(`GetTransformationPlan failed after ${getTransformationPlanMaxAttempts} attempts.`)
                     throw e
                 }
 
                 const expDelayMs = this.getExpDelayForApiRetryMs(getTransformationPlanAttempt)
                 this.logging.log(
-                    `poll : Attempt ${getTransformationPlanAttempt}/${getTransformationPlanMaxAttempts} to get transformation plan failed, retry in ${expDelayMs} seconds`
+                    `Attempt ${getTransformationPlanAttempt}/${getTransformationPlanMaxAttempts} to get transformation plan failed, retry in ${expDelayMs} seconds`
                 )
                 await this.sleep(expDelayMs * 1000)
             }
@@ -242,10 +235,10 @@ export class TransformHandler {
                     transformationJobId: request.TransformationJobId,
                 } as StopTransformationRequest
                 this.logging.log(
-                    'send request to cancel transform plan api: ' + JSON.stringify(stopCodeTransformationRequest)
+                    'Sending request to cancel transform plan api: ' + JSON.stringify(stopCodeTransformationRequest)
                 )
                 const response = await this.client.codeModernizerStopCodeTransformation(stopCodeTransformationRequest)
-                this.logging.log('received response from cancel transform plan api: ' + JSON.stringify(response))
+                this.logging.log('Received response from cancel transform plan api: ' + JSON.stringify(response))
                 let status: CancellationJobStatus
                 switch (response.transformationStatus) {
                     case 'STOPPED':
@@ -264,9 +257,7 @@ export class TransformHandler {
 
                 cancelTransformationAttempt += 1
                 if (cancelTransformationAttempt >= cancelTransformationMaxAttempts) {
-                    this.logging.log(
-                        `CodeTransformation: CancelTransformation failed after ${cancelTransformationMaxAttempts} attempts.`
-                    )
+                    this.logging.log(`CancelTransformation failed after ${cancelTransformationMaxAttempts} attempts.`)
                     return {
                         TransformationJobStatus: CancellationJobStatus.FAILED_TO_CANCEL,
                     } as CancelTransformResponse
@@ -274,7 +265,7 @@ export class TransformHandler {
 
                 const expDelayMs = this.getExpDelayForApiRetryMs(cancelTransformationAttempt)
                 this.logging.log(
-                    `poll : Attempt ${cancelTransformationAttempt}/${cancelTransformationMaxAttempts} to get transformation plan failed, retry in ${expDelayMs} seconds`
+                    `Attempt ${cancelTransformationAttempt}/${cancelTransformationMaxAttempts} to get transformation plan failed, retry in ${expDelayMs} seconds`
                 )
                 await this.sleep(expDelayMs * 1000)
             }
@@ -292,15 +283,13 @@ export class TransformHandler {
         const getCodeTransformationRequest = {
             transformationJobId: request.TransformationJobId,
         } as GetTransformationRequest
-        this.logging.log('poll : send request to get transform  api: ' + JSON.stringify(getCodeTransformationRequest))
         let response = await this.client.codeModernizerGetCodeTransformation(getCodeTransformationRequest)
-        this.logging.log(
-            'poll : received response from get transform api, the job status is ' + response.transformationJob?.status
-        )
-        let status = response?.transformationJob?.status ?? PollTransformationStatus.NOT_FOUND
+        this.logging.log('Start polling for transformation plan.')
+        this.logging.log('The valid status to exit polling are: ' + validExitStatus)
+        this.logging.log('The failure status are: ' + failureStates)
 
-        this.logging.log('validExitStatus here are : ' + validExitStatus)
-        this.logging.log('failureStatus here are : ' + failureStates)
+        this.logging.log('Transformation status: ' + response.transformationJob?.status)
+        let status = response?.transformationJob?.status ?? PollTransformationStatus.NOT_FOUND
 
         while (status != PollTransformationStatus.TIMEOUT && !failureStates.includes(status)) {
             try {
@@ -309,31 +298,18 @@ export class TransformHandler {
                 const getCodeTransformationRequest = {
                     transformationJobId: request.TransformationJobId,
                 } as GetTransformationRequest
-                this.logging.log(
-                    'poll : send request to get transform  api: ' + JSON.stringify(getCodeTransformationRequest)
-                )
                 response = await this.client.codeModernizerGetCodeTransformation(getCodeTransformationRequest)
-                this.logging.log(
-                    'poll : received response from get transform api, the job status is ' +
-                        response.transformationJob?.status
-                )
-
-                if (response.transformationJob?.status) {
-                    this.logging.log(
-                        'status is included in validExitSTatus for poll ' +
-                            validExitStatus.includes(response.transformationJob.status)
-                    )
-                }
+                this.logging.log('Transformation status: ' + response.transformationJob?.status)
 
                 if (validExitStatus.includes(status)) {
-                    this.logging.log('returning status as : ' + status)
+                    this.logging.log('Exiting polling for transformation plan with transformation status: ' + status)
                     break
                 }
 
                 status = response.transformationJob.status!
                 await this.sleep(10 * 1000)
                 timer += 10
-                this.logging.log('current polling timer ' + timer)
+                this.logging.log('Current polling timer ' + timer)
 
                 if (timer > 24 * 3600 * 1000) {
                     status = PollTransformationStatus.TIMEOUT
@@ -342,25 +318,23 @@ export class TransformHandler {
                 getTransformAttempt = 0 // a successful polling will reset attempt
             } catch (e: any) {
                 const errorMessage = (e as Error).message ?? 'Error in GetTransformation API call'
-                this.logging.log('poll : error polling transformation job from the server: ' + errorMessage)
+                this.logging.log('Error polling transformation job from the server: ' + errorMessage)
 
                 getTransformAttempt += 1
                 if (getTransformAttempt >= getTransformMaxAttempts) {
-                    this.logging.log(
-                        `CodeTransformation: GetTransformation failed after ${getTransformMaxAttempts} attempts.`
-                    )
+                    this.logging.log(`GetTransformation failed after ${getTransformMaxAttempts} attempts.`)
                     status = PollTransformationStatus.NOT_FOUND
                     break
                 }
 
                 const expDelayMs = this.getExpDelayForApiRetryMs(getTransformAttempt)
                 this.logging.log(
-                    `poll : Attempt ${getTransformAttempt}/${getTransformMaxAttempts} to get transformation plan failed, retry in ${expDelayMs} seconds`
+                    `Attempt ${getTransformAttempt}/${getTransformMaxAttempts} to get transformation plan failed, retry in ${expDelayMs} seconds`
                 )
                 await this.sleep(expDelayMs * 1000)
             }
         }
-        this.logging.log('poll : returning response from server : ' + JSON.stringify(response))
+        this.logging.log('Returning response from server : ' + JSON.stringify(response))
         this.logSuggestionForFailureResponse(request, response.transformationJob, failureStates)
         return {
             TransformationJob: response.transformationJob,
@@ -376,10 +350,10 @@ export class TransformHandler {
             })
 
             const buffer = []
-            this.logging.log('artifact downloaded successfully.')
+            this.logging.log('Artifact was successfully downloaded.')
 
             if (result.body === undefined) {
-                throw new Error('Empty response from CodeWhisperer Streaming service.')
+                throw new Error('Empty response from CodeWhisperer streaming service.')
             }
 
             for await (const chunk of result.body) {
@@ -392,7 +366,7 @@ export class TransformHandler {
             }
             const saveToWorkspace = path.join(saveToDir, workspaceFolderName)
             const pathContainingArchive = await this.archivePathGenerator(exportId, buffer, saveToWorkspace)
-            this.logging.log('pathContainingArchive :' + pathContainingArchive)
+            this.logging.log('PathContainingArchive :' + pathContainingArchive)
             return {
                 PathTosave: pathContainingArchive,
             } as DownloadArtifactsResponse

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -59,14 +59,12 @@ export const QNetTransformServerToken =
                 switch (params.command) {
                     case StartTransformCommand: {
                         const request = params as StartTransformRequest
-                        logging.log('Calling startTransformRequest: ' + request.SolutionRootPath)
                         const response = await transformHandler.startTransformation(request)
                         emitTransformationJobStartedTelemetry(telemetry, response)
                         return response
                     }
                     case GetTransformCommand: {
                         const request = params as GetTransformRequest
-                        logging.log('Calling getTransform request with job Id: ' + request.TransformationJobId)
                         const response = await transformHandler.getTransformation(request)
                         if (response != null) {
                             emitTransformationJobReceivedTelemetry(telemetry, response)
@@ -75,52 +73,32 @@ export const QNetTransformServerToken =
                     }
                     case PollTransformCommand: {
                         const request = params as GetTransformRequest
-                        logging.log('Calling pollTransform request with job Id: ' + request.TransformationJobId)
                         const response = await transformHandler.pollTransformation(
                             request,
                             validStatesForComplete,
                             failureStates
-                        )
-                        logging.log(
-                            'Transformation job for job Id' +
-                                request.TransformationJobId +
-                                ' is ' +
-                                JSON.stringify(response)
                         )
                         emitTransformationJobPolledTelemetry(telemetry, response)
                         return response
                     }
                     case PollTransformForPlanCommand: {
                         const request = params as GetTransformRequest
-                        logging.log('Calling pollTransformForPlan request with job Id: ' + request.TransformationJobId)
                         const response = await transformHandler.pollTransformation(
                             request,
                             validStatesForGettingPlan,
                             failureStates
-                        )
-                        logging.log(
-                            'Transformation job for job Id' +
-                                request.TransformationJobId +
-                                ' is ' +
-                                JSON.stringify(response)
                         )
                         emitTransformationJobPolledForPlanTelemetry(telemetry, response)
                         return response
                     }
                     case GetTransformPlanCommand: {
                         const request = params as GetTransformPlanRequest
-                        logging.log('Calling getTransformPlan request with job Id: ' + request.TransformationJobId)
                         const response = await transformHandler.getTransformationPlan(request)
-                        logging.log(
-                            'Received getTransformPlan response and updated transformation plan for job Id' +
-                                request.TransformationJobId
-                        )
                         emitTransformationPlanReceivedTelemetry(telemetry, response, request.TransformationJobId)
                         return response
                     }
                     case CancelTransformCommand: {
                         const request = params as CancelTransformRequest
-                        logging.log('request job ID: ' + request.TransformationJobId)
                         const response = await transformHandler.cancelTransformation(request)
                         emitTransformationJobCancelledTelemetry(telemetry, response, request.TransformationJobId)
                         return response
@@ -132,7 +110,7 @@ export const QNetTransformServerToken =
                             credentialsProvider,
                             customCWClientConfig
                         )
-                        logging.log('Calling Download Archive  with job Id: ' + request.TransformationJobId)
+
                         const response = await transformHandler.downloadExportResultArchive(
                             cwStreamingClient,
                             request.TransformationJobId,

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -112,10 +112,8 @@ export const QNetTransformServerToken =
                         logging.log('Calling getTransformPlan request with job Id: ' + request.TransformationJobId)
                         const response = await transformHandler.getTransformationPlan(request)
                         logging.log(
-                            'Transformation plan for job Id' +
-                                request.TransformationJobId +
-                                ' is ' +
-                                JSON.stringify(response)
+                            'Received getTransformPlan response and updated transformation plan for job Id' +
+                                request.TransformationJobId
                         )
                         emitTransformationPlanReceivedTelemetry(telemetry, response, request.TransformationJobId)
                         return response


### PR DESCRIPTION
## Problem

## Solution
This PR trims logs that don't add value to customer experience.
1. The response Json string from PollTransform and GetTransform endpoints
2. The duplicate logging for sending API request

Example of updated log
During the planning:
```
Info: [2024-11-08T01:14:02.911Z] Received transformation job Id: 63f66812-eb87-458a-8f89-f043eb2ebd9c
Info: [2024-11-08T01:14:08.797Z] aws/qNetTransform/pollTransformForPlan
Info: [2024-11-08T01:14:09.147Z] Start polling for transformation plan.
Info: [2024-11-08T01:14:09.147Z] The valid status to exit polling are: COMPLETED,PARTIALLY_COMPLETED,PLANNED,TRANSFORMING,TRANSFORMED
Info: [2024-11-08T01:14:09.148Z] The failure status are: FAILED,STOPPING,STOPPED,REJECTED
Info: [2024-11-08T01:14:09.148Z] Transformation status: ACCEPTED
Info: [2024-11-08T01:14:09.502Z] Transformation status: ACCEPTED
Info: [2024-11-08T01:14:19.862Z] Transformation status: ACCEPTED
Info: [2024-11-08T01:14:30.204Z] Transformation status: PLANNING
Info: [2024-11-08T01:14:40.531Z] Transformation status: PLANNING
Info: [2024-11-08T01:14:50.879Z] Transformation status: PLANNING
Info: [2024-11-08T01:15:01.230Z] Transformation status: TRANSFORMING
Info: [2024-11-08T01:15:11.610Z] Transformation status: TRANSFORMING
Info: [2024-11-08T01:15:11.610Z] Exiting polling for transformation plan with transformation status: TRANSFORMING
Info: [2024-11-08T01:15:11.610Z] Returning response from server : {"transformationJob":{"jobId":"63f66812-eb87-458a-8f89-f043eb2ebd9c","transformationSpec":{"transformationType":"LANGUAGE_UPGRADE","source":{"language":"C_SHARP","runtimeEnv":{"dotNet":"NET_CORE_APP_3_1"},"platformConfig":{"operatingSystemFamily":"WINDOWS"}},"target":{"language":"C_SHARP","runtimeEnv":{"dotNet":"NET_8_0"},"platformConfig":{"operatingSystemFamily":"LINUX"}}},"status":"TRANSFORMING","creationTime":"2024-11-08T01:14:00.246Z"}}
```
During the polling:
```
Info: [2024-11-08T01:15:44.729Z] aws/qNetTransform/getTransform
Info: [2024-11-08T01:15:45.082Z] Transformation status: TRANSFORMING
Info: [2024-11-08T01:15:45.119Z] aws/qNetTransform/getTransformPlan
Info: [2024-11-08T01:15:55.734Z] aws/qNetTransform/getTransform
Info: [2024-11-08T01:15:56.028Z] Transformation status: TRANSFORMING
Info: [2024-11-08T01:15:56.071Z] aws/qNetTransform/getTransformPlan
Info: [2024-11-08T01:16:06.497Z] aws/qNetTransform/getTransform
Info: [2024-11-08T01:16:06.835Z] Transformation status: TRANSFORMING
Info: [2024-11-08T01:16:06.887Z] aws/qNetTransform/getTransformPlan
```
During the cancellation:
```
Info: [2024-11-08T01:16:39.190Z] aws/qNetTransform/cancelTransform
Info: [2024-11-08T01:16:39.191Z] Sending CancelTransformRequest with job Id: 63f66812-eb87-458a-8f89-f043eb2ebd9c
Info: [2024-11-08T01:16:39.256Z] Transformation status: STOPPED
Info: [2024-11-08T01:16:39.342Z] aws/qNetTransform/getTransformPlan
Info: [2024-11-08T01:16:49.938Z] aws/qNetTransform/getTransform
Info: [2024-11-08T01:16:49.938Z] Sending GetTransformRequest...
Info: [2024-11-08T01:16:50.362Z] Transformation status: STOPPED
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
