### PR TITLE
chore: fix failing tests for windows github actions

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/utilities/supplementalContextUtil/crossFileContextUtil.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utilities/supplementalContextUtil/crossFileContextUtil.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-nodejs-modules */
 // Port of implementation in AWS Toolkit for VSCode
 // https://github.com/aws/aws-toolkit-vscode/blob/9d8ddbd85f4533e539a58e76f7c46883d8e50a79/packages/core/src/codewhisperer/util/supplementalContext/crossFileContextUtil.ts
 // Implementation is converted to work with LSP TextDocument instead of vscode APIs.


### PR DESCRIPTION
## Problem
Windows tests are failing (because of [breaking github action env. changes](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/))

## Solution
Updated the tests to create a proper fileURL from any file uri.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
