### PR TITLE
Load proxy configurations in code whisperer base class

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -125,7 +125,7 @@ describe('ChatController', () => {
             emitMetric: sinon.stub(),
             onClientTelemetry: sinon.stub(),
         }
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
         invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
         chatController = new ChatController(chatSessionManagementService, testFeatures, telemetryService)
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -274,8 +274,7 @@ export const CodewhispererServerFactory =
             credentialsProvider,
             codeWhispererService.getCredentialsType(),
             telemetry,
-            logging,
-            {}
+            logging
         )
 
         lsp.addInitializer((params: InitializeParams) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -7,50 +7,23 @@ import { QNetTransformServerToken } from './netTransformServer'
 import { QChatServer } from './qChatServer'
 import { QConfigurationServerToken } from './configuration/qConfigurationServer'
 import { readFileSync } from 'fs'
-import { ConfigurationOptions } from 'aws-sdk'
 import { HttpsProxyAgent } from 'hpagent'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 
-const makeProxyConfig = () => {
-    let additionalAwsConfig: ConfigurationOptions = {}
-    const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
-
-    if (proxyUrl) {
-        const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
-        const agent = new HttpsProxyAgent({
-            proxy: proxyUrl,
-            ca: certs,
-        })
-
-        additionalAwsConfig = {
-            httpOptions: {
-                agent: agent,
-            },
-        }
-    }
-
-    return additionalAwsConfig
-}
-
 export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credentialsProvider => {
-    const additionalAwsConfig = makeProxyConfig()
-
-    return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
+    return new CodeWhispererServiceToken(credentialsProvider)
 })
 
 export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(credentialsProvider => {
-    const additionalAwsConfig = makeProxyConfig()
-    return new CodeWhispererServiceIAM(credentialsProvider, additionalAwsConfig)
+    return new CodeWhispererServiceIAM(credentialsProvider)
 })
 
 export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken(credentialsProvider => {
-    const additionalAwsConfig = makeProxyConfig()
-    return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
+    return new CodeWhispererServiceToken(credentialsProvider)
 })
 
 export const QNetTransformServerTokenProxy = QNetTransformServerToken(credentialsProvider => {
-    const additionalAwsConfig = makeProxyConfig()
-    return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
+    return new CodeWhispererServiceToken(credentialsProvider)
 })
 
 export const QChatServerProxy = QChatServer(credentialsProvider => {
@@ -82,6 +55,5 @@ export const QChatServerProxy = QChatServer(credentialsProvider => {
 })
 
 export const QConfigurationServerTokenProxy = QConfigurationServerToken(credentialsProvider => {
-    const additionalAwsConfig = makeProxyConfig()
-    return new CodeWhispererServiceToken(credentialsProvider, additionalAwsConfig)
+    return new CodeWhispererServiceToken(credentialsProvider)
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -11,7 +11,7 @@ export const QChatServer =
         const { chat, credentialsProvider, telemetry, logging, lsp, runtime } = features
 
         const chatSessionManagementService: ChatSessionManagementService = service(credentialsProvider)
-        const telemetryService = new TelemetryService(credentialsProvider, 'bearer', telemetry, logging, {})
+        const telemetryService = new TelemetryService(credentialsProvider, 'bearer', telemetry, logging)
 
         const chatController = new ChatController(chatSessionManagementService, features, telemetryService)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
@@ -105,7 +105,7 @@ describe('TelemetryService', () => {
     })
 
     it('updateUserContext updates the userContext property', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging)
         const mockUserContext: UserContext = {
             clientId: 'aaaabbbbccccdddd',
             ideCategory: 'ECLIPSE',
@@ -119,7 +119,7 @@ describe('TelemetryService', () => {
     })
 
     it('updateOptOutPreference updates the optOutPreference property', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging)
         const mockOptOutPreference: OptOutPreference = 'OPTIN'
         telemetryService.updateOptOutPreference(mockOptOutPreference)
 
@@ -127,14 +127,14 @@ describe('TelemetryService', () => {
     })
 
     it('updateEnableTelemetryEventsToDestination updates the enableTelemetryEventsToDestination property', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging)
         telemetryService.updateEnableTelemetryEventsToDestination(true)
 
         sinon.assert.match((telemetryService as any).enableTelemetryEventsToDestination, true)
     })
 
     it('getSuggestionState fetches the suggestion state from CodeWhispererSession', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging)
         const getSuggestionState = (telemetryService as any).getSuggestionState.bind(telemetryService)
         let session = {
             getAggregatedUserTriggerDecision: () => {
@@ -175,7 +175,7 @@ describe('TelemetryService', () => {
     })
 
     it('should not emit user trigger decision if login is invalid (IAM)', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', telemetry, logging)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
 
         telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
@@ -189,7 +189,7 @@ describe('TelemetryService', () => {
                 startUrl: BUILDER_ID_START_URL,
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
         telemetryService.updateOptOutPreference('OPTOUT')
 
@@ -199,7 +199,7 @@ describe('TelemetryService', () => {
     })
 
     it('should handle SSO connection type change at runtime', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
         const sendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
             .returns(Promise.resolve())
@@ -255,7 +255,7 @@ describe('TelemetryService', () => {
                 startUrl: 'idc-start-url',
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
         telemetryService.updateEnableTelemetryEventsToDestination(true)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -302,7 +302,7 @@ describe('TelemetryService', () => {
                 startUrl: BUILDER_ID_START_URL,
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
         telemetryService.updateEnableTelemetryEventsToDestination(false)
         telemetryService.updateOptOutPreference('OPTOUT')
         telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
@@ -323,7 +323,7 @@ describe('TelemetryService', () => {
                     startUrl: 'idc-start-url',
                 },
             })
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
             invokeSendTelemetryEventStub = sinon
                 .stub(telemetryService, 'sendTelemetryEvent' as any)
                 .returns(Promise.resolve())
@@ -395,7 +395,7 @@ describe('TelemetryService', () => {
                     startUrl: BUILDER_ID_START_URL,
                 },
             })
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging)
             telemetryService.updateEnableTelemetryEventsToDestination(false)
             telemetryService.updateOptOutPreference('OPTOUT')
             telemetryService.emitChatInteractWithMessage(metric, {
@@ -423,7 +423,7 @@ describe('TelemetryService', () => {
         })
 
         it('should not send InteractWithMessage when credentialsType is IAM', () => {
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', telemetry, logging, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', telemetry, logging)
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             const metric = {
                 cwsprChatMessageId: 'message123',
@@ -446,7 +446,7 @@ describe('TelemetryService', () => {
                     startUrl: BUILDER_ID_START_URL,
                 },
             })
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.updateOptOutPreference('OPTOUT')
             const metric = {
@@ -514,7 +514,7 @@ describe('TelemetryService', () => {
                 startUrl: 'idc-start-url',
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
             .returns(Promise.resolve())
@@ -553,7 +553,7 @@ describe('TelemetryService', () => {
                 startUrl: BUILDER_ID_START_URL,
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
         telemetryService.updateOptOutPreference('OPTOUT')
         telemetryService.updateEnableTelemetryEventsToDestination(false)
 
@@ -580,7 +580,7 @@ describe('TelemetryService', () => {
                 startUrl: 'idc-start-url',
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
             .returns(Promise.resolve())
@@ -623,7 +623,7 @@ describe('TelemetryService', () => {
                 startUrl: 'idc-start-url',
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
         telemetryService.updateEnableTelemetryEventsToDestination(true)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -667,7 +667,7 @@ describe('TelemetryService', () => {
                 startUrl: BUILDER_ID_START_URL,
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
         telemetryService.updateEnableTelemetryEventsToDestination(false)
         telemetryService.updateOptOutPreference('OPTOUT')
         telemetryService.emitChatUserModificationEvent({
@@ -693,7 +693,7 @@ describe('TelemetryService', () => {
                     startUrl: 'idc-start-url',
                 },
             })
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
             invokeSendTelemetryEventStub = sinon
                 .stub(telemetryService, 'sendTelemetryEvent' as any)
                 .returns(Promise.resolve())
@@ -781,7 +781,7 @@ describe('TelemetryService', () => {
                     startUrl: BUILDER_ID_START_URL,
                 },
             })
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', {} as Telemetry, logging)
             telemetryService.updateOptOutPreference('OPTOUT')
             telemetryService.updateEnableTelemetryEventsToDestination(false)
             telemetryService.emitChatAddMessage(
@@ -829,7 +829,7 @@ describe('TelemetryService', () => {
         })
 
         it('should not send ChatAddMessage when credentialsType is IAM', () => {
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', telemetry, logging, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', telemetry, logging)
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.emitChatAddMessage(
                 {
@@ -848,7 +848,7 @@ describe('TelemetryService', () => {
                     startUrl: BUILDER_ID_START_URL,
                 },
             })
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, {})
+            telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.updateOptOutPreference('OPTOUT')
             telemetryService.emitChatAddMessage(

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
@@ -56,10 +56,9 @@ export class TelemetryService extends CodeWhispererServiceToken {
         credentialsProvider: CredentialsProvider,
         credentialsType: CredentialsType,
         telemetry: Telemetry,
-        logging: Logging,
-        additionalAwsConfig: AWS.ConfigurationOptions = {}
+        logging: Logging
     ) {
-        super(credentialsProvider, additionalAwsConfig)
+        super(credentialsProvider)
         this.credentialsProvider = credentialsProvider
         this.credentialsType = credentialsType
         this.telemetry = telemetry


### PR DESCRIPTION
## Problem
Reference: https://issues.amazon.com/issues/AWS-Cloud9-28845
The PR aims to initialize proxy settings in Code Whisperer base class rather than fetching the value passed from constructor. 

## Solution

- The PR loads the proxy configurations from the code whisperer base class and sets the proxy configurations once the client is initialized. 
- The PR also contains the requisite changes to update the client specific AWS configuration, rather than loading global configurations. 
- Other servers which were using CodeWhispererServer/IAM - TokenProxy now no need to pass this proxy configuration in the constructor.
- The above changes have been tested on local environment. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
