### PR TITLE
[INTERNAL REVIEW] Setting a flag to retain generated input artifacts

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
@@ -5,6 +5,7 @@ import {
     SDKInitializator,
     SDKClientConstructorV2,
     SDKClientConstructorV3,
+    Runtime,
 } from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import { HttpResponse } from 'aws-sdk'
@@ -47,6 +48,7 @@ const payloadFileName = 'C:\\test.zip'
 describe('Test Transform handler ', () => {
     let client: StubbedInstance<CodeWhispererServiceToken>
     let workspace: StubbedInstance<Workspace>
+    let runtime: StubbedInstance<Runtime>
     let transformHandler: TransformHandler
     const mockedLogging = stubInterface<Logging>()
     const awsQRegion: string = DEFAULT_AWS_Q_REGION
@@ -55,7 +57,8 @@ describe('Test Transform handler ', () => {
         // Set up the server with a mock service
         client = stubInterface<CodeWhispererServiceToken>()
         workspace = stubInterface<Workspace>()
-        transformHandler = new TransformHandler(client, workspace, mockedLogging)
+        runtime = stubInterface<Runtime>()
+        transformHandler = new TransformHandler(client, workspace, mockedLogging, runtime)
     })
 
     describe('test upload artifact', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -1,5 +1,5 @@
 import { CodeWhispererStreaming, ExportIntent } from '@amzn/codewhisperer-streaming'
-import { Logging, Workspace } from '@aws/language-server-runtimes/server-interface'
+import { Logging, Runtime, Workspace } from '@aws/language-server-runtimes/server-interface'
 import * as fs from 'fs'
 import got from 'got'
 import { v4 as uuidv4 } from 'uuid'
@@ -41,10 +41,12 @@ export class TransformHandler {
     private client: CodeWhispererServiceToken
     private workspace: Workspace
     private logging: Logging
-    constructor(client: CodeWhispererServiceToken, workspace: Workspace, logging: Logging) {
+    private runtime: Runtime
+    constructor(client: CodeWhispererServiceToken, workspace: Workspace, logging: Logging, runtime: Runtime) {
         this.client = client
         this.workspace = workspace
         this.logging = logging
+        this.runtime = runtime
     }
 
     async startTransformation(userInputrequest: StartTransformRequest): Promise<StartTransformResponse> {
@@ -98,7 +100,10 @@ export class TransformHandler {
             this.logging.log(errorMessage)
             throw new Error(errorMessage)
         } finally {
-            artifactManager.cleanup()
+            const env = this.runtime.getConfiguration('RUNENV') ?? ""
+            if (env.toUpperCase() != "TEST") {
+                artifactManager.cleanup()
+            }
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -63,167 +63,167 @@ export const QNetTransformServerToken =
             sdkInitializator: SDKInitializator
         ) => CodeWhispererServiceToken
     ): Server =>
-    ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime, sdkInitializator }) => {
-        const codewhispererclient = service(
-            credentialsProvider,
-            workspace,
-            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
-            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
-            sdkInitializator
-        )
-        const transformHandler = new TransformHandler(codewhispererclient, workspace, logging)
-        const runTransformCommand = async (params: ExecuteCommandParams, _token: CancellationToken) => {
-            try {
-                switch (params.command) {
-                    case StartTransformCommand: {
-                        const request = params as StartTransformRequest
-                        const response = await transformHandler.startTransformation(request)
-                        emitTransformationJobStartedTelemetry(telemetry, response)
-                        return response
-                    }
-                    case GetTransformCommand: {
-                        const request = params as GetTransformRequest
-                        const response = await transformHandler.getTransformation(request)
-                        if (response != null) {
-                            emitTransformationJobReceivedTelemetry(telemetry, response)
+        ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime, sdkInitializator }) => {
+            const codewhispererclient = service(
+                credentialsProvider,
+                workspace,
+                runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
+                runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
+                sdkInitializator
+            )
+            const transformHandler = new TransformHandler(codewhispererclient, workspace, logging, runtime)
+            const runTransformCommand = async (params: ExecuteCommandParams, _token: CancellationToken) => {
+                try {
+                    switch (params.command) {
+                        case StartTransformCommand: {
+                            const request = params as StartTransformRequest
+                            const response = await transformHandler.startTransformation(request)
+                            emitTransformationJobStartedTelemetry(telemetry, response)
+                            return response
                         }
-                        return response
-                    }
-                    case PollTransformCommand: {
-                        const request = params as GetTransformRequest
-                        const response = await transformHandler.pollTransformation(
-                            request,
-                            validStatesForComplete,
-                            failureStates
-                        )
-                        emitTransformationJobPolledTelemetry(telemetry, response)
-                        return response
-                    }
-                    case PollTransformForPlanCommand: {
-                        const request = params as GetTransformRequest
-                        const response = await transformHandler.pollTransformation(
-                            request,
-                            validStatesForGettingPlan,
-                            failureStates
-                        )
-                        emitTransformationJobPolledForPlanTelemetry(telemetry, response)
-                        return response
-                    }
-                    case GetTransformPlanCommand: {
-                        const request = params as GetTransformPlanRequest
-                        const response = await transformHandler.getTransformationPlan(request)
-                        emitTransformationPlanReceivedTelemetry(telemetry, response, request.TransformationJobId)
-                        return response
-                    }
-                    case CancelTransformCommand: {
-                        const request = params as CancelTransformRequest
-                        const response = await transformHandler.cancelTransformation(request)
-                        emitTransformationJobCancelledTelemetry(telemetry, response, request.TransformationJobId)
-                        return response
-                    }
-                    case DownloadArtifactsCommand: {
-                        const request = params as DownloadArtifactsRequest
-                        const cwStreamingClientInstance = new StreamingClient()
-                        const cwStreamingClient = await cwStreamingClientInstance.getStreamingClient(
-                            credentialsProvider,
-                            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
-                            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
-                            sdkInitializator,
-                            customCWClientConfig
-                        )
+                        case GetTransformCommand: {
+                            const request = params as GetTransformRequest
+                            const response = await transformHandler.getTransformation(request)
+                            if (response != null) {
+                                emitTransformationJobReceivedTelemetry(telemetry, response)
+                            }
+                            return response
+                        }
+                        case PollTransformCommand: {
+                            const request = params as GetTransformRequest
+                            const response = await transformHandler.pollTransformation(
+                                request,
+                                validStatesForComplete,
+                                failureStates
+                            )
+                            emitTransformationJobPolledTelemetry(telemetry, response)
+                            return response
+                        }
+                        case PollTransformForPlanCommand: {
+                            const request = params as GetTransformRequest
+                            const response = await transformHandler.pollTransformation(
+                                request,
+                                validStatesForGettingPlan,
+                                failureStates
+                            )
+                            emitTransformationJobPolledForPlanTelemetry(telemetry, response)
+                            return response
+                        }
+                        case GetTransformPlanCommand: {
+                            const request = params as GetTransformPlanRequest
+                            const response = await transformHandler.getTransformationPlan(request)
+                            emitTransformationPlanReceivedTelemetry(telemetry, response, request.TransformationJobId)
+                            return response
+                        }
+                        case CancelTransformCommand: {
+                            const request = params as CancelTransformRequest
+                            const response = await transformHandler.cancelTransformation(request)
+                            emitTransformationJobCancelledTelemetry(telemetry, response, request.TransformationJobId)
+                            return response
+                        }
+                        case DownloadArtifactsCommand: {
+                            const request = params as DownloadArtifactsRequest
+                            const cwStreamingClientInstance = new StreamingClient()
+                            const cwStreamingClient = await cwStreamingClientInstance.getStreamingClient(
+                                credentialsProvider,
+                                runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
+                                runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
+                                sdkInitializator,
+                                customCWClientConfig
+                            )
 
-                        const response = await transformHandler.downloadExportResultArchive(
-                            cwStreamingClient,
-                            request.TransformationJobId,
-                            request.SolutionRootPath
-                        )
-                        emitTransformationJobArtifactsDownloadedTelemetry(
-                            telemetry,
-                            response,
-                            request.TransformationJobId
-                        )
-                        return response
+                            const response = await transformHandler.downloadExportResultArchive(
+                                cwStreamingClient,
+                                request.TransformationJobId,
+                                request.SolutionRootPath
+                            )
+                            emitTransformationJobArtifactsDownloadedTelemetry(
+                                telemetry,
+                                response,
+                                request.TransformationJobId
+                            )
+                            return response
+                        }
                     }
-                }
-                return
-            } catch (e: any) {
-                logging.log('Server side error while executing transformer Command ' + e)
+                    return
+                } catch (e: any) {
+                    logging.log('Server side error while executing transformer Command ' + e)
 
-                switch (params.command) {
-                    case StartTransformCommand: {
-                        const request = params as StartTransformRequest
-                        emitTransformationJobStartedFailure(telemetry, request, e)
-                        break
-                    }
-                    case GetTransformCommand: {
-                        const request = params as GetTransformRequest
-                        emitTransformationJobReceivedFailure(telemetry, request, e)
-                        break
-                    }
-                    case PollTransformCommand: {
-                        const request = params as GetTransformRequest
-                        emitTransformationJobPolledFailure(telemetry, request, e)
-                        break
-                    }
-                    case PollTransformForPlanCommand: {
-                        const request = params as GetTransformRequest
-                        emitTransformationJobPolledForPlanFailure(telemetry, request, e)
-                        break
-                    }
-                    case GetTransformPlanCommand: {
-                        const request = params as GetTransformPlanRequest
-                        emitTransformationPlanReceivedFailure(telemetry, request, e)
-                        break
-                    }
-                    case CancelTransformCommand: {
-                        const request = params as CancelTransformRequest
-                        emitTransformationJobCancelledFailure(telemetry, request, e)
-                        break
-                    }
-                    case DownloadArtifactsCommand: {
-                        const request = params as DownloadArtifactsRequest
-                        emitTransformationJobArtifactsDownloadedFailure(telemetry, request, e)
-                        break
+                    switch (params.command) {
+                        case StartTransformCommand: {
+                            const request = params as StartTransformRequest
+                            emitTransformationJobStartedFailure(telemetry, request, e)
+                            break
+                        }
+                        case GetTransformCommand: {
+                            const request = params as GetTransformRequest
+                            emitTransformationJobReceivedFailure(telemetry, request, e)
+                            break
+                        }
+                        case PollTransformCommand: {
+                            const request = params as GetTransformRequest
+                            emitTransformationJobPolledFailure(telemetry, request, e)
+                            break
+                        }
+                        case PollTransformForPlanCommand: {
+                            const request = params as GetTransformRequest
+                            emitTransformationJobPolledForPlanFailure(telemetry, request, e)
+                            break
+                        }
+                        case GetTransformPlanCommand: {
+                            const request = params as GetTransformPlanRequest
+                            emitTransformationPlanReceivedFailure(telemetry, request, e)
+                            break
+                        }
+                        case CancelTransformCommand: {
+                            const request = params as CancelTransformRequest
+                            emitTransformationJobCancelledFailure(telemetry, request, e)
+                            break
+                        }
+                        case DownloadArtifactsCommand: {
+                            const request = params as DownloadArtifactsRequest
+                            emitTransformationJobArtifactsDownloadedFailure(telemetry, request, e)
+                            break
+                        }
                     }
                 }
             }
-        }
 
-        const onExecuteCommandHandler = async (
-            params: ExecuteCommandParams,
-            _token: CancellationToken
-        ): Promise<any> => {
-            logging.log(params.command)
-            return runTransformCommand(params, _token)
-        }
+            const onExecuteCommandHandler = async (
+                params: ExecuteCommandParams,
+                _token: CancellationToken
+            ): Promise<any> => {
+                logging.log(params.command)
+                return runTransformCommand(params, _token)
+            }
 
-        const customCWClientConfig: CodeWhispererStreamingClientConfig = {}
-        const onInitializeHandler = (params: InitializeParams) => {
-            // Cache user agent to reuse between commands calls
-            customCWClientConfig.customUserAgent = getUserAgent(params, runtime.serverInfo)
+            const customCWClientConfig: CodeWhispererStreamingClientConfig = {}
+            const onInitializeHandler = (params: InitializeParams) => {
+                // Cache user agent to reuse between commands calls
+                customCWClientConfig.customUserAgent = getUserAgent(params, runtime.serverInfo)
 
-            codewhispererclient.updateClientConfig({
-                customUserAgent: customCWClientConfig.customUserAgent,
-            })
+                codewhispererclient.updateClientConfig({
+                    customUserAgent: customCWClientConfig.customUserAgent,
+                })
 
-            return {
-                capabilities: {
-                    executeCommandProvider: {
-                        commands: [
-                            StartTransformCommand,
-                            GetTransformCommand,
-                            PollTransformCommand,
-                            PollTransformForPlanCommand,
-                            GetTransformPlanCommand,
-                            CancelTransformCommand,
-                            DownloadArtifactsCommand,
-                        ],
+                return {
+                    capabilities: {
+                        executeCommandProvider: {
+                            commands: [
+                                StartTransformCommand,
+                                GetTransformCommand,
+                                PollTransformCommand,
+                                PollTransformForPlanCommand,
+                                GetTransformPlanCommand,
+                                CancelTransformCommand,
+                                DownloadArtifactsCommand,
+                            ],
+                        },
                     },
-                },
+                }
             }
-        }
-        lsp.addInitializer(onInitializeHandler)
-        lsp.onExecuteCommand(onExecuteCommandHandler)
+            lsp.addInitializer(onInitializeHandler)
+            lsp.onExecuteCommand(onExecuteCommandHandler)
 
-        return () => {}
-    }
+            return () => {}
+        }


### PR DESCRIPTION
## Problem 
Needed a flag in LSP to disable artifact cleanup() wile running integration test

## Solution
Have introduced a check on flag RUNENV .When set to value TEST , the artifact cleanup will be skipped.


