### PR TITLE
[Internal Review] deduping nuget packages folder

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
+++ b/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
@@ -3235,7 +3235,7 @@
         },
         "TransformationProgressUpdateStatus": {
             "type": "string",
-            "enum": ["IN_PROGRESS", "COMPLETED", "FAILED", "PAUSED", "AWAITING_CLIENT_ACTION"]
+            "enum": ["IN_PROGRESS", "COMPLETED", "FAILED", "PAUSED", "AWAITING_CLIENT_ACTION", "SKIPPED"]
         },
         "TransformationProjectArtifactDescriptor": {
             "type": "structure",
@@ -3354,7 +3354,7 @@
         },
         "TransformationStepStatus": {
             "type": "string",
-            "enum": ["CREATED", "COMPLETED", "PARTIALLY_COMPLETED", "STOPPED", "FAILED", "PAUSED"]
+            "enum": ["CREATED", "COMPLETED", "PARTIALLY_COMPLETED", "STOPPED", "FAILED", "PAUSED", "SKIPPED"]
         },
         "TransformationSteps": {
             "type": "list",

--- a/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
+++ b/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
@@ -3235,7 +3235,7 @@
         },
         "TransformationProgressUpdateStatus": {
             "type": "string",
-            "enum": ["IN_PROGRESS", "COMPLETED", "FAILED", "PAUSED", "AWAITING_CLIENT_ACTION", "SKIPPED"]
+            "enum": ["IN_PROGRESS", "COMPLETED", "FAILED", "PAUSED", "AWAITING_CLIENT_ACTION"]
         },
         "TransformationProjectArtifactDescriptor": {
             "type": "structure",
@@ -3354,7 +3354,7 @@
         },
         "TransformationStepStatus": {
             "type": "string",
-            "enum": ["CREATED", "COMPLETED", "PARTIALLY_COMPLETED", "STOPPED", "FAILED", "PAUSED", "SKIPPED"]
+            "enum": ["CREATED", "COMPLETED", "PARTIALLY_COMPLETED", "STOPPED", "FAILED", "PAUSED"]
         },
         "TransformationSteps": {
             "type": "list",

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -55,7 +55,7 @@ export class ArtifactManager {
             return
         }
         fs.rmSync(packagesFolder, { recursive: true, force: true })
-        this.logging.log('Removed nuget packages folder: ' + packagesFolder)
+        this.logging.log(`Removed nuget packages folder: ${packagesFolder}`)
     }
 
     async createRequirementJson(request: StartTransformRequest) {


### PR DESCRIPTION
## Problem
V1642391964
Currently when we are packaging artifacts.zip on the IDE, the nuget packages are part of 

1. default "packages" folder in the root solution/ source Code
2. newly created the references folder in artifactsWorkspace. 

This is causing increased artifacts size.



## Solution

Verified that we are not using packages folder from sourceCode, we are using nuget packages from references folder. 
So we can safely delete packages folder before zipping to save on space.


Simple example on saving space is 
Sample applications - Bobs Bookstore
Size of packages folder - 241MB

size of Artifacts zip BEFORE below changes of deduping - 179 MB

<img width="747" alt="image" src="https://github.com/user-attachments/assets/d9195eb1-3ec2-47cd-818f-f128ea7a98af" />



size of Artifacts zip AFTER below changes of deduping - 89 MB
<img width="966" alt="image" src="https://github.com/user-attachments/assets/04f2c3cc-e625-4446-87c8-37d952793254" />

we are saving almost 45% space in artifacts zipping and thereby for uploads. This will also benefit for customer issues with large codebase 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
