### PR TITLE
chore: adding http keepAlive agent in AWS SDK client

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -17,6 +17,7 @@ import {
     CodeWhispererTokenClientConfigurationOptions,
     createCodeWhispererTokenClient,
 } from '../client/token/codewhisperer'
+import * as https from 'node:https'
 
 // Define our own Suggestion interface to wrap the differences between Token and IAM Client
 export interface Suggestion extends CodeWhispererTokenClient.Completion, CodeWhispererSigv4Client.Recommendation {
@@ -154,6 +155,13 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
                     })
                 },
             ],
+            httpOptions: {
+                agent: new https.Agent({
+                    keepAlive: true,
+                    keepAliveMsecs: 30000, // Keep alive for 30 seconds
+                    maxSockets: 10, // Maximum number of sockets to allow per host
+                }),
+            },
         }
         this.client = createCodeWhispererTokenClient(options, sdkInitializator)
     }


### PR DESCRIPTION
## Problem
Adding http keepalive agent in AWS SDK Client to help in reducing the latency of generateCompletions API.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
