### PR TITLE
chore(chat-client): extend chat client README with list of events supported and config

### DIFF
--- a/chat-client/README.md
+++ b/chat-client/README.md
@@ -11,4 +11,44 @@ The chat client communicates with the host application (e.g., an IDE extension) 
 
 ## Usage
 
-To use the chat client, embed it in a webview within your application and handle the `postMessage` communication as needed.
+To use the chat client, embed it in a webview within your application and handle the `postMessage` communication as needed. Chat client is based on inbound (from a destination to the chat client) and outbound events (from the chat client to a destination). Events consist of `command` and `params`:
+```
+interface SomeEvent {
+    command: string;
+    params: SomeOptions;
+}
+```
+
+### Inbound events
+| Name                        | Description                       | command                  | params  |
+| --------------------------- | --------------------------------- | ------------------------ | ----------- |
+| sendChatPrompt response     |  Provides response to sendChatPrompt request   | `aws/chat/sendChatPrompt` | [ChatResult](https://github.com/aws/language-server-runtimes/blob/main/types/chat.ts#L76)         |
+| sendToPrompt                |  Request to send selection to prompt | `sendToPrompt` | [SendToPromptParams](https://github.com/aws/language-server-runtimes/blob/fe2669c34479d4925f2bdbe5527417ea8aed6c39/chat-client-ui-types/src/uiContracts.ts#L50C18-L50C36)         |
+| genericCommand              |  Request to execute generic command   | `genericCommand` | [GenericCommandParams](https://github.com/aws/language-server-runtimes/blob/fe2669c34479d4925f2bdbe5527417ea8aed6c39/chat-client-ui-types/src/uiContracts.ts#L76)         |
+| errorMessage                |  Request to show error in chat UI   | `errorMessage` | [ErrorParams](https://github.com/aws/language-server-runtimes/blob/fe2669c34479d4925f2bdbe5527417ea8aed6c39/chat-client-ui-types/src/uiContracts.ts#L88C18-L88C29)         |
+| chatOptions                 | Configures chat startup options   | `chatOptions`            | [ChatOptions](https://github.com/aws/language-server-runtimes/blob/main/types/chat.ts#L127)         |
+
+### Outbound events
+| Name                        | Description                 | command                  | params  |
+| --------------------------- | --------------------------- | ------------------------ | ----------- |
+| disclaimerAcknowledged      | Notifies destination that legal disclaimer was acknowlegded by a user | `disclaimerAcknowledged` | N/A |
+
+TODO: Provide full list of events
+
+### Configuration
+
+Configuration can be passed as an explicit parameter when creating chat inside of webview, for example:
+```
+amazonQChat.createChat(acquireVsCodeApi(), configuration);
+```
+
+Configuration values:
+```
+// Configures quick actions
+quickActionCommands?: QuickActionCommandGroup[]
+
+// Configures chat client not to show legal disclaimer as it has already been acknowledged before
+disclaimerAcknowledged?: boolean
+```
+
+


### PR DESCRIPTION

## Problem

No information about how to use the chat-client.

## Solution

Extended README with chat-client events and configuration.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
