### PR TITLE
chore: add options to start VSCode client with unencrypted connection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -84,6 +84,7 @@
             "env": {
                 "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-codewhisperer-runtimes/out/token-standalone.js",
                 "ENABLE_INLINE_COMPLETION": "true",
+                "ENABLE_ENCRYPTION": "true",
                 "ENABLE_TOKEN_PROVIDER": "true",
                 "ENABLE_CUSTOM_COMMANDS": "true",
                 "ENABLE_CHAT": "true",

--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -58,7 +58,7 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
      */
     const enableIamProvider = process.env.ENABLE_IAM_PROVIDER === 'true'
     const enableBearerTokenProvider = process.env.ENABLE_TOKEN_PROVIDER === 'true'
-    const enableEncryptionInit = enableIamProvider || enableBearerTokenProvider
+    const enableEncryptionInit = process.env.ENABLE_ENCRYPTION === 'true'
 
     const debugOptions = { execArgv: ['--nolazy', '--inspect=6012', '--preserve-symlinks'] }
 
@@ -172,11 +172,11 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
     const client = new LanguageClient('awsDocuments', 'AWS Documents Language Server', serverOptions, clientOptions)
 
     if (enableIamProvider) {
-        await registerIamCredentialsProviderSupport(client, extensionContext)
+        await registerIamCredentialsProviderSupport(client, extensionContext, enableEncryptionInit)
     }
 
     if (enableBearerTokenProvider) {
-        await registerBearerTokenProviderSupport(client, extensionContext)
+        await registerBearerTokenProviderSupport(client, extensionContext, enableEncryptionInit)
     }
 
     if (enableInlineCompletion) {


### PR DESCRIPTION
## Problem
VSCode sample client works only with encrypted connection to Language Server runtime.

## Solution
Allow to start unencrypted connection, controlled with `ENABLE_ENCRYPTION` env variable.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
