### PR TITLE
refactor: simplify initialize overrides in ServerBase and servers extending it

### DIFF
--- a/server/aws-lsp-identity/src/language-server/identityServer.ts
+++ b/server/aws-lsp-identity/src/language-server/identityServer.ts
@@ -96,7 +96,7 @@ export class IdentityServer extends ServerBase {
             ...result,
             ...{
                 serverInfo: {
-                    name: 'AWS Toolkit Language Server for Identity',
+                    name: 'Language Server for AWS Identity Management',
                 },
             },
         }

--- a/server/aws-lsp-identity/src/language-server/identityServer.ts
+++ b/server/aws-lsp-identity/src/language-server/identityServer.ts
@@ -8,9 +8,7 @@ import {
     GetSsoTokenParams,
     InvalidateSsoTokenParams,
     InitializeParams,
-    HandlerResult,
     PartialInitializeResult,
-    InitializeError,
 } from '@aws/language-server-runtimes/server-interface'
 import { SharedConfigProfileStore } from './profiles/sharedConfigProfileStore'
 import { IdentityService } from './identityService'
@@ -30,9 +28,9 @@ export class IdentityServer extends ServerBase {
         return new IdentityServer(features)[Symbol.dispose]
     }
 
-    protected override initialize(
-        params: InitializeParams
-    ): HandlerResult<PartialInitializeResult<any>, InitializeError> {
+    protected override async initialize(params: InitializeParams): Promise<PartialInitializeResult<any>> {
+        const result = await super.initialize(params)
+
         // Callbacks for server->client JSON-RPC calls
         const showUrl: ShowUrl = (url: URL) =>
             this.features.lsp.window.showDocument({ uri: url.toString(), external: true })
@@ -94,7 +92,14 @@ export class IdentityServer extends ServerBase {
 
         this.disposables.push(autoRefresher)
 
-        return { capabilities: {} }
+        return {
+            ...result,
+            ...{
+                serverInfo: {
+                    name: 'AWS Toolkit Language Server for Identity',
+                },
+            },
+        }
     }
 
     private getClientName(params: InitializeParams): string {

--- a/server/aws-lsp-notification/src/notifications/toolkits/criteriaFilteringFetcher.ts
+++ b/server/aws-lsp-notification/src/notifications/toolkits/criteriaFilteringFetcher.ts
@@ -1,6 +1,6 @@
 import { Fetcher } from '../fetcher'
 
-export class CritieriaFilteringFetcher implements Fetcher {
+export class CriteriaFilteringFetcher implements Fetcher {
     constructor(private readonly next: Fetcher) {}
 
     fetch(): Promise<Notification[]> {


### PR DESCRIPTION
## Problem
`initialize` method on ServerBase was not async and required implementations to handle catching errors and returning to meet the LSP return type of `HandlerResult<..., InitializeError>`.

Other changes:
* Added ServerState enum to ServerBase to support NotificationsServer
* Cleaned up showNotification impl in NotificationServer
* Fixed typo in CriteriaFilteringFetcher

## Solution
Simplified implementation of `initialize` method so error handling isn't necessary (handled by wrapper in ServerBase) and async code in initialize is now possible.  Updated IdentityServer for the initialize function declaration change.

Tested with `npm run test` and using vscode sample client IdentityServer function to see various identity server functions called/return values.

![image](https://github.com/user-attachments/assets/3f5e3084-e032-4f8a-89d0-863fc76aaacd)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
