### PR TITLE
Update @aws/language-server-runtimes to 0.2.26

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -10,7 +10,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1"
     },

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@aws/lsp-partiql": "^0.0.4"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.25"
+        "@aws/language-server-runtimes": "^0.2.26"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -270,7 +270,7 @@
         "@aws-sdk/credential-providers": "^3.614.0",
         "@aws-sdk/types": "^3.535.0",
         "@aws/chat-client-ui-types": "^0.0.8",
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.88.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1"
             },
@@ -64,7 +64,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -72,7 +72,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -92,7 +92,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -100,7 +100,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@aws/lsp-partiql": "^0.0.4"
             },
             "devDependencies": {
@@ -124,7 +124,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -144,7 +144,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -166,7 +166,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.25"
+                "@aws/language-server-runtimes": "^0.2.26"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -233,7 +233,7 @@
                 "@aws-sdk/credential-providers": "^3.614.0",
                 "@aws-sdk/types": "^3.535.0",
                 "@aws/chat-client-ui-types": "^0.0.8",
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.88.0",
                 "jose": "^5.2.4",
@@ -3189,9 +3189,10 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.25",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.25.tgz",
-            "integrity": "sha512-3CW08/XltCJuOHinI/gkiTEbsaeVbHKIMpspoRgoLkDjfElNVE8gDvAK153phf1VPhYNUaj/AgtafnCsvzcImA==",
+            "version": "0.2.26",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.26.tgz",
+            "integrity": "sha512-ttRod2I68uwr2JKB77V5eJsXCYTx66iAKBVHH/Y2ixfSVoZ8TquJWK0MbIX846++BYXtlknsnEOwrytwrDGPvw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.7",
                 "jose": "^5.9.6",
@@ -17286,7 +17287,7 @@
                 "@amzn/codewhisperer-streaming": "*",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.0.8",
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
@@ -17846,7 +17847,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.614.0",
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^3.1.5",
                 "https-proxy-agent": "^7.0.5",
@@ -17886,7 +17887,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -17900,7 +17901,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@aws/lsp-core": "0.0.1",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -17939,7 +17940,7 @@
             "version": "0.0.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4",
                 "web-tree-sitter": "0.22.6"
@@ -17972,7 +17973,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -17986,7 +17987,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -17997,7 +17998,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.25",
+                "@aws/language-server-runtimes": "^0.2.26",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -35,7 +35,7 @@
         "@amzn/codewhisperer-streaming": "*",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.0.8",
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.614.0",
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^3.1.5",
         "https-proxy-agent": "^7.0.5",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha 'out/**/*.test.js'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@aws/lsp-core": "0.0.1",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.25",
+        "@aws/language-server-runtimes": "^0.2.26",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Notes 

Update @aws/language-server-runtimes dependency to 0.2.26


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
