### PR TITLE
Revert "Bump @aws-sdk/client-sso-oidc from 3.658.1 to 3.691.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -322,12 +322,30 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
         "node_modules/@aws-crypto/crc32c": {
             "version": "5.2.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/crc32c/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.6.2"
             }
         },
@@ -343,45 +361,16 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-crypto/sha256-browser": {
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@aws-crypto/supports-web-crypto": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-            "dependencies": {
-                "@aws-crypto/sha256-js": "^5.2.0",
-                "@aws-crypto/supports-web-crypto": "^5.2.0",
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-crypto/sha256-js": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-            "dependencies": {
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@aws-crypto/util": {
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@aws-crypto/util": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
                 "@smithy/util-utf8": "^2.0.0",
@@ -439,108 +428,73 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.658.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.658.1.tgz",
-            "integrity": "sha512-RGcZAI3qEA05JszPKwa0cAyp8rnS1nUvs0Sqw4hqLNQ1kD7b7V6CPjRXe7EFQqCOMvM4kGqx0+cEEVTOmBsFLw==",
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.658.1",
-                "@aws-sdk/credential-provider-node": "3.658.1",
-                "@aws-sdk/middleware-host-header": "3.654.0",
-                "@aws-sdk/middleware-logger": "3.654.0",
-                "@aws-sdk/middleware-recursion-detection": "3.654.0",
-                "@aws-sdk/middleware-user-agent": "3.654.0",
-                "@aws-sdk/region-config-resolver": "3.654.0",
-                "@aws-sdk/types": "3.654.0",
-                "@aws-sdk/util-endpoints": "3.654.0",
-                "@aws-sdk/util-user-agent-browser": "3.654.0",
-                "@aws-sdk/util-user-agent-node": "3.654.0",
-                "@smithy/config-resolver": "^3.0.8",
-                "@smithy/core": "^2.4.6",
-                "@smithy/fetch-http-handler": "^3.2.8",
-                "@smithy/hash-node": "^3.0.6",
-                "@smithy/invalid-dependency": "^3.0.6",
-                "@smithy/middleware-content-length": "^3.0.8",
-                "@smithy/middleware-endpoint": "^3.1.3",
-                "@smithy/middleware-retry": "^3.0.21",
-                "@smithy/middleware-serde": "^3.0.6",
-                "@smithy/middleware-stack": "^3.0.6",
-                "@smithy/node-config-provider": "^3.1.7",
-                "@smithy/node-http-handler": "^3.2.3",
-                "@smithy/protocol-http": "^4.1.3",
-                "@smithy/smithy-client": "^3.3.5",
-                "@smithy/types": "^3.4.2",
-                "@smithy/url-parser": "^3.0.6",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.21",
-                "@smithy/util-defaults-mode-node": "^3.0.21",
-                "@smithy/util-endpoints": "^2.1.2",
-                "@smithy/util-middleware": "^3.0.6",
-                "@smithy/util-retry": "^3.0.6",
-                "@smithy/util-utf8": "^3.0.0",
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.658.1"
             }
         },
-        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
-            "version": "3.658.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.658.1.tgz",
-            "integrity": "sha512-yw9hc5blTnbT1V6mR7Cx9HGc9KQpcLQ1QXj8rntiJi6tIYu3aFNVEyy81JHL7NsuBSeQulJTvHO3y6r3O0sfRg==",
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/client-sso-oidc": "3.658.1",
-                "@aws-sdk/core": "3.658.1",
-                "@aws-sdk/credential-provider-node": "3.658.1",
-                "@aws-sdk/middleware-host-header": "3.654.0",
-                "@aws-sdk/middleware-logger": "3.654.0",
-                "@aws-sdk/middleware-recursion-detection": "3.654.0",
-                "@aws-sdk/middleware-user-agent": "3.654.0",
-                "@aws-sdk/region-config-resolver": "3.654.0",
-                "@aws-sdk/types": "3.654.0",
-                "@aws-sdk/util-endpoints": "3.654.0",
-                "@aws-sdk/util-user-agent-browser": "3.654.0",
-                "@aws-sdk/util-user-agent-node": "3.654.0",
-                "@smithy/config-resolver": "^3.0.8",
-                "@smithy/core": "^2.4.6",
-                "@smithy/fetch-http-handler": "^3.2.8",
-                "@smithy/hash-node": "^3.0.6",
-                "@smithy/invalid-dependency": "^3.0.6",
-                "@smithy/middleware-content-length": "^3.0.8",
-                "@smithy/middleware-endpoint": "^3.1.3",
-                "@smithy/middleware-retry": "^3.0.21",
-                "@smithy/middleware-serde": "^3.0.6",
-                "@smithy/middleware-stack": "^3.0.6",
-                "@smithy/node-config-provider": "^3.1.7",
-                "@smithy/node-http-handler": "^3.2.3",
-                "@smithy/protocol-http": "^4.1.3",
-                "@smithy/smithy-client": "^3.3.5",
-                "@smithy/types": "^3.4.2",
-                "@smithy/url-parser": "^3.0.6",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.21",
-                "@smithy/util-defaults-mode-node": "^3.0.21",
-                "@smithy/util-endpoints": "^2.1.2",
-                "@smithy/util-middleware": "^3.0.6",
-                "@smithy/util-retry": "^3.0.6",
-                "@smithy/util-utf8": "^3.0.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
@@ -632,6 +586,21 @@
                 }
             }
         },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/config-resolver": {
+            "version": "3.0.9",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/fetch-http-handler": {
             "version": "3.2.9",
             "dev": true,
@@ -642,6 +611,206 @@
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/hash-node": {
+            "version": "3.0.7",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-content-length": {
+            "version": "3.0.9",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-retry": {
+            "version": "3.0.22",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/service-error-classification": "^3.0.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-middleware": "^3.0.7",
+                "@smithy/util-retry": "^3.0.7",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-serde": {
+            "version": "3.0.7",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.8",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/service-error-classification": {
+            "version": "3.0.7",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/smithy-client": {
+            "version": "3.3.6",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.1.4",
+                "@smithy/middleware-stack": "^3.0.7",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-stream": "^3.1.9",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "3.0.22",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "3.0.22",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^3.0.9",
+                "@smithy/credential-provider-imds": "^3.2.4",
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-retry": {
+            "version": "3.0.7",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^3.0.7",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
@@ -735,106 +904,67 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.658.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.658.1.tgz",
-            "integrity": "sha512-RGcZAI3qEA05JszPKwa0cAyp8rnS1nUvs0Sqw4hqLNQ1kD7b7V6CPjRXe7EFQqCOMvM4kGqx0+cEEVTOmBsFLw==",
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.658.1",
-                "@aws-sdk/credential-provider-node": "3.658.1",
-                "@aws-sdk/middleware-host-header": "3.654.0",
-                "@aws-sdk/middleware-logger": "3.654.0",
-                "@aws-sdk/middleware-recursion-detection": "3.654.0",
-                "@aws-sdk/middleware-user-agent": "3.654.0",
-                "@aws-sdk/region-config-resolver": "3.654.0",
-                "@aws-sdk/types": "3.654.0",
-                "@aws-sdk/util-endpoints": "3.654.0",
-                "@aws-sdk/util-user-agent-browser": "3.654.0",
-                "@aws-sdk/util-user-agent-node": "3.654.0",
-                "@smithy/config-resolver": "^3.0.8",
-                "@smithy/core": "^2.4.6",
-                "@smithy/fetch-http-handler": "^3.2.8",
-                "@smithy/hash-node": "^3.0.6",
-                "@smithy/invalid-dependency": "^3.0.6",
-                "@smithy/middleware-content-length": "^3.0.8",
-                "@smithy/middleware-endpoint": "^3.1.3",
-                "@smithy/middleware-retry": "^3.0.21",
-                "@smithy/middleware-serde": "^3.0.6",
-                "@smithy/middleware-stack": "^3.0.6",
-                "@smithy/node-config-provider": "^3.1.7",
-                "@smithy/node-http-handler": "^3.2.3",
-                "@smithy/protocol-http": "^4.1.3",
-                "@smithy/smithy-client": "^3.3.5",
-                "@smithy/types": "^3.4.2",
-                "@smithy/url-parser": "^3.0.6",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.21",
-                "@smithy/util-defaults-mode-node": "^3.0.21",
-                "@smithy/util-endpoints": "^2.1.2",
-                "@smithy/util-middleware": "^3.0.6",
-                "@smithy/util-retry": "^3.0.6",
-                "@smithy/util-utf8": "^3.0.0",
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
                 "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.658.1"
             }
         },
-        "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
-            "version": "3.658.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.658.1.tgz",
-            "integrity": "sha512-yw9hc5blTnbT1V6mR7Cx9HGc9KQpcLQ1QXj8rntiJi6tIYu3aFNVEyy81JHL7NsuBSeQulJTvHO3y6r3O0sfRg==",
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/client-sso-oidc": "3.658.1",
-                "@aws-sdk/core": "3.658.1",
-                "@aws-sdk/credential-provider-node": "3.658.1",
-                "@aws-sdk/middleware-host-header": "3.654.0",
-                "@aws-sdk/middleware-logger": "3.654.0",
-                "@aws-sdk/middleware-recursion-detection": "3.654.0",
-                "@aws-sdk/middleware-user-agent": "3.654.0",
-                "@aws-sdk/region-config-resolver": "3.654.0",
-                "@aws-sdk/types": "3.654.0",
-                "@aws-sdk/util-endpoints": "3.654.0",
-                "@aws-sdk/util-user-agent-browser": "3.654.0",
-                "@aws-sdk/util-user-agent-node": "3.654.0",
-                "@smithy/config-resolver": "^3.0.8",
-                "@smithy/core": "^2.4.6",
-                "@smithy/fetch-http-handler": "^3.2.8",
-                "@smithy/hash-node": "^3.0.6",
-                "@smithy/invalid-dependency": "^3.0.6",
-                "@smithy/middleware-content-length": "^3.0.8",
-                "@smithy/middleware-endpoint": "^3.1.3",
-                "@smithy/middleware-retry": "^3.0.21",
-                "@smithy/middleware-serde": "^3.0.6",
-                "@smithy/middleware-stack": "^3.0.6",
-                "@smithy/node-config-provider": "^3.1.7",
-                "@smithy/node-http-handler": "^3.2.3",
-                "@smithy/protocol-http": "^4.1.3",
-                "@smithy/smithy-client": "^3.3.5",
-                "@smithy/types": "^3.4.2",
-                "@smithy/url-parser": "^3.0.6",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.21",
-                "@smithy/util-defaults-mode-node": "^3.0.21",
-                "@smithy/util-endpoints": "^2.1.2",
-                "@smithy/util-middleware": "^3.0.6",
-                "@smithy/util-retry": "^3.0.6",
-                "@smithy/util-utf8": "^3.0.0",
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
@@ -920,6 +1050,20 @@
                 }
             }
         },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/config-resolver": {
+            "version": "3.0.9",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-s3/node_modules/@smithy/fetch-http-handler": {
             "version": "3.2.9",
             "license": "Apache-2.0",
@@ -929,6 +1073,191 @@
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/hash-node": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-content-length": {
+            "version": "3.0.9",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-retry": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/service-error-classification": "^3.0.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-middleware": "^3.0.7",
+                "@smithy/util-retry": "^3.0.7",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-serde": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/service-error-classification": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/smithy-client": {
+            "version": "3.3.6",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.1.4",
+                "@smithy/middleware-stack": "^3.0.7",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-stream": "^3.1.9",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^3.0.9",
+                "@smithy/credential-provider-imds": "^3.2.4",
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-retry": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^3.0.7",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-utf8": {
@@ -1001,47 +1330,46 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.691.0.tgz",
-            "integrity": "sha512-3njUhD4buM1RfigU6IXZ18/R9V5mbqNrAftgDabnNn4/V4Qly32nz+KQONXT5x0GqPszGhp+0mmwuLai9DxSrQ==",
+            "version": "3.658.1",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/credential-provider-node": "3.691.0",
-                "@aws-sdk/middleware-host-header": "3.686.0",
-                "@aws-sdk/middleware-logger": "3.686.0",
-                "@aws-sdk/middleware-recursion-detection": "3.686.0",
-                "@aws-sdk/middleware-user-agent": "3.691.0",
-                "@aws-sdk/region-config-resolver": "3.686.0",
-                "@aws-sdk/types": "3.686.0",
-                "@aws-sdk/util-endpoints": "3.686.0",
-                "@aws-sdk/util-user-agent-browser": "3.686.0",
-                "@aws-sdk/util-user-agent-node": "3.691.0",
-                "@smithy/config-resolver": "^3.0.10",
-                "@smithy/core": "^2.5.1",
-                "@smithy/fetch-http-handler": "^4.0.0",
-                "@smithy/hash-node": "^3.0.8",
-                "@smithy/invalid-dependency": "^3.0.8",
-                "@smithy/middleware-content-length": "^3.0.10",
-                "@smithy/middleware-endpoint": "^3.2.1",
-                "@smithy/middleware-retry": "^3.0.25",
-                "@smithy/middleware-serde": "^3.0.8",
-                "@smithy/middleware-stack": "^3.0.8",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/node-http-handler": "^3.2.5",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "@smithy/url-parser": "^3.0.8",
+                "@aws-sdk/core": "3.658.1",
+                "@aws-sdk/credential-provider-node": "3.658.1",
+                "@aws-sdk/middleware-host-header": "3.654.0",
+                "@aws-sdk/middleware-logger": "3.654.0",
+                "@aws-sdk/middleware-recursion-detection": "3.654.0",
+                "@aws-sdk/middleware-user-agent": "3.654.0",
+                "@aws-sdk/region-config-resolver": "3.654.0",
+                "@aws-sdk/types": "3.654.0",
+                "@aws-sdk/util-endpoints": "3.654.0",
+                "@aws-sdk/util-user-agent-browser": "3.654.0",
+                "@aws-sdk/util-user-agent-node": "3.654.0",
+                "@smithy/config-resolver": "^3.0.8",
+                "@smithy/core": "^2.4.6",
+                "@smithy/fetch-http-handler": "^3.2.8",
+                "@smithy/hash-node": "^3.0.6",
+                "@smithy/invalid-dependency": "^3.0.6",
+                "@smithy/middleware-content-length": "^3.0.8",
+                "@smithy/middleware-endpoint": "^3.1.3",
+                "@smithy/middleware-retry": "^3.0.21",
+                "@smithy/middleware-serde": "^3.0.6",
+                "@smithy/middleware-stack": "^3.0.6",
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/node-http-handler": "^3.2.3",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/smithy-client": "^3.3.5",
+                "@smithy/types": "^3.4.2",
+                "@smithy/url-parser": "^3.0.6",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.25",
-                "@smithy/util-defaults-mode-node": "^3.0.25",
-                "@smithy/util-endpoints": "^2.1.4",
-                "@smithy/util-middleware": "^3.0.8",
-                "@smithy/util-retry": "^3.0.8",
+                "@smithy/util-defaults-mode-browser": "^3.0.21",
+                "@smithy/util-defaults-mode-node": "^3.0.21",
+                "@smithy/util-endpoints": "^2.1.2",
+                "@smithy/util-middleware": "^3.0.6",
+                "@smithy/util-retry": "^3.0.6",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -1049,266 +1377,359 @@
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.691.0"
+                "@aws-sdk/client-sts": "^3.658.1"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/client-sso": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.691.0.tgz",
-            "integrity": "sha512-bzp4ni6zGxwrlSWhG0MfOh57ORgzdUFlIc2JeQHLO9b6n0iNnG57ILHzo90sQxom6LfW1bXZrsKvYH3vAU8sdA==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/middleware-host-header": "3.686.0",
-                "@aws-sdk/middleware-logger": "3.686.0",
-                "@aws-sdk/middleware-recursion-detection": "3.686.0",
-                "@aws-sdk/middleware-user-agent": "3.691.0",
-                "@aws-sdk/region-config-resolver": "3.686.0",
-                "@aws-sdk/types": "3.686.0",
-                "@aws-sdk/util-endpoints": "3.686.0",
-                "@aws-sdk/util-user-agent-browser": "3.686.0",
-                "@aws-sdk/util-user-agent-node": "3.691.0",
-                "@smithy/config-resolver": "^3.0.10",
-                "@smithy/core": "^2.5.1",
-                "@smithy/fetch-http-handler": "^4.0.0",
-                "@smithy/hash-node": "^3.0.8",
-                "@smithy/invalid-dependency": "^3.0.8",
-                "@smithy/middleware-content-length": "^3.0.10",
-                "@smithy/middleware-endpoint": "^3.2.1",
-                "@smithy/middleware-retry": "^3.0.25",
-                "@smithy/middleware-serde": "^3.0.8",
-                "@smithy/middleware-stack": "^3.0.8",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/node-http-handler": "^3.2.5",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "@smithy/url-parser": "^3.0.8",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.25",
-                "@smithy/util-defaults-mode-node": "^3.0.25",
-                "@smithy/util-endpoints": "^2.1.4",
-                "@smithy/util-middleware": "^3.0.8",
-                "@smithy/util-retry": "^3.0.8",
-                "@smithy/util-utf8": "^3.0.0",
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/core": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.691.0.tgz",
-            "integrity": "sha512-5hyCj6gX92fXRf1kyfIpJetjVx0NxHbNmcLcrMy6oXuGNIBeJkMp+ZC6uJo3PsIjyPgGQSC++EhjLxpWiF/wHg==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/core": "^2.5.1",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/signature-v4": "^4.2.1",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-middleware": "^3.0.8",
-                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.691.0.tgz",
-            "integrity": "sha512-c4Ip7tSNxt5VANVyryl6XjfEUCbm7f+iCUEfEWEezywll4DjNZ1N0l7nNmX4dDbwRAB42XH3rk5fbqBe0lXT8g==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/types": "^3.6.0",
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.691.0.tgz",
-            "integrity": "sha512-RL2/d4DbUGeX8xKhXcwQvhAqd+WM3P87znSS5nEQA5pSwqeJsC3l2DCj+09yUM6I9n7nOppe5XephiiBpq190w==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/fetch-http-handler": "^4.0.0",
-                "@smithy/node-http-handler": "^3.2.5",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-stream": "^3.2.1",
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.691.0.tgz",
-            "integrity": "sha512-NB5jbiBLAWD/oz2CHksKRHo+Q8KI8ljyZUDW091j7IDYEYZZ/c2jDkYWX7eGnJqKNZLxGtcc1B+yYJrE9xXnbQ==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/credential-provider-env": "3.691.0",
-                "@aws-sdk/credential-provider-http": "3.691.0",
-                "@aws-sdk/credential-provider-process": "3.691.0",
-                "@aws-sdk/credential-provider-sso": "3.691.0",
-                "@aws-sdk/credential-provider-web-identity": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/credential-provider-imds": "^3.2.5",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.691.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.691.0.tgz",
-            "integrity": "sha512-GjQvajKDz6nKWS1Cxdzz2Ecu9R8aojOhRIPAgnG62MG5BvlqDddanF6szcDVSYtlWx+cv2SZ6lDYjoHnDnideQ==",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.691.0",
-                "@aws-sdk/credential-provider-http": "3.691.0",
-                "@aws-sdk/credential-provider-ini": "3.691.0",
-                "@aws-sdk/credential-provider-process": "3.691.0",
-                "@aws-sdk/credential-provider-sso": "3.691.0",
-                "@aws-sdk/credential-provider-web-identity": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/credential-provider-imds": "^3.2.5",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
-                "@smithy/types": "^3.6.0",
+                "@aws-sdk/types": "3.654.0",
+                "@aws-sdk/util-endpoints": "3.654.0",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.691.0.tgz",
-            "integrity": "sha512-tEoLkcxhF98aVHEyJ0n50rnNRewGUYYXszrNi8/sLh8enbDMWWByWReFPhNriE9oOdcrS5AKU7lCoY9i6zXQ3A==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
-                "@smithy/types": "^3.6.0",
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/types": "^3.4.2",
+                "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.691.0.tgz",
-            "integrity": "sha512-CxEiF2LMesk93dG+fCglLyVS9m7rjkWAZFUSSbjW7YbJC0VDks83hQG8EsFv+Grl/kvFITEvU0NoiavI6hbDlw==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.691.0",
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/token-providers": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.691.0.tgz",
-            "integrity": "sha512-54FgLnyWpSTlQ8/plZRFSXkI83wgPhJ4zqcX+n+K3BcGil4/Vsn/8+JQSY+6CA6JtDSqhpKAe54o+2DbDexsVg==",
-            "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/types": "^3.6.0",
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.691.0"
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
-            "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/config-resolver": {
+            "version": "3.0.9",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/types": "^3.6.0",
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/types": "^3.5.0",
                 "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.8",
+                "@smithy/util-middleware": "^3.0.7",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/token-providers": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.691.0.tgz",
-            "integrity": "sha512-XtBnNUOzdezdC/7bFYAenrUQCZI5raHZ1F+7qWEbEDbshz4nR6v0MczVXkaPsSJ6mel0sQMhYs7b3Y/0yUkB6w==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/fetch-http-handler": {
+            "version": "3.2.9",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
-                "@smithy/types": "^3.6.0",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/querystring-builder": "^3.0.7",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sso-oidc": "^3.691.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
-            "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/hash-node": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.6.0",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
-            "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-endpoints": "^2.1.4",
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-content-length": {
+            "version": "3.0.9",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-retry": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/service-error-classification": "^3.0.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-middleware": "^3.0.7",
+                "@smithy/util-retry": "^3.0.7",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/middleware-serde": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/service-error-classification": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/smithy-client": {
+            "version": "3.3.6",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.1.4",
+                "@smithy/middleware-stack": "^3.0.7",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-stream": "^3.1.9",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^3.0.9",
+                "@smithy/credential-provider-imds": "^3.2.4",
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-retry": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^3.0.7",
+                "@smithy/types": "^3.5.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1317,8 +1738,7 @@
         },
         "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-buffer-from": "^3.0.0",
                 "tslib": "^2.6.2"
@@ -1329,14 +1749,76 @@
         },
         "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
@@ -1422,6 +1904,20 @@
                 }
             }
         },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/config-resolver": {
+            "version": "3.0.9",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-sso/node_modules/@smithy/fetch-http-handler": {
             "version": "3.2.9",
             "license": "Apache-2.0",
@@ -1431,6 +1927,191 @@
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/hash-node": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-content-length": {
+            "version": "3.0.9",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-retry": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/service-error-classification": "^3.0.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-middleware": "^3.0.7",
+                "@smithy/util-retry": "^3.0.7",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/middleware-serde": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/service-error-classification": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/smithy-client": {
+            "version": "3.3.6",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.1.4",
+                "@smithy/middleware-stack": "^3.0.7",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-stream": "^3.1.9",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^3.0.9",
+                "@smithy/credential-provider-imds": "^3.2.4",
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-retry": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^3.0.7",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
@@ -1456,49 +2137,47 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.691.0.tgz",
-            "integrity": "sha512-Qmj2euPnmIni/eFSrc9LUkg52/2D487fTcKMwZh0ldHv4fD4ossuXX7AaDur8SD9Lc9EOxn/hXCsI644YnGwew==",
-            "peer": true,
+            "version": "3.658.1",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/client-sso-oidc": "3.691.0",
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/credential-provider-node": "3.691.0",
-                "@aws-sdk/middleware-host-header": "3.686.0",
-                "@aws-sdk/middleware-logger": "3.686.0",
-                "@aws-sdk/middleware-recursion-detection": "3.686.0",
-                "@aws-sdk/middleware-user-agent": "3.691.0",
-                "@aws-sdk/region-config-resolver": "3.686.0",
-                "@aws-sdk/types": "3.686.0",
-                "@aws-sdk/util-endpoints": "3.686.0",
-                "@aws-sdk/util-user-agent-browser": "3.686.0",
-                "@aws-sdk/util-user-agent-node": "3.691.0",
-                "@smithy/config-resolver": "^3.0.10",
-                "@smithy/core": "^2.5.1",
-                "@smithy/fetch-http-handler": "^4.0.0",
-                "@smithy/hash-node": "^3.0.8",
-                "@smithy/invalid-dependency": "^3.0.8",
-                "@smithy/middleware-content-length": "^3.0.10",
-                "@smithy/middleware-endpoint": "^3.2.1",
-                "@smithy/middleware-retry": "^3.0.25",
-                "@smithy/middleware-serde": "^3.0.8",
-                "@smithy/middleware-stack": "^3.0.8",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/node-http-handler": "^3.2.5",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "@smithy/url-parser": "^3.0.8",
+                "@aws-sdk/client-sso-oidc": "3.658.1",
+                "@aws-sdk/core": "3.658.1",
+                "@aws-sdk/credential-provider-node": "3.658.1",
+                "@aws-sdk/middleware-host-header": "3.654.0",
+                "@aws-sdk/middleware-logger": "3.654.0",
+                "@aws-sdk/middleware-recursion-detection": "3.654.0",
+                "@aws-sdk/middleware-user-agent": "3.654.0",
+                "@aws-sdk/region-config-resolver": "3.654.0",
+                "@aws-sdk/types": "3.654.0",
+                "@aws-sdk/util-endpoints": "3.654.0",
+                "@aws-sdk/util-user-agent-browser": "3.654.0",
+                "@aws-sdk/util-user-agent-node": "3.654.0",
+                "@smithy/config-resolver": "^3.0.8",
+                "@smithy/core": "^2.4.6",
+                "@smithy/fetch-http-handler": "^3.2.8",
+                "@smithy/hash-node": "^3.0.6",
+                "@smithy/invalid-dependency": "^3.0.6",
+                "@smithy/middleware-content-length": "^3.0.8",
+                "@smithy/middleware-endpoint": "^3.1.3",
+                "@smithy/middleware-retry": "^3.0.21",
+                "@smithy/middleware-serde": "^3.0.6",
+                "@smithy/middleware-stack": "^3.0.6",
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/node-http-handler": "^3.2.3",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/smithy-client": "^3.3.5",
+                "@smithy/types": "^3.4.2",
+                "@smithy/url-parser": "^3.0.6",
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-body-length-browser": "^3.0.0",
                 "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.25",
-                "@smithy/util-defaults-mode-node": "^3.0.25",
-                "@smithy/util-endpoints": "^2.1.4",
-                "@smithy/util-middleware": "^3.0.8",
-                "@smithy/util-retry": "^3.0.8",
+                "@smithy/util-defaults-mode-browser": "^3.0.21",
+                "@smithy/util-defaults-mode-node": "^3.0.21",
+                "@smithy/util-endpoints": "^2.1.2",
+                "@smithy/util-middleware": "^3.0.6",
+                "@smithy/util-retry": "^3.0.6",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -1506,276 +2185,356 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.691.0.tgz",
-            "integrity": "sha512-bzp4ni6zGxwrlSWhG0MfOh57ORgzdUFlIc2JeQHLO9b6n0iNnG57ILHzo90sQxom6LfW1bXZrsKvYH3vAU8sdA==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/middleware-host-header": "3.686.0",
-                "@aws-sdk/middleware-logger": "3.686.0",
-                "@aws-sdk/middleware-recursion-detection": "3.686.0",
-                "@aws-sdk/middleware-user-agent": "3.691.0",
-                "@aws-sdk/region-config-resolver": "3.686.0",
-                "@aws-sdk/types": "3.686.0",
-                "@aws-sdk/util-endpoints": "3.686.0",
-                "@aws-sdk/util-user-agent-browser": "3.686.0",
-                "@aws-sdk/util-user-agent-node": "3.691.0",
-                "@smithy/config-resolver": "^3.0.10",
-                "@smithy/core": "^2.5.1",
-                "@smithy/fetch-http-handler": "^4.0.0",
-                "@smithy/hash-node": "^3.0.8",
-                "@smithy/invalid-dependency": "^3.0.8",
-                "@smithy/middleware-content-length": "^3.0.10",
-                "@smithy/middleware-endpoint": "^3.2.1",
-                "@smithy/middleware-retry": "^3.0.25",
-                "@smithy/middleware-serde": "^3.0.8",
-                "@smithy/middleware-stack": "^3.0.8",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/node-http-handler": "^3.2.5",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "@smithy/url-parser": "^3.0.8",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.25",
-                "@smithy/util-defaults-mode-node": "^3.0.25",
-                "@smithy/util-endpoints": "^2.1.4",
-                "@smithy/util-middleware": "^3.0.8",
-                "@smithy/util-retry": "^3.0.8",
-                "@smithy/util-utf8": "^3.0.0",
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.691.0.tgz",
-            "integrity": "sha512-5hyCj6gX92fXRf1kyfIpJetjVx0NxHbNmcLcrMy6oXuGNIBeJkMp+ZC6uJo3PsIjyPgGQSC++EhjLxpWiF/wHg==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/core": "^2.5.1",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/signature-v4": "^4.2.1",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-middleware": "^3.0.8",
-                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.691.0.tgz",
-            "integrity": "sha512-c4Ip7tSNxt5VANVyryl6XjfEUCbm7f+iCUEfEWEezywll4DjNZ1N0l7nNmX4dDbwRAB42XH3rk5fbqBe0lXT8g==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/types": "^3.6.0",
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.691.0.tgz",
-            "integrity": "sha512-RL2/d4DbUGeX8xKhXcwQvhAqd+WM3P87znSS5nEQA5pSwqeJsC3l2DCj+09yUM6I9n7nOppe5XephiiBpq190w==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/fetch-http-handler": "^4.0.0",
-                "@smithy/node-http-handler": "^3.2.5",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-stream": "^3.2.1",
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.691.0.tgz",
-            "integrity": "sha512-NB5jbiBLAWD/oz2CHksKRHo+Q8KI8ljyZUDW091j7IDYEYZZ/c2jDkYWX7eGnJqKNZLxGtcc1B+yYJrE9xXnbQ==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/credential-provider-env": "3.691.0",
-                "@aws-sdk/credential-provider-http": "3.691.0",
-                "@aws-sdk/credential-provider-process": "3.691.0",
-                "@aws-sdk/credential-provider-sso": "3.691.0",
-                "@aws-sdk/credential-provider-web-identity": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/credential-provider-imds": "^3.2.5",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.691.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.691.0.tgz",
-            "integrity": "sha512-GjQvajKDz6nKWS1Cxdzz2Ecu9R8aojOhRIPAgnG62MG5BvlqDddanF6szcDVSYtlWx+cv2SZ6lDYjoHnDnideQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.691.0",
-                "@aws-sdk/credential-provider-http": "3.691.0",
-                "@aws-sdk/credential-provider-ini": "3.691.0",
-                "@aws-sdk/credential-provider-process": "3.691.0",
-                "@aws-sdk/credential-provider-sso": "3.691.0",
-                "@aws-sdk/credential-provider-web-identity": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/credential-provider-imds": "^3.2.5",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
-                "@smithy/types": "^3.6.0",
+                "@aws-sdk/types": "3.654.0",
+                "@aws-sdk/util-endpoints": "3.654.0",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.691.0.tgz",
-            "integrity": "sha512-tEoLkcxhF98aVHEyJ0n50rnNRewGUYYXszrNi8/sLh8enbDMWWByWReFPhNriE9oOdcrS5AKU7lCoY9i6zXQ3A==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
-                "@smithy/types": "^3.6.0",
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/types": "^3.4.2",
+                "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.691.0.tgz",
-            "integrity": "sha512-CxEiF2LMesk93dG+fCglLyVS9m7rjkWAZFUSSbjW7YbJC0VDks83hQG8EsFv+Grl/kvFITEvU0NoiavI6hbDlw==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.654.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.691.0",
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/token-providers": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.691.0.tgz",
-            "integrity": "sha512-54FgLnyWpSTlQ8/plZRFSXkI83wgPhJ4zqcX+n+K3BcGil4/Vsn/8+JQSY+6CA6JtDSqhpKAe54o+2DbDexsVg==",
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/types": "^3.6.0",
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.691.0"
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.686.0.tgz",
-            "integrity": "sha512-6zXD3bSD8tcsMAVVwO1gO7rI1uy2fCD3czgawuPGPopeLiPpo6/3FoUWCQzk2nvEhj7p9Z4BbjwZGSlRkVrXTw==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/config-resolver": {
+            "version": "3.0.9",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/types": "^3.6.0",
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/types": "^3.5.0",
                 "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.8",
+                "@smithy/util-middleware": "^3.0.7",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.691.0.tgz",
-            "integrity": "sha512-XtBnNUOzdezdC/7bFYAenrUQCZI5raHZ1F+7qWEbEDbshz4nR6v0MczVXkaPsSJ6mel0sQMhYs7b3Y/0yUkB6w==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/fetch-http-handler": {
+            "version": "3.2.9",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
-                "@smithy/types": "^3.6.0",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/querystring-builder": "^3.0.7",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sso-oidc": "^3.691.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
-            "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/hash-node": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.6.0",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
-            "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
-            "peer": true,
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-endpoints": "^2.1.4",
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-content-length": {
+            "version": "3.0.9",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-retry": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/service-error-classification": "^3.0.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-middleware": "^3.0.7",
+                "@smithy/util-retry": "^3.0.7",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-serde": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/service-error-classification": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.5.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/smithy-client": {
+            "version": "3.3.6",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.1.4",
+                "@smithy/middleware-stack": "^3.0.7",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-stream": "^3.1.9",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "3.0.22",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^3.0.9",
+                "@smithy/credential-provider-imds": "^3.2.4",
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/smithy-client": "^3.3.6",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-retry": {
+            "version": "3.0.7",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^3.0.7",
+                "@smithy/types": "^3.5.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1784,9 +2543,7 @@
         },
         "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-            "peer": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/util-buffer-from": "^3.0.0",
                 "tslib": "^2.6.2"
@@ -1797,9 +2554,7 @@
         },
         "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-            "peer": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^3.0.0",
                 "tslib": "^2.6.2"
@@ -1821,6 +2576,34 @@
                 "@smithy/types": "^3.4.2",
                 "@smithy/util-middleware": "^3.0.6",
                 "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core/node_modules/@smithy/smithy-client": {
+            "version": "3.3.6",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.1.4",
+                "@smithy/middleware-stack": "^3.0.7",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-stream": "^3.1.9",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1882,6 +2665,55 @@
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/smithy-client": {
+            "version": "3.3.6",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.1.4",
+                "@smithy/middleware-stack": "^3.0.7",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-stream": "^3.1.9",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
@@ -2000,244 +2832,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.658.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.658.1.tgz",
-            "integrity": "sha512-RGcZAI3qEA05JszPKwa0cAyp8rnS1nUvs0Sqw4hqLNQ1kD7b7V6CPjRXe7EFQqCOMvM4kGqx0+cEEVTOmBsFLw==",
-            "dev": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.658.1",
-                "@aws-sdk/credential-provider-node": "3.658.1",
-                "@aws-sdk/middleware-host-header": "3.654.0",
-                "@aws-sdk/middleware-logger": "3.654.0",
-                "@aws-sdk/middleware-recursion-detection": "3.654.0",
-                "@aws-sdk/middleware-user-agent": "3.654.0",
-                "@aws-sdk/region-config-resolver": "3.654.0",
-                "@aws-sdk/types": "3.654.0",
-                "@aws-sdk/util-endpoints": "3.654.0",
-                "@aws-sdk/util-user-agent-browser": "3.654.0",
-                "@aws-sdk/util-user-agent-node": "3.654.0",
-                "@smithy/config-resolver": "^3.0.8",
-                "@smithy/core": "^2.4.6",
-                "@smithy/fetch-http-handler": "^3.2.8",
-                "@smithy/hash-node": "^3.0.6",
-                "@smithy/invalid-dependency": "^3.0.6",
-                "@smithy/middleware-content-length": "^3.0.8",
-                "@smithy/middleware-endpoint": "^3.1.3",
-                "@smithy/middleware-retry": "^3.0.21",
-                "@smithy/middleware-serde": "^3.0.6",
-                "@smithy/middleware-stack": "^3.0.6",
-                "@smithy/node-config-provider": "^3.1.7",
-                "@smithy/node-http-handler": "^3.2.3",
-                "@smithy/protocol-http": "^4.1.3",
-                "@smithy/smithy-client": "^3.3.5",
-                "@smithy/types": "^3.4.2",
-                "@smithy/url-parser": "^3.0.6",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.21",
-                "@smithy/util-defaults-mode-node": "^3.0.21",
-                "@smithy/util-endpoints": "^2.1.2",
-                "@smithy/util-middleware": "^3.0.6",
-                "@smithy/util-retry": "^3.0.6",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.658.1"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
-            "version": "3.658.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.658.1.tgz",
-            "integrity": "sha512-yw9hc5blTnbT1V6mR7Cx9HGc9KQpcLQ1QXj8rntiJi6tIYu3aFNVEyy81JHL7NsuBSeQulJTvHO3y6r3O0sfRg==",
-            "dev": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/client-sso-oidc": "3.658.1",
-                "@aws-sdk/core": "3.658.1",
-                "@aws-sdk/credential-provider-node": "3.658.1",
-                "@aws-sdk/middleware-host-header": "3.654.0",
-                "@aws-sdk/middleware-logger": "3.654.0",
-                "@aws-sdk/middleware-recursion-detection": "3.654.0",
-                "@aws-sdk/middleware-user-agent": "3.654.0",
-                "@aws-sdk/region-config-resolver": "3.654.0",
-                "@aws-sdk/types": "3.654.0",
-                "@aws-sdk/util-endpoints": "3.654.0",
-                "@aws-sdk/util-user-agent-browser": "3.654.0",
-                "@aws-sdk/util-user-agent-node": "3.654.0",
-                "@smithy/config-resolver": "^3.0.8",
-                "@smithy/core": "^2.4.6",
-                "@smithy/fetch-http-handler": "^3.2.8",
-                "@smithy/hash-node": "^3.0.6",
-                "@smithy/invalid-dependency": "^3.0.6",
-                "@smithy/middleware-content-length": "^3.0.8",
-                "@smithy/middleware-endpoint": "^3.1.3",
-                "@smithy/middleware-retry": "^3.0.21",
-                "@smithy/middleware-serde": "^3.0.6",
-                "@smithy/middleware-stack": "^3.0.6",
-                "@smithy/node-config-provider": "^3.1.7",
-                "@smithy/node-http-handler": "^3.2.3",
-                "@smithy/protocol-http": "^4.1.3",
-                "@smithy/smithy-client": "^3.3.5",
-                "@smithy/types": "^3.4.2",
-                "@smithy/url-parser": "^3.0.6",
-                "@smithy/util-base64": "^3.0.0",
-                "@smithy/util-body-length-browser": "^3.0.0",
-                "@smithy/util-body-length-node": "^3.0.0",
-                "@smithy/util-defaults-mode-browser": "^3.0.21",
-                "@smithy/util-defaults-mode-node": "^3.0.21",
-                "@smithy/util-endpoints": "^2.1.2",
-                "@smithy/util-middleware": "^3.0.6",
-                "@smithy/util-retry": "^3.0.6",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.654.0.tgz",
-            "integrity": "sha512-rxGgVHWKp8U2ubMv+t+vlIk7QYUaRCHaVpmUlJv0Wv6Q0KeO9a42T9FxHphjOTlCGQOLcjCreL9CF8Qhtb4mdQ==",
-            "dev": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.654.0",
-                "@smithy/protocol-http": "^4.1.3",
-                "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.654.0.tgz",
-            "integrity": "sha512-OQYb+nWlmASyXfRb989pwkJ9EVUMP1CrKn2eyTk3usl20JZmKo2Vjis6I0tLUkMSxMhnBJJlQKyWkRpD/u1FVg==",
-            "dev": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.654.0",
-                "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.654.0.tgz",
-            "integrity": "sha512-gKSomgltKVmsT8sC6W7CrADZ4GHwX9epk3GcH6QhebVO3LA9LRbkL3TwOPUXakxxOLLUTYdOZLIOtFf7iH00lg==",
-            "dev": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.654.0",
-                "@smithy/protocol-http": "^4.1.3",
-                "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.654.0.tgz",
-            "integrity": "sha512-liCcqPAyRsr53cy2tYu4qeH4MMN0eh9g6k56XzI5xd4SghXH5YWh4qOYAlQ8T66ZV4nPMtD8GLtLXGzsH8moFg==",
-            "dev": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.654.0",
-                "@aws-sdk/util-endpoints": "3.654.0",
-                "@smithy/protocol-http": "^4.1.3",
-                "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.654.0.tgz",
-            "integrity": "sha512-ykYAJqvnxLt7wfrqya28wuH3/7NdrwzfiFd7NqEVQf7dXVxL5RPEpD7DxjcyQo3DsHvvdUvGZVaQhozycn1pzA==",
-            "dev": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.654.0",
-                "@smithy/types": "^3.4.2",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.654.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.654.0.tgz",
-            "integrity": "sha512-a0ojjdBN6pqv6gB4H/QPPSfhs7mFtlVwnmKCM/QrTaFzN0U810PJ1BST3lBx5sa23I5jWHGaoFY+5q65C3clLQ==",
-            "dev": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.654.0",
-                "@smithy/node-config-provider": "^3.1.7",
-                "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/fetch-http-handler": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
-            "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
-            "dev": true,
-            "dependencies": {
-                "@smithy/protocol-http": "^4.1.4",
-                "@smithy/querystring-builder": "^3.0.7",
-                "@smithy/types": "^3.5.0",
-                "@smithy/util-base64": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-            "dev": true,
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-            "dev": true,
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
             "version": "3.654.0",
             "license": "Apache-2.0",
@@ -2248,6 +2842,19 @@
                 "@smithy/protocol-http": "^4.1.3",
                 "@smithy/types": "^3.4.2",
                 "@smithy/util-config-provider": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.8",
+                "@smithy/types": "^3.5.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2286,6 +2893,19 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-buffer-from": {
             "version": "3.0.0",
             "license": "Apache-2.0",
@@ -2308,89 +2928,12 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
-            "integrity": "sha512-+Yc6rO02z+yhFbHmRZGvEw1vmzf/ifS9a4aBjJGeVVU+ZxaUvnk+IUZWrj4YQopUQ+bSujmMUzJLXSkbDq7yuw==",
-            "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
-            "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-location-constraint": {
             "version": "3.654.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.654.0",
                 "@smithy/types": "^3.4.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.686.0.tgz",
-            "integrity": "sha512-cX43ODfA2+SPdX7VRxu6gXk4t4bdVJ9pkktbfnkE5t27OlwNfvSGGhnHrQL8xTOFeyQ+3T+oowf26gf1OI+vIg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
-            "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.686.0.tgz",
-            "integrity": "sha512-jF9hQ162xLgp9zZ/3w5RUNhmwVnXDBlABEUX8jCgzaFpaa742qR/KKtjjZQ6jMbQnP+8fOCSXFAVNMU+s6v81w==",
-            "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
-            "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2414,6 +2957,34 @@
                 "@smithy/util-middleware": "^3.0.6",
                 "@smithy/util-stream": "^3.1.8",
                 "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/smithy-client": {
+            "version": "3.3.6",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.1.4",
+                "@smithy/middleware-stack": "^3.0.7",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
+                "@smithy/util-stream": "^3.1.9",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2454,70 +3025,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.691.0.tgz",
-            "integrity": "sha512-d1ieFuOw7Lh4PQguSWceOgX0B4YkZOuYPRZhlAbwx/LQayoZ7LDh//0bbdDdgDgKyNxCTN5EjdoCh/MAPaKIjQ==",
-            "dependencies": {
-                "@aws-sdk/core": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@aws-sdk/util-endpoints": "3.686.0",
-                "@smithy/core": "^2.5.1",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/core": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.691.0.tgz",
-            "integrity": "sha512-5hyCj6gX92fXRf1kyfIpJetjVx0NxHbNmcLcrMy6oXuGNIBeJkMp+ZC6uJo3PsIjyPgGQSC++EhjLxpWiF/wHg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/core": "^2.5.1",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/signature-v4": "^4.2.1",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-middleware": "^3.0.8",
-                "fast-xml-parser": "4.4.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
-            "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.686.0.tgz",
-            "integrity": "sha512-7msZE2oYl+6QYeeRBjlDgxQUhq/XRky3cXE0FqLFs2muLS7XSuQEXkpOXB3R782ygAP6JX0kmBxPTLurRTikZg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-endpoints": "^2.1.4",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@aws-sdk/region-config-resolver": {
             "version": "3.654.0",
             "license": "Apache-2.0",
@@ -2527,6 +3034,19 @@
                 "@smithy/types": "^3.4.2",
                 "@smithy/util-config-provider": "^3.0.0",
                 "@smithy/util-middleware": "^3.0.6",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.9",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.8",
+                "@smithy/shared-ini-file-loader": "^3.1.9",
+                "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2636,64 +3156,6 @@
             },
             "engines": {
                 "node": ">= 14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.686.0.tgz",
-            "integrity": "sha512-YiQXeGYZegF1b7B2GOR61orhgv79qmI0z7+Agm3NXLO6hGfVV3kFUJbXnjtH1BgWo5hbZYW7HQ2omGb3dnb6Lg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/types": "^3.6.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
-            "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.691.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.691.0.tgz",
-            "integrity": "sha512-n+g337W2W/S3Ju47vBNs970477WsLidmdQp1jaxFaBYjSV8l7Tm4dZNMtrq4AEvS+2ErkLpm9BmTiREoWR38Ag==",
-            "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.691.0",
-                "@aws-sdk/types": "3.686.0",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
-            "version": "3.686.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.686.0.tgz",
-            "integrity": "sha512-xFnrb3wxOoJcW2Xrh63ZgFo5buIu9DF7bOHnwoUxHdNpUXicUh0AHw85TjXxyxIAd0d1psY/DU7QHoNI3OswgQ==",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
@@ -4462,15 +4924,34 @@
                 "tslib": "^2.6.2"
             }
         },
-        "node_modules/@smithy/config-resolver": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.10.tgz",
-            "integrity": "sha512-Uh0Sz9gdUuz538nvkPiyv1DZRX9+D15EKDtnQP5rYVAzM/dnYk3P8cg73jcxyOitPgT3mE3OVj7ky7sibzHWkw==",
+        "node_modules/@smithy/chunked-blob-reader-native/node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-config-provider": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.8",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/chunked-blob-reader-native/node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/chunked-blob-reader-native/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4492,6 +4973,24 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/core/node_modules/@smithy/middleware-serde": {
+            "version": "3.0.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/core/node_modules/@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/core/node_modules/@smithy/util-buffer-from": {
@@ -4524,6 +5023,19 @@
                 "@smithy/property-provider": "^3.1.8",
                 "@smithy/types": "^3.6.0",
                 "@smithy/url-parser": "^3.0.8",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.9",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.8",
+                "@smithy/shared-ini-file-loader": "^3.1.9",
+                "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4597,18 +5109,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/fetch-http-handler": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
-            "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/querystring-builder": "^3.0.8",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-base64": "^3.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
         "node_modules/@smithy/hash-blob-browser": {
             "version": "3.1.6",
             "license": "Apache-2.0",
@@ -4617,44 +5117,6 @@
                 "@smithy/chunked-blob-reader-native": "^3.0.0",
                 "@smithy/types": "^3.5.0",
                 "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@smithy/hash-node": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.8.tgz",
-            "integrity": "sha512-tlNQYbfpWXHimHqrvgo14DrMAgUBua/cNoz9fMYcDmYej7MAmUcjav/QKQbFc3NrcPxeJ7QClER4tWZmfwoPng==",
-            "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/hash-stream-node": {
@@ -4692,11 +5154,10 @@
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.8.tgz",
-            "integrity": "sha512-7Qynk6NWtTQhnGTTZwks++nJhQ1O54Mzi7fz4PqZOiYXb4Z1Flpb2yRvdALoggTS8xjtohWUM+RygOtB30YL3Q==",
+            "version": "3.0.7",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.6.0",
+                "@smithy/types": "^3.5.0",
                 "tslib": "^2.6.2"
             }
         },
@@ -4741,19 +5202,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/middleware-content-length": {
-            "version": "3.0.10",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.10.tgz",
-            "integrity": "sha512-T4dIdCs1d/+/qMpwhJ1DzOhxCZjZHbHazEPJWdB4GDi2HjIZllVzeBEcdJUN0fomV8DURsgOyrbEUzg3vzTaOg==",
-            "dependencies": {
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/middleware-endpoint": {
             "version": "3.2.1",
             "license": "Apache-2.0",
@@ -4771,30 +5219,23 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/middleware-retry": {
-            "version": "3.0.25",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.25.tgz",
-            "integrity": "sha512-m1F70cPaMBML4HiTgCw5I+jFNtjgz5z5UdGnUbG37vw6kh4UvizFYjqJGHvicfgKMkDL6mXwyPp5mhZg02g5sg==",
+        "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/middleware-serde": {
+            "version": "3.0.8",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/service-error-classification": "^3.0.8",
-                "@smithy/smithy-client": "^3.4.2",
                 "@smithy/types": "^3.6.0",
-                "@smithy/util-middleware": "^3.0.8",
-                "@smithy/util-retry": "^3.0.8",
-                "tslib": "^2.6.2",
-                "uuid": "^9.0.1"
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/middleware-serde": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.8.tgz",
-            "integrity": "sha512-Xg2jK9Wc/1g/MBMP/EUn2DLspN8LNt+GMe7cgF+Ty3vl+Zvu+VeZU5nmhveU+H8pxyTsjrAkci8NqY6OuvZnjA==",
+        "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.9",
+            "license": "Apache-2.0",
             "dependencies": {
+                "@smithy/property-provider": "^3.1.8",
+                "@smithy/shared-ini-file-loader": "^3.1.9",
                 "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
             },
@@ -4806,20 +5247,6 @@
             "version": "3.0.8",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/node-config-provider": {
-            "version": "3.1.9",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
-            "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/shared-ini-file-loader": "^3.1.9",
                 "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
             },
@@ -4886,17 +5313,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/service-error-classification": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.8.tgz",
-            "integrity": "sha512-uEC/kCCFto83bz5ZzapcrgGqHOh/0r69sZ2ZuHlgoD5kYgXJEThCoTuw/y1Ub3cE7aaKdznb+jD9xRPIfIwD7g==",
-            "dependencies": {
-                "@smithy/types": "^3.6.0"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/shared-ini-file-loader": {
             "version": "3.1.9",
             "license": "Apache-2.0",
@@ -4909,15 +5325,14 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
-            "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
+            "version": "4.2.0",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^3.0.0",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/types": "^3.6.0",
+                "@smithy/protocol-http": "^4.1.4",
+                "@smithy/types": "^3.5.0",
                 "@smithy/util-hex-encoding": "^3.0.0",
-                "@smithy/util-middleware": "^3.0.8",
+                "@smithy/util-middleware": "^3.0.7",
                 "@smithy/util-uri-escape": "^3.0.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
@@ -4958,23 +5373,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/smithy-client": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.2.tgz",
-            "integrity": "sha512-dxw1BDxJiY9/zI3cBqfVrInij6ShjpV4fmGHesGZZUiP9OSE/EVfdwdRz0PgvkEvrZHpsj2htRaHJfftE8giBA==",
-            "dependencies": {
-                "@smithy/core": "^2.5.1",
-                "@smithy/middleware-endpoint": "^3.2.1",
-                "@smithy/middleware-stack": "^3.0.8",
-                "@smithy/protocol-http": "^4.1.5",
-                "@smithy/types": "^3.6.0",
-                "@smithy/util-stream": "^3.2.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/types": {
             "version": "3.6.0",
             "license": "Apache-2.0",
@@ -4992,62 +5390,6 @@
                 "@smithy/querystring-parser": "^3.0.8",
                 "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@smithy/util-base64": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
-            "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "@smithy/util-utf8": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@smithy/util-body-length-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
-            "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@smithy/util-body-length-node": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
-            "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-buffer-from": {
@@ -5081,45 +5423,25 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "3.0.25",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.25.tgz",
-            "integrity": "sha512-fRw7zymjIDt6XxIsLwfJfYUfbGoO9CmCJk6rjJ/X5cd20+d2Is7xjU5Kt/AiDt6hX8DAf5dztmfP5O82gR9emA==",
-            "dependencies": {
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "3.0.25",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.25.tgz",
-            "integrity": "sha512-H3BSZdBDiVZGzt8TG51Pd2FvFO0PAx/A0mJ0EH8a13KJ6iUCdYnw/Dk/MdC1kTd0eUuUGisDFaxXVXo4HHFL1g==",
-            "dependencies": {
-                "@smithy/config-resolver": "^3.0.10",
-                "@smithy/credential-provider-imds": "^3.2.5",
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/property-provider": "^3.1.8",
-                "@smithy/smithy-client": "^3.4.2",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
         "node_modules/@smithy/util-endpoints": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.4.tgz",
-            "integrity": "sha512-kPt8j4emm7rdMWQyL0F89o92q10gvCUa6sBkBtDJ7nV2+P7wpXczzOfoDJ49CKXe5CCqb8dc1W+ZdLlrKzSAnQ==",
+            "version": "2.1.3",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^3.1.9",
-                "@smithy/types": "^3.6.0",
+                "@smithy/node-config-provider": "^3.1.8",
+                "@smithy/types": "^3.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.8",
+                "@smithy/types": "^3.5.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -5137,19 +5459,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@smithy/util-retry": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.8.tgz",
-            "integrity": "sha512-TCEhLnY581YJ+g1x0hapPz13JFqzmh/pMWL2KEFASC51qCfw3+Y47MrTmea4bUE5vsdxQ4F6/KFbUeSz22Q1ow==",
-            "dependencies": {
-                "@smithy/service-error-classification": "^3.0.8",
-                "@smithy/types": "^3.6.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/@smithy/util-stream": {
             "version": "3.2.1",
             "license": "Apache-2.0",
@@ -5160,6 +5469,29 @@
                 "@smithy/util-base64": "^3.0.0",
                 "@smithy/util-buffer-from": "^3.0.0",
                 "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+            "version": "4.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.1.5",
+                "@smithy/querystring-builder": "^3.0.8",
+                "@smithy/types": "^3.6.0",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/util-stream/node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
                 "@smithy/util-utf8": "^3.0.0",
                 "tslib": "^2.6.2"
             },
@@ -16988,6 +17320,47 @@
                 "node": ">=18.0.0"
             }
         },
+        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
         "server/aws-lsp-codewhisperer/node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.654.0",
             "license": "Apache-2.0",
@@ -17071,6 +17444,20 @@
                 }
             }
         },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/config-resolver": {
+            "version": "3.0.10",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.9",
+                "@smithy/types": "^3.6.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.8",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/fetch-http-handler": {
             "version": "3.2.9",
             "license": "Apache-2.0",
@@ -17080,6 +17467,84 @@
                 "@smithy/types": "^3.5.0",
                 "@smithy/util-base64": "^3.0.0",
                 "tslib": "^2.6.2"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/hash-node": {
+            "version": "3.0.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.6.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-content-length": {
+            "version": "3.0.10",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.1.5",
+                "@smithy/types": "^3.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-retry": {
+            "version": "3.0.25",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.9",
+                "@smithy/protocol-http": "^4.1.5",
+                "@smithy/service-error-classification": "^3.0.8",
+                "@smithy/smithy-client": "^3.4.2",
+                "@smithy/types": "^3.6.0",
+                "@smithy/util-middleware": "^3.0.8",
+                "@smithy/util-retry": "^3.0.8",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/middleware-serde": {
+            "version": "3.0.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/node-config-provider": {
+            "version": "3.1.9",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.8",
+                "@smithy/shared-ini-file-loader": "^3.1.9",
+                "@smithy/types": "^3.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/node-http-handler": {
@@ -17145,11 +17610,119 @@
                 "node": ">=14.0.0"
             }
         },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/service-error-classification": {
+            "version": "3.0.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^3.6.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/smithy-client": {
+            "version": "3.4.2",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^2.5.1",
+                "@smithy/middleware-endpoint": "^3.2.1",
+                "@smithy/middleware-stack": "^3.0.8",
+                "@smithy/protocol-http": "^4.1.5",
+                "@smithy/types": "^3.6.0",
+                "@smithy/util-stream": "^3.2.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "server/aws-lsp-codewhisperer/node_modules/@smithy/util-buffer-from": {
             "version": "3.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "3.0.25",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.8",
+                "@smithy/smithy-client": "^3.4.2",
+                "@smithy/types": "^3.6.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "3.0.25",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^3.0.10",
+                "@smithy/credential-provider-imds": "^3.2.5",
+                "@smithy/node-config-provider": "^3.1.9",
+                "@smithy/property-provider": "^3.1.8",
+                "@smithy/smithy-client": "^3.4.2",
+                "@smithy/types": "^3.6.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/@smithy/util-retry": {
+            "version": "3.0.8",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^3.0.8",
+                "@smithy/types": "^3.6.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -17273,7 +17846,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "^3.691.0",
+                "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.614.0",
                 "@aws/language-server-runtimes": "^0.2.26",
                 "@smithy/node-http-handler": "^3.2.5",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -21,7 +21,7 @@
         "test-unit": "mocha 'out/**/*.test.js'"
     },
     "dependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.691.0",
+        "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.614.0",
         "@aws/language-server-runtimes": "^0.2.26",
         "@smithy/node-http-handler": "^3.2.5",


### PR DESCRIPTION
## Notes
Reverting a dependency bump because it sets a semver range as `^3.616.0` which can be too strict to resolve a dependency against some npm indexes. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
