### PR TITLE
chore: set dependabot to use conventional commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
           typescript-eslint:
               patterns:
                   - '@typescript-eslint/*'
+      commit-message:
+          prefix: 'chore'
     - package-ecosystem: 'npm'
       directory: '/core/codewhisperer-streaming'
       target-branch: 'main'

--- a/package-lock.json
+++ b/package-lock.json
@@ -2764,14 +2764,6 @@
                 "vscode-languageserver-types": "^3.17.5"
             }
         },
-        "node_modules/@aws/lsp-antlr4": {
-            "resolved": "server/aws-lsp-antlr4",
-            "link": true
-        },
-        "node_modules/@aws/lsp-antlr4-runtimes": {
-            "resolved": "app/aws-lsp-antlr4-runtimes",
-            "link": true
-        },
         "node_modules/@aws/language-server-runtimes/node_modules/rxjs": {
             "version": "7.8.1",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -2780,6 +2772,14 @@
             "dependencies": {
                 "tslib": "^2.1.0"
             }
+        },
+        "node_modules/@aws/lsp-antlr4": {
+            "resolved": "server/aws-lsp-antlr4",
+            "link": true
+        },
+        "node_modules/@aws/lsp-antlr4-runtimes": {
+            "resolved": "app/aws-lsp-antlr4-runtimes",
+            "link": true
         },
         "node_modules/@aws/lsp-buildspec": {
             "resolved": "server/aws-lsp-buildspec",


### PR DESCRIPTION
## Problem

PRs created by Dependabot do not follow Conventional Commit spec by default.

## Solution

Configure Dependabot to use Conventional Commit.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
