### PR TITLE
Amazon Q: port logic for CodePercentage modifications calculation

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -1602,7 +1602,7 @@ describe('CodeWhisperer Server', () => {
             const expectedSessionData = {
                 id: SESSION_IDS_LOG[0],
                 state: 'ACTIVE',
-                suggestions: [{ itemId: 'cwspr-item-id', content: 'recommendation' }],
+                suggestions: [{ itemId: 'cwspr-item-id', content: 'recommendation', insertText: 'recommendation' }],
                 responseContext: EXPECTED_RESPONSE_CONTEXT,
                 codewhispererSessionId: EXPECTED_RESPONSE_CONTEXT.codewhispererSessionId,
                 timeToFirstRecommendation: 0,
@@ -1670,7 +1670,7 @@ describe('CodeWhisperer Server', () => {
             const expectedSessionData = {
                 id: SESSION_IDS_LOG[2],
                 state: 'ACTIVE',
-                suggestions: [{ itemId: 'cwspr-item-id', content: 'recommendation' }],
+                suggestions: [{ itemId: 'cwspr-item-id', content: 'recommendation', insertText: 'recommendation' }],
             }
             assert(activeSession)
             sinon.assert.match(

--- a/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/session/sessionManager.ts
@@ -1,4 +1,9 @@
-import { InlineCompletionStates, Position, TextDocument } from '@aws/language-server-runtimes/server-interface'
+import {
+    InlineCompletionItemWithReferences,
+    InlineCompletionStates,
+    Position,
+    TextDocument,
+} from '@aws/language-server-runtimes/server-interface'
 import { v4 as uuidv4 } from 'uuid'
 import { CodewhispererAutomatedTriggerType, CodewhispererTriggerType } from '../auto-trigger/autoTrigger'
 import { GenerateSuggestionsRequest, ResponseContext, Suggestion } from '../codeWhispererService'
@@ -8,6 +13,10 @@ import { CodeWhispererSupplementalContext } from '../models/model'
 type SessionState = 'REQUESTING' | 'ACTIVE' | 'CLOSED' | 'ERROR' | 'DISCARD'
 export type UserDecision = 'Empty' | 'Filter' | 'Discard' | 'Accept' | 'Ignore' | 'Reject' | 'Unseen'
 type UserTriggerDecision = 'Accept' | 'Reject' | 'Empty' | 'Discard'
+
+interface CachedSuggestion extends Suggestion {
+    insertText?: string
+}
 
 export interface SessionData {
     document: TextDocument
@@ -36,7 +45,7 @@ export class CodeWhispererSession {
         line: 0,
         character: 0,
     }
-    suggestions: Suggestion[] = []
+    suggestions: CachedSuggestion[] = []
     suggestionsStates = new Map<string, UserDecision>()
     acceptedSuggestionId?: string = undefined
     responseContext?: ResponseContext

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codePercentage.test.ts
@@ -31,8 +31,8 @@ describe('CodePercentage', () => {
     })
 
     it('emits metrics every 5 minutes while editing', () => {
-        tracker.countTokens(LANGUAGE_ID, SOME_CONTENT)
-        tracker.countTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countTotalTokens(LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTotalTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
         tracker.countAcceptedTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
         tracker.countInvocation(LANGUAGE_ID)
         tracker.countSuccess(LANGUAGE_ID)
@@ -55,23 +55,23 @@ describe('CodePercentage', () => {
     })
 
     it('emits no metrics without invocations', () => {
-        tracker.countTokens(OTHER_LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTotalTokens(OTHER_LANGUAGE_ID, SOME_CONTENT)
 
-        clock.tick(5000 * 60)
+        clock.tick(5000 * 60 + 1)
 
         sinon.assert.notCalled(telemetryService.emitCodeCoverageEvent)
     })
 
     it('emits separate metrics for different languages', () => {
-        tracker.countTokens(LANGUAGE_ID, SOME_CONTENT)
-        tracker.countTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countTotalTokens(LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTotalTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
         tracker.countAcceptedTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
         tracker.countInvocation(LANGUAGE_ID)
         tracker.countSuccess(LANGUAGE_ID)
 
-        tracker.countTokens(OTHER_LANGUAGE_ID, SOME_CONTENT)
-        tracker.countTokens(OTHER_LANGUAGE_ID, SOME_CONTENT)
-        tracker.countTokens(OTHER_LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countTotalTokens(OTHER_LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTotalTokens(OTHER_LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTotalTokens(OTHER_LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
         tracker.countAcceptedTokens(OTHER_LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
         tracker.countInvocation(OTHER_LANGUAGE_ID)
         tracker.countSuccess(OTHER_LANGUAGE_ID)
@@ -108,8 +108,8 @@ describe('CodePercentage', () => {
     })
 
     it('emits metrics with customizationArn value', () => {
-        tracker.countTokens(LANGUAGE_ID, SOME_CONTENT)
-        tracker.countTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
+        tracker.countTotalTokens(LANGUAGE_ID, SOME_CONTENT)
+        tracker.countTotalTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
         tracker.countAcceptedTokens(LANGUAGE_ID, SOME_ACCEPTED_CONTENT)
         tracker.countInvocation(LANGUAGE_ID)
         tracker.countSuccess(LANGUAGE_ID)

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/userTriggerDecision.test.ts
@@ -508,9 +508,9 @@ describe('Telemetry', () => {
                     state: 'DISCARD',
                     codewhispererSessionId: 'cwspr-session-id-1',
                     suggestions: [
-                        { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                        { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                     ],
                     suggestionsStates: new Map([
                         ['cwspr-item-id-1', 'Discard'],
@@ -579,9 +579,9 @@ describe('Telemetry', () => {
                         'cwspr-item-id-3': { seen: true, accepted: false, discarded: false },
                     },
                     suggestions: [
-                        { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                        { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                     ],
                     suggestionsStates: new Map([
                         ['cwspr-item-id-1', 'Ignore'],
@@ -624,9 +624,9 @@ describe('Telemetry', () => {
 
                 const expectedUserTriggerDecisionMetric = aUserTriggerDecision({
                     suggestions: [
-                        { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                        { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                     ],
                     suggestionsStates: new Map([
                         ['cwspr-item-id-1', 'Reject'],
@@ -673,9 +673,9 @@ describe('Telemetry', () => {
 
                 const expectedUserTriggerDecisionMetric = aUserTriggerDecision({
                     suggestions: [
-                        { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                        { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                     ],
                     suggestionsStates: new Map([
                         ['cwspr-item-id-1', 'Discard'],
@@ -721,9 +721,9 @@ describe('Telemetry', () => {
                         'cwspr-item-id-3': { seen: true, accepted: false, discarded: false },
                     },
                     suggestions: [
-                        { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                        { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                     ],
                     suggestionsStates: new Map([
                         ['cwspr-item-id-1', 'Reject'],
@@ -754,9 +754,9 @@ describe('Telemetry', () => {
                     state: 'DISCARD',
                     codewhispererSessionId: 'cwspr-session-id-1',
                     suggestions: [
-                        { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                        { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                     ],
                     suggestionsStates: new Map([
                         ['cwspr-item-id-1', 'Discard'],
@@ -795,9 +795,9 @@ describe('Telemetry', () => {
                     state: 'DISCARD',
                     codewhispererSessionId: 'cwspr-session-id-1',
                     suggestions: [
-                        { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                        { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                     ],
                     suggestionsStates: new Map([
                         ['cwspr-item-id-1', 'Discard'],
@@ -858,9 +858,9 @@ describe('Telemetry', () => {
                     codewhispererSessionId: 'cwspr-session-id-1',
                     startPosition: { line: 2, character: 21 },
                     suggestions: [
-                        { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                        { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                     ],
                     suggestionsStates: {},
                     responseContext: { requestId: 'cwspr-request-id', codewhispererSessionId: 'cwspr-session-id-1' },
@@ -899,9 +899,9 @@ describe('Telemetry', () => {
                         state: 'DISCARD',
                         codewhispererSessionId: 'cwspr-session-id-2',
                         suggestions: [
-                            { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                            { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                            { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                            { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                            { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                            { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                         ],
                         suggestionsStates: new Map([
                             ['cwspr-item-id-1', 'Discard'],
@@ -959,9 +959,9 @@ describe('Telemetry', () => {
                         state: 'CLOSED',
                         codewhispererSessionId: 'cwspr-session-id-1',
                         suggestions: [
-                            { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                            { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                            { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                            { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                            { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                            { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                         ],
                         suggestionsStates: new Map([
                             ['cwspr-item-id-1', 'Reject'],
@@ -997,14 +997,17 @@ describe('Telemetry', () => {
                         {
                             itemId: 'cwspr-item-id-1',
                             content: 'recommendation',
+                            insertText: 'recommendation',
                         },
                         {
                             itemId: 'cwspr-item-id-2',
                             content: 'recommendation',
+                            insertText: 'recommendation',
                         },
                         {
                             itemId: 'cwspr-item-id-3',
                             content: 'recommendation',
+                            insertText: 'recommendation',
                         },
                     ],
                     suggestionsStates: {},
@@ -1088,9 +1091,9 @@ describe('Telemetry', () => {
                         codewhispererSessionId: 'cwspr-session-id-0',
                         state: 'DISCARD',
                         suggestions: [
-                            { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                            { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                            { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                            { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                            { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                            { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                         ],
                         suggestionsStates: new Map([
                             ['cwspr-item-id-1', 'Discard'],
@@ -1121,9 +1124,9 @@ describe('Telemetry', () => {
                     codewhispererSessionId: 'cwspr-session-id-1',
                     startPosition: { line: 2, character: 21 },
                     suggestions: [
-                        { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                        { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                     ],
                     suggestionsStates: {},
                     responseContext: { requestId: 'cwspr-request-id', codewhispererSessionId: 'cwspr-session-id-1' },
@@ -1168,9 +1171,9 @@ describe('Telemetry', () => {
                         closeTime: 1483228803770,
                         codewhispererSessionId: 'cwspr-session-id-2',
                         suggestions: [
-                            { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                            { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                            { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                            { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                            { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                            { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                         ],
                         suggestionsStates: new Map([
                             ['cwspr-item-id-1', 'Reject'],
@@ -1212,9 +1215,9 @@ describe('Telemetry', () => {
                 aUserTriggerDecision({
                     codewhispererSessionId: 'cwspr-session-id-1',
                     suggestions: [
-                        { itemId: 'cwspr-item-id-1', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-2', content: 'recommendation' },
-                        { itemId: 'cwspr-item-id-3', content: 'recommendation' },
+                        { itemId: 'cwspr-item-id-1', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-2', content: 'recommendation', insertText: 'recommendation' },
+                        { itemId: 'cwspr-item-id-3', content: 'recommendation', insertText: 'recommendation' },
                     ],
                     suggestionsStates: new Map([
                         ['cwspr-item-id-1', 'Reject'],


### PR DESCRIPTION
## Problem
* CodePercentage is emitted with 0 values when there were failed calls to service API. Expected behaviour - it should not emit telemetry
* When returned suggestion is right-merged with document content, it sometimes resulted in incorrect calculation of accepted token count being more than total document changes.
* CodeCoverage event calculation is not in sync with VSCode implementation. Up to date implementation is in https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts and it contains next changes:
  * New line characters inputs are treated as 1 character
  * Whitespace-only changes are ignored
  * Inserts over 50 characters are ignored

## Solution
Port logic from https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/codewhisperer/tracker/codewhispererCodeCoverageTracker.ts.

* Increment `CodePercentage.invocationCount` only after service call succeeds. Before we always incremented it, which resulted in telemetry being sent after errors with 0-ed values.
* Changed logic to ignore content that was right-merged by language server, by caching actually returned `insertText` for sugestions  in InlineCompletion `Session` object
* Update logic for `CodePercentage.countTotalTokens` to handle special cases mentioned above.
  * To prevent double-counting when accepted recommendation is less than 50 characters, added `fromCodeWhisperer` flag and special conditional case.


TODO
* [x] Check how changes for deletion are handled in VSCode - not handled
* [x] Unit tests

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
