### PR TITLE
refactor: inject a sdk runtime initializator into servers to initialize sdk clients at runtime

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -10,7 +10,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1"
     },

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-partiql": "^0.0.4"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.31"
+        "@aws/language-server-runtimes": "^0.2.34"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -270,7 +270,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.535.0",
         "@aws/chat-client-ui-types": "^0.1.0",
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.96.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -76,7 +76,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1"
             },
@@ -90,7 +90,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -98,7 +98,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -118,7 +118,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -126,7 +126,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-partiql": "^0.0.4"
             },
             "devDependencies": {
@@ -150,7 +150,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -170,7 +170,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -192,7 +192,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.31"
+                "@aws/language-server-runtimes": "^0.2.34"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -246,7 +246,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.535.0",
                 "@aws/chat-client-ui-types": "^0.1.0",
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.96.0",
                 "jose": "^5.2.4",
@@ -5370,12 +5370,14 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.31",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.31.tgz",
-            "integrity": "sha512-srdTFSM0LdOlE4A5DpXmG+9d3B+0qxAVqx510IzEFSYcLCosoMDZiJQcQSLFtPfT245MOzJKMG9Fgnfn3WGUJQ==",
-            "license": "Apache-2.0",
+            "version": "0.2.34",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.34.tgz",
+            "integrity": "sha512-LQ2ZoVer5sa9+TMwDAAXA3+hntKDhgMmEmfSkkfSHxYR7acZocRuJJV6l7EbHRvXpdgOQ5ezF1GWBjApz9Ogqg==",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.1.1",
+                "@smithy/node-http-handler": "^4.0.2",
+                "aws-sdk": "^2.1692.0",
+                "hpagent": "^1.2.0",
                 "jose": "^5.9.6",
                 "rxjs": "^7.8.1",
                 "vscode-languageserver": "^9.0.1",
@@ -5402,6 +5404,80 @@
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/@smithy/abort-controller": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
+            "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.2.tgz",
+            "integrity": "sha512-X66H9aah9hisLLSnGuzRYba6vckuFtGE+a5DcHLliI/YlqKrGoxhisD5XbX44KyoeRzoNlGr94eTsMVHFAzPOw==",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.1",
+                "@smithy/protocol-http": "^5.0.1",
+                "@smithy/querystring-builder": "^4.0.1",
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/@smithy/protocol-http": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
+            "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
+            "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+            "dependencies": {
+                "@smithy/types": "^4.1.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/@smithy/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws/language-server-runtimes/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws/language-server-runtimes/node_modules/rxjs": {
@@ -22070,7 +22146,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-core": "^0.0.1"
             },
             "devDependencies": {
@@ -22141,7 +22217,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.0",
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
@@ -22249,7 +22325,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.614.0",
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-core": "^0.0.1",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -22292,7 +22368,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -22306,7 +22382,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-core": "0.0.1",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -22345,7 +22421,7 @@
             "version": "0.0.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4",
                 "web-tree-sitter": "0.22.6"
@@ -22378,7 +22454,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -22392,7 +22468,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -22403,7 +22479,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.31",
+                "@aws/language-server-runtimes": "^0.2.34",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-core": "^0.0.1"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -30,7 +30,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.0",
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperer.ts
+++ b/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperer.ts
@@ -2,18 +2,18 @@ import { Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 const apiConfig = require('./service.json')
 import CodeWhispererClient = require('./codewhisperersigv4client')
-import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
+import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
 export type CodeWhispererSigv4ClientConfigurationOptions = ServiceConfigurationOptions
 
 export function createCodeWhispererSigv4Client(
     options: ServiceConfigurationOptions,
-    sdkRuntimeConfigurator: SDKRuntimeConfigurator
+    sdkInitializator: SDKInitializator
 ): CodeWhispererClient {
-    return createService(options, sdkRuntimeConfigurator) as CodeWhispererClient
+    return createService(options, sdkInitializator) as CodeWhispererClient
 }
 
-function createService(options: ServiceConfigurationOptions, sdkRuntimeConfigurator: SDKRuntimeConfigurator): Service {
-    const client = sdkRuntimeConfigurator.v2(Service, { apiConfig, ...options } as any)
+function createService(options: ServiceConfigurationOptions, sdkInitializator: SDKInitializator): Service {
+    const client = sdkInitializator.v2(Service, { apiConfig, ...options } as any)
     return client
 }

--- a/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperer.ts
+++ b/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperer.ts
@@ -2,14 +2,18 @@ import { Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 const apiConfig = require('./service.json')
 import CodeWhispererClient = require('./codewhisperersigv4client')
+import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
 
 export type CodeWhispererSigv4ClientConfigurationOptions = ServiceConfigurationOptions
 
-export function createCodeWhispererSigv4Client(options: ServiceConfigurationOptions): CodeWhispererClient {
-    return createService(options) as CodeWhispererClient
+export function createCodeWhispererSigv4Client(
+    options: ServiceConfigurationOptions,
+    sdkRuntimeConfigurator: SDKRuntimeConfigurator
+): CodeWhispererClient {
+    return createService(options, sdkRuntimeConfigurator) as CodeWhispererClient
 }
 
-function createService(options: ServiceConfigurationOptions): Service {
-    const client = new Service({ apiConfig, ...options } as any)
+function createService(options: ServiceConfigurationOptions, sdkRuntimeConfigurator: SDKRuntimeConfigurator): Service {
+    const client = sdkRuntimeConfigurator.v2(Service, { apiConfig, ...options } as any)
     return client
 }

--- a/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
+++ b/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
@@ -3,21 +3,21 @@ import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { readFileSync } from 'fs'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { HttpsProxyAgent } from 'hpagent'
-import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
+import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
 export class StreamingClient {
     public async getStreamingClient(
         credentialsProvider: any,
         codeWhispererRegion: string,
         codeWhispererEndpoint: string,
-        sdkRuntimeConfigurator: SDKRuntimeConfigurator,
+        sdkInitializator: SDKInitializator,
         config?: CodeWhispererStreamingClientConfig
     ) {
         return await createStreamingClient(
             credentialsProvider,
             codeWhispererRegion,
             codeWhispererEndpoint,
-            sdkRuntimeConfigurator,
+            sdkInitializator,
             config
         )
     }
@@ -26,7 +26,7 @@ export async function createStreamingClient(
     credentialsProvider: any,
     codeWhispererRegion: string,
     codeWhispererEndpoint: string,
-    sdkRuntimeConfigurator: SDKRuntimeConfigurator,
+    sdkInitializator: SDKInitializator,
     config?: CodeWhispererStreamingClientConfig
 ): Promise<CodeWhispererStreaming> {
     const creds = credentialsProvider.getCredentials('bearer')
@@ -55,13 +55,13 @@ export async function createStreamingClient(
         }
     }
 
-    const streamingClient = sdkRuntimeConfigurator.v3(CodeWhispererStreaming as any, {
+    const streamingClient = sdkInitializator(CodeWhispererStreaming, {
         region: codeWhispererRegion,
         endpoint: codeWhispererEndpoint,
         token: { token: creds.token },
         retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
         requestHandler: clientOptions?.requestHandler,
         ...config,
-    }) as CodeWhispererStreaming
+    })
     return streamingClient
 }

--- a/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
+++ b/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
@@ -3,21 +3,30 @@ import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { readFileSync } from 'fs'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { HttpsProxyAgent } from 'hpagent'
+import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
 
 export class StreamingClient {
     public async getStreamingClient(
         credentialsProvider: any,
         codeWhispererRegion: string,
         codeWhispererEndpoint: string,
+        sdkRuntimeConfigurator: SDKRuntimeConfigurator,
         config?: CodeWhispererStreamingClientConfig
     ) {
-        return await createStreamingClient(credentialsProvider, codeWhispererRegion, codeWhispererEndpoint, config)
+        return await createStreamingClient(
+            credentialsProvider,
+            codeWhispererRegion,
+            codeWhispererEndpoint,
+            sdkRuntimeConfigurator,
+            config
+        )
     }
 }
 export async function createStreamingClient(
     credentialsProvider: any,
     codeWhispererRegion: string,
     codeWhispererEndpoint: string,
+    sdkRuntimeConfigurator: SDKRuntimeConfigurator,
     config?: CodeWhispererStreamingClientConfig
 ): Promise<CodeWhispererStreaming> {
     const creds = credentialsProvider.getCredentials('bearer')
@@ -46,13 +55,13 @@ export async function createStreamingClient(
         }
     }
 
-    const streamingClient = new CodeWhispererStreaming({
+    const streamingClient = sdkRuntimeConfigurator.v3(CodeWhispererStreaming as any, {
         region: codeWhispererRegion,
         endpoint: codeWhispererEndpoint,
         token: { token: creds.token },
         retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
         requestHandler: clientOptions?.requestHandler,
         ...config,
-    })
+    }) as CodeWhispererStreaming
     return streamingClient
 }

--- a/server/aws-lsp-codewhisperer/src/client/token/codewhisperer.ts
+++ b/server/aws-lsp-codewhisperer/src/client/token/codewhisperer.ts
@@ -2,6 +2,7 @@ import { AWSError, Request, Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 const apiConfig = require('./bearer-token-service.json')
 import CodeWhispererClient = require('./codewhispererbearertokenclient')
+import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
 
 // PROOF OF CONCEPT
 // This client fiddling was copied from the AWS Toolkit for VS Code
@@ -20,18 +21,21 @@ export interface CodeWhispererTokenClientConfigurationOptions extends ServiceCon
 }
 
 export function createCodeWhispererTokenClient(
-    options: CodeWhispererTokenClientConfigurationOptions
+    options: CodeWhispererTokenClientConfigurationOptions,
+    sdkRuntimeConfigurator: SDKRuntimeConfigurator
 ): CodeWhispererClient {
-    return createService(options) as CodeWhispererClient
+    return createService(options, sdkRuntimeConfigurator) as CodeWhispererClient
 }
 
-function createService(options: CodeWhispererTokenClientConfigurationOptions): Service {
+function createService(
+    options: CodeWhispererTokenClientConfigurationOptions,
+    sdkRuntimeConfigurator: SDKRuntimeConfigurator
+): Service {
     const onRequest = options?.onRequestSetup ?? []
     const listeners = Array.isArray(onRequest) ? onRequest : [onRequest]
     const opt = { ...options }
     delete opt.onRequestSetup
-
-    const client = new Service({ apiConfig, ...options } as any)
+    const client = sdkRuntimeConfigurator.v2(Service, { apiConfig, ...options } as any)
     const originalClient = client.setupRequestListeners.bind(client)
 
     client.setupRequestListeners = (request: Request<any, AWSError>) => {

--- a/server/aws-lsp-codewhisperer/src/client/token/codewhisperer.ts
+++ b/server/aws-lsp-codewhisperer/src/client/token/codewhisperer.ts
@@ -2,7 +2,7 @@ import { AWSError, Request, Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 const apiConfig = require('./bearer-token-service.json')
 import CodeWhispererClient = require('./codewhispererbearertokenclient')
-import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
+import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
 // PROOF OF CONCEPT
 // This client fiddling was copied from the AWS Toolkit for VS Code
@@ -22,20 +22,20 @@ export interface CodeWhispererTokenClientConfigurationOptions extends ServiceCon
 
 export function createCodeWhispererTokenClient(
     options: CodeWhispererTokenClientConfigurationOptions,
-    sdkRuntimeConfigurator: SDKRuntimeConfigurator
+    sdkInitializator: SDKInitializator
 ): CodeWhispererClient {
-    return createService(options, sdkRuntimeConfigurator) as CodeWhispererClient
+    return createService(options, sdkInitializator) as CodeWhispererClient
 }
 
 function createService(
     options: CodeWhispererTokenClientConfigurationOptions,
-    sdkRuntimeConfigurator: SDKRuntimeConfigurator
+    sdkInitializator: SDKInitializator
 ): Service {
     const onRequest = options?.onRequestSetup ?? []
     const listeners = Array.isArray(onRequest) ? onRequest : [onRequest]
     const opt = { ...options }
     delete opt.onRequestSetup
-    const client = sdkRuntimeConfigurator.v2(Service, { apiConfig, ...options } as any)
+    const client = sdkInitializator.v2(Service, { apiConfig, ...options } as any)
     const originalClient = client.setupRequestListeners.bind(client)
 
     client.setupRequestListeners = (request: Request<any, AWSError>) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -11,10 +11,9 @@ import {
     Position,
     InsertToCursorPositionParams,
     TextDocumentEdit,
-    SDKRuntimeConfigurator,
-    ConstructorV2,
-    ConstructorV3,
-    SDKv3Client,
+    SDKInitializator,
+    SDKClientConstructorV2,
+    SDKClientConstructorV3,
 } from '@aws/language-server-runtimes/server-interface'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as assert from 'assert'
@@ -122,17 +121,17 @@ describe('ChatController', () => {
 
         disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
 
-        const mockSdkRuntimeConfigurator: SDKRuntimeConfigurator = {
-            v2: <T extends Service, P extends ServiceConfigurationOptions>(
-                Ctor: ConstructorV2<T, P>,
-                current_config: P
-            ): T => {
-                return new Ctor({ ...current_config })
-            },
-            v3: <T extends SDKv3Client, P>(Ctor: ConstructorV3<T, P>, current_config: P): T => {
-                return new Ctor({ ...current_config })
-            },
-        }
+        const mockSdkRuntimeConfigurator: SDKInitializator = Object.assign(
+            // Default callable function for v3 clients
+            <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T => new Ctor({ ...current_config }),
+            // Property for v2 clients
+            {
+                v2: <T extends Service, P extends ServiceConfigurationOptions>(
+                    Ctor: SDKClientConstructorV2<T, P>,
+                    current_config: P
+                ): T => new Ctor({ ...current_config }),
+            }
+        )
 
         chatSessionManagementService = ChatSessionManagementService.getInstance()
             .withCredentialsProvider(testFeatures.credentialsProvider)

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
@@ -1,8 +1,16 @@
-import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
+import {
+    CredentialsProvider,
+    SDKRuntimeConfigurator,
+    ConstructorV2,
+    ConstructorV3,
+    SDKv3Client,
+} from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import sinon from 'ts-sinon'
 import { ChatSessionManagementService } from './chatSessionManagementService'
 import { ChatSessionService } from './chatSessionService'
+import { Service } from 'aws-sdk'
+import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 
 describe('ChatSessionManagementService', () => {
     const mockSessionId = 'mockSessionId'
@@ -33,12 +41,25 @@ describe('ChatSessionManagementService', () => {
         let disposeStub: sinon.SinonStub
         let chatSessionManagementService: ChatSessionManagementService
 
+        const mockSdkRuntimeConfigurator: SDKRuntimeConfigurator = {
+            v2: <T extends Service, P extends ServiceConfigurationOptions>(
+                Ctor: ConstructorV2<T, P>,
+                current_config: P
+            ): T => {
+                return new Ctor({ ...current_config })
+            },
+            v3: <T extends SDKv3Client, P>(Ctor: ConstructorV3<T, P>, current_config: P): T => {
+                return new Ctor({ ...current_config })
+            },
+        }
+
         beforeEach(() => {
             disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
             chatSessionManagementService = ChatSessionManagementService.getInstance()
                 .withCredentialsProvider(mockCredentialsProvider)
                 .withCodeWhispererRegion(mockAwsQRegion)
                 .withCodeWhispererEndpoint(mockAwsQEndpointUrl)
+                .withSdkRuntimeConfigurator(mockSdkRuntimeConfigurator)
         })
 
         afterEach(() => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
@@ -1,9 +1,8 @@
 import {
     CredentialsProvider,
-    SDKRuntimeConfigurator,
-    ConstructorV2,
-    ConstructorV3,
-    SDKv3Client,
+    SDKInitializator,
+    SDKClientConstructorV2,
+    SDKClientConstructorV3,
 } from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import sinon from 'ts-sinon'
@@ -41,17 +40,17 @@ describe('ChatSessionManagementService', () => {
         let disposeStub: sinon.SinonStub
         let chatSessionManagementService: ChatSessionManagementService
 
-        const mockSdkRuntimeConfigurator: SDKRuntimeConfigurator = {
-            v2: <T extends Service, P extends ServiceConfigurationOptions>(
-                Ctor: ConstructorV2<T, P>,
-                current_config: P
-            ): T => {
-                return new Ctor({ ...current_config })
-            },
-            v3: <T extends SDKv3Client, P>(Ctor: ConstructorV3<T, P>, current_config: P): T => {
-                return new Ctor({ ...current_config })
-            },
-        }
+        const mockSdkRuntimeConfigurator: SDKInitializator = Object.assign(
+            // Default callable function for v3 clients
+            <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T => new Ctor({ ...current_config }),
+            // Property for v2 clients
+            {
+                v2: <T extends Service, P extends ServiceConfigurationOptions>(
+                    Ctor: SDKClientConstructorV2<T, P>,
+                    current_config: P
+                ): T => new Ctor({ ...current_config }),
+            }
+        )
 
         beforeEach(() => {
             disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
@@ -1,4 +1,4 @@
-import { CredentialsProvider, SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
+import { CredentialsProvider, SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 import { Result } from '../types'
 import { ChatSessionService, ChatSessionServiceConfig } from './chatSessionService'
 
@@ -10,7 +10,7 @@ export class ChatSessionManagementService {
     #customUserAgent?: string = '%Amazon-Q-For-LanguageServers%'
     #codeWhispererRegion?: string
     #codeWhispererEndpoint?: string
-    #sdkRuntimeConfigurator?: SDKRuntimeConfigurator
+    #sdkInitializator?: SDKInitializator
 
     public static getInstance() {
         if (!ChatSessionManagementService.#instance) {
@@ -50,8 +50,8 @@ export class ChatSessionManagementService {
         return this
     }
 
-    public withSdkRuntimeConfigurator(sdkRuntimeConfigurator: SDKRuntimeConfigurator) {
-        this.#sdkRuntimeConfigurator = sdkRuntimeConfigurator
+    public withSdkRuntimeConfigurator(sdkInitializator: SDKInitializator) {
+        this.#sdkInitializator = sdkInitializator
 
         return this
     }
@@ -80,10 +80,10 @@ export class ChatSessionManagementService {
                 success: false,
                 error: 'CodeWhispererEndpoint is not set',
             }
-        } else if (!this.#sdkRuntimeConfigurator) {
+        } else if (!this.#sdkInitializator) {
             return {
                 success: false,
-                error: 'SdkRuntimeConfigurator is not set',
+                error: 'SdkInitializator is not set',
             }
         } else if (this.#sessionByTab.has(tabId)) {
             return {
@@ -97,7 +97,7 @@ export class ChatSessionManagementService {
             this.#credentialsProvider,
             this.#codeWhispererRegion,
             this.#codeWhispererEndpoint,
-            this.#sdkRuntimeConfigurator,
+            this.#sdkInitializator,
             {
                 ...clientConfig,
                 customUserAgent: this.#customUserAgent,

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
@@ -1,4 +1,4 @@
-import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
+import { CredentialsProvider, SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
 import { Result } from '../types'
 import { ChatSessionService, ChatSessionServiceConfig } from './chatSessionService'
 
@@ -10,6 +10,7 @@ export class ChatSessionManagementService {
     #customUserAgent?: string = '%Amazon-Q-For-LanguageServers%'
     #codeWhispererRegion?: string
     #codeWhispererEndpoint?: string
+    #sdkRuntimeConfigurator?: SDKRuntimeConfigurator
 
     public static getInstance() {
         if (!ChatSessionManagementService.#instance) {
@@ -49,6 +50,12 @@ export class ChatSessionManagementService {
         return this
     }
 
+    public withSdkRuntimeConfigurator(sdkRuntimeConfigurator: SDKRuntimeConfigurator) {
+        this.#sdkRuntimeConfigurator = sdkRuntimeConfigurator
+
+        return this
+    }
+
     public setCustomUserAgent(customUserAgent: string) {
         this.#customUserAgent = customUserAgent
     }
@@ -73,6 +80,11 @@ export class ChatSessionManagementService {
                 success: false,
                 error: 'CodeWhispererEndpoint is not set',
             }
+        } else if (!this.#sdkRuntimeConfigurator) {
+            return {
+                success: false,
+                error: 'SdkRuntimeConfigurator is not set',
+            }
         } else if (this.#sessionByTab.has(tabId)) {
             return {
                 success: true,
@@ -85,6 +97,7 @@ export class ChatSessionManagementService {
             this.#credentialsProvider,
             this.#codeWhispererRegion,
             this.#codeWhispererEndpoint,
+            this.#sdkRuntimeConfigurator,
             {
                 ...clientConfig,
                 customUserAgent: this.#customUserAgent,

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
@@ -5,10 +5,9 @@ import {
 } from '@amzn/codewhisperer-streaming'
 import {
     CredentialsProvider,
-    SDKRuntimeConfigurator,
-    ConstructorV2,
-    ConstructorV3,
-    SDKv3Client,
+    SDKInitializator,
+    SDKClientConstructorV2,
+    SDKClientConstructorV3,
 } from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import sinon from 'ts-sinon'
@@ -30,17 +29,17 @@ describe('Chat Session Service', () => {
     const awsQEndpointUrl: string = DEFAULT_AWS_Q_ENDPOINT_URL
     const mockConversationId = 'mockConversationId'
 
-    const mockSdkRuntimeConfigurator: SDKRuntimeConfigurator = {
-        v2: <T extends Service, P extends ServiceConfigurationOptions>(
-            Ctor: ConstructorV2<T, P>,
-            current_config: P
-        ): T => {
-            return new Ctor({ ...current_config })
-        },
-        v3: <T extends SDKv3Client, P>(Ctor: ConstructorV3<T, P>, current_config: P): T => {
-            return new Ctor({ ...current_config })
-        },
-    }
+    const mockSdkRuntimeConfigurator: SDKInitializator = Object.assign(
+        // Default callable function for v3 clients
+        <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T => new Ctor({ ...current_config }),
+        // Property for v2 clients
+        {
+            v2: <T extends Service, P extends ServiceConfigurationOptions>(
+                Ctor: SDKClientConstructorV2<T, P>,
+                current_config: P
+            ): T => new Ctor({ ...current_config }),
+        }
+    )
 
     const mockRequestParams: SendMessageCommandInput = {
         conversationState: {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
@@ -3,11 +3,19 @@ import {
     SendMessageCommandInput,
     SendMessageCommandOutput,
 } from '@amzn/codewhisperer-streaming'
-import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
+import {
+    CredentialsProvider,
+    SDKRuntimeConfigurator,
+    ConstructorV2,
+    ConstructorV3,
+    SDKv3Client,
+} from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import sinon from 'ts-sinon'
 import { ChatSessionService } from './chatSessionService'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
+import { Service } from 'aws-sdk'
+import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 
 describe('Chat Session Service', () => {
     let sendMessageStub: sinon.SinonStub<any, any>
@@ -21,6 +29,18 @@ describe('Chat Session Service', () => {
     const awsQRegion: string = DEFAULT_AWS_Q_REGION
     const awsQEndpointUrl: string = DEFAULT_AWS_Q_ENDPOINT_URL
     const mockConversationId = 'mockConversationId'
+
+    const mockSdkRuntimeConfigurator: SDKRuntimeConfigurator = {
+        v2: <T extends Service, P extends ServiceConfigurationOptions>(
+            Ctor: ConstructorV2<T, P>,
+            current_config: P
+        ): T => {
+            return new Ctor({ ...current_config })
+        },
+        v3: <T extends SDKv3Client, P>(Ctor: ConstructorV3<T, P>, current_config: P): T => {
+            return new Ctor({ ...current_config })
+        },
+    }
 
     const mockRequestParams: SendMessageCommandInput = {
         conversationState: {
@@ -45,7 +65,12 @@ describe('Chat Session Service', () => {
             .stub(CodeWhispererStreaming.prototype, 'sendMessage')
             .callsFake(() => Promise.resolve(mockRequestResponse))
 
-        chatSessionService = new ChatSessionService(mockCredentialsProvider, awsQRegion, awsQEndpointUrl)
+        chatSessionService = new ChatSessionService(
+            mockCredentialsProvider,
+            awsQRegion,
+            awsQEndpointUrl,
+            mockSdkRuntimeConfigurator
+        )
     })
 
     afterEach(() => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -7,14 +7,14 @@ import {
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
 import { getBearerTokenFromProvider } from '../utils'
-import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
+import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
     readonly #codeWhispererRegion: string
     readonly #codeWhispererEndpoint: string
-    #sdkRuntimeConfigurator: SDKRuntimeConfigurator
+    #sdkInitializator: SDKInitializator
     #abortController?: AbortController
     #credentialsProvider: CredentialsProvider
     #config?: CodeWhispererStreamingClientConfig
@@ -32,13 +32,13 @@ export class ChatSessionService {
         credentialsProvider: CredentialsProvider,
         codeWhispererRegion: string,
         codeWhispererEndpoint: string,
-        sdkRuntimeConfigurator: SDKRuntimeConfigurator,
+        sdkInitializator: SDKInitializator,
         config?: CodeWhispererStreamingClientConfig
     ) {
         this.#credentialsProvider = credentialsProvider
         this.#codeWhispererRegion = codeWhispererRegion
         this.#codeWhispererEndpoint = codeWhispererEndpoint
-        this.#sdkRuntimeConfigurator = sdkRuntimeConfigurator
+        this.#sdkInitializator = sdkInitializator
         this.#config = config
     }
 
@@ -49,13 +49,13 @@ export class ChatSessionService {
             request.conversationState.conversationId = this.#conversationId
         }
 
-        const client = this.#sdkRuntimeConfigurator.v3(CodeWhispererStreaming as any, {
+        const client = this.#sdkInitializator(CodeWhispererStreaming, {
             region: this.#codeWhispererRegion,
             endpoint: this.#codeWhispererEndpoint,
             token: () => Promise.resolve({ token: getBearerTokenFromProvider(this.#credentialsProvider) }),
             retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
             ...this.#config,
-        }) as CodeWhispererStreaming
+        })
 
         const response = await client.sendMessage(request, {
             abortSignal: this.#abortController?.signal,

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -19,6 +19,7 @@ import { SecurityScanEvent } from './telemetry/types'
 import { getErrorMessage, parseJson } from './utils'
 import { getUserAgent } from './utilities/telemetryUtils'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../constants'
+import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
 
 const RunSecurityScanCommand = 'aws/codewhisperer/runSecurityScan'
 const CancelSecurityScanCommand = 'aws/codewhisperer/cancelSecurityScan'
@@ -29,15 +30,17 @@ export const SecurityScanServerToken =
             credentialsProvider: CredentialsProvider,
             workspace: Workspace,
             awsQRegion: string,
-            awsQEndpointUrl: string
+            awsQEndpointUrl: string,
+            sdkRuntimeConfigurator: SDKRuntimeConfigurator
         ) => CodeWhispererServiceToken
     ): Server =>
-    ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime }) => {
+    ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime, sdkRuntimeConfigurator }) => {
         const codewhispererclient = service(
             credentialsProvider,
             workspace,
             runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
-            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
+            sdkRuntimeConfigurator
         )
         const diagnosticsProvider = new SecurityScanDiagnosticsProvider(lsp, logging)
         const scanHandler = new SecurityScanHandler(codewhispererclient, workspace, logging)

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -19,7 +19,7 @@ import { SecurityScanEvent } from './telemetry/types'
 import { getErrorMessage, parseJson } from './utils'
 import { getUserAgent } from './utilities/telemetryUtils'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../constants'
-import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
+import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
 const RunSecurityScanCommand = 'aws/codewhisperer/runSecurityScan'
 const CancelSecurityScanCommand = 'aws/codewhisperer/cancelSecurityScan'
@@ -31,16 +31,16 @@ export const SecurityScanServerToken =
             workspace: Workspace,
             awsQRegion: string,
             awsQEndpointUrl: string,
-            sdkRuntimeConfigurator: SDKRuntimeConfigurator
+            sdkInitializator: SDKInitializator
         ) => CodeWhispererServiceToken
     ): Server =>
-    ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime, sdkRuntimeConfigurator }) => {
+    ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime, sdkInitializator }) => {
         const codewhispererclient = service(
             credentialsProvider,
             workspace,
             runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
             runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
         const diagnosticsProvider = new SecurityScanDiagnosticsProvider(lsp, logging)
         const scanHandler = new SecurityScanHandler(codewhispererclient, workspace, logging)

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -13,7 +13,7 @@ import {
     Telemetry,
     TextDocument,
     Workspace,
-    SDKRuntimeConfigurator,
+    SDKInitializator,
 } from '@aws/language-server-runtimes/server-interface'
 import { AWSError } from 'aws-sdk'
 import { autoTrigger, triggerType } from './auto-trigger/autoTrigger'
@@ -266,10 +266,10 @@ export const CodewhispererServerFactory =
             workspace: Workspace,
             awsQRegion: string,
             awsQEndpointUrl: string,
-            sdkRuntimeConfigurator: SDKRuntimeConfigurator
+            sdkInitializator: SDKInitializator
         ) => CodeWhispererServiceBase
     ): Server =>
-    ({ credentialsProvider, lsp, workspace, telemetry, logging, runtime, sdkRuntimeConfigurator }) => {
+    ({ credentialsProvider, lsp, workspace, telemetry, logging, runtime, sdkInitializator }) => {
         let lastUserModificationTime: number
         let timeSinceLastUserModification: number = 0
 
@@ -282,7 +282,7 @@ export const CodewhispererServerFactory =
             workspace,
             awsQRegion,
             awsQEndpointUrl,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
         const telemetryService = new TelemetryService(
             credentialsProvider,
@@ -292,7 +292,7 @@ export const CodewhispererServerFactory =
             workspace,
             awsQRegion,
             awsQEndpointUrl,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
 
         lsp.addInitializer((params: InitializeParams) => {
@@ -628,9 +628,9 @@ export const CodewhispererServerFactory =
                         `Inline completion configuration updated to use ${codeWhispererService.customizationArn}`
                     )
                     /*
-                                                The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
-                                                configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
-                                             */
+                                                    The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
+                                                    configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
+                                                 */
                     // const enableTelemetryEventsToDestination = true
                     // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
                     const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'
@@ -688,16 +688,10 @@ export const CodewhispererServerFactory =
     }
 
 export const CodeWhispererServerIAM = CodewhispererServerFactory(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) =>
-        new CodeWhispererServiceIAM(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator)
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) =>
+        new CodeWhispererServiceIAM(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator)
 )
 export const CodeWhispererServerToken = CodewhispererServerFactory(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) =>
-        new CodeWhispererServiceToken(
-            credentialsProvider,
-            workspace,
-            awsQRegion,
-            awsQEndpointUrl,
-            sdkRuntimeConfigurator
-        )
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) =>
+        new CodeWhispererServiceToken(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator)
 )

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -3,7 +3,7 @@ import {
     CredentialsProvider,
     CredentialsType,
     Workspace,
-    SDKRuntimeConfigurator,
+    SDKInitializator,
 } from '@aws/language-server-runtimes/server-interface'
 import { AWSError, ConfigurationOptions, CredentialProviderChain, Credentials } from 'aws-sdk'
 import { PromiseResult } from 'aws-sdk/lib/request'
@@ -82,7 +82,7 @@ export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
         workspace: Workspace,
         codeWhispererRegion: string,
         codeWhispererEndpoint: string,
-        sdkRuntimeConfigurator: SDKRuntimeConfigurator
+        sdkInitializator: SDKInitializator
     ) {
         super(workspace, codeWhispererRegion, codeWhispererEndpoint)
         const options: CodeWhispererSigv4ClientConfigurationOptions = {
@@ -92,7 +92,7 @@ export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
                 () => credentialsProvider.getCredentials('iam') as Credentials,
             ]),
         }
-        this.client = createCodeWhispererSigv4Client(options, sdkRuntimeConfigurator)
+        this.client = createCodeWhispererSigv4Client(options, sdkInitializator)
         this.updateClientConfig(this.proxyConfig)
         this.client.setupRequestListeners = ({ httpRequest }) => {
             httpRequest.headers['x-amzn-codewhisperer-optout'] = `${!this.shareCodeWhispererContentWithAWS}`
@@ -134,7 +134,7 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
         workspace: Workspace,
         codeWhispererRegion: string,
         codeWhispererEndpoint: string,
-        sdkRuntimeConfigurator: SDKRuntimeConfigurator
+        sdkInitializator: SDKInitializator
     ) {
         super(workspace, codeWhispererRegion, codeWhispererEndpoint)
         const options: CodeWhispererTokenClientConfigurationOptions = {
@@ -153,7 +153,7 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
                 },
             ],
         }
-        this.client = createCodeWhispererTokenClient(options, sdkRuntimeConfigurator)
+        this.client = createCodeWhispererTokenClient(options, sdkInitializator)
         this.updateClientConfig(this.proxyConfig)
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -3,6 +3,7 @@ import {
     CredentialsProvider,
     CredentialsType,
     Workspace,
+    SDKRuntimeConfigurator,
 } from '@aws/language-server-runtimes/server-interface'
 import { AWSError, ConfigurationOptions, CredentialProviderChain, Credentials } from 'aws-sdk'
 import { PromiseResult } from 'aws-sdk/lib/request'
@@ -76,12 +77,12 @@ export abstract class CodeWhispererServiceBase {
 
 export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
     client: CodeWhispererSigv4Client
-
     constructor(
         credentialsProvider: CredentialsProvider,
         workspace: Workspace,
         codeWhispererRegion: string,
-        codeWhispererEndpoint: string
+        codeWhispererEndpoint: string,
+        sdkRuntimeConfigurator: SDKRuntimeConfigurator
     ) {
         super(workspace, codeWhispererRegion, codeWhispererEndpoint)
         const options: CodeWhispererSigv4ClientConfigurationOptions = {
@@ -91,7 +92,7 @@ export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
                 () => credentialsProvider.getCredentials('iam') as Credentials,
             ]),
         }
-        this.client = createCodeWhispererSigv4Client(options)
+        this.client = createCodeWhispererSigv4Client(options, sdkRuntimeConfigurator)
         this.updateClientConfig(this.proxyConfig)
         this.client.setupRequestListeners = ({ httpRequest }) => {
             httpRequest.headers['x-amzn-codewhisperer-optout'] = `${!this.shareCodeWhispererContentWithAWS}`
@@ -132,7 +133,8 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
         credentialsProvider: CredentialsProvider,
         workspace: Workspace,
         codeWhispererRegion: string,
-        codeWhispererEndpoint: string
+        codeWhispererEndpoint: string,
+        sdkRuntimeConfigurator: SDKRuntimeConfigurator
     ) {
         super(workspace, codeWhispererRegion, codeWhispererEndpoint)
         const options: CodeWhispererTokenClientConfigurationOptions = {
@@ -151,7 +153,7 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
                 },
             ],
         }
-        this.client = createCodeWhispererTokenClient(options)
+        this.client = createCodeWhispererTokenClient(options, sdkRuntimeConfigurator)
         this.updateClientConfig(this.proxyConfig)
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -9,7 +9,7 @@ import {
 import { CodeWhispererServiceToken } from '../codeWhispererService'
 import { getUserAgent } from '../utilities/telemetryUtils'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
-import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
+import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
 // The configuration section that the server will register and listen to
 export const Q_CONFIGURATION_SECTION = 'aws.q'
@@ -20,16 +20,16 @@ export const QConfigurationServerToken =
             workspace: Workspace,
             awsQRegion: string,
             awsQEndpointUrl: string,
-            sdkRuntimeConfigurator: SDKRuntimeConfigurator
+            sdkInitializator: SDKInitializator
         ) => CodeWhispererServiceToken
     ): Server =>
-    ({ credentialsProvider, lsp, logging, runtime, workspace, sdkRuntimeConfigurator }) => {
+    ({ credentialsProvider, lsp, logging, runtime, workspace, sdkInitializator }) => {
         const codeWhispererService = service(
             credentialsProvider,
             workspace,
             runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
             runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
 
         lsp.addInitializer((params: InitializeParams) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -9,6 +9,7 @@ import {
 import { CodeWhispererServiceToken } from '../codeWhispererService'
 import { getUserAgent } from '../utilities/telemetryUtils'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
+import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
 
 // The configuration section that the server will register and listen to
 export const Q_CONFIGURATION_SECTION = 'aws.q'
@@ -18,15 +19,17 @@ export const QConfigurationServerToken =
             credentials: CredentialsProvider,
             workspace: Workspace,
             awsQRegion: string,
-            awsQEndpointUrl: string
+            awsQEndpointUrl: string,
+            sdkRuntimeConfigurator: SDKRuntimeConfigurator
         ) => CodeWhispererServiceToken
     ): Server =>
-    ({ credentialsProvider, lsp, logging, runtime, workspace }) => {
+    ({ credentialsProvider, lsp, logging, runtime, workspace, sdkRuntimeConfigurator }) => {
         const codeWhispererService = service(
             credentialsProvider,
             workspace,
             runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
-            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
+            sdkRuntimeConfigurator
         )
 
         lsp.addInitializer((params: InitializeParams) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
@@ -2,10 +2,9 @@ import { CodeWhispererStreaming } from '@amzn/codewhisperer-streaming'
 import {
     Logging,
     Workspace,
-    SDKRuntimeConfigurator,
-    ConstructorV2,
-    ConstructorV3,
-    SDKv3Client,
+    SDKInitializator,
+    SDKClientConstructorV2,
+    SDKClientConstructorV3,
 } from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import { HttpResponse } from 'aws-sdk'
@@ -211,17 +210,17 @@ describe('Test Transform handler ', () => {
         getCredentials: sinon.stub().returns({ token: 'mockedToken' }),
     }
 
-    const mockSdkRuntimeConfigurator: SDKRuntimeConfigurator = {
-        v2: <T extends Service, P extends ServiceConfigurationOptions>(
-            Ctor: ConstructorV2<T, P>,
-            current_config: P
-        ): T => {
-            return new Ctor({ ...current_config })
-        },
-        v3: <T extends SDKv3Client, P>(Ctor: ConstructorV3<T, P>, current_config: P): T => {
-            return new Ctor({ ...current_config })
-        },
-    }
+    const mockSdkRuntimeConfigurator: SDKInitializator = Object.assign(
+        // Default callable function for v3 clients
+        <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T => new Ctor({ ...current_config }),
+        // Property for v2 clients
+        {
+            v2: <T extends Service, P extends ServiceConfigurationOptions>(
+                Ctor: SDKClientConstructorV2<T, P>,
+                current_config: P
+            ): T => new Ctor({ ...current_config }),
+        }
+    )
 
     describe('StreamingClient', () => {
         it('should create a new streaming client', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -46,6 +46,7 @@ const GetTransformPlanCommand = 'aws/qNetTransform/getTransformPlan'
 const CancelTransformCommand = 'aws/qNetTransform/cancelTransform'
 const DownloadArtifactsCommand = 'aws/qNetTransform/downloadArtifacts'
 import { DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL } from '../constants'
+import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
 
 /**
  *
@@ -58,15 +59,17 @@ export const QNetTransformServerToken =
             credentialsProvider: CredentialsProvider,
             workspace: Workspace,
             awsQRegion: string,
-            awsQEndpointUrl: string
+            awsQEndpointUrl: string,
+            sdkRuntimeConfigurator: SDKRuntimeConfigurator
         ) => CodeWhispererServiceToken
     ): Server =>
-    ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime }) => {
+    ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime, sdkRuntimeConfigurator }) => {
         const codewhispererclient = service(
             credentialsProvider,
             workspace,
             runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
-            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
+            sdkRuntimeConfigurator
         )
         const transformHandler = new TransformHandler(codewhispererclient, workspace, logging)
         const runTransformCommand = async (params: ExecuteCommandParams, _token: CancellationToken) => {
@@ -125,6 +128,7 @@ export const QNetTransformServerToken =
                             credentialsProvider,
                             runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
                             runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
+                            sdkRuntimeConfigurator,
                             customCWClientConfig
                         )
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -46,7 +46,7 @@ const GetTransformPlanCommand = 'aws/qNetTransform/getTransformPlan'
 const CancelTransformCommand = 'aws/qNetTransform/cancelTransform'
 const DownloadArtifactsCommand = 'aws/qNetTransform/downloadArtifacts'
 import { DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL } from '../constants'
-import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
+import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
 /**
  *
@@ -60,16 +60,16 @@ export const QNetTransformServerToken =
             workspace: Workspace,
             awsQRegion: string,
             awsQEndpointUrl: string,
-            sdkRuntimeConfigurator: SDKRuntimeConfigurator
+            sdkInitializator: SDKInitializator
         ) => CodeWhispererServiceToken
     ): Server =>
-    ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime, sdkRuntimeConfigurator }) => {
+    ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime, sdkInitializator }) => {
         const codewhispererclient = service(
             credentialsProvider,
             workspace,
             runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
             runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
         const transformHandler = new TransformHandler(codewhispererclient, workspace, logging)
         const runTransformCommand = async (params: ExecuteCommandParams, _token: CancellationToken) => {
@@ -128,7 +128,7 @@ export const QNetTransformServerToken =
                             credentialsProvider,
                             runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
                             runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
-                            sdkRuntimeConfigurator,
+                            sdkInitializator,
                             customCWClientConfig
                         )
 

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -11,66 +11,99 @@ import { HttpsProxyAgent } from 'hpagent'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 
 export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) => {
-        return new CodeWhispererServiceToken(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+        return new CodeWhispererServiceToken(
+            credentialsProvider,
+            workspace,
+            awsQRegion,
+            awsQEndpointUrl,
+            sdkRuntimeConfigurator
+        )
     }
 )
 
 export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) => {
-        return new CodeWhispererServiceIAM(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+        return new CodeWhispererServiceIAM(
+            credentialsProvider,
+            workspace,
+            awsQRegion,
+            awsQEndpointUrl,
+            sdkRuntimeConfigurator
+        )
     }
 )
 
 export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) => {
-        return new CodeWhispererServiceToken(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+        return new CodeWhispererServiceToken(
+            credentialsProvider,
+            workspace,
+            awsQRegion,
+            awsQEndpointUrl,
+            sdkRuntimeConfigurator
+        )
     }
 )
 
 export const QNetTransformServerTokenProxy = QNetTransformServerToken(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) => {
-        return new CodeWhispererServiceToken(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+        return new CodeWhispererServiceToken(
+            credentialsProvider,
+            workspace,
+            awsQRegion,
+            awsQEndpointUrl,
+            sdkRuntimeConfigurator
+        )
     }
 )
 
-export const QChatServerProxy = QChatServer((credentialsProvider, awsQRegion, awsQEndpointUrl) => {
-    let clientOptions: ChatSessionServiceConfig | undefined
-    // short term solution to fix webworker bundling, broken due to this node.js specific logic in here
-    const isNodeJS: boolean = typeof process !== 'undefined' && process.release && process.release.name === 'node'
-    const proxyUrl = isNodeJS ? (process.env.HTTPS_PROXY ?? process.env.https_proxy) : undefined
-    const certs = isNodeJS
-        ? process.env.AWS_CA_BUNDLE
-            ? [readFileSync(process.env.AWS_CA_BUNDLE)]
+export const QChatServerProxy = QChatServer(
+    (credentialsProvider, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+        let clientOptions: ChatSessionServiceConfig | undefined
+        // short term solution to fix webworker bundling, broken due to this node.js specific logic in here
+        const isNodeJS: boolean = typeof process !== 'undefined' && process.release && process.release.name === 'node'
+        const proxyUrl = isNodeJS ? (process.env.HTTPS_PROXY ?? process.env.https_proxy) : undefined
+        const certs = isNodeJS
+            ? process.env.AWS_CA_BUNDLE
+                ? [readFileSync(process.env.AWS_CA_BUNDLE)]
+                : undefined
             : undefined
-        : undefined
 
-    if (proxyUrl) {
-        clientOptions = () => {
-            // this mimics aws-sdk-v3-js-proxy
-            const agent = new HttpsProxyAgent({
-                proxy: proxyUrl,
-                ca: certs,
-            })
+        if (proxyUrl) {
+            clientOptions = () => {
+                // this mimics aws-sdk-v3-js-proxy
+                const agent = new HttpsProxyAgent({
+                    proxy: proxyUrl,
+                    ca: certs,
+                })
 
-            return {
-                requestHandler: new NodeHttpHandler({
-                    httpAgent: agent,
-                    httpsAgent: agent,
-                }),
+                return {
+                    requestHandler: new NodeHttpHandler({
+                        httpAgent: agent,
+                        httpsAgent: agent,
+                    }),
+                }
             }
         }
-    }
 
-    return ChatSessionManagementService.getInstance()
-        .withCredentialsProvider(credentialsProvider)
-        .withCodeWhispererEndpoint(awsQEndpointUrl)
-        .withCodeWhispererRegion(awsQRegion)
-        .withConfig(clientOptions)
-})
+        return ChatSessionManagementService.getInstance()
+            .withCredentialsProvider(credentialsProvider)
+            .withCodeWhispererEndpoint(awsQEndpointUrl)
+            .withCodeWhispererRegion(awsQRegion)
+            .withSdkRuntimeConfigurator(sdkRuntimeConfigurator)
+            .withConfig(clientOptions)
+    }
+)
 
 export const QConfigurationServerTokenProxy = QConfigurationServerToken(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl) => {
-        return new CodeWhispererServiceToken(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+        return new CodeWhispererServiceToken(
+            credentialsProvider,
+            workspace,
+            awsQRegion,
+            awsQEndpointUrl,
+            sdkRuntimeConfigurator
+        )
     }
 )

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -11,55 +11,55 @@ import { HttpsProxyAgent } from 'hpagent'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 
 export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
         return new CodeWhispererServiceToken(
             credentialsProvider,
             workspace,
             awsQRegion,
             awsQEndpointUrl,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
     }
 )
 
 export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
         return new CodeWhispererServiceIAM(
             credentialsProvider,
             workspace,
             awsQRegion,
             awsQEndpointUrl,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
     }
 )
 
 export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
         return new CodeWhispererServiceToken(
             credentialsProvider,
             workspace,
             awsQRegion,
             awsQEndpointUrl,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
     }
 )
 
 export const QNetTransformServerTokenProxy = QNetTransformServerToken(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
         return new CodeWhispererServiceToken(
             credentialsProvider,
             workspace,
             awsQRegion,
             awsQEndpointUrl,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
     }
 )
 
 export const QChatServerProxy = QChatServer(
-    (credentialsProvider, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+    (credentialsProvider, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
         let clientOptions: ChatSessionServiceConfig | undefined
         // short term solution to fix webworker bundling, broken due to this node.js specific logic in here
         const isNodeJS: boolean = typeof process !== 'undefined' && process.release && process.release.name === 'node'
@@ -91,19 +91,19 @@ export const QChatServerProxy = QChatServer(
             .withCredentialsProvider(credentialsProvider)
             .withCodeWhispererEndpoint(awsQEndpointUrl)
             .withCodeWhispererRegion(awsQRegion)
-            .withSdkRuntimeConfigurator(sdkRuntimeConfigurator)
+            .withSdkRuntimeConfigurator(sdkInitializator)
             .withConfig(clientOptions)
     }
 )
 
 export const QConfigurationServerTokenProxy = QConfigurationServerToken(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator) => {
+    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
         return new CodeWhispererServiceToken(
             credentialsProvider,
             workspace,
             awsQRegion,
             awsQEndpointUrl,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
     }
 )

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -58,43 +58,41 @@ export const QNetTransformServerTokenProxy = QNetTransformServerToken(
     }
 )
 
-export const QChatServerProxy = QChatServer(
-    (credentialsProvider, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
-        let clientOptions: ChatSessionServiceConfig | undefined
-        // short term solution to fix webworker bundling, broken due to this node.js specific logic in here
-        const isNodeJS: boolean = typeof process !== 'undefined' && process.release && process.release.name === 'node'
-        const proxyUrl = isNodeJS ? (process.env.HTTPS_PROXY ?? process.env.https_proxy) : undefined
-        const certs = isNodeJS
-            ? process.env.AWS_CA_BUNDLE
-                ? [readFileSync(process.env.AWS_CA_BUNDLE)]
-                : undefined
+export const QChatServerProxy = QChatServer((credentialsProvider, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
+    let clientOptions: ChatSessionServiceConfig | undefined
+    // short term solution to fix webworker bundling, broken due to this node.js specific logic in here
+    const isNodeJS: boolean = typeof process !== 'undefined' && process.release && process.release.name === 'node'
+    const proxyUrl = isNodeJS ? (process.env.HTTPS_PROXY ?? process.env.https_proxy) : undefined
+    const certs = isNodeJS
+        ? process.env.AWS_CA_BUNDLE
+            ? [readFileSync(process.env.AWS_CA_BUNDLE)]
             : undefined
+        : undefined
 
-        if (proxyUrl) {
-            clientOptions = () => {
-                // this mimics aws-sdk-v3-js-proxy
-                const agent = new HttpsProxyAgent({
-                    proxy: proxyUrl,
-                    ca: certs,
-                })
+    if (proxyUrl) {
+        clientOptions = () => {
+            // this mimics aws-sdk-v3-js-proxy
+            const agent = new HttpsProxyAgent({
+                proxy: proxyUrl,
+                ca: certs,
+            })
 
-                return {
-                    requestHandler: new NodeHttpHandler({
-                        httpAgent: agent,
-                        httpsAgent: agent,
-                    }),
-                }
+            return {
+                requestHandler: new NodeHttpHandler({
+                    httpAgent: agent,
+                    httpsAgent: agent,
+                }),
             }
         }
-
-        return ChatSessionManagementService.getInstance()
-            .withCredentialsProvider(credentialsProvider)
-            .withCodeWhispererEndpoint(awsQEndpointUrl)
-            .withCodeWhispererRegion(awsQRegion)
-            .withSdkRuntimeConfigurator(sdkInitializator)
-            .withConfig(clientOptions)
     }
-)
+
+    return ChatSessionManagementService.getInstance()
+        .withCredentialsProvider(credentialsProvider)
+        .withCodeWhispererEndpoint(awsQEndpointUrl)
+        .withCodeWhispererRegion(awsQRegion)
+        .withSdkRuntimeConfigurator(sdkInitializator)
+        .withConfig(clientOptions)
+})
 
 export const QConfigurationServerTokenProxy = QConfigurationServerToken(
     (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -5,7 +5,7 @@ import { CLEAR_QUICK_ACTION, HELP_QUICK_ACTION } from './chat/quickActions'
 import { TelemetryService } from './telemetryService'
 import { getUserAgent, makeUserContextObject } from './utilities/telemetryUtils'
 import { DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL } from '../constants'
-import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
+import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
 export const QChatServer =
     (
@@ -13,12 +13,11 @@ export const QChatServer =
             credentialsProvider: CredentialsProvider,
             awsQRegion: string,
             awsQEndpointUrl: string,
-            sdkRuntimeConfigurator: SDKRuntimeConfigurator
+            sdkInitializator: SDKInitializator
         ) => ChatSessionManagementService
     ): Server =>
     features => {
-        const { chat, credentialsProvider, telemetry, logging, lsp, runtime, workspace, sdkRuntimeConfigurator } =
-            features
+        const { chat, credentialsProvider, telemetry, logging, lsp, runtime, workspace, sdkInitializator } = features
 
         const awsQRegion = runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION
         const awsQEndpointUrl = runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
@@ -26,7 +25,7 @@ export const QChatServer =
             credentialsProvider,
             awsQRegion,
             awsQEndpointUrl,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
         const telemetryService = new TelemetryService(
             credentialsProvider,
@@ -36,7 +35,7 @@ export const QChatServer =
             workspace,
             awsQRegion,
             awsQEndpointUrl,
-            sdkRuntimeConfigurator
+            sdkInitializator
         )
 
         const chatController = new ChatController(chatSessionManagementService, features, telemetryService)

--- a/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/qChatServer.ts
@@ -5,24 +5,28 @@ import { CLEAR_QUICK_ACTION, HELP_QUICK_ACTION } from './chat/quickActions'
 import { TelemetryService } from './telemetryService'
 import { getUserAgent, makeUserContextObject } from './utilities/telemetryUtils'
 import { DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL } from '../constants'
+import { SDKRuntimeConfigurator } from '@aws/language-server-runtimes/server-interface'
 
 export const QChatServer =
     (
         service: (
             credentialsProvider: CredentialsProvider,
             awsQRegion: string,
-            awsQEndpointUrl: string
+            awsQEndpointUrl: string,
+            sdkRuntimeConfigurator: SDKRuntimeConfigurator
         ) => ChatSessionManagementService
     ): Server =>
     features => {
-        const { chat, credentialsProvider, telemetry, logging, lsp, runtime, workspace } = features
+        const { chat, credentialsProvider, telemetry, logging, lsp, runtime, workspace, sdkRuntimeConfigurator } =
+            features
 
         const awsQRegion = runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION
         const awsQEndpointUrl = runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
         const chatSessionManagementService: ChatSessionManagementService = service(
             credentialsProvider,
             awsQRegion,
-            awsQEndpointUrl
+            awsQEndpointUrl,
+            sdkRuntimeConfigurator
         )
         const telemetryService = new TelemetryService(
             credentialsProvider,
@@ -31,7 +35,8 @@ export const QChatServer =
             logging,
             workspace,
             awsQRegion,
-            awsQEndpointUrl
+            awsQEndpointUrl,
+            sdkRuntimeConfigurator
         )
 
         const chatController = new ChatController(chatSessionManagementService, features, telemetryService)

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
@@ -8,10 +8,9 @@ import {
     Logging,
     Telemetry,
     Workspace,
-    SDKRuntimeConfigurator,
-    ConstructorV2,
-    ConstructorV3,
-    SDKv3Client,
+    SDKInitializator,
+    SDKClientConstructorV2,
+    SDKClientConstructorV3,
 } from '@aws/language-server-runtimes/server-interface'
 import { UserContext, OptOutPreference } from '../client/token/codewhispererbearertokenclient'
 import { CodeWhispererSession } from './session/sessionManager'
@@ -99,17 +98,17 @@ describe('TelemetryService', () => {
         },
     }
 
-    const mockSdkRuntimeConfigurator: SDKRuntimeConfigurator = {
-        v2: <T extends Service, P extends ServiceConfigurationOptions>(
-            Ctor: ConstructorV2<T, P>,
-            current_config: P
-        ): T => {
-            return new Ctor({ ...current_config })
-        },
-        v3: <T extends SDKv3Client, P>(Ctor: ConstructorV3<T, P>, current_config: P): T => {
-            return new Ctor({ ...current_config })
-        },
-    }
+    const mockSdkRuntimeConfigurator: SDKInitializator = Object.assign(
+        // Default callable function for v3 clients
+        <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T => new Ctor({ ...current_config }),
+        // Property for v2 clients
+        {
+            v2: <T extends Service, P extends ServiceConfigurationOptions>(
+                Ctor: SDKClientConstructorV2<T, P>,
+                current_config: P
+            ): T => new Ctor({ ...current_config }),
+        }
+    )
 
     beforeEach(() => {
         clock = sinon.useFakeTimers({

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
@@ -8,12 +8,18 @@ import {
     Logging,
     Telemetry,
     Workspace,
+    SDKRuntimeConfigurator,
+    ConstructorV2,
+    ConstructorV3,
+    SDKv3Client,
 } from '@aws/language-server-runtimes/server-interface'
 import { UserContext, OptOutPreference } from '../client/token/codewhispererbearertokenclient'
 import { CodeWhispererSession } from './session/sessionManager'
 import sinon from 'ts-sinon'
 import { BUILDER_ID_START_URL } from './constants'
 import { ChatInteractionType } from './telemetry/types'
+import { Service } from 'aws-sdk'
+import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 
 class MockCredentialsProvider implements CredentialsProvider {
     private mockIamCredentials: IamCredentials | undefined
@@ -93,6 +99,18 @@ describe('TelemetryService', () => {
         },
     }
 
+    const mockSdkRuntimeConfigurator: SDKRuntimeConfigurator = {
+        v2: <T extends Service, P extends ServiceConfigurationOptions>(
+            Ctor: ConstructorV2<T, P>,
+            current_config: P
+        ): T => {
+            return new Ctor({ ...current_config })
+        },
+        v3: <T extends SDKv3Client, P>(Ctor: ConstructorV3<T, P>, current_config: P): T => {
+            return new Ctor({ ...current_config })
+        },
+    }
+
     beforeEach(() => {
         clock = sinon.useFakeTimers({
             now: 1483228800000,
@@ -117,7 +135,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         const mockUserContext: UserContext = {
             clientId: 'aaaabbbbccccdddd',
@@ -139,7 +158,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         const mockOptOutPreference: OptOutPreference = 'OPTIN'
         telemetryService.updateOptOutPreference(mockOptOutPreference)
@@ -155,7 +175,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         telemetryService.updateEnableTelemetryEventsToDestination(true)
 
@@ -170,7 +191,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         const getSuggestionState = (telemetryService as any).getSuggestionState.bind(telemetryService)
         let session = {
@@ -219,7 +241,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
 
@@ -241,7 +264,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
         telemetryService.updateOptOutPreference('OPTOUT')
@@ -259,7 +283,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         const sendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -323,7 +348,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         telemetryService.updateEnableTelemetryEventsToDestination(true)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
@@ -378,7 +404,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         telemetryService.updateEnableTelemetryEventsToDestination(false)
         telemetryService.updateOptOutPreference('OPTOUT')
@@ -407,7 +434,8 @@ describe('TelemetryService', () => {
                 logging,
                 mockWorkspace,
                 mockAwsQRegion,
-                mockAwsQEndpointUrl
+                mockAwsQEndpointUrl,
+                mockSdkRuntimeConfigurator
             )
             invokeSendTelemetryEventStub = sinon
                 .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -487,7 +515,8 @@ describe('TelemetryService', () => {
                 logging,
                 mockWorkspace,
                 mockAwsQRegion,
-                mockAwsQEndpointUrl
+                mockAwsQEndpointUrl,
+                mockSdkRuntimeConfigurator
             )
             telemetryService.updateEnableTelemetryEventsToDestination(false)
             telemetryService.updateOptOutPreference('OPTOUT')
@@ -523,7 +552,8 @@ describe('TelemetryService', () => {
                 logging,
                 mockWorkspace,
                 mockAwsQRegion,
-                mockAwsQEndpointUrl
+                mockAwsQEndpointUrl,
+                mockSdkRuntimeConfigurator
             )
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             const metric = {
@@ -554,7 +584,8 @@ describe('TelemetryService', () => {
                 logging,
                 mockWorkspace,
                 mockAwsQRegion,
-                mockAwsQEndpointUrl
+                mockAwsQEndpointUrl,
+                mockSdkRuntimeConfigurator
             )
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.updateOptOutPreference('OPTOUT')
@@ -630,7 +661,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -677,7 +709,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         telemetryService.updateOptOutPreference('OPTOUT')
         telemetryService.updateEnableTelemetryEventsToDestination(false)
@@ -712,7 +745,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
             .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -763,7 +797,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         telemetryService.updateEnableTelemetryEventsToDestination(true)
         const invokeSendTelemetryEventStub: sinon.SinonStub = sinon
@@ -815,7 +850,8 @@ describe('TelemetryService', () => {
             logging,
             mockWorkspace,
             mockAwsQRegion,
-            mockAwsQEndpointUrl
+            mockAwsQEndpointUrl,
+            mockSdkRuntimeConfigurator
         )
         telemetryService.updateEnableTelemetryEventsToDestination(false)
         telemetryService.updateOptOutPreference('OPTOUT')
@@ -849,7 +885,8 @@ describe('TelemetryService', () => {
                 logging,
                 mockWorkspace,
                 mockAwsQRegion,
-                mockAwsQEndpointUrl
+                mockAwsQEndpointUrl,
+                mockSdkRuntimeConfigurator
             )
             invokeSendTelemetryEventStub = sinon
                 .stub(telemetryService, 'sendTelemetryEvent' as any)
@@ -945,7 +982,8 @@ describe('TelemetryService', () => {
                 logging,
                 mockWorkspace,
                 mockAwsQRegion,
-                mockAwsQEndpointUrl
+                mockAwsQEndpointUrl,
+                mockSdkRuntimeConfigurator
             )
             telemetryService.updateOptOutPreference('OPTOUT')
             telemetryService.updateEnableTelemetryEventsToDestination(false)
@@ -1001,7 +1039,8 @@ describe('TelemetryService', () => {
                 logging,
                 mockWorkspace,
                 mockAwsQRegion,
-                mockAwsQEndpointUrl
+                mockAwsQEndpointUrl,
+                mockSdkRuntimeConfigurator
             )
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.emitChatAddMessage(
@@ -1028,7 +1067,8 @@ describe('TelemetryService', () => {
                 logging,
                 mockWorkspace,
                 mockAwsQRegion,
-                mockAwsQEndpointUrl
+                mockAwsQEndpointUrl,
+                mockSdkRuntimeConfigurator
             )
             invokeSendTelemetryEventStub = sinon.stub(telemetryService, 'sendTelemetryEvent' as any)
             telemetryService.updateOptOutPreference('OPTOUT')

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
@@ -5,6 +5,7 @@ import {
     Logging,
     Telemetry,
     Workspace,
+    SDKRuntimeConfigurator,
 } from '@aws/language-server-runtimes/server-interface'
 import { CodeWhispererSession } from './session/sessionManager'
 import {
@@ -60,9 +61,10 @@ export class TelemetryService extends CodeWhispererServiceToken {
         logging: Logging,
         workspace: Workspace,
         awsQRegion: string,
-        awsQEndpointUrl: string
+        awsQEndpointUrl: string,
+        sdkRuntimeConfigurator: SDKRuntimeConfigurator
     ) {
-        super(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl)
+        super(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator)
         this.credentialsProvider = credentialsProvider
         this.credentialsType = credentialsType
         this.telemetry = telemetry

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.ts
@@ -5,7 +5,7 @@ import {
     Logging,
     Telemetry,
     Workspace,
-    SDKRuntimeConfigurator,
+    SDKInitializator,
 } from '@aws/language-server-runtimes/server-interface'
 import { CodeWhispererSession } from './session/sessionManager'
 import {
@@ -62,9 +62,9 @@ export class TelemetryService extends CodeWhispererServiceToken {
         workspace: Workspace,
         awsQRegion: string,
         awsQEndpointUrl: string,
-        sdkRuntimeConfigurator: SDKRuntimeConfigurator
+        sdkInitializator: SDKInitializator
     ) {
-        super(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkRuntimeConfigurator)
+        super(credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator)
         this.credentialsProvider = credentialsProvider
         this.credentialsType = credentialsType
         this.telemetry = telemetry

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.614.0",
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-core": "^0.0.1",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha 'out/**/*.test.js'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-core": "0.0.1",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b 'src/**/*.test.ts'"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.31",
+        "@aws/language-server-runtimes": "^0.2.34",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem
We need to be able to set runtime/environment specific options for aws sdk clients while keeping capability servers runtime/environment agnostic. This is currently not done, for instance, currently we have nodejs env if/else check for proxy in the capability servers. 

## Solution
Initialize sdk clients at runtime, by wrapping them into a sdk client initializator, which will use the specific sdk client constructor and options passed from the capability servers to initialize the clients at runtime. The sdk runtime initializator allows us to set additional runtime/environment-specific options (e.g. proxy). The sdk client initializator should be generic enough to work with any sdk clients, both v2 and v3.

## Important notes

This PR depends on [this PR](https://github.com/aws/language-server-runtimes/pull/316) in runtimes, tests here will fail till we release the changes made in runtimes.

I locally tested the changes configuring proxy at runtime, it works fine, I will open a new PR for the proxy changes to avoid making this PR too big, and for better separation.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
