### PR TITLE
fix: convert makeProxyConfig to sync to allow proxy configs to be loa…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -59,9 +59,7 @@ export abstract class CodeWhispererServiceBase {
     abstract generateSuggestions(request: GenerateSuggestionsRequest): Promise<GenerateSuggestionsResponse>
 
     constructor(workspace: Workspace, codeWhispererRegion: string, codeWhispererEndpoint: string) {
-        ;(async () => {
-            this.proxyConfig = await makeProxyConfig(workspace)
-        })()
+        this.proxyConfig = makeProxyConfig(workspace)
         this.codeWhispererRegion = codeWhispererRegion
         this.codeWhispererEndpoint = codeWhispererEndpoint
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -131,7 +131,7 @@ export function getEndPositionForAcceptedSuggestion(content: string, startPositi
     return endPosition
 }
 
-export const makeProxyConfig = async (workspace: Workspace) => {
+export const makeProxyConfig = (workspace: Workspace) => {
     let additionalAwsConfig: ConfigurationOptions = {}
     // short term solution to fix webworker bundling, broken due to this node.js specific logic in here
     const isNodeJS: boolean = typeof process !== 'undefined' && process.release && process.release.name === 'node'
@@ -140,7 +140,7 @@ export const makeProxyConfig = async (workspace: Workspace) => {
     if (proxyUrl) {
         const certs = isNodeJS
             ? process.env.AWS_CA_BUNDLE
-                ? [await workspace.fs.readFile(process.env.AWS_CA_BUNDLE)]
+                ? [workspace.fs.readFileSync(process.env.AWS_CA_BUNDLE).toString()]
                 : undefined
             : undefined
         const agent = new HttpsProxyAgent({

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -140,7 +140,7 @@ export const makeProxyConfig = (workspace: Workspace) => {
     if (proxyUrl) {
         const certs = isNodeJS
             ? process.env.AWS_CA_BUNDLE
-                ? [workspace.fs.readFileSync(process.env.AWS_CA_BUNDLE).toString()]
+                ? [workspace.fs.readFileSync(process.env.AWS_CA_BUNDLE)]
                 : undefined
             : undefined
         const agent = new HttpsProxyAgent({


### PR DESCRIPTION
convert makeProxyConfig function to sync as to allow proxy configurations to be loaded before being used. There has been an issue where proxy was not working for inline completions as the configurations were being loaded asyncronously and when the client was setting the configs, they were not set. The change aims to fix the issue and it has been tested on local environment to be working fine using Charles proxy for inline completions.

[[ THE CHANGE IS DEPENDENT ON THIS PR https://github.com/aws/language-server-runtimes/pull/299/files]

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
