### PR TITLE
Add GetSsoTokenResult.updateCredentialsParams to avoid decrypt/recrtyt in destinations

### DIFF
--- a/server/aws-lsp-identity/src/language-server/identityService.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.ts
@@ -73,7 +73,10 @@ export class IdentityService {
         })
 
         this.observability.logging.log('Successfully retrieved/logged-in to get SSO token.')
-        return { ssoToken: { accessToken: ssoToken.accessToken, id: ssoSession.name } }
+        return {
+            ssoToken: { accessToken: ssoToken.accessToken, id: ssoSession.name },
+            updateCredentialsParams: { data: { token: ssoToken.accessToken }, encrypted: false },
+        }
     }
 
     async invalidateSsoToken(


### PR DESCRIPTION
This PR updates the aws-lsp-identity server to support the additional GetSsoTokenResult.updateCredentialsParams added in https://github.com/aws/language-server-runtimes/pull/253. That PR must be approved and released first before this one can be merged.