### PR TITLE
Make logging stubs more resilient to runtime changes

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -67,7 +67,7 @@ describe('ChatController', () => {
         log: (message: string) => {
             console.log(message)
         },
-    }
+    } as Logging
 
     let sendMessageStub: sinon.SinonStub
     let disposeStub: sinon.SinonStub

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
@@ -55,7 +55,7 @@ describe('TelemetryService', () => {
         log: (message: string) => {
             console.log(message)
         },
-    }
+    } as Logging
     const mockSession: Partial<CodeWhispererSession> = {
         codewhispererSessionId: 'test-session-id',
         responseContext: {


### PR DESCRIPTION
## Problem
Whenever there is a change in the runtimes related to the Logging interface, we need to update our tests. For cases where logging functionality is not the main subject under test, tests shouldn't be impacted by runtimes changes

## Solution
Update the tests to use type assertion so that any changes to runtimes doesn't break the tests

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
