### PR TITLE
chore: increase open file size limit to 40k for chat context

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentContext.ts
@@ -17,7 +17,7 @@ export interface DocumentContextExtractorConfig {
 }
 
 export class DocumentContextExtractor {
-    private static readonly DEFAULT_CHARACTER_LIMIT = 9000
+    private static readonly DEFAULT_CHARACTER_LIMIT = 40000
 
     #characterLimits: number
     #logger?: Features['logging']


### PR DESCRIPTION
## Problem

Reference ticket: https://sim.amazon.com/issues/AWS-Cloud9-29137
Currently Q chat open file size context is limited to 9000 characters, which truncates a lot of context for larger files. This PR aims to increase the size to 40000 characters. 

One thing to note from the constructor of DocumentContextExtractor is config?.characterLimits will always be undefined as only logger is passed while initializing the constructor. Hence, directly updating the DEFAULT_CHARACTER_LIMIT constant value
`this.#characterLimits = config?.characterLimits ?? DocumentContextExtractor.DEFAULT_CHARACTER_LIMIT`


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
