### PR TITLE
fix: adding tests for covering the special characters case for auto t…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/testUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/testUtils.ts
@@ -9,6 +9,8 @@ export const HELLO_WORLD_IN_CSHARP = `class HelloWorld
     }
 }`
 
+export const SPECIAL_CHARACTER_HELLO_WORLD = `{class HelloWorld`
+
 export const HELLO_WORLD_WITH_WINDOWS_ENDING = HELLO_WORLD_IN_CSHARP.replaceAll('\n', '\r\n')
 
 export const SOME_FILE = TextDocument.create('file:///test.cs', 'csharp', 1, HELLO_WORLD_IN_CSHARP)


### PR DESCRIPTION
## Problem
* In https://github.com/aws/language-servers/blob/main/server/aws-lsp-codewhisperer/src/language-server/auto-trigger/autoTrigger.test.ts we test for newlines and special characters.

* In https://github.com/aws/language-servers/commit/ff0a714ef3e3bf596547f684e7686cd31b368d83 we use that result to determine whether we should go by the auto-trigger result to return an empty list.

* In https://github.com/aws/language-servers/blob/main/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts#L885, we test against 2 auto-trigger scenarios. One where the threshold is met, and one where it is not met. There actually is a third scenario, where it doesn't matter if the threshold is met or not, since the NEWLINE or SPECIAL_CHARACTER takes priority. This PR adds a test for the same 

## Solution
* Adding test for a string that falls below the threshold calculated for auto trigger condition but because a special character ( Here : { ) is here present, we must still auto trigger 
* Test successfully passes

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
