### PR TITLE
feat(chat-client): handle 'openTab' requests

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -10,7 +10,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1"
     },

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.34"
+        "@aws/language-server-runtimes": "^0.2.40"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -28,6 +28,8 @@ import {
     InfoLinkClickParams,
     LINK_CLICK_NOTIFICATION_METHOD,
     LinkClickParams,
+    OPEN_TAB_REQUEST_METHOD,
+    OpenTabResult,
     QUICK_ACTION_REQUEST_METHOD,
     QuickActionParams,
     READY_NOTIFICATION_METHOD,
@@ -75,6 +77,9 @@ export const createChat = (
         switch (message?.command) {
             case CHAT_REQUEST_METHOD:
                 mynahApi.addChatResponse(message.params, message.tabId, message.isPartialResult)
+                break
+            case OPEN_TAB_REQUEST_METHOD:
+                mynahApi.openTab(message.tabId)
                 break
             case SEND_TO_PROMPT:
                 mynahApi.sendToPrompt((message as SendToPromptMessage).params)
@@ -160,6 +165,9 @@ export const createChat = (
         },
         disclaimerAcknowledged: () => {
             sendMessageToClient({ command: DISCLAIMER_ACKNOWLEDGED })
+        },
+        onOpenTab: (result: OpenTabResult) => {
+            sendMessageToClient({ command: OPEN_TAB_REQUEST_METHOD, params: result })
         },
     }
 

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -17,6 +17,7 @@ import {
     FollowUpClickParams,
     InfoLinkClickParams,
     LinkClickParams,
+    OpenTabResult,
     QuickActionParams,
     SourceLinkClickParams,
     TabAddParams,
@@ -58,6 +59,7 @@ export interface OutboundChatApi {
     infoLinkClick(params: InfoLinkClickParams): void
     uiReady(): void
     disclaimerAcknowledged(): void
+    onOpenTab(result: OpenTabResult): void
 }
 
 export class Messager {
@@ -151,5 +153,9 @@ export class Messager {
 
     onError = (params: ErrorParams): void => {
         this.chatApi.telemetry({ ...params, name: ERROR_MESSAGE_TELEMETRY_EVENT })
+    }
+
+    onOpenTab = (tabId: string): void => {
+        this.chatApi.onOpenTab({ tabId })
     }
 }

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -19,6 +19,8 @@ describe('MynahUI', () => {
     let addChatItemSpy: sinon.SinonSpy
     let onChatPromptSpy: sinon.SinonSpy
     let onQuickActionSpy: sinon.SinonSpy
+    let onOpenTabSpy: sinon.SinonSpy
+    let selectTabSpy: sinon.SinonSpy
 
     beforeEach(() => {
         outboundChatApi = {
@@ -38,11 +40,13 @@ describe('MynahUI', () => {
             infoLinkClick: sinon.stub(),
             uiReady: sinon.stub(),
             disclaimerAcknowledged: sinon.stub(),
+            onOpenTab: sinon.stub(),
         }
 
         messager = new Messager(outboundChatApi)
         onChatPromptSpy = sinon.spy(messager, 'onChatPrompt')
         onQuickActionSpy = sinon.spy(messager, 'onQuickActionCommand')
+        onOpenTabSpy = sinon.spy(messager, 'onOpenTab')
 
         const tabFactory = new TabFactory({})
         createTabStub = sinon.stub(tabFactory, 'createTab')
@@ -54,6 +58,7 @@ describe('MynahUI', () => {
         getAllTabsStub = sinon.stub(mynahUi, 'getAllTabs').returns({})
         updateStoreSpy = sinon.spy(mynahUi, 'updateStore')
         addChatItemSpy = sinon.spy(mynahUi, 'addChatItem')
+        selectTabSpy = sinon.spy(mynahUi, 'selectTab')
     })
 
     afterEach(() => {
@@ -104,6 +109,44 @@ describe('MynahUI', () => {
             })
             assert.calledOnce(updateStoreSpy)
             assert.calledWith(updateStoreSpy, tabId, { loadingChat: true, promptInputDisabledState: true })
+        })
+    })
+
+    describe('openTab', () => {
+        it('should create a new tab if tabId not passed', () => {
+            createTabStub.resetHistory()
+
+            inboundChatApi.openTab()
+
+            sinon.assert.calledOnceWithExactly(createTabStub, false, false)
+            sinon.assert.notCalled(selectTabSpy)
+            sinon.assert.calledOnce(onOpenTabSpy)
+        })
+
+        it('should open existing tab if tabId passed and tabId not selected', () => {
+            createTabStub.resetHistory()
+
+            getSelectedTabIdStub.returns('1')
+            const tabId = '2'
+
+            inboundChatApi.openTab(tabId)
+
+            sinon.assert.notCalled(createTabStub)
+            sinon.assert.calledOnceWithExactly(selectTabSpy, tabId)
+            sinon.assert.calledOnceWithExactly(onOpenTabSpy, tabId)
+        })
+
+        it('should not open existing tab if tabId passed but tabId already selected', () => {
+            createTabStub.resetHistory()
+
+            const tabId = '1'
+            getSelectedTabIdStub.returns(tabId)
+
+            inboundChatApi.openTab(tabId)
+
+            sinon.assert.notCalled(createTabStub)
+            sinon.assert.notCalled(selectTabSpy)
+            sinon.assert.calledOnceWithExactly(onOpenTabSpy, tabId)
         })
     })
 

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -118,7 +118,7 @@ describe('MynahUI', () => {
 
             inboundChatApi.openTab()
 
-            sinon.assert.calledOnceWithExactly(createTabStub, false, false)
+            sinon.assert.calledOnceWithExactly(createTabStub, true, false)
             sinon.assert.notCalled(selectTabSpy)
             sinon.assert.calledOnce(onOpenTabSpy)
         })

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -278,8 +278,8 @@ export const createMynahUi = (
         return tabId ? mynahUi.getAllTabs()[tabId]?.store : undefined
     }
 
-    const createTabId = () => {
-        const tabId = mynahUi.updateStore('', tabFactory.createTab(false, disclaimerCardActive))
+    const createTabId = (needWelcomeMessages: boolean = false) => {
+        const tabId = mynahUi.updateStore('', tabFactory.createTab(needWelcomeMessages, disclaimerCardActive))
         if (tabId === undefined) {
             mynahUi.notify({
                 content: uiComponentsTexts.noMoreTabsTooltip,
@@ -405,7 +405,7 @@ ${params.message}`,
             mynahUi.selectTab(tabId)
         }
         if (!tabId) {
-            tabId = createTabId()
+            tabId = createTabId(true)
         }
 
         if (tabId) {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -31,6 +31,7 @@ export interface InboundChatApi {
     sendToPrompt(params: SendToPromptParams): void
     sendGenericCommand(params: GenericCommandParams): void
     showError(params: ErrorParams): void
+    openTab(tabId?: string): void
 }
 
 export const handleChatPrompt = (
@@ -399,11 +400,25 @@ ${params.message}`,
         messager.onError(params)
     }
 
+    const openTab = (tabId?: string) => {
+        if (tabId && tabId !== mynahUi.getSelectedTabId()) {
+            mynahUi.selectTab(tabId)
+        }
+        if (!tabId) {
+            tabId = createTabId()
+        }
+
+        if (tabId) {
+            messager.onOpenTab(tabId)
+        }
+    }
+
     const api = {
         addChatResponse: addChatResponse,
         sendToPrompt: sendToPrompt,
         sendGenericCommand: sendGenericCommand,
         showError: showError,
+        openTab: openTab,
     }
 
     return [mynahUi, api]

--- a/chat-client/src/contracts/serverContracts.ts
+++ b/chat-client/src/contracts/serverContracts.ts
@@ -19,6 +19,8 @@ import {
     SOURCE_LINK_CLICK_NOTIFICATION_METHOD,
     INFO_LINK_CLICK_NOTIFICATION_METHOD,
     QUICK_ACTION_REQUEST_METHOD,
+    OpenTabResult,
+    OPEN_TAB_REQUEST_METHOD,
 } from '@aws/language-server-runtimes-types'
 
 export const TELEMETRY = 'telemetry/event'
@@ -36,6 +38,7 @@ export type ServerMessageCommand =
     | typeof SOURCE_LINK_CLICK_NOTIFICATION_METHOD
     | typeof INFO_LINK_CLICK_NOTIFICATION_METHOD
     | typeof QUICK_ACTION_REQUEST_METHOD
+    | typeof OPEN_TAB_REQUEST_METHOD
 
 export interface Message {
     command: ServerMessageCommand
@@ -61,3 +64,4 @@ export type ServerMessageParams =
     | InfoLinkClickParams
     | SourceLinkClickParams
     | FollowUpClickParams
+    | OpenTabResult

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -78,6 +78,11 @@
                 "category": "Test Amazon Q Extension"
             },
             {
+                "command": "aws.sample-vscode-ext-amazonq.openTab",
+                "title": "Open tab",
+                "category": "Test Amazon Q Extension"
+            },
+            {
                 "command": "aws.sample-vscode-ext-amazonq.invokeInlineCompletion",
                 "title": "Manual trigger inline code completions",
                 "category": "Test Amazon Q Extension"

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -270,7 +270,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.0",
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.96.0",
         "jose": "^5.2.4",

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -154,6 +154,13 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri, 
             params: { selection: selection, triggerType },
         })
     })
+
+    commands.registerCommand('aws.sample-vscode-ext-amazonq.openTab', data => {
+        panel.webview.postMessage({
+            command: 'aws/chat/openTab',
+            params: {},
+        })
+    })
 }
 
 function getWebviewContent(webView: Webview, extensionUri: Uri) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -77,7 +77,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1"
             },
@@ -92,7 +92,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -100,7 +100,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -120,7 +120,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -152,7 +152,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -172,7 +172,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -194,7 +194,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.34"
+                "@aws/language-server-runtimes": "^0.2.40"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -238,7 +238,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.0",
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.96.0",
                 "jose": "^5.2.4",
@@ -6439,15 +6439,15 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.38",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.38.tgz",
-            "integrity": "sha512-671Tno3sKEpseAXsBLSHohBuCKACx6tqbVu0TARcUspfHav5Sa7/EbnJpq33ncU3wMV4DV8kEznVgTpotOM9/g==",
+            "version": "0.2.40",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.40.tgz",
+            "integrity": "sha512-dQfvfxeqZgsvCrPWG05ERbna8HQuWQkuCCIusg8htJ+DN9bvOVdxzcLWAzSNZompyZuThDpKGdzPj6G/zNPtIw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.9.1",
                 "@aws-crypto/sha256-js": "^5.2.0",
                 "@aws-sdk/client-cognito-identity": "^3.734.0",
-                "@aws/language-server-runtimes-types": "^0.1.2",
+                "@aws/language-server-runtimes-types": "^0.1.3",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
                 "@opentelemetry/resources": "^1.30.1",
@@ -6474,9 +6474,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.2.tgz",
-            "integrity": "sha512-GjXOCY9M7QB2scsR/9eJPRzUEUmQHBpq3dsLkyG33PO44CTjUFntKCr9ggsOrU7LF0XA824pARKdkT9SwD83lw==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.3.tgz",
+            "integrity": "sha512-r062ejJxghQKj657eR6LwtleS5wypNSG4ancdcEBG6vgPulSIgkNO8H2TBEQO5cUcir1tPAhUvZwLPmCxp2nYQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -25386,7 +25386,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-core": "^0.0.1"
             },
             "devDependencies": {
@@ -25457,7 +25457,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.0",
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
@@ -25577,7 +25577,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-core": "^0.0.1",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -25652,7 +25652,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -25666,7 +25666,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-core": "0.0.1",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -25695,7 +25695,7 @@
             "version": "0.0.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -25728,7 +25728,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-core": "^0.0.1",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -25742,7 +25742,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -25753,7 +25753,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.40",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-core": "^0.0.1"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -30,7 +30,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.0",
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -147,6 +147,7 @@ describe('ChatController', () => {
                     startUrl: undefined,
                 },
             }),
+            getConnectionType: sinon.stub().returns('none'),
         }
 
         const mockWorkspace = {} as unknown as Workspace

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -4,6 +4,8 @@ import {
     ErrorCodes,
     FeedbackParams,
     InsertToCursorPositionParams,
+    OpenTabParams,
+    OpenTabResult,
     TextDocumentEdit,
     TextEdit,
     chatRequestType,
@@ -42,7 +44,7 @@ import { Q_CONFIGURATION_SECTION } from '../configuration/qConfigurationServer'
 import { undefinedIfEmpty } from '../utilities/textUtils'
 import { TelemetryService } from '../telemetryService'
 
-type ChatHandlers = LspHandlers<Chat>
+type ChatHandlers = Omit<LspHandlers<Chat>, 'openTab'>
 
 export class ChatController implements ChatHandlers {
     #features: Features

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
@@ -34,6 +34,7 @@ describe('ChatSessionManagementService', () => {
             hasCredentials: sinon.stub().returns(true),
             getCredentials: sinon.stub().returns(Promise.resolve({ token: 'mockToken' })),
             getConnectionMetadata: sinon.stub(),
+            getConnectionType: sinon.stub(),
         }
 
         const mockSessionId2 = 'mockSessionId2'

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
@@ -24,6 +24,7 @@ describe('Chat Session Service', () => {
         hasCredentials: sinon.stub().returns(true),
         getCredentials: sinon.stub().returns(Promise.resolve({ token: 'mockToken ' })),
         getConnectionMetadata: sinon.stub(),
+        getConnectionType: sinon.stub(),
     }
     const awsQRegion: string = DEFAULT_AWS_Q_REGION
     const awsQEndpointUrl: string = DEFAULT_AWS_Q_ENDPOINT_URL

--- a/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetryService.test.ts
@@ -11,6 +11,7 @@ import {
     SDKInitializator,
     SDKClientConstructorV2,
     SDKClientConstructorV3,
+    SsoConnectionType,
 } from '@aws/language-server-runtimes/server-interface'
 import { UserContext, OptOutPreference } from '../client/token/codewhispererbearertokenclient'
 import { CodeWhispererSession } from './session/sessionManager'
@@ -24,6 +25,7 @@ class MockCredentialsProvider implements CredentialsProvider {
     private mockIamCredentials: IamCredentials | undefined
     private mockBearerCredentials: BearerCredentials | undefined
     private mockConnectionMetadata: ConnectionMetadata | undefined
+    private mockConnectionType: SsoConnectionType | undefined
 
     hasCredentials(type: CredentialsType): boolean {
         if (type === 'iam') {
@@ -47,8 +49,16 @@ class MockCredentialsProvider implements CredentialsProvider {
         return this.mockConnectionMetadata
     }
 
+    getConnectionType(): SsoConnectionType {
+        return this.mockConnectionType ?? 'none'
+    }
+
     setConnectionMetadata(metadata: ConnectionMetadata | undefined) {
         this.mockConnectionMetadata = metadata
+    }
+
+    setConnectionType(connectionType: SsoConnectionType | undefined) {
+        this.mockConnectionType = connectionType
     }
 }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.test.ts
@@ -12,39 +12,27 @@ import { BUILDER_ID_START_URL } from './constants'
 
 describe('getBearerTokenFromProvider', () => {
     const mockToken = 'mockToken'
+    const mockCredsProvider: CredentialsProvider = {
+        hasCredentials: sinon.stub().returns(true),
+        getCredentials: sinon.stub().returns({ token: mockToken }),
+        getConnectionMetadata: sinon.stub(),
+        getConnectionType: sinon.stub(),
+    }
     it('returns the bearer token from the provider', () => {
-        const mockCredentialsProvider: CredentialsProvider = {
-            hasCredentials: sinon.stub().returns(true),
-            getCredentials: sinon.stub().returns({ token: mockToken }),
-            getConnectionMetadata: sinon.stub(),
-        }
-
-        assert.strictEqual(getBearerTokenFromProvider(mockCredentialsProvider), mockToken)
+        assert.strictEqual(getBearerTokenFromProvider(mockCredsProvider), mockToken)
     })
 
     it('throws an error if the credentials does not contain bearer credentials', () => {
-        const mockCredentialsProvider: CredentialsProvider = {
-            hasCredentials: sinon.stub().returns(false),
-            getCredentials: sinon.stub().returns({ token: mockToken }),
-            getConnectionMetadata: sinon.stub(),
-        }
-
         assert.throws(
-            () => getBearerTokenFromProvider(mockCredentialsProvider),
+            () => getBearerTokenFromProvider(mockCredsProvider),
             Error,
             'credentialsProvider does not have bearer token credentials'
         )
     })
 
     it('throws an error if token is empty in bearer token', () => {
-        const mockCredentialsProvider: CredentialsProvider = {
-            hasCredentials: sinon.stub().returns(true),
-            getCredentials: sinon.stub().returns({ token: '' }),
-            getConnectionMetadata: sinon.stub(),
-        }
-
         assert.throws(
-            () => getBearerTokenFromProvider(mockCredentialsProvider),
+            () => getBearerTokenFromProvider(mockCredsProvider),
             Error,
             'credentialsProvider does not have bearer token credentials'
         )
@@ -52,6 +40,13 @@ describe('getBearerTokenFromProvider', () => {
 })
 
 describe('getSsoConnectionType', () => {
+    const mockToken = 'mockToken'
+    const mockCredsProvider: CredentialsProvider = {
+        hasCredentials: sinon.stub().returns(true),
+        getCredentials: sinon.stub().returns({ token: mockToken }),
+        getConnectionMetadata: sinon.stub(),
+        getConnectionType: sinon.stub(),
+    }
     it('should return ssoConnectionType as builderId', () => {
         const mockCredentialsProvider: CredentialsProvider = {
             hasCredentials: sinon.stub().returns(true),
@@ -61,6 +56,7 @@ describe('getSsoConnectionType', () => {
                     startUrl: BUILDER_ID_START_URL,
                 },
             }),
+            getConnectionType: sinon.stub(),
         }
         const ssoConnectionType = getSsoConnectionType(mockCredentialsProvider)
         expect(ssoConnectionType).to.equal('builderId')
@@ -75,18 +71,14 @@ describe('getSsoConnectionType', () => {
                     startUrl: 'idc-url',
                 },
             }),
+            getConnectionType: sinon.stub(),
         }
         const ssoConnectionType = getSsoConnectionType(mockCredentialsProvider)
         expect(ssoConnectionType).to.equal('identityCenter')
     })
 
     it('should return ssoConnectionType as none when getConnectionMetadata returns undefined', () => {
-        const mockCredentialsProvider: CredentialsProvider = {
-            hasCredentials: sinon.stub().returns(true),
-            getCredentials: sinon.stub().returns({ token: 'token' }),
-            getConnectionMetadata: sinon.stub().returns(undefined),
-        }
-        const ssoConnectionType = getSsoConnectionType(mockCredentialsProvider)
+        const ssoConnectionType = getSsoConnectionType(mockCredsProvider)
         expect(ssoConnectionType).to.equal('none')
     })
 
@@ -97,6 +89,7 @@ describe('getSsoConnectionType', () => {
             getConnectionMetadata: sinon.stub().returns({
                 sso: undefined,
             }),
+            getConnectionType: sinon.stub(),
         }
         const ssoConnectionType = getSsoConnectionType(mockCredentialsProvider)
         expect(ssoConnectionType).to.equal('none')
@@ -111,6 +104,7 @@ describe('getSsoConnectionType', () => {
                     startUrl: '',
                 },
             }),
+            getConnectionType: sinon.stub(),
         }
         const ssoConnectionType = getSsoConnectionType(mockCredentialsProvider)
         expect(ssoConnectionType).to.equal('none')
@@ -125,6 +119,7 @@ describe('getSsoConnectionType', () => {
                     startUrl: undefined,
                 },
             }),
+            getConnectionType: sinon.stub(),
         }
         const ssoConnectionType = getSsoConnectionType(mockCredentialsProvider)
         expect(ssoConnectionType).to.equal('none')

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.test.ts
@@ -12,14 +12,14 @@ import { BUILDER_ID_START_URL } from './constants'
 
 describe('getBearerTokenFromProvider', () => {
     const mockToken = 'mockToken'
-    const mockCredsProvider: CredentialsProvider = {
-        hasCredentials: sinon.stub().returns(true),
-        getCredentials: sinon.stub().returns({ token: mockToken }),
-        getConnectionMetadata: sinon.stub(),
-        getConnectionType: sinon.stub(),
-    }
     it('returns the bearer token from the provider', () => {
-        assert.strictEqual(getBearerTokenFromProvider(mockCredsProvider), mockToken)
+        const mockCredentialsProvider: CredentialsProvider = {
+            hasCredentials: sinon.stub().returns(true),
+            getCredentials: sinon.stub().returns({ token: mockToken }),
+            getConnectionMetadata: sinon.stub(),
+            getConnectionType: sinon.stub(),
+        }
+        assert.strictEqual(getBearerTokenFromProvider(mockCredentialsProvider), mockToken)
     })
 
     it('throws an error if the credentials does not contain bearer credentials', () => {
@@ -37,8 +37,14 @@ describe('getBearerTokenFromProvider', () => {
     })
 
     it('throws an error if token is empty in bearer token', () => {
+        const mockCredentialsProvider: CredentialsProvider = {
+            hasCredentials: sinon.stub().returns(true),
+            getCredentials: sinon.stub().returns({ token: '' }),
+            getConnectionMetadata: sinon.stub(),
+            getConnectionType: sinon.stub(),
+        }
         assert.throws(
-            () => getBearerTokenFromProvider(mockCredsProvider),
+            () => getBearerTokenFromProvider(mockCredentialsProvider),
             Error,
             'credentialsProvider does not have bearer token credentials'
         )

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.test.ts
@@ -23,8 +23,14 @@ describe('getBearerTokenFromProvider', () => {
     })
 
     it('throws an error if the credentials does not contain bearer credentials', () => {
+        const mockCredentialsProvider: CredentialsProvider = {
+            hasCredentials: sinon.stub().returns(false),
+            getCredentials: sinon.stub().returns({ token: mockToken }),
+            getConnectionMetadata: sinon.stub(),
+            getConnectionType: sinon.stub(),
+        }
         assert.throws(
-            () => getBearerTokenFromProvider(mockCredsProvider),
+            () => getBearerTokenFromProvider(mockCredentialsProvider),
             Error,
             'credentialsProvider does not have bearer token credentials'
         )

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-core": "^0.0.1",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-core": "0.0.1",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-core": "^0.0.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.40",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem

There is no way to request chat UI to open new or existing tab.

## Solution

The corresponding `openTab` logic was added and tested.
`@aws/language-server-runtimes` was updated to the latest release to contain new protocol.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
