### PR TITLE
chore: release lsp-identity server to NPM

### DIFF
--- a/.github/workflows/npm-packaging.yaml
+++ b/.github/workflows/npm-packaging.yaml
@@ -23,11 +23,11 @@ jobs:
                   npm run compile
             - name: Pack public npm packages
               run: |
-                  npm pack -w server/aws-lsp-codewhisperer -w server/aws-lsp-partiql -w server/aws-lsp-json -w server/aws-lsp-yaml
+                  npm pack -w server/aws-lsp-codewhisperer -w server/aws-lsp-partiql -w server/aws-lsp-json -w server/aws-lsp-yaml -w server/aws-lsp-identity
             - name: Create test package
               run: |
                   cd tests
-                  npm install ../aws-lsp-codewhisperer-*.tgz ../aws-lsp-partiql-*.tgz ../aws-lsp-json-*.tgz ../aws-lsp-yaml-*.tgz
+                  npm install ../aws-lsp-codewhisperer-*.tgz ../aws-lsp-partiql-*.tgz ../aws-lsp-json-*.tgz ../aws-lsp-yaml-*.tgz ../aws-lsp-identity-*.tgz
             - name: Test imports
               run: |
                   cd tests

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -92,3 +92,7 @@ jobs:
             - name: Publish LSP Yaml to npm
               run: npm publish --workspace server/aws-lsp-yaml
               if: ${{ steps.release.outputs['server/aws-lsp-yaml--release_created'] }}
+
+            - name: Publish LSP Identity to npm
+              run: npm publish --workspace server/aws-lsp-identity
+              if: ${{ steps.release.outputs['server/aws-lsp-identity--release_created'] }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,6 @@
     "server/aws-lsp-codewhisperer": "0.0.26",
     "server/aws-lsp-json": "0.1.0",
     "server/aws-lsp-partiql": "0.0.4",
-    "server/aws-lsp-yaml": "0.1.0"
+    "server/aws-lsp-yaml": "0.1.0",
+    "server/aws-lsp-identity": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,6 +29,9 @@
         },
         "server/aws-lsp-yaml": {
             "component": "lsp-yaml"
+        },
+        "server/aws-lsp-identity": {
+            "component": "lsp-identity"
         }
     },
     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Problem
`lsp-identity` server is not released to NPM now.

## Solution
Release `lsp-identity` to NPM so that we follow Flare repository release paradigm.

## License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
