### PR TITLE
fix : revert "chore: bump @aws-sdk/middleware-user-agent from 3.654.0 to 3.…

### DIFF
--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -16,7 +16,7 @@
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {
-        "@types/node": "^22.10.2",
+        "@types/node": "^22.9.0",
         "path": "^0.12.7",
         "path-browserify": "^1.0.1",
         "ts-loader": "^9.5.1",

--- a/core/codewhisperer-streaming/package.json
+++ b/core/codewhisperer-streaming/package.json
@@ -23,7 +23,7 @@
         "@aws-sdk/middleware-host-header": "3.654.0",
         "@aws-sdk/middleware-logger": "3.654.0",
         "@aws-sdk/middleware-recursion-detection": "3.654.0",
-        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
         "@aws-sdk/region-config-resolver": "3.654.0",
         "@aws-sdk/token-providers": "3.654.0",
         "@aws-sdk/types": "3.654.0",
@@ -63,7 +63,7 @@
         "downlevel-dts": "0.10.1",
         "rimraf": "^3.0.0",
         "typescript": "~4.9.5",
-        "@types/node": "^22.10.2",
+        "@types/node": "^22.9.0",
         "@types/uuid": "^9.0.4"
     },
     "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
             "devDependencies": {
                 "@commitlint/cli": "^19.5.0",
                 "@commitlint/config-conventional": "^19.5.0",
-                "@types/node": "^22.10.2",
+                "@types/node": "^22.9.0",
                 "@typescript-eslint/eslint-plugin": "^7.7.1",
                 "@typescript-eslint/parser": "^7.7.1",
                 "conventional-changelog-conventionalcommits": "^8.0.0",
@@ -155,7 +155,7 @@
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
-                "@types/node": "^22.10.2",
+                "@types/node": "^22.9.0",
                 "path": "^0.12.7",
                 "path-browserify": "^1.0.1",
                 "ts-loader": "^9.5.1",
@@ -292,7 +292,7 @@
                 "@aws-sdk/middleware-host-header": "3.654.0",
                 "@aws-sdk/middleware-logger": "3.654.0",
                 "@aws-sdk/middleware-recursion-detection": "3.654.0",
-                "@aws-sdk/middleware-user-agent": "3.709.0",
+                "@aws-sdk/middleware-user-agent": "3.654.0",
                 "@aws-sdk/region-config-resolver": "3.654.0",
                 "@aws-sdk/token-providers": "3.654.0",
                 "@aws-sdk/types": "3.654.0",
@@ -329,7 +329,7 @@
             },
             "devDependencies": {
                 "@tsconfig/node16": "16.1.3",
-                "@types/node": "^22.10.2",
+                "@types/node": "^22.9.0",
                 "@types/uuid": "^9.0.4",
                 "concurrently": "7.0.0",
                 "downlevel-dts": "0.10.1",
@@ -2480,52 +2480,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.709.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.709.0.tgz",
-            "integrity": "sha512-ooc9ZJvgkjPhi9q05XwSfNTXkEBEIfL4hleo5rQBKwHG3aTHvwOM7LLzhdX56QZVa6sorPBp6fwULuRDSqiQHw==",
+            "version": "3.654.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.654.0.tgz",
+            "integrity": "sha512-liCcqPAyRsr53cy2tYu4qeH4MMN0eh9g6k56XzI5xd4SghXH5YWh4qOYAlQ8T66ZV4nPMtD8GLtLXGzsH8moFg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.709.0",
-                "@aws-sdk/types": "3.709.0",
-                "@aws-sdk/util-endpoints": "3.709.0",
-                "@smithy/core": "^2.5.5",
-                "@smithy/protocol-http": "^4.1.8",
-                "@smithy/types": "^3.7.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/core": {
-            "version": "3.709.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.709.0.tgz",
-            "integrity": "sha512-7kuSpzdOTAE026j85wq/fN9UDZ70n0OHw81vFqMWwlEFtm5IQ/MRCLKcC4HkXxTdfy1PqFlmoXxWqeBa15tujw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.709.0",
-                "@smithy/core": "^2.5.5",
-                "@smithy/node-config-provider": "^3.1.12",
-                "@smithy/property-provider": "^3.1.11",
-                "@smithy/protocol-http": "^4.1.8",
-                "@smithy/signature-v4": "^4.2.4",
-                "@smithy/smithy-client": "^3.5.0",
-                "@smithy/types": "^3.7.2",
-                "@smithy/util-middleware": "^3.0.11",
-                "fast-xml-parser": "4.4.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
-            "version": "3.709.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.709.0.tgz",
-            "integrity": "sha512-ArtLTMxgjf13Kfu3gWH3Ez9Q5TkDdcRZUofpKH3pMGB/C6KAbeSCtIIDKfoRTUABzyGlPyCrZdnFjKyH+ypIpg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^3.7.2",
+                "@aws-sdk/types": "3.654.0",
+                "@aws-sdk/util-endpoints": "3.654.0",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2533,14 +2496,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.709.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.709.0.tgz",
-            "integrity": "sha512-Mbc7AtL5WGCTKC16IGeUTz+sjpC3ptBda2t0CcK0kMVw3THDdcSq6ZlNKO747cNqdbwUvW34oHteUiHv4/z88Q==",
+            "version": "3.654.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.654.0.tgz",
+            "integrity": "sha512-i902fcBknHs0Irgdpi62+QMvzxE+bczvILXigYrlHL4+PiEnlMVpni5L5W1qCkNZXf8AaMrSBuR1NZAGp6UOUw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.709.0",
-                "@smithy/types": "^3.7.2",
-                "@smithy/util-endpoints": "^2.1.7",
+                "@aws-sdk/types": "3.654.0",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-endpoints": "^2.1.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6388,9 +6351,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "22.10.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-            "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+            "version": "22.10.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+            "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.20.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "devDependencies": {
         "@commitlint/cli": "^19.5.0",
         "@commitlint/config-conventional": "^19.5.0",
-        "@types/node": "^22.10.2",
+        "@types/node": "^22.9.0",
         "@typescript-eslint/eslint-plugin": "^7.7.1",
         "@typescript-eslint/parser": "^7.7.1",
         "conventional-changelog-conventionalcommits": "^8.0.0",


### PR DESCRIPTION
## Problem
* The streaming client dependabot changes should not be merged 

## Solution

* Reverted dependabot changes. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
