### PR TITLE
Revert "feat: bugfix for artifacts upload (#749)"

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
@@ -19,7 +19,6 @@ import { TransformHandler } from '../transformHandler'
 import { EXAMPLE_REQUEST } from './mockData'
 import sinon = require('sinon')
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../../constants'
-import { Readable } from 'stream'
 
 const mocked$Response = {
     $response: {
@@ -36,24 +35,6 @@ const mocked$Response = {
 const testUploadId = 'test-upoload-id'
 const testTransformId = 'test-transform-id'
 const payloadFileName = 'C:\\test.zip'
-const mockReadStream = {
-    on: sinon.stub(),
-    pipe: sinon.stub(),
-}
-
-export function createMockReadableStream(chunks: any[]): Readable {
-    const readable = new Readable({
-        read() {
-            if (chunks.length > 0) {
-                this.push(chunks.shift())
-            } else {
-                this.push(null) // Signal end of stream
-            }
-        },
-    })
-
-    return readable
-}
 
 describe('Test Transform handler ', () => {
     let client: StubbedInstance<CodeWhispererServiceToken>
@@ -72,8 +53,7 @@ describe('Test Transform handler ', () => {
     describe('test upload artifact', () => {
         it('call upload method correctly', async () => {
             const putStub = sinon.stub(got, 'put').resolves({ statusCode: 'Success' })
-
-            const createReadStreamStub = sinon.stub(fs, 'createReadStream').returns(mockReadStream as any)
+            const readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('text file content')
             await transformHandler.uploadArtifactToS3Async(
                 payloadFileName,
                 {
@@ -85,9 +65,9 @@ describe('Test Transform handler ', () => {
                 'dummy-256'
             )
             simon.assert.callCount(putStub, 1)
-            simon.assert.callCount(createReadStreamStub, 1)
+            simon.assert.callCount(readFileSyncStub, 1)
             putStub.restore()
-            createReadStreamStub.restore()
+            readFileSyncStub.restore()
         })
     })
 
@@ -103,23 +83,19 @@ describe('Test Transform handler ', () => {
         })
 
         it('returns upload id correctly', async () => {
-            const chunks = ['Hello, ', 'World!']
-            const mockStream = createMockReadableStream(chunks)
-            const createReadStreamStub = sinon.stub(fs, 'createReadStream').returns(mockStream as any)
+            const readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('text file content')
             const uploadStub = sinon.stub(transformHandler, 'uploadArtifactToS3Async')
             const res = await transformHandler.uploadPayloadAsync(payloadFileName)
-            simon.assert.callCount(createReadStreamStub, 1)
+            simon.assert.callCount(readFileSyncStub, 1)
             simon.assert.callCount(uploadStub, 1)
             assert.equal(res, testUploadId)
             uploadStub.restore()
-            createReadStreamStub.restore()
+            readFileSyncStub.restore()
         })
 
         it('should throw error if uploadArtifactToS3Async fails', async () => {
             const mockError = new Error('Error in uploadArtifactToS3 call')
-            const chunks = ['Hello, ', 'World!']
-            const mockStream = createMockReadableStream(chunks)
-            const createReadStreamStub = sinon.stub(fs, 'createReadStream').returns(mockStream as any)
+            const readFileSyncStub = sinon.stub(fs, 'readFileSync').returns('text file content')
             sinon.stub(transformHandler, 'uploadArtifactToS3Async').rejects(mockError)
 
             // Call the method to be tested
@@ -128,8 +104,8 @@ describe('Test Transform handler ', () => {
             } catch (error) {
                 // Assertions
                 expect((error as Error).message).to.equal(mockError.message)
-                sinon.assert.calledOnce(createReadStreamStub)
-                createReadStreamStub.restore()
+                sinon.assert.calledOnce(readFileSyncStub)
+                readFileSyncStub.restore()
             }
         })
         /*

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -114,7 +114,7 @@ export class TransformHandler {
     }
 
     async uploadPayloadAsync(payloadFileName: string): Promise<string> {
-        const sha256 = await ArtifactManager.getSha256Async(payloadFileName)
+        const sha256 = ArtifactManager.getSha256(payloadFileName)
         let response: CreateUploadUrlResponse
         try {
             response = await this.client.codeModernizerCreateUploadUrl({
@@ -150,9 +150,8 @@ export class TransformHandler {
     async uploadArtifactToS3Async(fileName: string, resp: CreateUploadUrlResponse, sha256: string) {
         const headersObj = this.getHeadersObj(sha256, resp.kmsKeyArn)
         try {
-            const fileStream = fs.createReadStream(fileName)
             const response = await got.put(resp.uploadUrl, {
-                body: fileStream,
+                body: fs.readFileSync(fileName),
                 headers: headersObj,
             })
 


### PR DESCRIPTION
## Problem

- CodeFIles list is missing from Requirements.json. 
- Requirements.json gets created as artifact when user starts transformation

Some changes with PR https://github.com/aws/language-servers/pull/749 introduced delays in writing codeFiles list to requirements.json

We do not need codeFiles from requirements.json for transformation job but it is needed for summary generation. 
On IDE, this summary is parsed to update counts, diffs for file changes

## Solution
This reverts commit 71c0a19974428037160152cc7e40cd6c399ceec9. 


## Test

Verified that after reverting this commit, we could get successfully .bak files in view diff screen
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b28d40a8-37b8-40d6-80b0-4ef526855deb" />



failing test CI job does not seem to be connected with nettransform. will connect with flare team for more guidance on it. 
when I run ```npm run test``` locally, gave me all successful executions

failing test is already failing with mainline commit - https://github.com/aws/language-servers/actions/runs/13075234433/job/36485706871

```
1) crossFileContextUtil
       getCrossFileCandidate
         should return opened files, exclude test files and sorted ascendingly by file distance:
     TypeError: Invalid URL
      at new NodeError (node:internal/errors:405:5)
      at new URL (node:internal/url:676:13)
      at D:\a\language-servers\language-servers\server\aws-lsp-codewhisperer\src\language-server\utilities\supplementalContextUtil\crossFileContextUtil.ts:241:29
      at Array.filter (<anonymous>)
      at Object.getCrossFileCandidates (src\language-server\utilities\supplementalContextUtil\crossFileContextUtil.ts:236:10)
      at Context.<anonymous> (src\language-server\utilities\supplementalContextUtil\crossFileContextUtil.test.ts:137:28)
```
<img width="578" alt="image" src="https://github.com/user-attachments/assets/fcbb2fe2-fc98-446c-abde-2529381e257d" />

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
