### PR TITLE
feat(chat-client)!: add legal disclaimer with acknowledgement button

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,7 +283,7 @@ This Language Servers repository includes set of packages, which demonstrate how
 
 #### Developing both Language Servers and Runtimes projects
 
-Sometimes there is a need to build and develop both Language Servers with Language Server Runtimes projects. Since [`language-server-runtimes`](https://github.com/aws/language-server-runtimes) is used as an nmp dependency, it can be developed using `npm link` in this repo.
+Sometimes there is a need to build and develop both Language Servers with Language Server Runtimes projects. Since [`language-server-runtimes`](https://github.com/aws/language-server-runtimes) is used as an npm dependency, it can be developed using `npm link` in this repo.
 
 1. Clone the [`language-servers`](https://github.com/aws/language-servers) and the [`language-server-runtimes`](https://github.com/aws/language-server-runtimes) repos:
 

--- a/chat-client/CHANGELOG.md
+++ b/chat-client/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.1.0] - 2024-12-12
+
+### Added
+
+- Add new `DISCLAIMER_ACKNOWLEDGED` event to the chat client
+- Add new `disclaimerAcknowledged?: boolean` flag to the config
+- Add an acknowledgeable legal disclaimer to every tab based on the `disclaimerAcknowledged` flag
+
+### Changed
+
+- Update `@aws/chat-client-ui-types` to 0.0.9
+- Shortened legal text in the footer
+
 ## [0.0.9] - 2024-11-20
 
 ### Changed

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/chat-client",
-    "version": "0.0.9",
+    "version": "0.1.0",
     "description": "AWS Chat Client",
     "main": "out/index.js",
     "repository": {

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -21,7 +21,7 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.0.8",
+        "@aws/chat-client-ui-types": "^0.0.9",
         "@aws/language-server-runtimes-types": "^0.0.7",
         "@aws/mynah-ui": "^4.18.1"
     },

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -48,7 +48,7 @@ import { TabFactory } from './tabs/tabFactory'
 const DEFAULT_TAB_DATA = {
     tabTitle: 'Chat',
     promptInputInfo:
-        'Amazon Q Developer uses generative AI. You may need to verify responses. See the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/). Amazon Q Developer processes data across all US Regions. See [here](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/cross-region-inference.html) for more info. Amazon Q may retain chats to provide and maintain the service.',
+        'Amazon Q Developer uses generative AI. You may need to verify responses. See the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
     promptInputPlaceholder: 'Ask a question or enter "/" for quick actions',
 }
 

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -90,7 +90,7 @@ export const createChat = (
                 const chatConfig: ChatClientConfig = params?.quickActions?.quickActionsCommandGroups
                     ? {
                           quickActionCommands: params.quickActions.quickActionsCommandGroups,
-                          disclaimerAcknowledged: config?.disclaimerAcknowledged,
+                          disclaimerAcknowledged: config?.disclaimerAcknowledged ?? false,
                       }
                     : {}
 

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -92,7 +92,7 @@ export const createChat = (
                           quickActionCommands: params.quickActions.quickActionsCommandGroups,
                           disclaimerAcknowledged: config?.disclaimerAcknowledged ?? false,
                       }
-                    : {}
+                    : { disclaimerAcknowledged: config?.disclaimerAcknowledged ?? false }
 
                 tabFactory.updateDefaultTabData(chatConfig)
 

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -57,6 +57,7 @@ export interface OutboundChatApi {
     sourceLinkClick(params: SourceLinkClickParams): void
     infoLinkClick(params: InfoLinkClickParams): void
     uiReady(): void
+    disclaimerAcknowledged(): void
 }
 
 export class Messager {
@@ -77,6 +78,10 @@ export class Messager {
 
     onUiReady = (): void => {
         this.chatApi.uiReady()
+    }
+
+    onDisclaimerAcknowledged = (): void => {
+        this.chatApi.disclaimerAcknowledged()
     }
 
     onFocusStateChanged = (focusState: boolean): void => {

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -37,6 +37,7 @@ describe('MynahUI', () => {
             sourceLinkClick: sinon.stub(),
             infoLinkClick: sinon.stub(),
             uiReady: sinon.stub(),
+            disclaimerAcknowledged: sinon.stub(),
         }
 
         messager = new Messager(outboundChatApi)
@@ -46,7 +47,7 @@ describe('MynahUI', () => {
         const tabFactory = new TabFactory({})
         createTabStub = sinon.stub(tabFactory, 'createTab')
         createTabStub.returns({})
-        const mynahUiResult = createMynahUi(messager, tabFactory)
+        const mynahUiResult = createMynahUi(messager, tabFactory, true)
         mynahUi = mynahUiResult[0]
         inboundChatApi = mynahUiResult[1]
         getSelectedTabIdStub = sinon.stub(mynahUi, 'getSelectedTabId')

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -118,7 +118,7 @@ describe('MynahUI', () => {
             getSelectedTabIdStub.returns(undefined)
             inboundChatApi.sendGenericCommand({ genericCommand, selection, tabId, triggerType })
 
-            sinon.assert.calledOnceWithExactly(createTabStub, false)
+            sinon.assert.calledOnceWithExactly(createTabStub, false, false)
             sinon.assert.calledThrice(updateStoreSpy)
         })
 
@@ -134,11 +134,11 @@ describe('MynahUI', () => {
             getSelectedTabIdStub.returns(tabId)
             inboundChatApi.sendGenericCommand({ genericCommand, selection, tabId, triggerType })
 
-            sinon.assert.calledOnceWithExactly(createTabStub, false)
+            sinon.assert.calledOnceWithExactly(createTabStub, false, false)
             sinon.assert.calledThrice(updateStoreSpy)
         })
 
-        it('should not create a new tab if one exits already', () => {
+        it('should not create a new tab if one exists already', () => {
             createTabStub.resetHistory()
             const genericCommand = 'Explain'
             const selection = 'const x = 5;'

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -24,6 +24,7 @@ import { ChatItem, ChatItemType, ChatPrompt, MynahUI, MynahUIDataModel, Notifica
 import { VoteParams } from '../contracts/telemetry'
 import { Messager } from './messager'
 import { TabFactory } from './tabs/tabFactory'
+import { disclaimerAcknowledgeButtonId, disclaimerCard } from './texts/disclaimer'
 
 export interface InboundChatApi {
     addChatResponse(params: ChatResult, tabId: string, isPartialResult: boolean): void
@@ -83,8 +84,13 @@ export const handleChatPrompt = (
     })
 }
 
-export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [MynahUI, InboundChatApi] => {
+export const createMynahUi = (
+    messager: Messager,
+    tabFactory: TabFactory,
+    disclaimerAcknowledged: boolean
+): [MynahUI, InboundChatApi] => {
     const initialTabId = TabFactory.generateUniqueId()
+    let disclaimerCardActive = !disclaimerAcknowledged
 
     const mynahUi = new MynahUI({
         onCodeInsertToCursorPosition(
@@ -144,6 +150,7 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
             messager.onTabAdd(tabId)
             const defaultTabConfig: Partial<MynahUIDataModel> = {
                 quickActionCommands: tabFactory.getDefaultTabData().quickActionCommands,
+                ...(disclaimerCardActive ? { promptInputStickyCard: disclaimerCard } : {}),
             }
             mynahUi.updateStore(tabId, defaultTabConfig)
         },
@@ -237,14 +244,30 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
             }
             messager.onInfoLinkClick(payload)
         },
+        onInBodyButtonClicked: (tabId, messageId, action, eventId) => {
+            if (action.id === disclaimerAcknowledgeButtonId) {
+                // Hide the legal disclaimer card
+                disclaimerCardActive = false
+
+                // Update the disclaimer getting acknowledged
+                messager.onDisclaimerAcknowledged()
+
+                // TODO: create telemetry
+
+                // Remove all disclaimer cards from all tabs
+                Object.keys(mynahUi.getAllTabs()).forEach(storeTabKey => {
+                    mynahUi.updateStore(storeTabKey, { promptInputStickyCard: null })
+                })
+            }
+        },
         tabs: {
             [initialTabId]: {
                 isSelected: true,
-                store: tabFactory.createTab(true),
+                store: tabFactory.createTab(true, disclaimerCardActive),
             },
         },
         defaults: {
-            store: tabFactory.createTab(true),
+            store: tabFactory.createTab(true, disclaimerCardActive),
         },
         config: {
             maxTabs: 10,
@@ -257,7 +280,7 @@ export const createMynahUi = (messager: Messager, tabFactory: TabFactory): [Myna
     }
 
     const createTabId = () => {
-        const tabId = mynahUi.updateStore('', tabFactory.createTab(false))
+        const tabId = mynahUi.updateStore('', tabFactory.createTab(false, disclaimerCardActive))
         if (tabId === undefined) {
             mynahUi.notify({
                 content: uiComponentsTexts.noMoreTabsTooltip,

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -252,8 +252,6 @@ export const createMynahUi = (
                 // Update the disclaimer getting acknowledged
                 messager.onDisclaimerAcknowledged()
 
-                // TODO: create telemetry
-
                 // Remove all disclaimer cards from all tabs
                 Object.keys(mynahUi.getAllTabs()).forEach(storeTabKey => {
                     mynahUi.updateStore(storeTabKey, { promptInputStickyCard: null })
@@ -267,7 +265,7 @@ export const createMynahUi = (
             },
         },
         defaults: {
-            store: tabFactory.createTab(true, disclaimerCardActive),
+            store: tabFactory.createTab(true, false),
         },
         config: {
             maxTabs: 10,

--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -1,4 +1,5 @@
 import { ChatItemType, MynahUIDataModel } from '@aws/mynah-ui'
+import { disclaimerCard } from '../texts/disclaimer'
 
 export type DefaultTabData = MynahUIDataModel
 
@@ -12,7 +13,7 @@ export class TabFactory {
 
     constructor(private defaultTabData: DefaultTabData) {}
 
-    public createTab(needWelcomeMessages: boolean): MynahUIDataModel {
+    public createTab(needWelcomeMessages: boolean, disclaimerCardActive: boolean): MynahUIDataModel {
         const tabData: MynahUIDataModel = {
             ...this.defaultTabData,
             chatItems: needWelcomeMessages
@@ -29,6 +30,7 @@ export class TabFactory {
                       },
                   ]
                 : [],
+            ...(disclaimerCardActive ? { promptInputStickyCard: disclaimerCard } : {}),
         }
         return tabData
     }

--- a/chat-client/src/client/texts/disclaimer.ts
+++ b/chat-client/src/client/texts/disclaimer.ts
@@ -1,0 +1,15 @@
+import { ChatItem, MynahIcons } from '@aws/mynah-ui'
+
+export const disclaimerAcknowledgeButtonId = 'amazonq-disclaimer-acknowledge-button-id'
+export const disclaimerCard: Partial<ChatItem> = {
+    messageId: 'amazonq-disclaimer-card',
+    body: 'Amazon Q Developer uses generative AI. You may need to verify responses. See the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/). Amazon Q Developer processes data across all US Regions. See [here](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/cross-region-inference.html) for more info. Amazon Q may retain chats to provide and maintain the service.',
+    buttons: [
+        {
+            text: 'Acknowledge',
+            id: disclaimerAcknowledgeButtonId,
+            status: 'info',
+            icon: MynahIcons.OK,
+        },
+    ],
+}

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -269,7 +269,7 @@
     "devDependencies": {
         "@aws-sdk/credential-providers": "^3.614.0",
         "@aws-sdk/types": "^3.535.0",
-        "@aws/chat-client-ui-types": "^0.0.8",
+        "@aws/chat-client-ui-types": "^0.0.9",
         "@aws/language-server-runtimes": "^0.2.27",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.88.0",

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -198,7 +198,7 @@ function generateJS(webView: Webview, extensionUri: Uri): string {
     <script type="text/javascript" src="${entrypoint.toString()}" defer onload="init()"></script>
     <script type="text/javascript">
         const init = () => {
-            amazonQChat.createChat(acquireVsCodeApi());
+            amazonQChat.createChat(acquireVsCodeApi(), {disclaimerAcknowledged: false});
         }
     </script>
     `

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,7 +186,7 @@
             "version": "0.0.9",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.0.8",
+                "@aws/chat-client-ui-types": "^0.0.9",
                 "@aws/language-server-runtimes-types": "^0.0.7",
                 "@aws/mynah-ui": "^4.18.1"
             },
@@ -209,7 +209,7 @@
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.614.0",
                 "@aws-sdk/types": "^3.535.0",
-                "@aws/chat-client-ui-types": "^0.0.8",
+                "@aws/chat-client-ui-types": "^0.0.9",
                 "@aws/language-server-runtimes": "^0.2.27",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.88.0",
@@ -16887,7 +16887,7 @@
             "dependencies": {
                 "@amzn/codewhisperer-streaming": "*",
                 "@aws-sdk/util-retry": "^3.374.0",
-                "@aws/chat-client-ui-types": "^0.0.8",
+                "@aws/chat-client-ui-types": "^0.0.9",
                 "@aws/language-server-runtimes": "^0.2.27",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@smithy/node-http-handler": "^2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2516,10 +2516,9 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.0.8.tgz",
-            "integrity": "sha512-aU8r0FaCKIhMiTWvr/yuWYZmVWPgE2vBAPsVcafhlu7ucubiH/+YodqDw+0Owk0R0kxxZDdjdZghPZSyy0G84A==",
-            "license": "Apache-2.0",
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.0.9.tgz",
+            "integrity": "sha512-VDm2diWBYJUBfJYAYQTvW02/5/fDUreEl6UuAL7vrM2EVq13a0pljUbdOJARNkOFpevxrInQJqcNcX5hxEgS0Q==",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.0.7"
             }

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -29,7 +29,7 @@
     "dependencies": {
         "@amzn/codewhisperer-streaming": "*",
         "@aws-sdk/util-retry": "^3.374.0",
-        "@aws/chat-client-ui-types": "^0.0.8",
+        "@aws/chat-client-ui-types": "^0.0.9",
         "@aws/language-server-runtimes": "^0.2.27",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@smithy/node-http-handler": "^2.5.0",


### PR DESCRIPTION
## Problem
Currently, we show long disclaimer on the bottom of chat: [source](https://github.com/aws/language-servers/blob/main/chat-client/src/client/chat.ts#L51). This needs to move to promptInputStickyCard with "Acknowledge" button in every active or newly added tab, until user clicks that "Acknowledge" button. When user hits that, it should disappear from all the tabs and shouldn't be visible ever again.

## Solution
- Shortened the legal disclaimer in the footer (always visible)
- Added `disclaimerAcknowledged` event to `OutboundChatApi` (`DISCLAIMER_ACKNOWLEDGED` has been added to the contract in `language-server-runtimes`, will be available through NPM once a new release is made there)
- Extended the ChatClientConfig by a boolean flag `disclaimerAcknowledged`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
