### PR TITLE
Inject fs feature for reading proxy configs

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -122,25 +122,7 @@ describe('ChatController', () => {
             }),
         }
 
-        const mockWorkspace: Workspace = {
-            getWorkspaceFolder: sinon.stub(),
-            getTextDocument: sinon.stub(),
-            getAllTextDocuments: sinon.stub(),
-            fs: {
-                copyFile: sinon.stub(),
-                exists: sinon.stub(),
-                getFileSize: sinon.stub(),
-                getServerDataDirPath: sinon.stub(),
-                getTempDirPath: sinon.stub(),
-                readFile: sinon.stub(),
-                readdir: sinon.stub(),
-                isFile: sinon.stub(),
-                rm: sinon.stub(),
-                writeFile: sinon.stub(),
-                appendFile: sinon.stub(),
-                mkdir: sinon.stub(),
-            },
-        }
+        const mockWorkspace = {} as unknown as Workspace
 
         telemetry = {
             emitMetric: sinon.stub(),

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -7,6 +7,7 @@ import {
     CredentialsProvider,
     Telemetry,
     Logging,
+    Workspace,
 } from '@aws/language-server-runtimes/server-interface'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as assert from 'assert'
@@ -121,11 +122,31 @@ describe('ChatController', () => {
             }),
         }
 
+        const mockWorkspace: Workspace = {
+            getWorkspaceFolder: sinon.stub(),
+            getTextDocument: sinon.stub(),
+            getAllTextDocuments: sinon.stub(),
+            fs: {
+                copyFile: sinon.stub(),
+                exists: sinon.stub(),
+                getFileSize: sinon.stub(),
+                getServerDataDirPath: sinon.stub(),
+                getTempDirPath: sinon.stub(),
+                readFile: sinon.stub(),
+                readdir: sinon.stub(),
+                isFile: sinon.stub(),
+                rm: sinon.stub(),
+                writeFile: sinon.stub(),
+                appendFile: sinon.stub(),
+                mkdir: sinon.stub(),
+            },
+        }
+
         telemetry = {
             emitMetric: sinon.stub(),
             onClientTelemetry: sinon.stub(),
         }
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging)
+        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, mockWorkspace)
         invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
         chatController = new ChatController(chatSessionManagementService, testFeatures, telemetryService)
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -4,6 +4,7 @@ import {
     ExecuteCommandParams,
     InitializeParams,
     Server,
+    Workspace,
 } from '@aws/language-server-runtimes/server-interface'
 import { performance } from 'perf_hooks'
 import { pathToFileURL } from 'url'
@@ -22,9 +23,9 @@ const RunSecurityScanCommand = 'aws/codewhisperer/runSecurityScan'
 const CancelSecurityScanCommand = 'aws/codewhisperer/cancelSecurityScan'
 
 export const SecurityScanServerToken =
-    (service: (credentialsProvider: CredentialsProvider) => CodeWhispererServiceToken): Server =>
+    (service: (credentialsProvider: CredentialsProvider, workspace: Workspace) => CodeWhispererServiceToken): Server =>
     ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime }) => {
-        const codewhispererclient = service(credentialsProvider)
+        const codewhispererclient = service(credentialsProvider, workspace)
         const diagnosticsProvider = new SecurityScanDiagnosticsProvider(lsp, logging)
         const scanHandler = new SecurityScanHandler(codewhispererclient, workspace, logging)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -4,6 +4,7 @@ import {
     GetConfigurationFromServerParams,
     InitializeParams,
     Server,
+    Workspace,
 } from '@aws/language-server-runtimes/server-interface'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
 import { getUserAgent } from '../utilities/telemetryUtils'
@@ -11,9 +12,9 @@ import { getUserAgent } from '../utilities/telemetryUtils'
 // The configuration section that the server will register and listen to
 export const Q_CONFIGURATION_SECTION = 'aws.q'
 export const QConfigurationServerToken =
-    (service: (credentials: CredentialsProvider) => CodeWhispererServiceToken): Server =>
-    ({ credentialsProvider, lsp, logging, runtime }) => {
-        const codeWhispererService = service(credentialsProvider)
+    (service: (credentials: CredentialsProvider, workspace: Workspace) => CodeWhispererServiceToken): Server =>
+    ({ credentialsProvider, lsp, logging, runtime, workspace }) => {
+        const codeWhispererService = service(credentialsProvider, workspace)
 
         lsp.addInitializer((params: InitializeParams) => {
             codeWhispererService.updateClientConfig({

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -4,6 +4,7 @@ import {
     ExecuteCommandParams,
     InitializeParams,
     Server,
+    Workspace,
 } from '@aws/language-server-runtimes/server-interface'
 import { StreamingClient } from '../client/streamingClient/codewhispererStreamingClient'
 import { CodeWhispererServiceToken } from './codeWhispererService'
@@ -50,9 +51,9 @@ const DownloadArtifactsCommand = 'aws/qNetTransform/downloadArtifacts'
  * @returns  NetTransform server
  */
 export const QNetTransformServerToken =
-    (service: (credentialsProvider: CredentialsProvider) => CodeWhispererServiceToken): Server =>
+    (service: (credentialsProvider: CredentialsProvider, workspace: Workspace) => CodeWhispererServiceToken): Server =>
     ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime }) => {
-        const codewhispererclient = service(credentialsProvider)
+        const codewhispererclient = service(credentialsProvider, workspace)
         const transformHandler = new TransformHandler(codewhispererclient, workspace, logging)
         const runTransformCommand = async (params: ExecuteCommandParams, _token: CancellationToken) => {
             try {

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -10,20 +10,20 @@ import { readFileSync } from 'fs'
 import { HttpsProxyAgent } from 'hpagent'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 
-export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(credentialsProvider => {
-    return new CodeWhispererServiceToken(credentialsProvider)
+export const CodeWhispererServerTokenProxy = CodewhispererServerFactory((credentialsProvider, workspace) => {
+    return new CodeWhispererServiceToken(credentialsProvider, workspace)
 })
 
-export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(credentialsProvider => {
-    return new CodeWhispererServiceIAM(credentialsProvider)
+export const CodeWhispererServerIAMProxy = CodewhispererServerFactory((credentialsProvider, workspace) => {
+    return new CodeWhispererServiceIAM(credentialsProvider, workspace)
 })
 
-export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken(credentialsProvider => {
-    return new CodeWhispererServiceToken(credentialsProvider)
+export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken((credentialsProvider, workspace) => {
+    return new CodeWhispererServiceToken(credentialsProvider, workspace)
 })
 
-export const QNetTransformServerTokenProxy = QNetTransformServerToken(credentialsProvider => {
-    return new CodeWhispererServiceToken(credentialsProvider)
+export const QNetTransformServerTokenProxy = QNetTransformServerToken((credentialsProvider, workspace) => {
+    return new CodeWhispererServiceToken(credentialsProvider, workspace)
 })
 
 export const QChatServerProxy = QChatServer(credentialsProvider => {
@@ -54,6 +54,6 @@ export const QChatServerProxy = QChatServer(credentialsProvider => {
         .withConfig(clientOptions)
 })
 
-export const QConfigurationServerTokenProxy = QConfigurationServerToken(credentialsProvider => {
-    return new CodeWhispererServiceToken(credentialsProvider)
+export const QConfigurationServerTokenProxy = QConfigurationServerToken((credentialsProvider, workspace) => {
+    return new CodeWhispererServiceToken(credentialsProvider, workspace)
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -8,10 +8,10 @@ import { getUserAgent, makeUserContextObject } from './utilities/telemetryUtils'
 export const QChatServer =
     (service: (credentialsProvider: CredentialsProvider) => ChatSessionManagementService): Server =>
     features => {
-        const { chat, credentialsProvider, telemetry, logging, lsp, runtime } = features
+        const { chat, credentialsProvider, telemetry, logging, lsp, runtime, workspace } = features
 
         const chatSessionManagementService: ChatSessionManagementService = service(credentialsProvider)
-        const telemetryService = new TelemetryService(credentialsProvider, 'bearer', telemetry, logging)
+        const telemetryService = new TelemetryService(credentialsProvider, 'bearer', telemetry, logging, workspace)
 
         const chatController = new ChatController(chatSessionManagementService, features, telemetryService)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
@@ -57,25 +57,7 @@ describe('TelemetryService', () => {
             console.log(message)
         },
     } as Logging
-    const mockWorkspace: Workspace = {
-        getWorkspaceFolder: sinon.stub(),
-        getTextDocument: sinon.stub(),
-        getAllTextDocuments: sinon.stub(),
-        fs: {
-            copyFile: sinon.stub(),
-            exists: sinon.stub(),
-            getFileSize: sinon.stub(),
-            getServerDataDirPath: sinon.stub(),
-            getTempDirPath: sinon.stub(),
-            readFile: sinon.stub(),
-            readdir: sinon.stub(),
-            isFile: sinon.stub(),
-            rm: sinon.stub(),
-            writeFile: sinon.stub(),
-            appendFile: sinon.stub(),
-            mkdir: sinon.stub(),
-        },
-    }
+    const mockWorkspace = {} as unknown as Workspace
     const mockSession: Partial<CodeWhispererSession> = {
         codewhispererSessionId: 'test-session-id',
         responseContext: {

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
@@ -4,6 +4,7 @@ import {
     CredentialsType,
     Logging,
     Telemetry,
+    Workspace,
 } from '@aws/language-server-runtimes/server-interface'
 import { CodeWhispererSession } from './session/sessionManager'
 import {
@@ -56,9 +57,10 @@ export class TelemetryService extends CodeWhispererServiceToken {
         credentialsProvider: CredentialsProvider,
         credentialsType: CredentialsType,
         telemetry: Telemetry,
-        logging: Logging
+        logging: Logging,
+        workspace: Workspace
     ) {
-        super(credentialsProvider)
+        super(credentialsProvider, workspace)
         this.credentialsProvider = credentialsProvider
         this.credentialsType = credentialsType
         this.telemetry = telemetry

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -10,7 +10,6 @@ import { Suggestion } from './codeWhispererService'
 import { CodewhispererCompletionType } from './telemetry/types'
 import { BUILDER_ID_START_URL, MISSING_BEARER_TOKEN_ERROR } from './constants'
 import { ServerInfo } from '@aws/language-server-runtimes/server-interface/runtime'
-import { readFileSync } from 'fs'
 import { HttpsProxyAgent } from 'hpagent'
 export type SsoConnectionType = 'builderId' | 'identityCenter' | 'none'
 

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -1,4 +1,9 @@
-import { BearerCredentials, CredentialsProvider, Position } from '@aws/language-server-runtimes/server-interface'
+import {
+    BearerCredentials,
+    CredentialsProvider,
+    Position,
+    Workspace,
+} from '@aws/language-server-runtimes/server-interface'
 import { AWSError, ConfigurationOptions } from 'aws-sdk'
 import { distance } from 'fastest-levenshtein'
 import { Suggestion } from './codeWhispererService'
@@ -127,12 +132,12 @@ export function getEndPositionForAcceptedSuggestion(content: string, startPositi
     return endPosition
 }
 
-export const makeProxyConfig = () => {
+export const makeProxyConfig = async (workspace: Workspace) => {
     let additionalAwsConfig: ConfigurationOptions = {}
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
 
     if (proxyUrl) {
-        const certs = process.env.AWS_CA_BUNDLE ? [readFileSync(process.env.AWS_CA_BUNDLE)] : undefined
+        const certs = process.env.AWS_CA_BUNDLE ? [await workspace.fs.readFile(process.env.AWS_CA_BUNDLE)] : undefined
         const agent = new HttpsProxyAgent({
             proxy: proxyUrl,
             ca: certs,


### PR DESCRIPTION
## Problem
node `fs` is used to read proxy configurations. This results in webpack bundling to fail since it's not available in browser

## Solution
Use the `workspace.fs` feature injected from runtimes instead

- Inject workspace to server creation
- Create mock `workspace` for tests

Note: to be tested in local

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
