### PR TITLE
chore: update the generated codewhisperer sigv4 client

### DIFF
--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -40,9 +40,9 @@ jobs:
               run: |
                   npm run package
             - name: Attach bundles
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
-                  name: language-servers
+                  name: language-servers-${{ matrix.runs-on }}
                   # Make sure you don't include node_modules
                   path: app/**/build/*
     test-windows:
@@ -78,8 +78,8 @@ jobs:
               run: |
                   npm run package
             - name: Attach bundles
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
-                  name: language-servers
+                  name: language-servers-pack-win-${{ matrix.runs-on }}
                   # Make sure you don't include node_modules
                   path: app/**/build/*

--- a/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperersigv4client.d.ts
+++ b/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperersigv4client.d.ts
@@ -20,13 +20,160 @@ declare class CodeWhispererSigV4Client extends Service {
   /**
    * 
    */
+  createCodeScan(params: CodeWhispererSigV4Client.Types.CreateCodeScanRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateCodeScanResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateCodeScanResponse, AWSError>;
+  /**
+   * 
+   */
+  createCodeScan(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateCodeScanResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateCodeScanResponse, AWSError>;
+  /**
+   * 
+   */
+  createCodeScanUploadUrl(params: CodeWhispererSigV4Client.Types.CreateUploadUrlRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateUploadUrlResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateUploadUrlResponse, AWSError>;
+  /**
+   * 
+   */
+  createCodeScanUploadUrl(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateUploadUrlResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateUploadUrlResponse, AWSError>;
+  /**
+   * 
+   */
+  createProfile(params: CodeWhispererSigV4Client.Types.CreateProfileRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateProfileResponse, AWSError>;
+  /**
+   * 
+   */
+  createProfile(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateProfileResponse, AWSError>;
+  /**
+   * 
+   */
+  deleteProfile(params: CodeWhispererSigV4Client.Types.DeleteProfileRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.DeleteProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.DeleteProfileResponse, AWSError>;
+  /**
+   * 
+   */
+  deleteProfile(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.DeleteProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.DeleteProfileResponse, AWSError>;
+  /**
+   * 
+   */
   generateRecommendations(params: CodeWhispererSigV4Client.Types.GenerateRecommendationsRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GenerateRecommendationsResponse) => void): Request<CodeWhispererSigV4Client.Types.GenerateRecommendationsResponse, AWSError>;
   /**
    * 
    */
   generateRecommendations(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GenerateRecommendationsResponse) => void): Request<CodeWhispererSigV4Client.Types.GenerateRecommendationsResponse, AWSError>;
+  /**
+   * 
+   */
+  getAccessToken(params: CodeWhispererSigV4Client.Types.GetAccessTokenRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GetAccessTokenResponse) => void): Request<CodeWhispererSigV4Client.Types.GetAccessTokenResponse, AWSError>;
+  /**
+   * 
+   */
+  getAccessToken(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GetAccessTokenResponse) => void): Request<CodeWhispererSigV4Client.Types.GetAccessTokenResponse, AWSError>;
+  /**
+   * 
+   */
+  getCodeScan(params: CodeWhispererSigV4Client.Types.GetCodeScanRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GetCodeScanResponse) => void): Request<CodeWhispererSigV4Client.Types.GetCodeScanResponse, AWSError>;
+  /**
+   * 
+   */
+  getCodeScan(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GetCodeScanResponse) => void): Request<CodeWhispererSigV4Client.Types.GetCodeScanResponse, AWSError>;
+  /**
+   * 
+   */
+  listCodeScanFindings(params: CodeWhispererSigV4Client.Types.ListCodeScanFindingsRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListCodeScanFindingsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListCodeScanFindingsResponse, AWSError>;
+  /**
+   * 
+   */
+  listCodeScanFindings(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListCodeScanFindingsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListCodeScanFindingsResponse, AWSError>;
+  /**
+   * 
+   */
+  listProfiles(params: CodeWhispererSigV4Client.Types.ListProfilesRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListProfilesResponse) => void): Request<CodeWhispererSigV4Client.Types.ListProfilesResponse, AWSError>;
+  /**
+   * 
+   */
+  listProfiles(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListProfilesResponse) => void): Request<CodeWhispererSigV4Client.Types.ListProfilesResponse, AWSError>;
+  /**
+   * 
+   */
+  listRecommendations(params: CodeWhispererSigV4Client.Types.ListRecommendationsRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListRecommendationsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListRecommendationsResponse, AWSError>;
+  /**
+   * 
+   */
+  listRecommendations(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListRecommendationsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListRecommendationsResponse, AWSError>;
+  /**
+   * 
+   */
+  listTagsForResource(params: CodeWhispererSigV4Client.Types.ListTagsForResourceRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListTagsForResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.ListTagsForResourceResponse, AWSError>;
+  /**
+   * 
+   */
+  listTagsForResource(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListTagsForResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.ListTagsForResourceResponse, AWSError>;
+  /**
+   * 
+   */
+  tagResource(params: CodeWhispererSigV4Client.Types.TagResourceRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.TagResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.TagResourceResponse, AWSError>;
+  /**
+   * 
+   */
+  tagResource(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.TagResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.TagResourceResponse, AWSError>;
+  /**
+   * 
+   */
+  untagResource(params: CodeWhispererSigV4Client.Types.UntagResourceRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UntagResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.UntagResourceResponse, AWSError>;
+  /**
+   * 
+   */
+  untagResource(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UntagResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.UntagResourceResponse, AWSError>;
+  /**
+   * 
+   */
+  updateProfile(params: CodeWhispererSigV4Client.Types.UpdateProfileRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UpdateProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.UpdateProfileResponse, AWSError>;
+  /**
+   * 
+   */
+  updateProfile(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UpdateProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.UpdateProfileResponse, AWSError>;
 }
 declare namespace CodeWhispererSigV4Client {
+  export type ArtifactMap = {[key: string]: UploadId};
+  export type ArtifactType = "SourceCode"|"BuiltJars"|string;
+  export type Base64EncodedPaginationToken = string;
+  export type CodeScanFindingsSchema = "codescan/findings/1.0"|string;
+  export type CodeScanStatus = "Completed"|"Pending"|"Failed"|string;
+  export interface CreateCodeScanRequest {
+    artifacts: ArtifactMap;
+    programmingLanguage: ProgrammingLanguage;
+    clientToken?: CreateCodeScanRequestClientTokenString;
+  }
+  export type CreateCodeScanRequestClientTokenString = string;
+  export interface CreateCodeScanResponse {
+    jobId: CreateCodeScanResponseJobIdString;
+    status: CodeScanStatus;
+    errorMessage?: String;
+  }
+  export type CreateCodeScanResponseJobIdString = string;
+  export interface CreateProfileRequest {
+    identitySource: IdentitySource;
+    profileName: ProfileName;
+    referenceTrackerConfiguration: ReferenceTrackerConfiguration;
+    clientToken?: IdempotencyToken;
+    kmsKeyArn?: ResourceArn;
+    tags?: TagList;
+  }
+  export interface CreateProfileResponse {
+    profileArn: ResourceArn;
+  }
+  export interface CreateUploadUrlRequest {
+    contentMd5?: CreateUploadUrlRequestContentMd5String;
+    artifactType?: ArtifactType;
+  }
+  export type CreateUploadUrlRequestContentMd5String = string;
+  export interface CreateUploadUrlResponse {
+    uploadId: UploadId;
+    uploadUrl: PreSignedUrl;
+    kmsKeyArn?: ResourceArn;
+  }
+  export interface DeleteProfileRequest {
+    profileArn: ResourceArn;
+  }
+  export interface DeleteProfileResponse {
+  }
   export interface FileContext {
     leftFileContent: FileContextLeftFileContentString;
     rightFileContent: FileContextRightFileContentString;
@@ -36,8 +183,16 @@ declare namespace CodeWhispererSigV4Client {
   export type FileContextFilenameString = string;
   export type FileContextLeftFileContentString = string;
   export type FileContextRightFileContentString = string;
+  export interface SupplementalContext {
+    filePath: SupplementalContextFilePathString;
+    content: SupplementalContextContentString;
+  }
+  export type SupplementalContextFilePathString = string;
+  export type SupplementalContextContentString = string;
+  export type SupplementalContextList = SupplementalContext[];
   export interface GenerateRecommendationsRequest {
     fileContext: FileContext;
+    supplementalContexts?: SupplementalContextList;
     maxResults?: GenerateRecommendationsRequestMaxResultsInteger;
     nextToken?: GenerateRecommendationsRequestNextTokenString;
     referenceTrackerConfiguration?: ReferenceTrackerConfiguration;
@@ -48,11 +203,82 @@ declare namespace CodeWhispererSigV4Client {
     recommendations?: RecommendationsList;
     nextToken?: String;
   }
+  export interface GetAccessTokenRequest {
+    identityToken: GetAccessTokenRequestIdentityTokenString;
+  }
+  export type GetAccessTokenRequestIdentityTokenString = string;
+  export interface GetAccessTokenResponse {
+    accessToken?: SensitiveString;
+  }
+  export interface GetCodeScanRequest {
+    jobId: GetCodeScanRequestJobIdString;
+  }
+  export type GetCodeScanRequestJobIdString = string;
+  export interface GetCodeScanResponse {
+    status: CodeScanStatus;
+    errorMessage?: String;
+  }
+  export type IdempotencyToken = string;
+  export interface IdentityDetails {
+    ssoIdentityDetails?: SSOIdentityDetails;
+  }
+  export interface IdentitySource {
+    ssoIdentitySource?: SSOIdentitySource;
+  }
   export interface Import {
     statement?: ImportStatementString;
   }
   export type ImportStatementString = string;
   export type Imports = Import[];
+  export interface ListCodeScanFindingsRequest {
+    jobId: ListCodeScanFindingsRequestJobIdString;
+    nextToken?: PaginationToken;
+    codeScanFindingsSchema: CodeScanFindingsSchema;
+  }
+  export type ListCodeScanFindingsRequestJobIdString = string;
+  export interface ListCodeScanFindingsResponse {
+    nextToken?: PaginationToken;
+    codeScanFindings: String;
+  }
+  export interface ListProfilesRequest {
+    maxResults?: ListProfilesRequestMaxResultsInteger;
+    nextToken?: Base64EncodedPaginationToken;
+  }
+  export type ListProfilesRequestMaxResultsInteger = number;
+  export interface ListProfilesResponse {
+    profiles: ProfileList;
+    nextToken?: Base64EncodedPaginationToken;
+  }
+  export interface ListRecommendationsRequest {
+    fileContext: FileContext;
+    maxResults?: ListRecommendationsRequestMaxResultsInteger;
+    supplementalContexts?: SupplementalContextList;
+    nextToken?: ListRecommendationsRequestNextTokenString;
+    referenceTrackerConfiguration?: ReferenceTrackerConfiguration;
+  }
+  export type ListRecommendationsRequestMaxResultsInteger = number;
+  export type ListRecommendationsRequestNextTokenString = string;
+  export interface ListRecommendationsResponse {
+    recommendations?: RecommendationsList;
+    nextToken?: String;
+  }
+  export interface ListTagsForResourceRequest {
+    resourceName: ResourceArn;
+  }
+  export interface ListTagsForResourceResponse {
+    tags?: TagList;
+  }
+  export type PaginationToken = string;
+  export type PreSignedUrl = string;
+  export interface Profile {
+    arn: ResourceArn;
+    identityDetails: IdentityDetails;
+    profileName: ProfileName;
+    referenceTrackerConfiguration: ReferenceTrackerConfiguration;
+    kmsKeyArn?: ResourceArn;
+  }
+  export type ProfileList = Profile[];
+  export type ProfileName = string;
   export interface ProgrammingLanguage {
     languageName: ProgrammingLanguageLanguageNameString;
   }
@@ -78,6 +304,15 @@ declare namespace CodeWhispererSigV4Client {
   }
   export type ReferenceUrlString = string;
   export type References = Reference[];
+  export type ResourceArn = string;
+  export interface SSOIdentityDetails {
+    instanceArn: ResourceArn;
+    oidcClientId: String;
+  }
+  export interface SSOIdentitySource {
+    instanceArn: ResourceArn;
+  }
+  export type SensitiveString = string;
   export interface Span {
     start?: SpanStartInteger;
     end?: SpanEndInteger;
@@ -85,6 +320,36 @@ declare namespace CodeWhispererSigV4Client {
   export type SpanEndInteger = number;
   export type SpanStartInteger = number;
   export type String = string;
+  export interface Tag {
+    key: TagKey;
+    value: TagValue;
+  }
+  export type TagKey = string;
+  export type TagKeyList = TagKey[];
+  export type TagList = Tag[];
+  export interface TagResourceRequest {
+    resourceName: ResourceArn;
+    tags: TagList;
+  }
+  export interface TagResourceResponse {
+  }
+  export type TagValue = string;
+  export interface UntagResourceRequest {
+    resourceName: ResourceArn;
+    tagKeys: TagKeyList;
+  }
+  export interface UntagResourceResponse {
+  }
+  export interface UpdateProfileRequest {
+    profileArn: ResourceArn;
+    profileName?: ProfileName;
+    referenceTrackerConfiguration?: ReferenceTrackerConfiguration;
+    kmsKeyArn?: ResourceArn;
+  }
+  export interface UpdateProfileResponse {
+    profileArn: ResourceArn;
+  }
+  export type UploadId = string;
   /**
    * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
    */

--- a/server/aws-lsp-codewhisperer/src/client/sigv4/service.json
+++ b/server/aws-lsp-codewhisperer/src/client/sigv4/service.json
@@ -13,6 +13,134 @@
         "uid": "codewhisperer-2022-06-15"
     },
     "operations": {
+        "CreateCodeScan": {
+            "name": "CreateCodeScan",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "CreateCodeScanRequest"
+            },
+            "output": {
+                "shape": "CreateCodeScanResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "idempotent": true
+        },
+        "CreateCodeScanUploadUrl": {
+            "name": "CreateCodeScanUploadUrl",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "CreateUploadUrlRequest"
+            },
+            "output": {
+                "shape": "CreateUploadUrlResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "idempotent": true
+        },
+        "CreateProfile": {
+            "name": "CreateProfile",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "CreateProfileRequest"
+            },
+            "output": {
+                "shape": "CreateProfileResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
+        },
+        "DeleteProfile": {
+            "name": "DeleteProfile",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "DeleteProfileRequest"
+            },
+            "output": {
+                "shape": "DeleteProfileResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
+        },
         "GenerateRecommendations": {
             "name": "GenerateRecommendations",
             "http": {
@@ -39,6 +167,267 @@
                     "shape": "AccessDeniedException"
                 }
             ]
+        },
+        "GetAccessToken": {
+            "name": "GetAccessToken",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "GetAccessTokenRequest"
+            },
+            "output": {
+                "shape": "GetAccessTokenResponse"
+            },
+            "errors": [
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
+        },
+        "GetCodeScan": {
+            "name": "GetCodeScan",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "GetCodeScanRequest"
+            },
+            "output": {
+                "shape": "GetCodeScanResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
+        },
+        "ListCodeScanFindings": {
+            "name": "ListCodeScanFindings",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "ListCodeScanFindingsRequest"
+            },
+            "output": {
+                "shape": "ListCodeScanFindingsResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
+        },
+        "ListProfiles": {
+            "name": "ListProfiles",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "ListProfilesRequest"
+            },
+            "output": {
+                "shape": "ListProfilesResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
+        },
+        "ListRecommendations": {
+            "name": "ListRecommendations",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "ListRecommendationsRequest"
+            },
+            "output": {
+                "shape": "ListRecommendationsResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
+        },
+        "ListTagsForResource": {
+            "name": "ListTagsForResource",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "ListTagsForResourceRequest"
+            },
+            "output": {
+                "shape": "ListTagsForResourceResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
+        },
+        "TagResource": {
+            "name": "TagResource",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "TagResourceRequest"
+            },
+            "output": {
+                "shape": "TagResourceResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
+        },
+        "UntagResource": {
+            "name": "UntagResource",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "UntagResourceRequest"
+            },
+            "output": {
+                "shape": "UntagResourceResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
+        },
+        "UpdateProfile": {
+            "name": "UpdateProfile",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "UpdateProfileRequest"
+            },
+            "output": {
+                "shape": "UpdateProfileResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ]
         }
     },
     "shapes": {
@@ -52,6 +441,35 @@
             },
             "exception": true
         },
+        "ArtifactMap": {
+            "type": "map",
+            "key": {
+                "shape": "ArtifactType"
+            },
+            "value": {
+                "shape": "UploadId"
+            },
+            "max": 64,
+            "min": 1
+        },
+        "ArtifactType": {
+            "type": "string",
+            "enum": ["SourceCode", "BuiltJars"]
+        },
+        "Base64EncodedPaginationToken": {
+            "type": "string",
+            "max": 2048,
+            "min": 1,
+            "pattern": "(?:[A-Za-z0-9\\+/]{4})*(?:[A-Za-z0-9\\+/]{2}\\=\\=|[A-Za-z0-9\\+/]{3}\\=)?"
+        },
+        "CodeScanFindingsSchema": {
+            "type": "string",
+            "enum": ["codescan/findings/1.0"]
+        },
+        "CodeScanStatus": {
+            "type": "string",
+            "enum": ["Completed", "Pending", "Failed"]
+        },
         "ConflictException": {
             "type": "structure",
             "required": ["message"],
@@ -61,6 +479,125 @@
                 }
             },
             "exception": true
+        },
+        "CreateCodeScanRequest": {
+            "type": "structure",
+            "required": ["artifacts", "programmingLanguage"],
+            "members": {
+                "artifacts": {
+                    "shape": "ArtifactMap"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                },
+                "clientToken": {
+                    "shape": "CreateCodeScanRequestClientTokenString",
+                    "idempotencyToken": true
+                }
+            }
+        },
+        "CreateCodeScanRequestClientTokenString": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+        },
+        "CreateCodeScanResponse": {
+            "type": "structure",
+            "required": ["jobId", "status"],
+            "members": {
+                "jobId": {
+                    "shape": "CreateCodeScanResponseJobIdString"
+                },
+                "status": {
+                    "shape": "CodeScanStatus"
+                },
+                "errorMessage": {
+                    "shape": "String"
+                }
+            }
+        },
+        "CreateCodeScanResponseJobIdString": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+        },
+        "CreateProfileRequest": {
+            "type": "structure",
+            "required": ["identitySource", "profileName", "referenceTrackerConfiguration"],
+            "members": {
+                "identitySource": {
+                    "shape": "IdentitySource"
+                },
+                "profileName": {
+                    "shape": "ProfileName"
+                },
+                "referenceTrackerConfiguration": {
+                    "shape": "ReferenceTrackerConfiguration"
+                },
+                "clientToken": {
+                    "shape": "IdempotencyToken",
+                    "idempotencyToken": true
+                },
+                "kmsKeyArn": {
+                    "shape": "ResourceArn"
+                },
+                "tags": {
+                    "shape": "TagList"
+                }
+            }
+        },
+        "CreateProfileResponse": {
+            "type": "structure",
+            "required": ["profileArn"],
+            "members": {
+                "profileArn": {
+                    "shape": "ResourceArn"
+                }
+            }
+        },
+        "CreateUploadUrlRequest": {
+            "type": "structure",
+            "members": {
+                "contentMd5": {
+                    "shape": "CreateUploadUrlRequestContentMd5String"
+                },
+                "artifactType": {
+                    "shape": "ArtifactType"
+                }
+            }
+        },
+        "CreateUploadUrlRequestContentMd5String": {
+            "type": "string",
+            "max": 128,
+            "min": 1
+        },
+        "CreateUploadUrlResponse": {
+            "type": "structure",
+            "required": ["uploadId", "uploadUrl"],
+            "members": {
+                "uploadId": {
+                    "shape": "UploadId"
+                },
+                "uploadUrl": {
+                    "shape": "PreSignedUrl"
+                },
+                "kmsKeyArn": {
+                    "shape": "ResourceArn"
+                }
+            }
+        },
+        "DeleteProfileRequest": {
+            "type": "structure",
+            "required": ["profileArn"],
+            "members": {
+                "profileArn": {
+                    "shape": "ResourceArn"
+                }
+            }
+        },
+        "DeleteProfileResponse": {
+            "type": "structure",
+            "members": {}
         },
         "FileContext": {
             "type": "structure",
@@ -97,12 +634,47 @@
             "min": 0,
             "sensitive": true
         },
+        "SupplementalContext": {
+            "type": "structure",
+            "required": ["filePath", "content"],
+            "members": {
+                "filePath": {
+                    "shape": "SupplementalContextFilePathString"
+                },
+                "content": {
+                    "shape": "SupplementalContextContentString"
+                }
+            }
+        },
+        "SupplementalContextFilePathString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
+        },
+        "SupplementalContextContentString": {
+            "type": "string",
+            "max": 5120,
+            "min": 0,
+            "sensitive": true
+        },
+        "SupplementalContextList": {
+            "type": "list",
+            "member": {
+                "shape": "SupplementalContext"
+            },
+            "max": 10,
+            "min": 0
+        },
         "GenerateRecommendationsRequest": {
             "type": "structure",
             "required": ["fileContext"],
             "members": {
                 "fileContext": {
                     "shape": "FileContext"
+                },
+                "supplementalContexts": {
+                    "shape": "SupplementalContextList"
                 },
                 "maxResults": {
                     "shape": "GenerateRecommendationsRequestMaxResultsInteger"
@@ -138,10 +710,77 @@
                 }
             }
         },
+        "GetAccessTokenRequest": {
+            "type": "structure",
+            "required": ["identityToken"],
+            "members": {
+                "identityToken": {
+                    "shape": "GetAccessTokenRequestIdentityTokenString"
+                }
+            }
+        },
+        "GetAccessTokenRequestIdentityTokenString": {
+            "type": "string",
+            "max": 1024,
+            "min": 0,
+            "sensitive": true
+        },
+        "GetAccessTokenResponse": {
+            "type": "structure",
+            "members": {
+                "accessToken": {
+                    "shape": "SensitiveString"
+                }
+            }
+        },
+        "GetCodeScanRequest": {
+            "type": "structure",
+            "required": ["jobId"],
+            "members": {
+                "jobId": {
+                    "shape": "GetCodeScanRequestJobIdString"
+                }
+            }
+        },
+        "GetCodeScanRequestJobIdString": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+        },
+        "GetCodeScanResponse": {
+            "type": "structure",
+            "required": ["status"],
+            "members": {
+                "status": {
+                    "shape": "CodeScanStatus"
+                },
+                "errorMessage": {
+                    "shape": "String"
+                }
+            }
+        },
         "IdempotencyToken": {
             "type": "string",
             "max": 256,
             "min": 1
+        },
+        "IdentityDetails": {
+            "type": "structure",
+            "members": {
+                "ssoIdentityDetails": {
+                    "shape": "SSOIdentityDetails"
+                }
+            },
+            "union": true
+        },
+        "IdentitySource": {
+            "type": "structure",
+            "members": {
+                "ssoIdentitySource": {
+                    "shape": "SSOIdentitySource"
+                }
+            },
+            "union": true
         },
         "Import": {
             "type": "structure",
@@ -179,6 +818,172 @@
                 "throttling": false
             }
         },
+        "ListCodeScanFindingsRequest": {
+            "type": "structure",
+            "required": ["jobId", "codeScanFindingsSchema"],
+            "members": {
+                "jobId": {
+                    "shape": "ListCodeScanFindingsRequestJobIdString"
+                },
+                "nextToken": {
+                    "shape": "PaginationToken"
+                },
+                "codeScanFindingsSchema": {
+                    "shape": "CodeScanFindingsSchema"
+                }
+            }
+        },
+        "ListCodeScanFindingsRequestJobIdString": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+        },
+        "ListCodeScanFindingsResponse": {
+            "type": "structure",
+            "required": ["codeScanFindings"],
+            "members": {
+                "nextToken": {
+                    "shape": "PaginationToken"
+                },
+                "codeScanFindings": {
+                    "shape": "String"
+                }
+            }
+        },
+        "ListProfilesRequest": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "shape": "ListProfilesRequestMaxResultsInteger"
+                },
+                "nextToken": {
+                    "shape": "Base64EncodedPaginationToken"
+                }
+            }
+        },
+        "ListProfilesRequestMaxResultsInteger": {
+            "type": "integer",
+            "box": true,
+            "max": 100,
+            "min": 1
+        },
+        "ListProfilesResponse": {
+            "type": "structure",
+            "required": ["profiles"],
+            "members": {
+                "profiles": {
+                    "shape": "ProfileList"
+                },
+                "nextToken": {
+                    "shape": "Base64EncodedPaginationToken"
+                }
+            }
+        },
+        "ListRecommendationsRequest": {
+            "type": "structure",
+            "required": ["fileContext"],
+            "members": {
+                "fileContext": {
+                    "shape": "FileContext"
+                },
+                "maxResults": {
+                    "shape": "ListRecommendationsRequestMaxResultsInteger"
+                },
+                "supplementalContexts": {
+                    "shape": "SupplementalContextList"
+                },
+                "nextToken": {
+                    "shape": "ListRecommendationsRequestNextTokenString"
+                },
+                "referenceTrackerConfiguration": {
+                    "shape": "ReferenceTrackerConfiguration"
+                }
+            }
+        },
+        "ListRecommendationsRequestMaxResultsInteger": {
+            "type": "integer",
+            "box": true,
+            "max": 10,
+            "min": 1
+        },
+        "ListRecommendationsRequestNextTokenString": {
+            "type": "string",
+            "max": 2048,
+            "min": 0,
+            "pattern": "(?:[A-Za-z0-9\\+/]{4})*(?:[A-Za-z0-9\\+/]{2}\\=\\=|[A-Za-z0-9\\+/]{3}\\=)?"
+        },
+        "ListRecommendationsResponse": {
+            "type": "structure",
+            "members": {
+                "recommendations": {
+                    "shape": "RecommendationsList"
+                },
+                "nextToken": {
+                    "shape": "String"
+                }
+            }
+        },
+        "ListTagsForResourceRequest": {
+            "type": "structure",
+            "required": ["resourceName"],
+            "members": {
+                "resourceName": {
+                    "shape": "ResourceArn"
+                }
+            }
+        },
+        "ListTagsForResourceResponse": {
+            "type": "structure",
+            "members": {
+                "tags": {
+                    "shape": "TagList"
+                }
+            }
+        },
+        "PaginationToken": {
+            "type": "string",
+            "max": 2048,
+            "min": 1,
+            "pattern": "\\S+"
+        },
+        "PreSignedUrl": {
+            "type": "string",
+            "max": 2048,
+            "min": 1
+        },
+        "Profile": {
+            "type": "structure",
+            "required": ["arn", "identityDetails", "profileName", "referenceTrackerConfiguration"],
+            "members": {
+                "arn": {
+                    "shape": "ResourceArn"
+                },
+                "identityDetails": {
+                    "shape": "IdentityDetails"
+                },
+                "profileName": {
+                    "shape": "ProfileName"
+                },
+                "referenceTrackerConfiguration": {
+                    "shape": "ReferenceTrackerConfiguration"
+                },
+                "kmsKeyArn": {
+                    "shape": "ResourceArn"
+                }
+            }
+        },
+        "ProfileList": {
+            "type": "list",
+            "member": {
+                "shape": "Profile"
+            }
+        },
+        "ProfileName": {
+            "type": "string",
+            "max": 100,
+            "min": 1,
+            "pattern": "[a-zA-Z][a-zA-Z0-9_-]*"
+        },
         "ProgrammingLanguage": {
             "type": "structure",
             "required": ["languageName"],
@@ -192,7 +997,7 @@
             "type": "string",
             "max": 128,
             "min": 1,
-            "pattern": "(python|javascript|java|csharp|typescript|c|cpp|go|kotlin|php|ruby|rust|scala|shell|sql|json|yaml|vue|tf|tsx|jsx)"
+            "pattern": "(python|javascript|java|csharp|typescript|c|cpp|go|kotlin|php|ruby|rust|scala|shell|sql)"
         },
         "Recommendation": {
             "type": "structure",
@@ -291,6 +1096,27 @@
             },
             "exception": true
         },
+        "SSOIdentityDetails": {
+            "type": "structure",
+            "required": ["instanceArn", "oidcClientId"],
+            "members": {
+                "instanceArn": {
+                    "shape": "ResourceArn"
+                },
+                "oidcClientId": {
+                    "shape": "String"
+                }
+            }
+        },
+        "SSOIdentitySource": {
+            "type": "structure",
+            "required": ["instanceArn"],
+            "members": {
+                "instanceArn": {
+                    "shape": "ResourceArn"
+                }
+            }
+        },
         "SensitiveString": {
             "type": "string",
             "sensitive": true
@@ -319,6 +1145,60 @@
         "String": {
             "type": "string"
         },
+        "Tag": {
+            "type": "structure",
+            "required": ["key", "value"],
+            "members": {
+                "key": {
+                    "shape": "TagKey"
+                },
+                "value": {
+                    "shape": "TagValue"
+                }
+            }
+        },
+        "TagKey": {
+            "type": "string",
+            "max": 128,
+            "min": 1
+        },
+        "TagKeyList": {
+            "type": "list",
+            "member": {
+                "shape": "TagKey"
+            },
+            "max": 200,
+            "min": 0
+        },
+        "TagList": {
+            "type": "list",
+            "member": {
+                "shape": "Tag"
+            },
+            "max": 200,
+            "min": 0
+        },
+        "TagResourceRequest": {
+            "type": "structure",
+            "required": ["resourceName", "tags"],
+            "members": {
+                "resourceName": {
+                    "shape": "ResourceArn"
+                },
+                "tags": {
+                    "shape": "TagList"
+                }
+            }
+        },
+        "TagResourceResponse": {
+            "type": "structure",
+            "members": {}
+        },
+        "TagValue": {
+            "type": "string",
+            "max": 256,
+            "min": 0
+        },
         "ThrottlingException": {
             "type": "structure",
             "required": ["message"],
@@ -331,6 +1211,54 @@
             "retryable": {
                 "throttling": false
             }
+        },
+        "UntagResourceRequest": {
+            "type": "structure",
+            "required": ["resourceName", "tagKeys"],
+            "members": {
+                "resourceName": {
+                    "shape": "ResourceArn"
+                },
+                "tagKeys": {
+                    "shape": "TagKeyList"
+                }
+            }
+        },
+        "UntagResourceResponse": {
+            "type": "structure",
+            "members": {}
+        },
+        "UpdateProfileRequest": {
+            "type": "structure",
+            "required": ["profileArn"],
+            "members": {
+                "profileArn": {
+                    "shape": "ResourceArn"
+                },
+                "profileName": {
+                    "shape": "ProfileName"
+                },
+                "referenceTrackerConfiguration": {
+                    "shape": "ReferenceTrackerConfiguration"
+                },
+                "kmsKeyArn": {
+                    "shape": "ResourceArn"
+                }
+            }
+        },
+        "UpdateProfileResponse": {
+            "type": "structure",
+            "required": ["profileArn"],
+            "members": {
+                "profileArn": {
+                    "shape": "ResourceArn"
+                }
+            }
+        },
+        "UploadId": {
+            "type": "string",
+            "max": 128,
+            "min": 1
         },
         "ValidationException": {
             "type": "structure",


### PR DESCRIPTION
## Problem

The codewhisperer sigv4 client is out of date and doesn't include `supplementalContext`. 

## Solution

Generated the client from the latest model from the [aws-toolkit-vscode](https://github.com/aws/aws-toolkit-vscode/blob/3a03e95599e5254341ee4e8acae6c39bdeee70a8/packages/core/src/codewhisperer/client/service-2.json)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
