### PR TITLE
build: update bundling of Codewhisperer language server

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/README.md
+++ b/app/aws-lsp-codewhisperer-runtimes/README.md
@@ -11,7 +11,7 @@ This command will compile package and produce 2 bundled Javascript programs in `
 - `./out/iam-standalone.js` - Amazon Q server using IAM Credentials provider
 - `./out/token-standalone.js` - Amazon Q server using Bearer Token SSO Credentials provider
 
-To test server you can use sample IDEs client in [`./client`](../../client) subpackages. In VSCode, you can use "Run and Debug" functionality with [sample client extension](../../CONTRIBUTING.md#with-minimal-vscode-client) and update `launch.json` configuration to point to [compiled bundle file](../../.vscode/launch.json#L60). Change value for `LSP_SERVER` valiable from `${workspaceFolder}/app/aws-lsp-codewhisperer-bundle/out/index.js` to `${workspaceFolder}/app/aws-lsp-codewhisperer-bundle/out/token-standalone.js`.
+To test server you can use sample IDEs client in [`./client`](../../client) subpackages. In VSCode, you can use "Run and Debug" functionality with [sample client extension](../../CONTRIBUTING.md#with-minimal-vscode-client) and update `launch.json` configuration to point to [compiled bundle file](../../.vscode/launch.json#L60). Change value for `LSP_SERVER` valiable from `${workspaceFolder}/app/aws-lsp-codewhisperer-runtimes/out/index.js` to `${workspaceFolder}/app/aws-lsp-codewhisperer-runtimes/out/token-standalone.js`.
 
 To verify compiled bundle can run, you can start it in your shell with NodeJS:
 

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -15,6 +15,7 @@
         "copyfiles": "^2.4.1"
     },
     "devDependencies": {
+        "node-loader": "^2.1.0",
         "ts-loader": "^9.4.4",
         "webpack": "^5.94.0",
         "webpack-cli": "^6.0.1"

--- a/app/aws-lsp-codewhisperer-runtimes/webpack.config.js
+++ b/app/aws-lsp-codewhisperer-runtimes/webpack.config.js
@@ -3,15 +3,16 @@ var path = require('path')
 const baseConfig = {
     mode: 'development',
     output: {
-        path: __dirname,
-        filename: 'build/[name].js',
+        path: path.resolve(__dirname, 'build'),
+        filename: '[name].js',
         globalObject: 'this',
+        chunkFormat: false,
         library: {
             type: 'umd',
         },
     },
     resolve: {
-        extensions: ['.ts', '.tsx', '.js'],
+        extensions: ['.ts', '.tsx', '.js', '.node'],
     },
     module: {
         rules: [
@@ -19,6 +20,13 @@ const baseConfig = {
                 test: /\.tsx?$/,
                 use: 'ts-loader',
                 exclude: /node_modules/,
+            },
+            {
+                test: /\.node$/,
+                loader: 'node-loader',
+                options: {
+                    name: '[name].[ext]', // Preserves original path and filename
+                },
             },
         ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
                 "copyfiles": "^2.4.1"
             },
             "devDependencies": {
+                "node-loader": "^2.1.0",
                 "ts-loader": "^9.4.4",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^6.0.1"
@@ -18332,6 +18333,54 @@
             "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/node-loader": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/node-loader/-/node-loader-2.1.0.tgz",
+            "integrity": "sha512-OwjPkyh8+7jW8DMd/iq71uU1Sspufr/C2+c3t0p08J3CrM9ApZ4U53xuisNrDXOHyGi5OYHgtfmmh+aK9zJA6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "loader-utils": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            }
+        },
+        "node_modules/node-loader/node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/node-loader/node_modules/loader-utils": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            }
         },
         "node_modules/node-releases": {
             "version": "2.0.19",


### PR DESCRIPTION
## Problem
Update in https://github.com/aws/language-server-runtimes/pull/335 will fail the build, as it introduces `.node` static files as part dependencies of standalone runtime.

## Solution
Configure webpack to load `.node` files correctly at `build` directory.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
