### PR TITLE
feat: bugfix for artifacts upload

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -75,7 +75,7 @@ export class ArtifactManager {
             await sourceCodeFilePaths.forEach(async filePath => {
                 try {
                     this.copySourceFile(request.SolutionRootPath, filePath)
-                    var contentHash = await this.calculateMD5Sync(filePath)
+                    var contentHash = await this.calculateMD5Async(filePath)
                     var relativePath = this.normalizeSourceFileRelativePath(request.SolutionRootPath, filePath)
                     codeFiles.push({
                         contentMd5Hash: contentHash,
@@ -136,7 +136,7 @@ export class ArtifactManager {
     //use fs.createReadStream() to handle the file in smaller, manageable chunks rather than loading the entire file
     // into memory. This avoids hitting the 2 GiB limit that occurs when using fs.readFile(),
     // as it loads the entire file into memory.
-    static async getSha256(fileName: string): Promise<string> {
+    static async getSha256Async(fileName: string): Promise<string> {
         const hasher = crypto.createHash('sha256')
         const stream = fs.createReadStream(fileName)
 
@@ -212,17 +212,14 @@ export class ArtifactManager {
         })
     }
 
-    async calculateMD5Sync(filePath: string): Promise<string> {
+    async calculateMD5Async(filePath: string): Promise<string> {
         try {
             const hash = crypto.createHash('md5')
-            //const stream = fs.createReadStream(filePath, { highWaterMark: 64 * 1024 }); // 64 KB chunks
             const stream = fs.createReadStream(filePath)
             for await (const chunk of stream) {
                 hash.update(chunk)
             }
 
-            //const data = fs.readFileSync(filePath)
-            //const hash = crypto.createHash('md5').update(data)
             return hash.digest('hex')
         } catch (error) {
             this.logging.log('Failed to calculate hashcode: ' + filePath + error)

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -14,21 +14,25 @@ export class ArtifactManager {
     private workspace: Workspace
     private logging: Logging
     private workspacePath: string
+
     constructor(workspace: Workspace, logging: Logging, workspacePath: string) {
         this.workspace = workspace
         this.logging = logging
         this.workspacePath = workspacePath
     }
+
     async createZip(request: StartTransformRequest): Promise<string> {
         await this.createRequirementJson(request)
         await this.copySolutionConfigFiles(request)
         return await this.zipArtifact()
     }
+
     async removeDir(dir: string) {
         if (await this.workspace.fs.exists(dir)) {
             await this.workspace.fs.rm(dir, { recursive: true, force: true })
         }
     }
+
     cleanup() {
         try {
             const artifactFolder = path.join(this.workspacePath, artifactFolderName)
@@ -128,9 +132,18 @@ export class ArtifactManager {
         return zipPath
     }
 
-    static getSha256(fileName: string) {
+    //To read large files in chunks (greater than 2 GiB) using Node.js,
+    //use fs.createReadStream() to handle the file in smaller, manageable chunks rather than loading the entire file
+    // into memory. This avoids hitting the 2 GiB limit that occurs when using fs.readFile(),
+    // as it loads the entire file into memory.
+    static async getSha256(fileName: string): Promise<string> {
         const hasher = crypto.createHash('sha256')
-        hasher.update(fs.readFileSync(fileName))
+        const stream = fs.createReadStream(fileName)
+
+        for await (const chunk of stream) {
+            hasher.update(chunk)
+        }
+
         return hasher.digest('base64')
     }
 
@@ -199,10 +212,17 @@ export class ArtifactManager {
         })
     }
 
-    calculateMD5Sync(filePath: string): string {
+    async calculateMD5Sync(filePath: string): Promise<string> {
         try {
-            const data = fs.readFileSync(filePath)
-            const hash = crypto.createHash('md5').update(data)
+            const hash = crypto.createHash('md5')
+            //const stream = fs.createReadStream(filePath, { highWaterMark: 64 * 1024 }); // 64 KB chunks
+            const stream = fs.createReadStream(filePath)
+            for await (const chunk of stream) {
+                hash.update(chunk)
+            }
+
+            //const data = fs.readFileSync(filePath)
+            //const hash = crypto.createHash('md5').update(data)
             return hash.digest('hex')
         } catch (error) {
             this.logging.log('Failed to calculate hashcode: ' + filePath + error)

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
@@ -53,7 +53,11 @@ describe('Test Transform handler ', () => {
     describe('test upload artifact', () => {
         it('call upload method correctly', async () => {
             const putStub = sinon.stub(got, 'put').resolves({ statusCode: 'Success' })
-            const readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('text file content')
+            const mockReadStream = {
+                on: sinon.stub(),
+                pipe: sinon.stub(),
+            }
+            const createReadStreamStub = sinon.stub(fs, 'createReadStream').returns(mockReadStream as any)
             await transformHandler.uploadArtifactToS3Async(
                 payloadFileName,
                 {
@@ -65,9 +69,9 @@ describe('Test Transform handler ', () => {
                 'dummy-256'
             )
             simon.assert.callCount(putStub, 1)
-            simon.assert.callCount(readFileSyncStub, 1)
+            simon.assert.callCount(createReadStreamStub, 1)
             putStub.restore()
-            readFileSyncStub.restore()
+            createReadStreamStub.restore()
         })
     })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -114,7 +114,7 @@ export class TransformHandler {
     }
 
     async uploadPayloadAsync(payloadFileName: string): Promise<string> {
-        const sha256 = await ArtifactManager.getSha256(payloadFileName)
+        const sha256 = await ArtifactManager.getSha256Async(payloadFileName)
         let response: CreateUploadUrlResponse
         try {
             response = await this.client.codeModernizerCreateUploadUrl({

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -114,7 +114,7 @@ export class TransformHandler {
     }
 
     async uploadPayloadAsync(payloadFileName: string): Promise<string> {
-        const sha256 = ArtifactManager.getSha256(payloadFileName)
+        const sha256 = await ArtifactManager.getSha256(payloadFileName)
         let response: CreateUploadUrlResponse
         try {
             response = await this.client.codeModernizerCreateUploadUrl({
@@ -150,8 +150,9 @@ export class TransformHandler {
     async uploadArtifactToS3Async(fileName: string, resp: CreateUploadUrlResponse, sha256: string) {
         const headersObj = this.getHeadersObj(sha256, resp.kmsKeyArn)
         try {
+            const fileStream = fs.createReadStream(fileName)
             const response = await got.put(resp.uploadUrl, {
-                body: fs.readFileSync(fileName),
+                body: fileStream,
                 headers: headersObj,
             })
 


### PR DESCRIPTION
## Problem
Node limit for 2 GiB for fs.readFile .  ‘File size is greater than 2 GiB’ is common error in node with fs.readFile. 
Reference https://github.com/nodejs/node/issues/55864 

We are using fs.readFile in 3 places in language server code. 

## Solution

use fs.createReadStream instead.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
