### PR TITLE
ci: open release-please pull requests as draft

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
     "plugins": ["node-workspace"],
     "tag-separator": "/",
     "include-v-in-tag": true,
+    "draft-pull-request": true,
     "packages": {
         "chat-client": {
             "component": "chat-client"


### PR DESCRIPTION
## Problem
Release Pull Requests managed by release-please do not trigger Github Actions automatically, blocking releases. 
This is caused by using default `GITHUB_TOKEN` in release-please Action:

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.

## Solution

There are several workarounds to this issue. The easiest and more straightforward is to mark Release-Please Pull Requests as draft, and require person to move PR to "Open" state. When done by human, Github Actions will start as usual.

Other possible workaround include using managed PAT, manually force-pushing something to release PR or closing and re-opening PR immediately by human. I prefer to try Draft PRs, as this seems to be more straight-forward.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
