### PR TITLE
ci: update release-please PR footer with troubleshooting information

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
     "always-link-local": false,
     "separate-pull-requests": false,
     "group-pull-request-title-pattern": "chore(release): release packages from branch ${branch}",
+    "pull-request-footer": "This PR was generated with [Release Please](https://github.com/googleapis/release-please) bot. When you are ready to release these changes, merge this PR.\n\n**Blocking GitHub Checks Issue:** if GitHub checks do not run, close and immediately re-open this PR manually.",
     "plugins": ["node-workspace"],
     "tag-separator": "/",
     "include-v-in-tag": true,


### PR DESCRIPTION
## Problem
Release Please PRs created by bot don't trigger GitHub workflows. Using draft PRs doesn't solve the issue - PR should be submitted by human to trigger GitHub checks on PR.

## Solution
Adding a message to release please PR footer with instructions on how to workaround the problem.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
