### PR TITLE
feat(amazonq): implement basic server for standard LSP completion API

### DIFF
--- a/app/aws-lsp-q-dev-completions/README.md
+++ b/app/aws-lsp-q-dev-completions/README.md
@@ -1,0 +1,24 @@
+# Amazon Q Completions and Device SSO Token server
+
+This package provides example configuration to produce Amazon Q server implementation bundled with [Language Server Standalone Runtime](https://github.com/aws/language-server-runtimes).
+
+Language Server contains:
+- `SsoAuthServer`: support for Device authentication SSO flow from [`amzn/device-sso-auth-lsp`](../../server/device-sso-auth-lsp/) package.
+- `AmazonQCompletionServerToken`: experimental implementation of [Amazon Q Developer Code Completions](../../server/aws-lsp-codewhisperer/src/experimental/README.md) with standard LSP `textDocument/completion` protocol.
+- `CodeWhispererServerTokenProxy`: support of Amazon Q `InlineCompletionWithReferences`.
+- `QChatServerProxy`: support of Amazon Q Chat server.
+
+## Installation and usage
+
+To create compiled bundle run:
+```bash
+npm run package
+```
+
+This command will compile package and produce bundled Javascript server in `./out/` directory: 
+- `./out/completions-with-device-sso.js` - Amazon Q server bundled application.
+
+To verify compiled bundle can run, you can start it in your shell with NodeJS:
+```bash
+node ./out/completions-with-device-sso.js --stdio
+```

--- a/app/aws-lsp-q-dev-completions/package.json
+++ b/app/aws-lsp-q-dev-completions/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "@amzn/aws-lsp-q-dev-completions",
+    "version": "0.0.1",
+    "description": "Amazon Q Developer Code Completions Language Server",
+    "main": "out/index.js",
+    "scripts": {
+        "clean": "rm -rf out/ bin/ tsconfig.tsbuildinfo",
+        "compile": "tsc --build",
+        "package": "npm run compile && npm run webpack",
+        "webpack": "webpack"
+    },
+    "dependencies": {
+        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/lsp-codewhisperer": "*",
+        "@amzn/device-sso-auth-lsp": "*"
+    },
+    "devDependencies": {
+        "ts-loader": "^9.4.4",
+        "webpack": "^5.94.0",
+        "webpack-cli": "^5.1.4"
+    }
+}

--- a/app/aws-lsp-q-dev-completions/src/completions-with-device-sso.ts
+++ b/app/aws-lsp-q-dev-completions/src/completions-with-device-sso.ts
@@ -1,0 +1,16 @@
+import { version } from '../package.json'
+import { standalone } from '@aws/language-server-runtimes/runtimes'
+import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
+import {
+    CodeWhispererServerTokenProxy,
+    QChatServerProxy,
+    QConfigurationServerTokenProxy,
+} from '@aws/lsp-codewhisperer/out/language-server/proxy-server'
+import { SsoAuthServer } from '@amzn/device-sso-auth-lsp'
+
+const props: RuntimeProps = {
+    version,
+    servers: [SsoAuthServer, CodeWhispererServerTokenProxy, QConfigurationServerTokenProxy, QChatServerProxy],
+    name: 'Amazon Q Developer Completions with Device SSO Token',
+}
+standalone(props)

--- a/app/aws-lsp-q-dev-completions/tsconfig.json
+++ b/app/aws-lsp-q-dev-completions/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.packages.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./out",
+        "resolveJsonModule": true
+    },
+    "include": ["src"]
+}

--- a/app/aws-lsp-q-dev-completions/webpack.config.js
+++ b/app/aws-lsp-q-dev-completions/webpack.config.js
@@ -1,0 +1,41 @@
+var path = require('path')
+
+const baseConfig = {
+    mode: 'development',
+    output: {
+        path: __dirname,
+        filename: 'build/[name].js',
+        globalObject: 'this',
+        library: {
+            type: 'umd',
+        },
+    },
+    resolve: {
+        extensions: ['.ts', '.tsx', '.js'],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                use: 'ts-loader',
+                exclude: /node_modules/,
+            },
+        ],
+    },
+}
+
+const completionsWithDeviceSsoConfig = {
+    ...baseConfig,
+    experiments: {
+        asyncWebAssembly: true,
+    },
+    entry: {
+        'amazon-q-completions-and-sso': path.join(__dirname, 'src/completions-with-device-sso.ts'),
+    },
+    resolve: {
+        ...baseConfig.resolve,
+    },
+    target: 'node',
+}
+
+module.exports = [completionsWithDeviceSsoConfig]

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,20 @@
                 "webpack-cli": "^5.1.4"
             }
         },
+        "app/aws-lsp-q-dev-completions": {
+            "name": "@amzn/aws-lsp-q-dev-completions",
+            "version": "0.0.1",
+            "dependencies": {
+                "@amzn/device-sso-auth-lsp": "*",
+                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/lsp-codewhisperer": "*"
+            },
+            "devDependencies": {
+                "ts-loader": "^9.4.4",
+                "webpack": "^5.94.0",
+                "webpack-cli": "^5.1.4"
+            }
+        },
         "app/aws-lsp-s3-runtimes": {
             "name": "@aws/lsp-s3-runtimes",
             "version": "0.0.1",
@@ -380,6 +394,10 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@amzn/aws-lsp-q-dev-completions": {
+            "resolved": "app/aws-lsp-q-dev-completions",
+            "link": true
         },
         "node_modules/@amzn/codewhisperer-streaming": {
             "resolved": "core/codewhisperer-streaming",

--- a/server/aws-lsp-codewhisperer/README.md
+++ b/server/aws-lsp-codewhisperer/README.md
@@ -33,3 +33,22 @@ NodeJS modules used in this package
 To override modules use next alternatives:
 - `path` - https://www.npmjs.com/package/path-browserify
 - `os` - https://www.npmjs.com/package/os-browserify
+
+## Configuration
+
+Language Servers support different configurations and can be configured using the following environment variables:
+
+- `AWS_Q_REGION`: The AWS region for Amazon Q services (default: us-east-1)
+- `AWS_Q_ENDPOINT_URL`: The endpoint URL for Amazon Q services
+
+### LSP Configuration Options
+
+LSP configuration options that can be set through the LSP client's `workspace.getConfiguration` protocol:
+
+1. `aws.q` section:
+   - `customization`: (string) Sets the customization ARN for Amazon Q. To be used with [`QConfigurationServer`](../language-server/configuration/qConfigurationServer.ts)
+   - `preselectSuggestionFromQ`: (boolean, default: true) Determines whether suggestions from Amazon Q should be preselected in response from `textDocument/completion`.
+
+2. `aws.codeWhisperer` section:
+   - `includeSuggestionsWithCodeReferences`: (boolean, default: true) Controls whether suggestions that include code references should be included in the results.
+   - `shareCodeWhispererContentWithAWS`: (boolean, default: false) Determines whether the content processed by CodeWhisperer should be shared with AWS for service improvement.


### PR DESCRIPTION
## Problem
Q/codewhisperer does not support LSP standard "textDocument/completion" method https://github.com/aws/language-servers/issues/724

## Solution

- Added simple experimental `AmazonQCompletionServer` implementation to support `textDocument/completion` protocol. More docs available in `server/aws-lsp-codewhisperer/src/experimental/README.md`.
- Added new testing app in `app/aws-lsp-q-dev-completions`, which includes `AmazonQCompletionServer` and device SSO token provider among other servers.

To test the server: fetch this PR or https://github.com/viktorsaws/language-servers/tree/experimental_lsp_completions branch and rebuild the project:
```
npm install && npm run package
```

Bundled language server is available at `./app/aws-lsp-q-dev-completions/build/amazon-q-completions-and-sso.js` path.

![6-fcf9be50f3](https://github.com/user-attachments/assets/19102416-a3fc-4ecb-b6e9-b0e3fc6a9455)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
