### PR TITLE
chore(chat-client): bump chat client ui types dependency

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -21,7 +21,7 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.0.9",
+        "@aws/chat-client-ui-types": "^0.1.0",
         "@aws/language-server-runtimes-types": "^0.0.7",
         "@aws/mynah-ui": "^4.18.1"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,10 +209,10 @@
         },
         "chat-client": {
             "name": "@aws/chat-client",
-            "version": "0.0.9",
+            "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.0.9",
+                "@aws/chat-client-ui-types": "^0.1.0",
                 "@aws/language-server-runtimes-types": "^0.0.7",
                 "@aws/mynah-ui": "^4.18.1"
             },
@@ -226,6 +226,14 @@
                 "ts-sinon": "^2.0.2",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^5.1.4"
+            }
+        },
+        "chat-client/node_modules/@aws/chat-client-ui-types": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.0.tgz",
+            "integrity": "sha512-MaBfB8oxUh4icuWNe0ODHOKAbvEGVrpko7QEf7d4PJ75xp6Onbr0AKuevEMrHve2ZtXHSx+TGonyfmzgD5BC2A==",
+            "dependencies": {
+                "@aws/language-server-runtimes-types": "^0.0.7"
             }
         },
         "client/vscode": {


### PR DESCRIPTION
## Description

Stop using versions marked as `0.0.x` and start using version `0.1.0`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
