### PR TITLE
Renamed @aws/dexp to @aws/flare in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aws/aws-ides-team @aws/dexp
+* @aws/flare


### PR DESCRIPTION
## Problem
As part of the renaming of "DEXP" to "Flare", the team name on GitHub has changed, and so the `.github/CODEOWNERS` file in this repository should be updated accordingly.

## Solution
Updated the `.github/CODEOWNERS` file accordingly. Also removed @aws/aws-ides-team approval requirement, as Flare owns this.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
