### PR TITLE
fix: marking aws field as optional in initializationOptions

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/utilities/telemetryUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utilities/telemetryUtils.ts
@@ -61,7 +61,7 @@ const mapClientNameToIdeCategory = (clientName: string): string | undefined => {
 // https://github.com/aws/language-server-runtimes/blob/main/runtimes/protocol/lsp.ts#L60-L69
 const getIdeCategory = (initializeParams: InitializeParams) => {
     let ideCategory
-    if (initializeParams.initializationOptions?.aws.clientInfo?.extension?.name) {
+    if (initializeParams.initializationOptions?.aws?.clientInfo?.extension?.name) {
         ideCategory = mapClientNameToIdeCategory(initializeParams.initializationOptions.aws.clientInfo.extension.name)
     }
 
@@ -94,9 +94,9 @@ export const makeUserContextObject = (
         ideCategory: getIdeCategory(initializeParams),
         operatingSystem: getOperatingSystem(platform),
         product: product,
-        clientId: initializeParams.initializationOptions?.aws.clientInfo?.clientId,
+        clientId: initializeParams.initializationOptions?.aws?.clientInfo?.clientId,
         ideVersion:
-            initializeParams.initializationOptions?.aws.clientInfo?.version || initializeParams.clientInfo?.version,
+            initializeParams.initializationOptions?.aws?.clientInfo?.version || initializeParams.clientInfo?.version,
     }
 
     if (userContext.ideCategory === 'UNKNOWN' || userContext.operatingSystem === 'UNKNOWN') {


### PR DESCRIPTION
## Problem
Related to https://github.com/aws/language-server-runtimes/pull/310 
`server/aws-lsp-codewhisperer/src/language-server/utilities/telemetryUtils.ts(99,13): error TS18048: 'initializeParams.initializationOptions.aws' is possibly 'undefined'.`
Since we updated the protocol to mark the aws field as optional, updating relevant files. 

## Solution

- Updates the files to mark the optional field as expected. 


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
