### PR TITLE
fix: replace setInterval with recursive setTimeout for browser compatibility

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
@@ -142,20 +142,23 @@ export class CodeDiffTracker<T extends AcceptedSuggestionEntry = AcceptedSuggest
 
     #startInterval() {
         if (!this.#interval) {
-            this.#interval = setInterval(async () => {
-                try {
-                    await this.flush()
-                } catch (e) {
-                    this.#logging.log(`flush failed: ${getErrorMessage(e)}`)
-                } finally {
-                    this.#interval?.refresh()
-                }
-            }, this.#flushInterval)
+            const recursiveSetTimeout = () => {
+                this.#interval = setTimeout(async () => {
+                    try {
+                        await this.flush()
+                    } catch (e) {
+                        this.#logging.log(`flush failed: ${getErrorMessage(e)}`)
+                    } finally {
+                        recursiveSetTimeout()
+                    }
+                }, this.#flushInterval)
+            }
+            recursiveSetTimeout()
         }
     }
 
     #clearInterval() {
-        clearInterval(this.#interval)
+        clearTimeout(this.#interval)
         this.#interval = undefined
     }
 }


### PR DESCRIPTION
## Problem
`codeDiffTracker.ts` uses NodeJS-spicific API - [Timeout->refresh()](https://nodejs.org/api/timers.html#timeoutrefresh) which doesn't exist in the browser. 
In the browser [`setInterval()` return a numeric `intervalID`](https://developer.mozilla.org/en-US/docs/Web/API/Window/setInterval#return_value) instead of a `Timeout` and calling refresh on it causes a runtime exception. 

## Solution
The `codeDiffTracker` uses the `Timeout->refresh()` API to ensure that the delay between execution will start only after the metrics have been flushed. 
This can be easily achieved in a cross-platform manner by using a recursive timeout instead of the `setInterval` + `Timeout.refresh()`. 
https://developer.mozilla.org/en-US/docs/Web/API/Window/setInterval#ensure_that_execution_duration_is_shorter_than_interval_frequency

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
