### PR TITLE
chore: update dependabot config to group @typescript-eslint dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       target-branch: 'main' # Avoid updates to "staging".
       schedule:
           interval: 'weekly'
+      groups:
+          typescript-eslint:
+              patterns:
+                  - '@typescript-eslint/*'
     - package-ecosystem: 'npm'
       directory: '/core/codewhisperer-streaming'
       target-branch: 'main'


### PR DESCRIPTION
## Description
Major version bumps on `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` cannot happen separately as they come from the same parent package and share common peer dependencies. We can make dependabot group these dependencies so that both versions gets updated in 

See recent update attempt on `@typescript-eslint/parser` failing: https://github.com/aws/language-servers/pull/643

Also see 4 month period in the past where dependabot was constantly trying to bump typescript-eslint dependencies:
<img width="720" alt="image" src="https://github.com/user-attachments/assets/417158cf-1784-463b-81d6-6f1d19627d12">



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
