### PR TITLE
refactor:  inject AWS_Q_REGION and AWS_Q_ENDPOINT_URL env variables via runtime

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
+++ b/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
@@ -1,17 +1,23 @@
 import { CodeWhispererStreaming, CodeWhispererStreamingClientConfig } from '@amzn/codewhisperer-streaming'
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { readFileSync } from 'fs'
-import { AWS_Q_REGION, AWS_Q_ENDPOINT_URL } from '../../constants'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { HttpsProxyAgent } from 'hpagent'
 
 export class StreamingClient {
-    public async getStreamingClient(credentialsProvider: any, config?: CodeWhispererStreamingClientConfig) {
-        return await createStreamingClient(credentialsProvider, config)
+    public async getStreamingClient(
+        credentialsProvider: any,
+        codeWhispererRegion: string,
+        codeWhispererEndpoint: string,
+        config?: CodeWhispererStreamingClientConfig
+    ) {
+        return await createStreamingClient(credentialsProvider, codeWhispererRegion, codeWhispererEndpoint, config)
     }
 }
 export async function createStreamingClient(
     credentialsProvider: any,
+    codeWhispererRegion: string,
+    codeWhispererEndpoint: string,
     config?: CodeWhispererStreamingClientConfig
 ): Promise<CodeWhispererStreaming> {
     const creds = credentialsProvider.getCredentials('bearer')
@@ -35,8 +41,8 @@ export async function createStreamingClient(
     }
 
     const streamingClient = new CodeWhispererStreaming({
-        region: AWS_Q_REGION,
-        endpoint: AWS_Q_ENDPOINT_URL,
+        region: codeWhispererRegion,
+        endpoint: codeWhispererEndpoint,
         token: { token: creds.token },
         retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
         requestHandler: clientOptions?.requestHandler,

--- a/server/aws-lsp-codewhisperer/src/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/constants.ts
@@ -1,2 +1,2 @@
-export const AWS_Q_ENDPOINT_URL = process?.env.AWS_Q_ENDPOINT_URL ?? 'https://codewhisperer.us-east-1.amazonaws.com/'
-export const AWS_Q_REGION = process?.env.AWS_Q_REGION ?? 'us-east-1'
+export const DEFAULT_AWS_Q_ENDPOINT_URL = 'https://codewhisperer.us-east-1.amazonaws.com/'
+export const DEFAULT_AWS_Q_REGION = 'us-east-1'

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -25,6 +25,7 @@ import * as utils from './utils'
 import { DEFAULT_HELP_FOLLOW_UP_PROMPT, HELP_MESSAGE } from './constants'
 import { TelemetryService } from '../telemetryService'
 import { TextEdit } from 'vscode-languageserver-textdocument'
+import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
 
 describe('ChatController', () => {
     const mockTabId = 'tab-1'
@@ -74,6 +75,9 @@ describe('ChatController', () => {
         },
     } as Logging
 
+    const awsQRegion: string = DEFAULT_AWS_Q_REGION
+    const awsQEndpointUrl: string = DEFAULT_AWS_Q_ENDPOINT_URL
+
     let sendMessageStub: sinon.SinonStub
     let disposeStub: sinon.SinonStub
     let activeTabSpy: {
@@ -112,9 +116,10 @@ describe('ChatController', () => {
 
         disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
 
-        chatSessionManagementService = ChatSessionManagementService.getInstance().withCredentialsProvider(
-            testFeatures.credentialsProvider
-        )
+        chatSessionManagementService = ChatSessionManagementService.getInstance()
+            .withCredentialsProvider(testFeatures.credentialsProvider)
+            .withCodeWhispererRegion(awsQRegion)
+            .withCodeWhispererEndpoint(awsQEndpointUrl)
 
         const mockCredentialsProvider: CredentialsProvider = {
             hasCredentials: sinon.stub().returns(true),
@@ -132,7 +137,15 @@ describe('ChatController', () => {
             emitMetric: sinon.stub(),
             onClientTelemetry: sinon.stub(),
         }
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, mockWorkspace)
+        telemetryService = new TelemetryService(
+            mockCredentialsProvider,
+            'bearer',
+            telemetry,
+            logging,
+            mockWorkspace,
+            awsQRegion,
+            awsQEndpointUrl
+        )
         invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
         chatController = new ChatController(chatSessionManagementService, testFeatures, telemetryService)
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
@@ -6,6 +6,8 @@ import { ChatSessionService } from './chatSessionService'
 
 describe('ChatSessionManagementService', () => {
     const mockSessionId = 'mockSessionId'
+    const mockAwsQRegion: string = 'mock-aws-q-region'
+    const mockAwsQEndpointUrl: string = 'mock-aws-q-endpoint-url'
 
     it('getInstance should return the same instance if initialized', () => {
         const instance = ChatSessionManagementService.getInstance()
@@ -33,8 +35,10 @@ describe('ChatSessionManagementService', () => {
 
         beforeEach(() => {
             disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
-            chatSessionManagementService =
-                ChatSessionManagementService.getInstance().withCredentialsProvider(mockCredentialsProvider)
+            chatSessionManagementService = ChatSessionManagementService.getInstance()
+                .withCredentialsProvider(mockCredentialsProvider)
+                .withCodeWhispererRegion(mockAwsQRegion)
+                .withCodeWhispererEndpoint(mockAwsQEndpointUrl)
         })
 
         afterEach(() => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
@@ -8,6 +8,8 @@ export class ChatSessionManagementService {
     #credentialsProvider?: CredentialsProvider
     #clientConfig?: ChatSessionServiceConfig | (() => ChatSessionServiceConfig) = {}
     #customUserAgent?: string = '%Amazon-Q-For-LanguageServers%'
+    #codeWhispererRegion?: string
+    #codeWhispererEndpoint?: string
 
     public static getInstance() {
         if (!ChatSessionManagementService.#instance) {
@@ -35,6 +37,18 @@ export class ChatSessionManagementService {
         return this
     }
 
+    public withCodeWhispererRegion(codeWhispererRegion: string) {
+        this.#codeWhispererRegion = codeWhispererRegion
+
+        return this
+    }
+
+    public withCodeWhispererEndpoint(codeWhispererEndpoint: string) {
+        this.#codeWhispererEndpoint = codeWhispererEndpoint
+
+        return this
+    }
+
     public setCustomUserAgent(customUserAgent: string) {
         this.#customUserAgent = customUserAgent
     }
@@ -49,6 +63,16 @@ export class ChatSessionManagementService {
                 success: false,
                 error: 'Credentials provider is not set',
             }
+        } else if (!this.#codeWhispererRegion) {
+            return {
+                success: false,
+                error: 'CodeWhispererRegion is not set',
+            }
+        } else if (!this.#codeWhispererEndpoint) {
+            return {
+                success: false,
+                error: 'CodeWhispererEndpoint is not set',
+            }
         } else if (this.#sessionByTab.has(tabId)) {
             return {
                 success: true,
@@ -57,10 +81,15 @@ export class ChatSessionManagementService {
         }
 
         const clientConfig = typeof this.#clientConfig === 'function' ? this.#clientConfig() : this.#clientConfig
-        const newSession = new ChatSessionService(this.#credentialsProvider, {
-            ...clientConfig,
-            customUserAgent: this.#customUserAgent,
-        })
+        const newSession = new ChatSessionService(
+            this.#credentialsProvider,
+            this.#codeWhispererRegion,
+            this.#codeWhispererEndpoint,
+            {
+                ...clientConfig,
+                customUserAgent: this.#customUserAgent,
+            }
+        )
 
         this.#sessionByTab.set(tabId, newSession)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
@@ -7,6 +7,7 @@ import { CredentialsProvider } from '@aws/language-server-runtimes/server-interf
 import * as assert from 'assert'
 import sinon from 'ts-sinon'
 import { ChatSessionService } from './chatSessionService'
+import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
 
 describe('Chat Session Service', () => {
     let sendMessageStub: sinon.SinonStub<any, any>
@@ -17,7 +18,8 @@ describe('Chat Session Service', () => {
         getCredentials: sinon.stub().returns(Promise.resolve({ token: 'mockToken ' })),
         getConnectionMetadata: sinon.stub(),
     }
-
+    const awsQRegion: string = DEFAULT_AWS_Q_REGION
+    const awsQEndpointUrl: string = DEFAULT_AWS_Q_ENDPOINT_URL
     const mockConversationId = 'mockConversationId'
 
     const mockRequestParams: SendMessageCommandInput = {
@@ -43,7 +45,7 @@ describe('Chat Session Service', () => {
             .stub(CodeWhispererStreaming.prototype, 'sendMessage')
             .callsFake(() => Promise.resolve(mockRequestResponse))
 
-        chatSessionService = new ChatSessionService(mockCredentialsProvider)
+        chatSessionService = new ChatSessionService(mockCredentialsProvider, awsQRegion, awsQEndpointUrl)
     })
 
     afterEach(() => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -7,13 +7,12 @@ import {
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
 import { getBearerTokenFromProvider } from '../utils'
-import { AWS_Q_REGION, AWS_Q_ENDPOINT_URL } from '../../constants'
 
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
-    readonly #codeWhispererRegion = AWS_Q_REGION
-    readonly #codeWhispererEndpoint = AWS_Q_ENDPOINT_URL
+    #codeWhispererRegion: string
+    #codeWhispererEndpoint: string
     #abortController?: AbortController
     #credentialsProvider: CredentialsProvider
     #config?: CodeWhispererStreamingClientConfig
@@ -27,8 +26,15 @@ export class ChatSessionService {
         this.#conversationId = value
     }
 
-    constructor(credentialsProvider: CredentialsProvider, config?: CodeWhispererStreamingClientConfig) {
+    constructor(
+        credentialsProvider: CredentialsProvider,
+        codeWhispererRegion: string,
+        codeWhispererEndpoint: string,
+        config?: CodeWhispererStreamingClientConfig
+    ) {
         this.#credentialsProvider = credentialsProvider
+        this.#codeWhispererRegion = codeWhispererRegion
+        this.#codeWhispererEndpoint = codeWhispererEndpoint
         this.#config = config
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -11,8 +11,8 @@ import { getBearerTokenFromProvider } from '../utils'
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
-    #codeWhispererRegion: string
-    #codeWhispererEndpoint: string
+    readonly #codeWhispererRegion: string
+    readonly #codeWhispererEndpoint: string
     #abortController?: AbortController
     #credentialsProvider: CredentialsProvider
     #config?: CodeWhispererStreamingClientConfig

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -18,14 +18,27 @@ import { SecurityScanRequestParams, SecurityScanResponse } from './securityScan/
 import { SecurityScanEvent } from './telemetry/types'
 import { getErrorMessage, parseJson } from './utils'
 import { getUserAgent } from './utilities/telemetryUtils'
+import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../constants'
 
 const RunSecurityScanCommand = 'aws/codewhisperer/runSecurityScan'
 const CancelSecurityScanCommand = 'aws/codewhisperer/cancelSecurityScan'
 
 export const SecurityScanServerToken =
-    (service: (credentialsProvider: CredentialsProvider, workspace: Workspace) => CodeWhispererServiceToken): Server =>
+    (
+        service: (
+            credentialsProvider: CredentialsProvider,
+            workspace: Workspace,
+            awsQRegion: string,
+            awsQEndpointUrl: string
+        ) => CodeWhispererServiceToken
+    ): Server =>
     ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime }) => {
-        const codewhispererclient = service(credentialsProvider, workspace)
+        const codewhispererclient = service(
+            credentialsProvider,
+            workspace,
+            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
+            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+        )
         const diagnosticsProvider = new SecurityScanDiagnosticsProvider(lsp, logging)
         const scanHandler = new SecurityScanHandler(codewhispererclient, workspace, logging)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -272,18 +272,18 @@ export const CodewhispererServerFactory =
         let timeSinceLastUserModification: number = 0
 
         const sessionManager = SessionManager.getInstance()
-        const codeWhispererService = service(
-            credentialsProvider,
-            workspace,
-            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
-            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
-        )
+
+        const awsQRegion = runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION
+        const awsQEndpointUrl = runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+        const codeWhispererService = service(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
         const telemetryService = new TelemetryService(
             credentialsProvider,
             codeWhispererService.getCredentialsType(),
             telemetry,
             logging,
-            workspace
+            workspace,
+            awsQRegion,
+            awsQEndpointUrl
         )
 
         lsp.addInitializer((params: InitializeParams) => {
@@ -619,9 +619,9 @@ export const CodewhispererServerFactory =
                         `Inline completion configuration updated to use ${codeWhispererService.customizationArn}`
                     )
                     /*
-                                The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
-                                configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
-                            */
+                                    The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
+                                    configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
+                                */
                     // const enableTelemetryEventsToDestination = true
                     // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
                     const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -39,6 +39,7 @@ import { fetchSupplementalContext } from './utilities/supplementalContextUtil/su
 import { undefinedIfEmpty } from './utilities/textUtils'
 import { TelemetryService } from './telemetryService'
 import { AcceptedSuggestionEntry, CodeDiffTracker } from './telemetry/codeDiffTracker'
+import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../constants'
 
 const EMPTY_RESULT = { sessionId: '', items: [] }
 export const CONTEXT_CHARACTERS_LIMIT = 10240
@@ -258,13 +259,25 @@ interface AcceptedInlineSuggestionEntry extends AcceptedSuggestionEntry {
 }
 
 export const CodewhispererServerFactory =
-    (service: (credentials: CredentialsProvider, workspace: Workspace) => CodeWhispererServiceBase): Server =>
+    (
+        service: (
+            credentials: CredentialsProvider,
+            workspace: Workspace,
+            awsQRegion: string,
+            awsQEndpointUrl: string
+        ) => CodeWhispererServiceBase
+    ): Server =>
     ({ credentialsProvider, lsp, workspace, telemetry, logging, runtime }) => {
         let lastUserModificationTime: number
         let timeSinceLastUserModification: number = 0
 
         const sessionManager = SessionManager.getInstance()
-        const codeWhispererService = service(credentialsProvider, workspace)
+        const codeWhispererService = service(
+            credentialsProvider,
+            workspace,
+            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
+            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+        )
         const telemetryService = new TelemetryService(
             credentialsProvider,
             codeWhispererService.getCredentialsType(),
@@ -606,9 +619,9 @@ export const CodewhispererServerFactory =
                         `Inline completion configuration updated to use ${codeWhispererService.customizationArn}`
                     )
                     /*
-                                        The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
-                                        configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
-                                     */
+                                The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
+                                configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
+                            */
                     // const enableTelemetryEventsToDestination = true
                     // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
                     const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'
@@ -666,8 +679,10 @@ export const CodewhispererServerFactory =
     }
 
 export const CodeWhispererServerIAM = CodewhispererServerFactory(
-    (credentialsProvider, workspace) => new CodeWhispererServiceIAM(credentialsProvider, workspace)
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) =>
+        new CodeWhispererServiceIAM(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
 )
 export const CodeWhispererServerToken = CodewhispererServerFactory(
-    (credentialsProvider, workspace) => new CodeWhispererServiceToken(credentialsProvider, workspace)
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) =>
+        new CodeWhispererServiceToken(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
 )

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -8,13 +8,26 @@ import {
 } from '@aws/language-server-runtimes/server-interface'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
 import { getUserAgent } from '../utilities/telemetryUtils'
+import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
 
 // The configuration section that the server will register and listen to
 export const Q_CONFIGURATION_SECTION = 'aws.q'
 export const QConfigurationServerToken =
-    (service: (credentials: CredentialsProvider, workspace: Workspace) => CodeWhispererServiceToken): Server =>
+    (
+        service: (
+            credentials: CredentialsProvider,
+            workspace: Workspace,
+            awsQRegion: string,
+            awsQEndpointUrl: string
+        ) => CodeWhispererServiceToken
+    ): Server =>
     ({ credentialsProvider, lsp, logging, runtime, workspace }) => {
-        const codeWhispererService = service(credentialsProvider, workspace)
+        const codeWhispererService = service(
+            credentialsProvider,
+            workspace,
+            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
+            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+        )
 
         lsp.addInitializer((params: InitializeParams) => {
             codeWhispererService.updateClientConfig({

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
@@ -18,6 +18,8 @@ import {
 import { TransformHandler } from '../transformHandler'
 import { EXAMPLE_REQUEST } from './mockData'
 import sinon = require('sinon')
+import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../../constants'
+
 const mocked$Response = {
     $response: {
         hasNextPage: simon.mock(),
@@ -39,6 +41,8 @@ describe('Test Transform handler ', () => {
     let workspace: StubbedInstance<Workspace>
     let transformHandler: TransformHandler
     const mockedLogging = stubInterface<Logging>()
+    const awsQRegion: string = DEFAULT_AWS_Q_REGION
+    const awsQEndpointUrl: string = DEFAULT_AWS_Q_ENDPOINT_URL
     beforeEach(async () => {
         // Set up the server with a mock service
         client = stubInterface<CodeWhispererServiceToken>()
@@ -177,14 +181,18 @@ describe('Test Transform handler ', () => {
     describe('StreamingClient', () => {
         it('should create a new streaming client', async () => {
             const streamingClient = new StreamingClient()
-            const client = await streamingClient.getStreamingClient(mockedCredentialsProvider)
+            const client = await streamingClient.getStreamingClient(
+                mockedCredentialsProvider,
+                awsQRegion,
+                awsQEndpointUrl
+            )
             expect(client).to.be.instanceOf(CodeWhispererStreaming)
         })
     })
 
     describe('createStreamingClient', () => {
         it('should create a new streaming client with correct configurations', async () => {
-            const client = await createStreamingClient(mockedCredentialsProvider)
+            const client = await createStreamingClient(mockedCredentialsProvider, awsQRegion, awsQEndpointUrl)
             expect(client).to.be.instanceOf(CodeWhispererStreaming)
         })
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -45,15 +45,29 @@ const PollTransformForPlanCommand = 'aws/qNetTransform/pollTransformForPlan'
 const GetTransformPlanCommand = 'aws/qNetTransform/getTransformPlan'
 const CancelTransformCommand = 'aws/qNetTransform/cancelTransform'
 const DownloadArtifactsCommand = 'aws/qNetTransform/downloadArtifacts'
+import { DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL } from '../constants'
+
 /**
  *
  * @param createService Inject service instance based on credentials provider.
  * @returns  NetTransform server
  */
 export const QNetTransformServerToken =
-    (service: (credentialsProvider: CredentialsProvider, workspace: Workspace) => CodeWhispererServiceToken): Server =>
+    (
+        service: (
+            credentialsProvider: CredentialsProvider,
+            workspace: Workspace,
+            awsQRegion: string,
+            awsQEndpointUrl: string
+        ) => CodeWhispererServiceToken
+    ): Server =>
     ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime }) => {
-        const codewhispererclient = service(credentialsProvider, workspace)
+        const codewhispererclient = service(
+            credentialsProvider,
+            workspace,
+            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
+            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+        )
         const transformHandler = new TransformHandler(codewhispererclient, workspace, logging)
         const runTransformCommand = async (params: ExecuteCommandParams, _token: CancellationToken) => {
             try {
@@ -109,6 +123,8 @@ export const QNetTransformServerToken =
                         const cwStreamingClientInstance = new StreamingClient()
                         const cwStreamingClient = await cwStreamingClientInstance.getStreamingClient(
                             credentialsProvider,
+                            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
+                            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
                             customCWClientConfig
                         )
 

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -10,23 +10,31 @@ import { readFileSync } from 'fs'
 import { HttpsProxyAgent } from 'hpagent'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 
-export const CodeWhispererServerTokenProxy = CodewhispererServerFactory((credentialsProvider, workspace) => {
-    return new CodeWhispererServiceToken(credentialsProvider, workspace)
-})
+export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) => {
+        return new CodeWhispererServiceToken(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+    }
+)
 
-export const CodeWhispererServerIAMProxy = CodewhispererServerFactory((credentialsProvider, workspace) => {
-    return new CodeWhispererServiceIAM(credentialsProvider, workspace)
-})
+export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) => {
+        return new CodeWhispererServiceIAM(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+    }
+)
 
-export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken((credentialsProvider, workspace) => {
-    return new CodeWhispererServiceToken(credentialsProvider, workspace)
-})
+export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken(
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) => {
+        return new CodeWhispererServiceToken(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+    }
+)
 
-export const QNetTransformServerTokenProxy = QNetTransformServerToken((credentialsProvider, workspace) => {
-    return new CodeWhispererServiceToken(credentialsProvider, workspace)
-})
+export const QNetTransformServerTokenProxy = QNetTransformServerToken(
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) => {
+        return new CodeWhispererServiceToken(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+    }
+)
 
-export const QChatServerProxy = QChatServer(credentialsProvider => {
+export const QChatServerProxy = QChatServer((credentialsProvider, awsQRegion, awsQEndpointUrl) => {
     let clientOptions: ChatSessionServiceConfig | undefined
 
     const proxyUrl = process.env.HTTPS_PROXY ?? process.env.https_proxy
@@ -51,9 +59,13 @@ export const QChatServerProxy = QChatServer(credentialsProvider => {
 
     return ChatSessionManagementService.getInstance()
         .withCredentialsProvider(credentialsProvider)
+        .withCodeWhispererEndpoint(awsQEndpointUrl)
+        .withCodeWhispererRegion(awsQRegion)
         .withConfig(clientOptions)
 })
 
-export const QConfigurationServerTokenProxy = QConfigurationServerToken((credentialsProvider, workspace) => {
-    return new CodeWhispererServiceToken(credentialsProvider, workspace)
-})
+export const QConfigurationServerTokenProxy = QConfigurationServerToken(
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) => {
+        return new CodeWhispererServiceToken(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+    }
+)

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -17,12 +17,22 @@ export const QChatServer =
     features => {
         const { chat, credentialsProvider, telemetry, logging, lsp, runtime, workspace } = features
 
+        const awsQRegion = runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION
+        const awsQEndpointUrl = runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
         const chatSessionManagementService: ChatSessionManagementService = service(
             credentialsProvider,
-            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
-            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+            awsQRegion,
+            awsQEndpointUrl
         )
-        const telemetryService = new TelemetryService(credentialsProvider, 'bearer', telemetry, logging, workspace)
+        const telemetryService = new TelemetryService(
+            credentialsProvider,
+            'bearer',
+            telemetry,
+            logging,
+            workspace,
+            awsQRegion,
+            awsQEndpointUrl
+        )
 
         const chatController = new ChatController(chatSessionManagementService, features, telemetryService)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -4,13 +4,24 @@ import { ChatSessionManagementService } from './chat/chatSessionManagementServic
 import { CLEAR_QUICK_ACTION, HELP_QUICK_ACTION } from './chat/quickActions'
 import { TelemetryService } from './telemetryService'
 import { getUserAgent, makeUserContextObject } from './utilities/telemetryUtils'
+import { DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL } from '../constants'
 
 export const QChatServer =
-    (service: (credentialsProvider: CredentialsProvider) => ChatSessionManagementService): Server =>
+    (
+        service: (
+            credentialsProvider: CredentialsProvider,
+            awsQregion: string,
+            awsQendpointUrl: string
+        ) => ChatSessionManagementService
+    ): Server =>
     features => {
         const { chat, credentialsProvider, telemetry, logging, lsp, runtime, workspace } = features
 
-        const chatSessionManagementService: ChatSessionManagementService = service(credentialsProvider)
+        const chatSessionManagementService: ChatSessionManagementService = service(
+            credentialsProvider,
+            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
+            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+        )
         const telemetryService = new TelemetryService(credentialsProvider, 'bearer', telemetry, logging, workspace)
 
         const chatController = new ChatController(chatSessionManagementService, features, telemetryService)

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -10,8 +10,8 @@ export const QChatServer =
     (
         service: (
             credentialsProvider: CredentialsProvider,
-            awsQregion: string,
-            awsQendpointUrl: string
+            awsQRegion: string,
+            awsQEndpointUrl: string
         ) => ChatSessionManagementService
     ): Server =>
     features => {

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
@@ -52,6 +52,9 @@ describe('TelemetryService', () => {
     let clock: sinon.SinonFakeTimers
     let telemetryService: TelemetryService
     let mockCredentialsProvider: MockCredentialsProvider
+    const mockAwsQRegion: string = 'mock-aws-q-region'
+    const mockAwsQEndpointUrl: string = 'mock-aws-q-endpoint-url'
+
     const logging: Logging = {
         log: (message: string) => {
             console.log(message)
@@ -112,7 +115,9 @@ describe('TelemetryService', () => {
             'bearer',
             {} as Telemetry,
             logging,
-            mockWorkspace
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
         )
         const mockUserContext: UserContext = {
             clientId: 'aaaabbbbccccdddd',
@@ -132,7 +137,9 @@ describe('TelemetryService', () => {
             'bearer',
             {} as Telemetry,
             logging,
-            mockWorkspace
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
         )
         const mockOptOutPreference: OptOutPreference = 'OPTIN'
         telemetryService.updateOptOutPreference(mockOptOutPreference)
@@ -146,7 +153,9 @@ describe('TelemetryService', () => {
             'bearer',
             {} as Telemetry,
             logging,
-            mockWorkspace
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
         )
         telemetryService.updateEnableTelemetryEventsToDestination(true)
 
@@ -159,7 +168,9 @@ describe('TelemetryService', () => {
             'bearer',
             {} as Telemetry,
             logging,
-            mockWorkspace
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
         )
         const getSuggestionState = (telemetryService as any).getSuggestionState.bind(telemetryService)
         let session = {
@@ -201,7 +212,15 @@ describe('TelemetryService', () => {
     })
 
     it('should not emit user trigger decision if login is invalid (IAM)', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', telemetry, logging, mockWorkspace)
+        telemetryService = new TelemetryService(
+            mockCredentialsProvider,
+            'iam',
+            telemetry,
+            logging,
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
+        )
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
 
         telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
@@ -215,7 +234,15 @@ describe('TelemetryService', () => {
                 startUrl: BUILDER_ID_START_URL,
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, mockWorkspace)
+        telemetryService = new TelemetryService(
+            mockCredentialsProvider,
+            'bearer',
+            telemetry,
+            logging,
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
+        )
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
         telemetryService.updateOptOutPreference('OPTOUT')
 
@@ -225,7 +252,15 @@ describe('TelemetryService', () => {
     })
 
     it('should handle SSO connection type change at runtime', () => {
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, mockWorkspace)
+        telemetryService = new TelemetryService(
+            mockCredentialsProvider,
+            'bearer',
+            telemetry,
+            logging,
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
+        )
         const sendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
             .returns(Promise.resolve())
@@ -281,7 +316,15 @@ describe('TelemetryService', () => {
                 startUrl: 'idc-start-url',
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, mockWorkspace)
+        telemetryService = new TelemetryService(
+            mockCredentialsProvider,
+            'bearer',
+            telemetry,
+            logging,
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
+        )
         telemetryService.updateEnableTelemetryEventsToDestination(true)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -328,7 +371,15 @@ describe('TelemetryService', () => {
                 startUrl: BUILDER_ID_START_URL,
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, mockWorkspace)
+        telemetryService = new TelemetryService(
+            mockCredentialsProvider,
+            'bearer',
+            telemetry,
+            logging,
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
+        )
         telemetryService.updateEnableTelemetryEventsToDestination(false)
         telemetryService.updateOptOutPreference('OPTOUT')
         telemetryService.emitUserTriggerDecision(mockSession as CodeWhispererSession)
@@ -354,7 +405,9 @@ describe('TelemetryService', () => {
                 'bearer',
                 telemetry,
                 logging,
-                mockWorkspace
+                mockWorkspace,
+                mockAwsQRegion,
+                mockAwsQEndpointUrl
             )
             invokeSendTelemetryEventStub = sinon
                 .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -432,7 +485,9 @@ describe('TelemetryService', () => {
                 'bearer',
                 {} as Telemetry,
                 logging,
-                mockWorkspace
+                mockWorkspace,
+                mockAwsQRegion,
+                mockAwsQEndpointUrl
             )
             telemetryService.updateEnableTelemetryEventsToDestination(false)
             telemetryService.updateOptOutPreference('OPTOUT')
@@ -461,7 +516,15 @@ describe('TelemetryService', () => {
         })
 
         it('should not send InteractWithMessage when credentialsType is IAM', () => {
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', telemetry, logging, mockWorkspace)
+            telemetryService = new TelemetryService(
+                mockCredentialsProvider,
+                'iam',
+                telemetry,
+                logging,
+                mockWorkspace,
+                mockAwsQRegion,
+                mockAwsQEndpointUrl
+            )
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             const metric = {
                 cwsprChatMessageId: 'message123',
@@ -489,7 +552,9 @@ describe('TelemetryService', () => {
                 'bearer',
                 telemetry,
                 logging,
-                mockWorkspace
+                mockWorkspace,
+                mockAwsQRegion,
+                mockAwsQEndpointUrl
             )
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.updateOptOutPreference('OPTOUT')
@@ -558,7 +623,15 @@ describe('TelemetryService', () => {
                 startUrl: 'idc-start-url',
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, mockWorkspace)
+        telemetryService = new TelemetryService(
+            mockCredentialsProvider,
+            'bearer',
+            telemetry,
+            logging,
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
+        )
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
             .returns(Promise.resolve())
@@ -597,7 +670,15 @@ describe('TelemetryService', () => {
                 startUrl: BUILDER_ID_START_URL,
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, mockWorkspace)
+        telemetryService = new TelemetryService(
+            mockCredentialsProvider,
+            'bearer',
+            telemetry,
+            logging,
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
+        )
         telemetryService.updateOptOutPreference('OPTOUT')
         telemetryService.updateEnableTelemetryEventsToDestination(false)
 
@@ -629,7 +710,9 @@ describe('TelemetryService', () => {
             'bearer',
             {} as Telemetry,
             logging,
-            mockWorkspace
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
         )
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -673,7 +756,15 @@ describe('TelemetryService', () => {
                 startUrl: 'idc-start-url',
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, mockWorkspace)
+        telemetryService = new TelemetryService(
+            mockCredentialsProvider,
+            'bearer',
+            telemetry,
+            logging,
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
+        )
         telemetryService.updateEnableTelemetryEventsToDestination(true)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -717,7 +808,15 @@ describe('TelemetryService', () => {
                 startUrl: BUILDER_ID_START_URL,
             },
         })
-        telemetryService = new TelemetryService(mockCredentialsProvider, 'bearer', telemetry, logging, mockWorkspace)
+        telemetryService = new TelemetryService(
+            mockCredentialsProvider,
+            'bearer',
+            telemetry,
+            logging,
+            mockWorkspace,
+            mockAwsQRegion,
+            mockAwsQEndpointUrl
+        )
         telemetryService.updateEnableTelemetryEventsToDestination(false)
         telemetryService.updateOptOutPreference('OPTOUT')
         telemetryService.emitChatUserModificationEvent({
@@ -748,7 +847,9 @@ describe('TelemetryService', () => {
                 'bearer',
                 telemetry,
                 logging,
-                mockWorkspace
+                mockWorkspace,
+                mockAwsQRegion,
+                mockAwsQEndpointUrl
             )
             invokeSendTelemetryEventStub = sinon
                 .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -842,7 +943,9 @@ describe('TelemetryService', () => {
                 'bearer',
                 {} as Telemetry,
                 logging,
-                mockWorkspace
+                mockWorkspace,
+                mockAwsQRegion,
+                mockAwsQEndpointUrl
             )
             telemetryService.updateOptOutPreference('OPTOUT')
             telemetryService.updateEnableTelemetryEventsToDestination(false)
@@ -891,7 +994,15 @@ describe('TelemetryService', () => {
         })
 
         it('should not send ChatAddMessage when credentialsType is IAM', () => {
-            telemetryService = new TelemetryService(mockCredentialsProvider, 'iam', telemetry, logging, mockWorkspace)
+            telemetryService = new TelemetryService(
+                mockCredentialsProvider,
+                'iam',
+                telemetry,
+                logging,
+                mockWorkspace,
+                mockAwsQRegion,
+                mockAwsQEndpointUrl
+            )
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.emitChatAddMessage(
                 {
@@ -915,7 +1026,9 @@ describe('TelemetryService', () => {
                 'bearer',
                 telemetry,
                 logging,
-                mockWorkspace
+                mockWorkspace,
+                mockAwsQRegion,
+                mockAwsQEndpointUrl
             )
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.updateOptOutPreference('OPTOUT')

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
@@ -58,9 +58,11 @@ export class TelemetryService extends CodeWhispererServiceToken {
         credentialsType: CredentialsType,
         telemetry: Telemetry,
         logging: Logging,
-        workspace: Workspace
+        workspace: Workspace,
+        awsQRegion: string,
+        awsQEndpointUrl: string
     ) {
-        super(credentialsProvider, workspace)
+        super(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
         this.credentialsProvider = credentialsProvider
         this.credentialsType = credentialsType
         this.telemetry = telemetry


### PR DESCRIPTION
## Problem
Inject AWS_Q_REGION and AWS_Q_ENDPOINT_URL env variables via runtime to avoid having node.js specific logic (i.e. process.env.VARIABLE) in lsp-codewhisperer.

## Solution
Inject the variables via runtime. The variables are pass down to the services via constructor, passing them down via setters/update function can leave room for errors, where the variables are passed via env, we forget to call those setters, and the values are set to the default value unintentionally.

**Some tests are currently failing due to the changes, once my approach is validated I will fix them.** 

I manually tested the following scenarios only via the token vscode client:
- Env variables are not set - inline suggestion and chat should work (using default values)
- Env variables are set to wrong values, inline suggestion and chat should not work
- Env variables are set to correct values, and default values are set to wrong values, inline suggestion and chat should work

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.