### PR TITLE
Add temporary workaround for .NET 9 validation in Q .NET transformation converter

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/converter.ts
@@ -31,7 +31,7 @@ export const targetFrameworkMap = new Map<string, string>([
     ['net6.0', 'NET_6_0'],
     ['net7.0', 'NET_7_0'],
     ['net8.0', 'NET_8_0'],
-    ['net9.0', 'NET_9_0'],
+    ['net9.0', 'NET_8_0'], // This is a temporary workaround.
     ['netstandard2.0', 'NET_STANDARD_2_0'],
 ])
 


### PR DESCRIPTION
## Problem

Gumby validation is blocking our ability to test .NET 9 support.

## Solution

We have introduced a temporary workaround in the converter for Q .NET transformation.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
