### PR TITLE
chore: ignore test files in the lsp cw package

### DIFF
--- a/server/aws-lsp-codewhisperer/.npmignore
+++ b/server/aws-lsp-codewhisperer/.npmignore
@@ -7,3 +7,6 @@ package-lock.json
 .*
 tsconfig.*
 webpack.*.config.js
+*.test.js
+*.test.d.ts
+*.test.js.map


### PR DESCRIPTION
## Problem
`*.test.*` files are included in the `@aws/lsp-codewhisperer` npm package.

## Solution
Updated `.npmignore` to exclude test files.
Impact:
* Removed 96 unnecessary files
* Reduced package size by 84.9kB
* Reduced unpacked size by 0.6MB

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
