### PR TITLE
Fixes early SSO token expiration bug.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
             "request": "attach",
             "port": 6012, // Hard defined in the vscode client activation.ts
             "outFiles": ["${workspaceFolder}/**/out/**/*.js"],
+            "skipFiles": ["<node_internals>/**", "${workspaceFolder}/**/node_modules/**/*.js"],
             "restart": {
                 "maxAttempts": 10,
                 "delay": 1000
@@ -151,6 +152,7 @@
                 "${workspaceFolder}/app/aws-lsp-identity-runtimes/out/**/*.js",
                 "${workspaceFolder}/server/aws-lsp-identity/out/**/*.js"
             ],
+            "skipFiles": ["<node_internals>/**", "${workspaceFolder}/**/node_modules/**/*.js"],
             "autoAttachChildProcesses": true
         },
         {
@@ -170,6 +172,7 @@
                 "${workspaceFolder}/app/aws-lsp-notification-runtimes/out/**/*.js",
                 "${workspaceFolder}/server/aws-lsp-notification/out/**/*.js"
             ],
+            "skipFiles": ["<node_internals>/**", "${workspaceFolder}/**/node_modules/**/*.js"],
             "autoAttachChildProcesses": true
         },
         {

--- a/server/aws-lsp-identity/src/language-server/identityService.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.ts
@@ -72,7 +72,7 @@ export class IdentityService {
             this.observability.logging.log(`Unable to auto-refresh token. ${reason}`)
         })
 
-        this.observability.logging.log('Successfully retrieved/logged-in to get SSO token.')
+        this.observability.logging.log('Successfully retrieved existing or newly authenticated SSO token.')
         return {
             ssoToken: { accessToken: ssoToken.accessToken, id: ssoSession.name },
             updateCredentialsParams: { data: { token: ssoToken.accessToken }, encrypted: false },

--- a/server/aws-lsp-identity/src/sso/cache/refreshingSsoCache.test.ts
+++ b/server/aws-lsp-identity/src/sso/cache/refreshingSsoCache.test.ts
@@ -123,13 +123,20 @@ describe('RefreshingSsoCache', () => {
             expect(actual).to.be.undefined
         })
 
-        it('Returns nothing on expired SSO token.', async () => {
+        it('Returns refreshed token on expired SSO token.', async () => {
             const ssoCache = stubSsoCache(createSsoClientRegistration(10000), createSsoToken(-10000))
             const sut = new RefreshingSsoCache(ssoCache, _ => {}, observability)
 
             const actual = await sut.getSsoToken('my-client-name', ssoSession)
 
-            expect(actual).to.be.undefined
+            expect(actual).not.to.be.empty
+            expect(actual?.accessToken).to.equal('new-access-token')
+            expect(actual?.clientId).to.equal('existing-client-id')
+            expect(actual?.clientSecret).to.equal('existing-client-secret')
+            expect(actual!.expiresAt).not.to.be.empty
+            expect(actual?.refreshToken).to.equal('new-refresh-token')
+            expect(actual?.region).to.equal('us-east-1')
+            expect(actual?.startUrl).to.equal('https://nowhere')
         })
 
         it('Returns existing SSO token before refresh window (5 minutes before expiration).', async () => {

--- a/server/aws-lsp-identity/src/sso/cache/refreshingSsoCache.ts
+++ b/server/aws-lsp-identity/src/sso/cache/refreshingSsoCache.ts
@@ -11,9 +11,10 @@ import {
 } from '../utils'
 import { RaiseSsoTokenChanged } from '../../language-server/ssoTokenAutoRefresher'
 import { Observability } from '../../language-server/utils'
+import { InvalidGrantException } from '@aws-sdk/client-sso-oidc'
 
 export const refreshWindowMillis: number = 5 * 60 * 1000
-export const retryWindowMillis: number = 30000
+export const retryCooldownWindowMillis: number = 30000
 
 interface SsoTokenDetail {
     lastRefreshMillis: number
@@ -113,37 +114,38 @@ export class RefreshingSsoCache implements SsoCache {
             return undefined
         }
 
-        const expiresAtMillis = Date.parse(ssoToken.expiresAt)
-
-        // Already expired? We're done
-        if (expiresAtMillis < Date.now()) {
-            this.observability.logging.log('SSO token expired.')
-            return undefined
-        }
-
-        // Current time is before start of refresh window? Just return it
-        const refreshAfterMillis = expiresAtMillis - refreshWindowMillis
-        if (Date.now() < refreshAfterMillis) {
-            this.observability.logging.log('SSO token before refresh window.')
-            return ssoToken
-        }
+        const nowMillis = Date.now()
+        const accessTokenExpiresAtMillis = Date.parse(ssoToken.expiresAt)
 
         // Get or create SsoTokenDetail
         const ssoTokenDetail =
             this.ssoTokenDetails[ssoSession.name] ?? (this.ssoTokenDetails[ssoSession.name] = { lastRefreshMillis: 0 })
 
-        // Last refresh attempt was less than the retry window?  Just return it
-        const retryAfterMillis = ssoTokenDetail.lastRefreshMillis + retryWindowMillis
-        if (Date.now() < retryAfterMillis) {
-            this.observability.logging.log('SSO token still in retry window from last refresh attempt.')
-            return ssoToken
+        // accessToken hasn't expired?  Determine if refresh should be attempted or just return the existing token
+        if (nowMillis < accessTokenExpiresAtMillis) {
+            // Current time is before start of refresh window? Just return it
+            const refreshAfterMillis = accessTokenExpiresAtMillis - refreshWindowMillis
+            if (nowMillis < refreshAfterMillis) {
+                this.observability.logging.log('SSO token before refresh window.  Returning current SSO token.')
+                return ssoToken
+            }
+
+            // Last refresh attempt was less than the retry window?  Just return it
+            const retryAfterMillis = ssoTokenDetail.lastRefreshMillis + retryCooldownWindowMillis
+            if (nowMillis < retryAfterMillis) {
+                this.observability.logging.log('SSO token in retry cooldown window.  Returning current SSO token.')
+                return ssoToken
+            }
         }
 
         // No refreshToken?  We're done
         if (!ssoToken.refreshToken) {
-            this.observability.logging.log('No SSO token refresh token.')
+            this.observability.logging.log('SSO token expired and no refresh token.')
             return undefined
         }
+
+        // Good to go, try a refresh
+        ssoTokenDetail.lastRefreshMillis = nowMillis
 
         const clientRegistration = await this.getSsoClientRegistration(clientName, ssoSession)
         if (!clientRegistration) {
@@ -164,11 +166,25 @@ export class RefreshingSsoCache implements SsoCache {
                 refreshToken: ssoToken.refreshToken,
             })
             .catch(reason => {
-                this.observability.logging.log('Cannot refresh SSO token.')
+                // Check if SSO session has expired
+                if (
+                    reason instanceof InvalidGrantException &&
+                    reason.error_description === 'Invalid refresh token provided'
+                ) {
+                    this.observability.logging.log('Cannot refresh SSO token.  SSO session has expired.')
+                    return undefined
+                }
+
+                this.observability.logging.log('Error when attempting to refresh SSO token.')
                 throw new AwsError('Cannot refresh SSO token.', AwsErrorCodes.E_CANNOT_REFRESH_SSO_TOKEN, {
                     cause: reason,
                 })
             })
+
+        // SSO session expired?  We're done
+        if (!result) {
+            return undefined
+        }
 
         UpdateSsoTokenFromCreateToken(result, clientRegistration, ssoSession, ssoToken)
 


### PR DESCRIPTION
The token would not be refreshed after the stored expirationAt date in the cached file.  This date was always an hour after the call to createToken to get a new access token.  The expected behavior is if you have a refreshToken, try to use it and you will either get a new accessToken or an error if the session has expired.

The code in refreshingSsoCache was updated to reflect the expected behavior.

https://docs.aws.amazon.com/sdkref/latest/guide/understanding-sso.html#idccredres3