### PR TITLE
Fix issue with telemetryService used before defined

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.test.ts
@@ -12,11 +12,11 @@ describe('TelemetryController', () => {
 
     let testFeatures: TestFeatures
     let telemetryController: ChatTelemetryController
-    let telemetryService: TelemetryService
 
     beforeEach(() => {
+        const telemetryServiceStub = <TelemetryService>{}
         testFeatures = new TestFeatures()
-        telemetryController = new ChatTelemetryController(testFeatures, telemetryService)
+        telemetryController = new ChatTelemetryController(testFeatures, telemetryServiceStub)
     })
 
     it('able to set and get activeTabId', () => {


### PR DESCRIPTION
## Problem

error TS2454: Variable 'telemetryService' is used before being assigned.

## Solution

Use stub instead of unassigned variable.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
