### PR TITLE
chore: add commit linting to prepush hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,3 +4,7 @@ if [ "$branch" = "refs/heads/main" ]; then
     echo "Direct push to the main branch is not allowed. Please create a new branch and open Pull Request."
     exit 1
 fi
+
+echo "[pre-push] linting commit message..." 
+npm run commitlint
+echo "[pre-commit] done linting commit message"


### PR DESCRIPTION
## Problem
If conventional commits through git hooks were ignored (with `--no-verify`), then pushing to remote will still succeed. Let's add an additional layer to it.

## Solution
Add commitlint command to the prepush script
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
