### PR TITLE
feat(aws-lsp-codewhisperer-runtimes): add webworker iam bundling

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -12,7 +12,11 @@
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.40",
         "@aws/lsp-codewhisperer": "*",
-        "copyfiles": "^2.4.1"
+        "copyfiles": "^2.4.1",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "^1.0.1",
+        "stream-http": "^3.2.0"
     },
     "devDependencies": {
         "node-loader": "^2.1.0",

--- a/app/aws-lsp-codewhisperer-runtimes/src/iam-webworker.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/src/iam-webworker.ts
@@ -1,0 +1,11 @@
+import { webworker } from '@aws/language-server-runtimes/runtimes/webworker'
+import { RuntimeProps } from '@aws/language-server-runtimes/runtimes/runtime'
+import { CodeWhispererServerIAM } from '@aws/lsp-codewhisperer/out/language-server/codeWhispererServer'
+
+const props: RuntimeProps = {
+    version: '1.0.0',
+    servers: [CodeWhispererServerIAM],
+    name: 'AWS CodeWhisperer',
+}
+
+webworker(props)

--- a/app/aws-lsp-codewhisperer-runtimes/webpack.config.js
+++ b/app/aws-lsp-codewhisperer-runtimes/webpack.config.js
@@ -54,4 +54,40 @@ const nodeJsIamBundleConfig = {
     target: 'node',
 }
 
-module.exports = [nodeJsBearerTokenBundleConfig, nodeJsIamBundleConfig]
+const webworkerIamBundleConfig = {
+    target: 'webworker',
+    mode: 'production',
+    output: {
+        path: path.resolve(__dirname, 'build'),
+        filename: '[name].js',
+    },
+    entry: {
+        worker: './src/iam-webworker.ts',
+    },
+    resolve: {
+        fallback: {
+            path: 'path-browserify',
+            os: 'os-browserify',
+            https: 'https-browserify',
+            http: 'stream-http',
+            process: false,
+        },
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+    },
+    module: {
+        parser: {
+            javascript: {
+                importMeta: false,
+            },
+        },
+        rules: [
+            {
+                test: /\.(ts|tsx)$/,
+                loader: 'ts-loader',
+                exclude: /node_modules/,
+            },
+        ],
+    },
+}
+
+module.exports = [nodeJsBearerTokenBundleConfig, nodeJsIamBundleConfig, webworkerIamBundleConfig]

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,11 @@
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.40",
                 "@aws/lsp-codewhisperer": "*",
-                "copyfiles": "^2.4.1"
+                "copyfiles": "^2.4.1",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
+                "path-browserify": "^1.0.1",
+                "stream-http": "^3.2.0"
             },
             "devDependencies": {
                 "node-loader": "^2.1.0",
@@ -13697,6 +13701,11 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="
+        },
         "node_modules/bundle-name": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -17240,6 +17249,11 @@
             "engines": {
                 "node": ">=10.19.0"
             }
+        },
+        "node_modules/https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="
         },
         "node_modules/https-proxy-agent": {
             "version": "7.0.6",
@@ -20786,6 +20800,11 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A=="
+        },
         "node_modules/own-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -20983,9 +21002,7 @@
         "node_modules/path-browserify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-            "dev": true,
-            "license": "MIT"
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
         },
         "node_modules/path-exists": {
             "version": "5.0.0",
@@ -21764,7 +21781,6 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -23039,6 +23055,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/stream-http": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+            "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+            "dependencies": {
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.6.0",
+                "xtend": "^4.0.2"
             }
         },
         "node_modules/stream-shift": {

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -41,11 +41,10 @@ import { undefinedIfEmpty } from './utilities/textUtils'
 import { TelemetryService } from './telemetryService'
 import { AcceptedSuggestionEntry, CodeDiffTracker } from './telemetry/codeDiffTracker'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../constants'
-import * as https from 'node:https'
 
 const EMPTY_RESULT = { sessionId: '', items: [] }
 export const CONTEXT_CHARACTERS_LIMIT = 10240
-console.log(https.globalAgent.maxSockets)
+
 // Both clients (token, sigv4) define their own types, this return value needs to match both of them.
 const getFileContext = (params: {
     textDocument: TextDocument
@@ -601,9 +600,9 @@ export const CodewhispererServerFactory =
                         `Inline completion configuration updated to use ${codeWhispererService.customizationArn}`
                     )
                     /*
-                                                            The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
-                                                            configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
-                                                         */
+                                                        The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
+                                                        configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
+                                                     */
                     // const enableTelemetryEventsToDestination = true
                     // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
                     const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -41,10 +41,11 @@ import { undefinedIfEmpty } from './utilities/textUtils'
 import { TelemetryService } from './telemetryService'
 import { AcceptedSuggestionEntry, CodeDiffTracker } from './telemetry/codeDiffTracker'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../constants'
+import * as https from 'node:https'
 
 const EMPTY_RESULT = { sessionId: '', items: [] }
 export const CONTEXT_CHARACTERS_LIMIT = 10240
-
+console.log(https.globalAgent.maxSockets)
 // Both clients (token, sigv4) define their own types, this return value needs to match both of them.
 const getFileContext = (params: {
     textDocument: TextDocument
@@ -600,9 +601,9 @@ export const CodewhispererServerFactory =
                         `Inline completion configuration updated to use ${codeWhispererService.customizationArn}`
                     )
                     /*
-                                                        The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
-                                                        configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
-                                                     */
+                                                            The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
+                                                            configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
+                                                         */
                     // const enableTelemetryEventsToDestination = true
                     // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
                     const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'


### PR DESCRIPTION
## Problem
We want to check whether webworker bundling of lsp-codewhisperer iam fails at compile time to prevent breaking it without noticing it. The `package` github action which runs npm run package (which does the bundling) will fail if webworker bundling fails.  

**Note**: The second commit is to prove the failing of the github action, I will revert it before merging.

## Solution
add a new config for webworker iam and add new config in webpack config file

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
