### PR TITLE
chore: Update dependabot to ignore all dependencies of streaming client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,14 @@ updates:
       schedule:
           interval: 'weekly'
       ignore:
-          - dependency-name: '*'
+          - dependency-name: 'tslib'
+          - dependency-name: '@aws-crypto/*'
+          - dependency-name: '@aws-sdk/*'
+          - dependency-name: '@smithy/*'
+          - dependency-name: 'uuid'
+          - dependency-name: '@tsconfig/node16'
+          - dependency-name: 'concurrently'
+          - dependency-name: 'downlevel-dts'
+          - dependency-name: 'rimraf'
+          - dependency-name: 'typescript'
+          - dependency-name: '@types/*'


### PR DESCRIPTION
## Description

We want dependabot to ignore the streaming client and not publish PRs for the streaming client but it is still creating PRs for it (see latest PR by dependabot https://github.com/aws/language-servers/pull/657) Putting `*` in the ignore clause doesn't seem to ignore the whole package so let's try ignoring every dependency explicitly 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
