### PR TITLE
perf: dispose chat controller in chatController tests

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -481,6 +481,10 @@ describe('ChatController', () => {
             testFeatures.workspace.getTextDocument = sinon.stub()
         })
 
+        afterEach(() => {
+            chatController.dispose()
+        })
+
         it('handles regular insertion correctly', async () => {
             const document: TextDocument = TextDocument.create('test.ts', 'typescript', 1, ' ')
             testFeatures.workspace.getTextDocument.resolves(document)


### PR DESCRIPTION
## Problem
When running `npm run test` in `server/aws-lsp-codewhisperer`, all tests pass but the test task does not finish/close because we forgot to dispose some resources we created, in particular it's about the `chatController` object.

## Solution
Dispose via` chatController.dispose()`
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
