### PR TITLE
fix: removing duplicated nuget packages folder

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -209,15 +209,15 @@ export class ArtifactManager {
     copyFile(sourceFilePath: string, destFilePath: string) {
         const dir = path.dirname(destFilePath)
         this.createFolderIfNotExist(dir)
-        fs.copyFile(sourceFilePath, destFilePath, error => {
-            if (error) {
-                if (!fs.existsSync(dir) && dir.includes(packagesFolderName)) {
-                    //Packages folder has been deleted to avoid duplicates in artifacts.zip
-                    return
-                }
-                this.logging.log('Failed to copy: ' + sourceFilePath + error)
+        try {
+            fs.copyFileSync(sourceFilePath, destFilePath)
+        } catch (err) {
+            if (!fs.existsSync(dir) && dir.includes(packagesFolderName)) {
+                //Packages folder has been deleted to avoid duplicates in artifacts.zip
+                return
             }
-        })
+            this.logging.log(`Failed to copy from ${sourceFilePath} and error is ${err}`)
+        }
     }
 
     calculateMD5Sync(filePath: string): string {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -9,6 +9,7 @@ const artifactFolderName = 'artifact'
 const referencesFolderName = 'references'
 const zipFileName = 'artifact.zip'
 const sourceCodeFolderName = 'sourceCode'
+const packagesFolderName = 'packages'
 
 export class ArtifactManager {
     private workspace: Workspace
@@ -22,6 +23,7 @@ export class ArtifactManager {
     async createZip(request: StartTransformRequest): Promise<string> {
         await this.createRequirementJson(request)
         await this.copySolutionConfigFiles(request)
+        await this.removeDuplicateNugetPackagesFolder(request)
         return await this.zipArtifact()
     }
     async removeDir(dir: string) {
@@ -39,6 +41,21 @@ export class ArtifactManager {
         } catch (error) {
             this.logging.log('Failed to cleanup:' + error)
         }
+    }
+
+    async removeDuplicateNugetPackagesFolder(request: StartTransformRequest) {
+        const packagesFolder = path.join(
+            this.workspacePath,
+            artifactFolderName,
+            sourceCodeFolderName,
+            packagesFolderName
+        )
+        if (!fs.existsSync(packagesFolder)) {
+            this.logging.log('Cannot find nuget packages folder in source code')
+            return
+        }
+        fs.rmSync(packagesFolder, { recursive: true, force: true })
+        this.logging.log(`Removed nuget packages folder: ${packagesFolder}`)
     }
 
     async createRequirementJson(request: StartTransformRequest) {
@@ -194,6 +211,10 @@ export class ArtifactManager {
         this.createFolderIfNotExist(dir)
         fs.copyFile(sourceFilePath, destFilePath, error => {
             if (error) {
+                if (!fs.existsSync(dir) && dir.includes(packagesFolderName)) {
+                    //Packages folder has been deleted to avoid duplicates in artifacts.zip
+                    return
+                }
                 this.logging.log('Failed to copy: ' + sourceFilePath + error)
             }
         })

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -50,12 +50,10 @@ export class ArtifactManager {
             sourceCodeFolderName,
             packagesFolderName
         )
-        if (!fs.existsSync(packagesFolder)) {
-            this.logging.log('Cannot find nuget packages folder in source code')
-            return
+        if (fs.existsSync(packagesFolder)) {
+            fs.rmSync(packagesFolder, { recursive: true, force: true })
+            this.logging.log(`Removed nuget packages folder: ${packagesFolder}`)
         }
-        fs.rmSync(packagesFolder, { recursive: true, force: true })
-        this.logging.log(`Removed nuget packages folder: ${packagesFolder}`)
     }
 
     async createRequirementJson(request: StartTransformRequest) {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -52,7 +52,9 @@ export class ArtifactManager {
         )
         if (fs.existsSync(packagesFolder)) {
             fs.rmSync(packagesFolder, { recursive: true, force: true })
-            this.logging.log(`Removed nuget packages folder: ${packagesFolder}`)
+            this.logging.log(
+                `Removed packages folder ${packagesFolder} from source code directory to be uploaded because it is a duplicate of references folder from artifacts`
+            )
         }
     }
 


### PR DESCRIPTION
## Problem
V1642391964
Currently when we are packaging artifacts.zip on the IDE, the nuget packages are part of 

1. default "packages" folder in the root solution/ source Code
2. newly created the references folder in artifactsWorkspace. 

This is causing increased artifacts size.



## Solution

 we are not using packages folder from sourceCode for transformations in Qnet CLI, we are only using nuget packages from references folder. 
So we can safely delete packages folder before zipping to save on space.


Simple example on saving space is 
Sample applications - Bobs Bookstore
Size of packages folder - 241MB

size of Artifacts zip BEFORE below changes of deduping - 179 MB

<img width="747" alt="image" src="https://github.com/user-attachments/assets/d9195eb1-3ec2-47cd-818f-f128ea7a98af" />




size of Artifacts zip AFTER below changes of deduping - 89 MB
<img width="966" alt="image" src="https://github.com/user-attachments/assets/04f2c3cc-e625-4446-87c8-37d952793254" />

we are saving almost 45% space in artifacts zipping and thereby for uploads. This will also benefit for customer issues with large codebase 


### UPDATE :
Also found that copyFile is async and we are zipping / deleting package folder even before all copying is complete.  so changed copyFile to Sync operation




## Testing 

Case : Updated a BobsBookstore application to bloat to 2.3 GB of artifacts.zip. 
with deduping, for same project artifacts size is - 1.2 GB

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
