### PR TITLE
chore: change release-please manifest to fix false major version bumps

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-    "bootstrap-sha": "30ec14a11a4f9544d6b36a0196097b4425670937",
+    "bootstrap-sha": "ea570718da2b32b552b4308de1b4b3c2ee444b2b",
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "always-link-local": false,


### PR DESCRIPTION
## Description

Due to the empty commits we made last week, release please now tries to make a version bump on every subpackage. 

By changing the inception commit of release-please I am aiming to fix the wrong release created by release please and have release please only release actually changed subpackages.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
