### PR TITLE
refactor: remove proxy logic (moved to runtimes)

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
+++ b/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
@@ -1,8 +1,5 @@
 import { CodeWhispererStreaming, CodeWhispererStreamingClientConfig } from '@amzn/codewhisperer-streaming'
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
-import { readFileSync } from 'fs'
-import { NodeHttpHandler } from '@smithy/node-http-handler'
-import { HttpsProxyAgent } from 'hpagent'
 import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
 export class StreamingClient {
@@ -31,36 +28,11 @@ export async function createStreamingClient(
 ): Promise<CodeWhispererStreaming> {
     const creds = credentialsProvider.getCredentials('bearer')
 
-    let clientOptions
-    // short term solution to fix webworker bundling, broken due to this node.js specific logic in here
-    const isNodeJS: boolean = typeof process !== 'undefined' && process.release && process.release.name === 'node'
-    const proxyUrl = isNodeJS ? (process.env.HTTPS_PROXY ?? process.env.https_proxy) : undefined
-    const certs = isNodeJS
-        ? process.env.AWS_CA_BUNDLE
-            ? [readFileSync(process.env.AWS_CA_BUNDLE)]
-            : undefined
-        : undefined
-
-    if (proxyUrl) {
-        const agent = new HttpsProxyAgent({
-            proxy: proxyUrl,
-            ca: certs,
-        })
-
-        clientOptions = {
-            requestHandler: new NodeHttpHandler({
-                httpAgent: agent,
-                httpsAgent: agent,
-            }),
-        }
-    }
-
     const streamingClient = sdkInitializator(CodeWhispererStreaming, {
         region: codeWhispererRegion,
         endpoint: codeWhispererEndpoint,
         token: { token: creds.token },
         retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
-        requestHandler: clientOptions?.requestHandler,
         ...config,
     })
     return streamingClient

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -43,14 +43,12 @@ export interface GenerateSuggestionsResponse {
 
 import CodeWhispererSigv4Client = require('../client/sigv4/codewhisperersigv4client')
 import CodeWhispererTokenClient = require('../client/token/codewhispererbearertokenclient')
-import { makeProxyConfig } from './utils'
 
 // Right now the only difference between the token client and the IAM client for codewhsiperer is the difference in function name
 // This abstract class can grow in the future to account for any additional changes across the clients
 export abstract class CodeWhispererServiceBase {
     protected readonly codeWhispererRegion
     protected readonly codeWhispererEndpoint
-    protected proxyConfig: ConfigurationOptions = {}
     public shareCodeWhispererContentWithAWS = false
     public customizationArn?: string
     abstract client: CodeWhispererSigv4Client | CodeWhispererTokenClient
@@ -60,7 +58,6 @@ export abstract class CodeWhispererServiceBase {
     abstract generateSuggestions(request: GenerateSuggestionsRequest): Promise<GenerateSuggestionsResponse>
 
     constructor(workspace: Workspace, codeWhispererRegion: string, codeWhispererEndpoint: string) {
-        this.proxyConfig = makeProxyConfig(workspace)
         this.codeWhispererRegion = codeWhispererRegion
         this.codeWhispererEndpoint = codeWhispererEndpoint
     }
@@ -93,7 +90,6 @@ export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
             ]),
         }
         this.client = createCodeWhispererSigv4Client(options, sdkInitializator)
-        this.updateClientConfig(this.proxyConfig)
         this.client.setupRequestListeners = ({ httpRequest }) => {
             httpRequest.headers['x-amzn-codewhisperer-optout'] = `${!this.shareCodeWhispererContentWithAWS}`
         }
@@ -154,7 +150,6 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
             ],
         }
         this.client = createCodeWhispererTokenClient(options, sdkInitializator)
-        this.updateClientConfig(this.proxyConfig)
     }
 
     getCredentialsType(): CredentialsType {

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -6,9 +6,6 @@ import { CodeWhispererServiceIAM, CodeWhispererServiceToken } from './codeWhispe
 import { QNetTransformServerToken } from './netTransformServer'
 import { QChatServer } from './qChatServer'
 import { QConfigurationServerToken } from './configuration/qConfigurationServer'
-import { readFileSync } from 'fs'
-import { HttpsProxyAgent } from 'hpagent'
-import { NodeHttpHandler } from '@smithy/node-http-handler'
 
 export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(
     (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
@@ -58,43 +55,13 @@ export const QNetTransformServerTokenProxy = QNetTransformServerToken(
     }
 )
 
-export const QChatServerProxy = QChatServer(
-    (credentialsProvider, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
-        let clientOptions: ChatSessionServiceConfig | undefined
-        // short term solution to fix webworker bundling, broken due to this node.js specific logic in here
-        const isNodeJS: boolean = typeof process !== 'undefined' && process.release && process.release.name === 'node'
-        const proxyUrl = isNodeJS ? (process.env.HTTPS_PROXY ?? process.env.https_proxy) : undefined
-        const certs = isNodeJS
-            ? process.env.AWS_CA_BUNDLE
-                ? [readFileSync(process.env.AWS_CA_BUNDLE)]
-                : undefined
-            : undefined
-
-        if (proxyUrl) {
-            clientOptions = () => {
-                // this mimics aws-sdk-v3-js-proxy
-                const agent = new HttpsProxyAgent({
-                    proxy: proxyUrl,
-                    ca: certs,
-                })
-
-                return {
-                    requestHandler: new NodeHttpHandler({
-                        httpAgent: agent,
-                        httpsAgent: agent,
-                    }),
-                }
-            }
-        }
-
-        return ChatSessionManagementService.getInstance()
-            .withCredentialsProvider(credentialsProvider)
-            .withCodeWhispererEndpoint(awsQEndpointUrl)
-            .withCodeWhispererRegion(awsQRegion)
-            .withSdkRuntimeConfigurator(sdkInitializator)
-            .withConfig(clientOptions)
-    }
-)
+export const QChatServerProxy = QChatServer((credentialsProvider, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
+    return ChatSessionManagementService.getInstance()
+        .withCredentialsProvider(credentialsProvider)
+        .withCodeWhispererEndpoint(awsQEndpointUrl)
+        .withCodeWhispererRegion(awsQRegion)
+        .withSdkRuntimeConfigurator(sdkInitializator)
+})
 
 export const QConfigurationServerTokenProxy = QConfigurationServerToken(
     (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -4,13 +4,12 @@ import {
     Position,
     Workspace,
 } from '@aws/language-server-runtimes/server-interface'
-import { AWSError, ConfigurationOptions } from 'aws-sdk'
+import { AWSError } from 'aws-sdk'
 import { distance } from 'fastest-levenshtein'
 import { Suggestion } from './codeWhispererService'
 import { CodewhispererCompletionType } from './telemetry/types'
 import { BUILDER_ID_START_URL, MISSING_BEARER_TOKEN_ERROR } from './constants'
 import { ServerInfo } from '@aws/language-server-runtimes/server-interface/runtime'
-import { HttpsProxyAgent } from 'hpagent'
 export type SsoConnectionType = 'builderId' | 'identityCenter' | 'none'
 
 export function isAwsError(error: unknown): error is AWSError {
@@ -129,30 +128,4 @@ export function getEndPositionForAcceptedSuggestion(content: string, startPositi
         }
     }
     return endPosition
-}
-
-export const makeProxyConfig = (workspace: Workspace) => {
-    let additionalAwsConfig: ConfigurationOptions = {}
-    // short term solution to fix webworker bundling, broken due to this node.js specific logic in here
-    const isNodeJS: boolean = typeof process !== 'undefined' && process.release && process.release.name === 'node'
-    const proxyUrl = isNodeJS ? (process.env.HTTPS_PROXY ?? process.env.https_proxy) : undefined
-
-    if (proxyUrl) {
-        const certs = isNodeJS
-            ? process.env.AWS_CA_BUNDLE
-                ? [workspace.fs.readFileSync(process.env.AWS_CA_BUNDLE)]
-                : undefined
-            : undefined
-        const agent = new HttpsProxyAgent({
-            proxy: proxyUrl,
-            ca: certs,
-        })
-        additionalAwsConfig = {
-            httpOptions: {
-                agent: agent,
-            },
-        }
-    }
-
-    return additionalAwsConfig
 }


### PR DESCRIPTION
## Problem
We moved the proxy setup to the runtimes repo with the introduction of the [sdkInitializator](https://github.com/aws/language-server-runtimes/pull/316). Since proxy setup is environment specific (we use it for nodejs envs only), and we want to keep capability servers environment-agnostic. 

## Solution
Removed the proxy code and moved it to the runtimes refer to the [runtimes PR](https://github.com/aws/language-server-runtimes/pull/316) for the changes.

I tested the proxy manually, and I am currently investigating whether there is a way to automate tests for proxy, which in case would follow up in a new PR.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
