### PR TITLE
chore: update the version of commitlint/cli and commitlint/config-conventional to 19.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
                 "typescript": "^5.5.3"
             },
             "devDependencies": {
-                "@commitlint/cli": "^19.5.0",
-                "@commitlint/config-conventional": "^19.5.0",
+                "@commitlint/cli": "^19.8.0",
+                "@commitlint/config-conventional": "^19.8.0",
                 "@types/node": "^22.9.0",
                 "@typescript-eslint/eslint-plugin": "^8.18.2",
                 "@typescript-eslint/parser": "^8.18.2",
@@ -7098,17 +7098,17 @@
             "license": "MIT"
         },
         "node_modules/@commitlint/cli": {
-            "version": "19.7.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.7.1.tgz",
-            "integrity": "sha512-iObGjR1tE/PfDtDTEfd+tnRkB3/HJzpQqRTyofS2MPPkDn1mp3DBC8SoPDayokfAy+xKhF8+bwRCJO25Nea0YQ==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.0.tgz",
+            "integrity": "sha512-t/fCrLVu+Ru01h0DtlgHZXbHV2Y8gKocTR5elDOqIRUzQd0/6hpt2VIWOj9b3NDo7y4/gfxeR2zRtXq/qO6iUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/format": "^19.5.0",
-                "@commitlint/lint": "^19.7.1",
-                "@commitlint/load": "^19.6.1",
-                "@commitlint/read": "^19.5.0",
-                "@commitlint/types": "^19.5.0",
+                "@commitlint/format": "^19.8.0",
+                "@commitlint/lint": "^19.8.0",
+                "@commitlint/load": "^19.8.0",
+                "@commitlint/read": "^19.8.0",
+                "@commitlint/types": "^19.8.0",
                 "tinyexec": "^0.3.0",
                 "yargs": "^17.0.0"
             },
@@ -7120,13 +7120,13 @@
             }
         },
         "node_modules/@commitlint/config-conventional": {
-            "version": "19.7.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.7.1.tgz",
-            "integrity": "sha512-fsEIF8zgiI/FIWSnykdQNj/0JE4av08MudLTyYHm4FlLWemKoQvPNUYU2M/3tktWcCEyq7aOkDDgtjrmgWFbvg==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.0.tgz",
+            "integrity": "sha512-9I2kKJwcAPwMoAj38hwqFXG0CzS2Kj+SAByPUQ0SlHTfb7VUhYVmo7G2w2tBrqmOf7PFd6MpZ/a1GQJo8na8kw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.5.0",
+                "@commitlint/types": "^19.8.0",
                 "conventional-changelog-conventionalcommits": "^7.0.2"
             },
             "engines": {
@@ -7147,13 +7147,13 @@
             }
         },
         "node_modules/@commitlint/config-validator": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.5.0.tgz",
-            "integrity": "sha512-CHtj92H5rdhKt17RmgALhfQt95VayrUo2tSqY9g2w+laAXyk7K/Ef6uPm9tn5qSIwSmrLjKaXK9eiNuxmQrDBw==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.0.tgz",
+            "integrity": "sha512-+r5ZvD/0hQC3w5VOHJhGcCooiAVdynFlCe2d6I9dU+PvXdV3O+fU4vipVg+6hyLbQUuCH82mz3HnT/cBQTYYuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.5.0",
+                "@commitlint/types": "^19.8.0",
                 "ajv": "^8.11.0"
             },
             "engines": {
@@ -7161,13 +7161,13 @@
             }
         },
         "node_modules/@commitlint/ensure": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.5.0.tgz",
-            "integrity": "sha512-Kv0pYZeMrdg48bHFEU5KKcccRfKmISSm9MvgIgkpI6m+ohFTB55qZlBW6eYqh/XDfRuIO0x4zSmvBjmOwWTwkg==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.0.tgz",
+            "integrity": "sha512-kNiNU4/bhEQ/wutI1tp1pVW1mQ0QbAjfPRo5v8SaxoVV+ARhkB8Wjg3BSseNYECPzWWfg/WDqQGIfV1RaBFQZg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.5.0",
+                "@commitlint/types": "^19.8.0",
                 "lodash.camelcase": "^4.3.0",
                 "lodash.kebabcase": "^4.1.1",
                 "lodash.snakecase": "^4.1.1",
@@ -7179,9 +7179,9 @@
             }
         },
         "node_modules/@commitlint/execute-rule": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.5.0.tgz",
-            "integrity": "sha512-aqyGgytXhl2ejlk+/rfgtwpPexYyri4t8/n4ku6rRJoRhGZpLFMqrZ+YaubeGysCP6oz4mMA34YSTaSOKEeNrg==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.0.tgz",
+            "integrity": "sha512-fuLeI+EZ9x2v/+TXKAjplBJWI9CNrHnyi5nvUQGQt4WRkww/d95oVRsc9ajpt4xFrFmqMZkd/xBQHZDvALIY7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7189,13 +7189,13 @@
             }
         },
         "node_modules/@commitlint/format": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.5.0.tgz",
-            "integrity": "sha512-yNy088miE52stCI3dhG/vvxFo9e4jFkU1Mj3xECfzp/bIS/JUay4491huAlVcffOoMK1cd296q0W92NlER6r3A==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.0.tgz",
+            "integrity": "sha512-EOpA8IERpQstxwp/WGnDArA7S+wlZDeTeKi98WMOvaDLKbjptuHWdOYYr790iO7kTCif/z971PKPI2PkWMfOxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.5.0",
+                "@commitlint/types": "^19.8.0",
                 "chalk": "^5.3.0"
             },
             "engines": {
@@ -7203,13 +7203,13 @@
             }
         },
         "node_modules/@commitlint/is-ignored": {
-            "version": "19.7.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.7.1.tgz",
-            "integrity": "sha512-3IaOc6HVg2hAoGleRK3r9vL9zZ3XY0rf1RsUf6jdQLuaD46ZHnXBiOPTyQ004C4IvYjSWqJwlh0/u2P73aIE3g==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.0.tgz",
+            "integrity": "sha512-L2Jv9yUg/I+jF3zikOV0rdiHUul9X3a/oU5HIXhAJLE2+TXTnEBfqYP9G5yMw/Yb40SnR764g4fyDK6WR2xtpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.5.0",
+                "@commitlint/types": "^19.8.0",
                 "semver": "^7.6.0"
             },
             "engines": {
@@ -7230,32 +7230,32 @@
             }
         },
         "node_modules/@commitlint/lint": {
-            "version": "19.7.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.7.1.tgz",
-            "integrity": "sha512-LhcPfVjcOcOZA7LEuBBeO00o3MeZa+tWrX9Xyl1r9PMd5FWsEoZI9IgnGqTKZ0lZt5pO3ZlstgnRyY1CJJc9Xg==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.0.tgz",
+            "integrity": "sha512-+/NZKyWKSf39FeNpqhfMebmaLa1P90i1Nrb1SrA7oSU5GNN/lksA4z6+ZTnsft01YfhRZSYMbgGsARXvkr/VLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/is-ignored": "^19.7.1",
-                "@commitlint/parse": "^19.5.0",
-                "@commitlint/rules": "^19.6.0",
-                "@commitlint/types": "^19.5.0"
+                "@commitlint/is-ignored": "^19.8.0",
+                "@commitlint/parse": "^19.8.0",
+                "@commitlint/rules": "^19.8.0",
+                "@commitlint/types": "^19.8.0"
             },
             "engines": {
                 "node": ">=v18"
             }
         },
         "node_modules/@commitlint/load": {
-            "version": "19.6.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.6.1.tgz",
-            "integrity": "sha512-kE4mRKWWNju2QpsCWt428XBvUH55OET2N4QKQ0bF85qS/XbsRGG1MiTByDNlEVpEPceMkDr46LNH95DtRwcsfA==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.0.tgz",
+            "integrity": "sha512-4rvmm3ff81Sfb+mcWT5WKlyOa+Hd33WSbirTVUer0wjS1Hv/Hzr07Uv1ULIV9DkimZKNyOwXn593c+h8lsDQPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/config-validator": "^19.5.0",
-                "@commitlint/execute-rule": "^19.5.0",
-                "@commitlint/resolve-extends": "^19.5.0",
-                "@commitlint/types": "^19.5.0",
+                "@commitlint/config-validator": "^19.8.0",
+                "@commitlint/execute-rule": "^19.8.0",
+                "@commitlint/resolve-extends": "^19.8.0",
+                "@commitlint/types": "^19.8.0",
                 "chalk": "^5.3.0",
                 "cosmiconfig": "^9.0.0",
                 "cosmiconfig-typescript-loader": "^6.1.0",
@@ -7268,9 +7268,9 @@
             }
         },
         "node_modules/@commitlint/message": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.5.0.tgz",
-            "integrity": "sha512-R7AM4YnbxN1Joj1tMfCyBryOC5aNJBdxadTZkuqtWi3Xj0kMdutq16XQwuoGbIzL2Pk62TALV1fZDCv36+JhTQ==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.0.tgz",
+            "integrity": "sha512-qs/5Vi9bYjf+ZV40bvdCyBn5DvbuelhR6qewLE8Bh476F7KnNyLfdM/ETJ4cp96WgeeHo6tesA2TMXS0sh5X4A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7278,13 +7278,13 @@
             }
         },
         "node_modules/@commitlint/parse": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.5.0.tgz",
-            "integrity": "sha512-cZ/IxfAlfWYhAQV0TwcbdR1Oc0/r0Ik1GEessDJ3Lbuma/MRO8FRQX76eurcXtmhJC//rj52ZSZuXUg0oIX0Fw==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.0.tgz",
+            "integrity": "sha512-YNIKAc4EXvNeAvyeEnzgvm1VyAe0/b3Wax7pjJSwXuhqIQ1/t2hD3OYRXb6D5/GffIvaX82RbjD+nWtMZCLL7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.5.0",
+                "@commitlint/types": "^19.8.0",
                 "conventional-changelog-angular": "^7.0.0",
                 "conventional-commits-parser": "^5.0.0"
             },
@@ -7293,14 +7293,14 @@
             }
         },
         "node_modules/@commitlint/read": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.5.0.tgz",
-            "integrity": "sha512-TjS3HLPsLsxFPQj6jou8/CZFAmOP2y+6V4PGYt3ihbQKTY1Jnv0QG28WRKl/d1ha6zLODPZqsxLEov52dhR9BQ==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.0.tgz",
+            "integrity": "sha512-6ywxOGYajcxK1y1MfzrOnwsXO6nnErna88gRWEl3qqOOP8MDu/DTeRkGLXBFIZuRZ7mm5yyxU5BmeUvMpNte5w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/top-level": "^19.5.0",
-                "@commitlint/types": "^19.5.0",
+                "@commitlint/top-level": "^19.8.0",
+                "@commitlint/types": "^19.8.0",
                 "git-raw-commits": "^4.0.0",
                 "minimist": "^1.2.8",
                 "tinyexec": "^0.3.0"
@@ -7310,14 +7310,14 @@
             }
         },
         "node_modules/@commitlint/resolve-extends": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.5.0.tgz",
-            "integrity": "sha512-CU/GscZhCUsJwcKTJS9Ndh3AKGZTNFIOoQB2n8CmFnizE0VnEuJoum+COW+C1lNABEeqk6ssfc1Kkalm4bDklA==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.0.tgz",
+            "integrity": "sha512-CLanRQwuG2LPfFVvrkTrBR/L/DMy3+ETsgBqW1OvRxmzp/bbVJW0Xw23LnnExgYcsaFtos967lul1CsbsnJlzQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/config-validator": "^19.5.0",
-                "@commitlint/types": "^19.5.0",
+                "@commitlint/config-validator": "^19.8.0",
+                "@commitlint/types": "^19.8.0",
                 "global-directory": "^4.0.1",
                 "import-meta-resolve": "^4.0.0",
                 "lodash.mergewith": "^4.6.2",
@@ -7328,25 +7328,25 @@
             }
         },
         "node_modules/@commitlint/rules": {
-            "version": "19.6.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.6.0.tgz",
-            "integrity": "sha512-1f2reW7lbrI0X0ozZMesS/WZxgPa4/wi56vFuJENBmed6mWq5KsheN/nxqnl/C23ioxpPO/PL6tXpiiFy5Bhjw==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.0.tgz",
+            "integrity": "sha512-IZ5IE90h6DSWNuNK/cwjABLAKdy8tP8OgGVGbXe1noBEX5hSsu00uRlLu6JuruiXjWJz2dZc+YSw3H0UZyl/mA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/ensure": "^19.5.0",
-                "@commitlint/message": "^19.5.0",
-                "@commitlint/to-lines": "^19.5.0",
-                "@commitlint/types": "^19.5.0"
+                "@commitlint/ensure": "^19.8.0",
+                "@commitlint/message": "^19.8.0",
+                "@commitlint/to-lines": "^19.8.0",
+                "@commitlint/types": "^19.8.0"
             },
             "engines": {
                 "node": ">=v18"
             }
         },
         "node_modules/@commitlint/to-lines": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.5.0.tgz",
-            "integrity": "sha512-R772oj3NHPkodOSRZ9bBVNq224DOxQtNef5Pl8l2M8ZnkkzQfeSTr4uxawV2Sd3ui05dUVzvLNnzenDBO1KBeQ==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.0.tgz",
+            "integrity": "sha512-3CKLUw41Cur8VMjh16y8LcsOaKbmQjAKCWlXx6B0vOUREplp6em9uIVhI8Cv934qiwkbi2+uv+mVZPnXJi1o9A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7354,9 +7354,9 @@
             }
         },
         "node_modules/@commitlint/top-level": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.5.0.tgz",
-            "integrity": "sha512-IP1YLmGAk0yWrImPRRc578I3dDUI5A2UBJx9FbSOjxe9sTlzFiwVJ+zeMLgAtHMtGZsC8LUnzmW1qRemkFU4ng==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.0.tgz",
+            "integrity": "sha512-Rphgoc/omYZisoNkcfaBRPQr4myZEHhLPx2/vTXNLjiCw4RgfPR1wEgUpJ9OOmDCiv5ZyIExhprNLhteqH4FuQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7367,9 +7367,9 @@
             }
         },
         "node_modules/@commitlint/types": {
-            "version": "19.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.5.0.tgz",
-            "integrity": "sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==",
+            "version": "19.8.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.0.tgz",
+            "integrity": "sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -20862,9 +20862,9 @@
             }
         },
         "node_modules/p-locate/node_modules/yocto-queue": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-            "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.0.tgz",
+            "integrity": "sha512-KHBC7z61OJeaMGnF3wqNZj+GGNXOyypZviiKpQeiHirG5Ib1ImwcLBH70rbMSkKfSmUNBsdf2PwaEJtKvgmkNw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
         "typescript": "^5.5.3"
     },
     "devDependencies": {
-        "@commitlint/cli": "^19.5.0",
-        "@commitlint/config-conventional": "^19.5.0",
+        "@commitlint/cli": "^19.8.0",
+        "@commitlint/config-conventional": "^19.8.0",
         "@types/node": "^22.9.0",
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",


### PR DESCRIPTION
manual update the version of commitlint/cli and commitlint/config-conventional to 19.8.0 as dependabot by default open 5 PRs at max and 19.8.0 version is available in language-server-runtimes.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
