### PR TITLE
Testing notifications routing with test vscode client

### DIFF
--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -148,6 +148,11 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
                     },
                     clientId: randomUUID(),
                 },
+                awsClientCapabilities: {
+                    window: {
+                        notifications: true,
+                    },
+                },
             },
         },
         synchronize: {

--- a/client/vscode/src/notificationActivation.ts
+++ b/client/vscode/src/notificationActivation.ts
@@ -1,5 +1,10 @@
 import { commands, window } from 'vscode'
-import { NotificationParams, showNotificationRequestType } from '@aws/language-server-runtimes/protocol'
+import {
+    AwsResponseError,
+    notificationFollowupRequestType,
+    NotificationParams,
+    showNotificationRequestType,
+} from '@aws/language-server-runtimes/protocol'
 
 import { LanguageClient } from 'vscode-languageclient/node'
 
@@ -21,17 +26,18 @@ function showNotificationHandler(params: NotificationParams): void {
 // Consider the code in this function a scratchpad, do not put anything you want to keep here.
 // Put whatever calls to the aws-lsp-notification server you want to experiment with/debug here
 async function execTestCommand(client: LanguageClient): Promise<void> {
-    window.showInformationMessage('TODO, Re-enable the following section when new runtimes is released')
-    /*
     try {
-        const result = await client.sendNotification(notificationFollowupRequestType, {
-            id: 'someid',
-            actions: ['Acknowledge'],
+        const id = '{"serverName":"AWS Toolkit Language Server for Notifications","id":"123"}'
+        const encodedId = Buffer.from(id).toString('base64')
+        client.info(`Triggering notification followup for id '${encodedId}'`)
+        await client.sendNotification(notificationFollowupRequestType.method, {
+            source: {
+                id: encodedId,
+            },
+            action: 'Acknowledge',
         })
-        window.showInformationMessage(`NotificationFollowup: ${JSON.stringify(result)}`)
     } catch (e) {
         const are = e as AwsResponseError
         window.showErrorMessage(`${are.message} [${are.data?.awsErrorCode}]`)
     }
-    */
 }

--- a/server/aws-lsp-notification/src/language-server/notificationServer.ts
+++ b/server/aws-lsp-notification/src/language-server/notificationServer.ts
@@ -7,7 +7,7 @@ import {
 } from '@aws/language-server-runtimes/server-interface'
 import { ServerBase, ServerFeatures } from '@aws/lsp-core'
 import { NotificationService, ShowNotification } from './notificationService'
-import { NotificationFollowupParams, NotificationParams } from '@aws/language-server-runtimes/protocol'
+import { MessageType, NotificationFollowupParams, NotificationParams } from '@aws/language-server-runtimes/protocol'
 import { FilesystemMetadataStore } from '../notifications/metadata/filesystemMetadataStore'
 import { S3Fetcher } from '../notifications/toolkits/s3Fetcher'
 import { CritieriaFilteringFetcher } from '../notifications/toolkits/criteriaFilteringFetcher'
@@ -55,13 +55,31 @@ export class NotificationServer extends ServerBase {
                 })
         )
 
-        return { capabilities: {} }
+        return {
+            serverInfo: {
+                name: 'AWS Toolkit Language Server for Notifications',
+            },
+            capabilities: {},
+        }
     }
 
     protected override initialized(params: InitializedParams): void {
         const startupFetcher = this.createFetcherPipeline()
         //startupFetcher.fetch()
-        //this.showNotification({})
+        this.features.logging.log('Pushing test notification to client.')
+        this.showNotification({
+            id: '123',
+            type: MessageType.Info,
+            content: {
+                text: 'Test notification',
+            },
+            actions: [
+                {
+                    type: 'Acknowledge',
+                    text: 'Do not show again',
+                },
+            ],
+        })
     }
 
     private createFetcherPipeline(): Fetcher {

--- a/server/aws-lsp-notification/src/language-server/notificationService.ts
+++ b/server/aws-lsp-notification/src/language-server/notificationService.ts
@@ -17,6 +17,7 @@ export class NotificationService {
     }
 
     async notificationFollowup(params: NotificationFollowupParams): Promise<void> {
-        // Acknowledge notification by ID in MetadataStore
+        this.observability.logging.log(`Received NotificationFollowup: ${JSON.stringify(params)}`)
+        // TODO: Acknowledge notification by ID in MetadataStore
     }
 }


### PR DESCRIPTION
## Problem

Test notifications routing logic with real client.
Related change: https://github.com/aws/language-server-runtimes/pull/259

## Solution

<img width="1180" alt="Screenshot 2024-11-19 at 15 27 44" src="https://github.com/user-attachments/assets/70c6b914-0cfd-4963-b8b1-4f16a0550fdb">


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
