### PR TITLE
chore: move starting commit for release-please to latest commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-    "bootstrap-sha": "facc9238e557af8daac49798922ffa67836104cb",
+    "bootstrap-sha": "30ec14a11a4f9544d6b36a0196097b4425670937",
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "always-link-local": false,


### PR DESCRIPTION
## Problem
Release-please automation use `bootstrap-sha` value to mark starting point for the automation to work. Merged commit was already released.

## Solution
Move bootstrap-sha to latest merged commit in main.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
