### PR TITLE
feat(amazonq): handle client signalling support for q developer profiles

### DIFF
--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -153,6 +153,9 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
                     clientId: randomUUID(),
                 },
                 awsClientCapabilities: {
+                    q: {
+                        developerProfiles: false,
+                    },
                     window: {
                         notifications: true,
                     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6446,9 +6446,9 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.42",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.42.tgz",
-            "integrity": "sha512-qik2++FLMi0vH1rREJ8q77bwdBKI2LlScfM3HjKYmCMBAsRFedgk25BJQnJie6kvNvhizDn5vTF3Yjay4fOpmg==",
+            "version": "0.2.43",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.43.tgz",
+            "integrity": "sha512-87opLxyZr8N3I4hoUYwYLiIzqW21qEvbajetgVh6N3MzZOaonpw3N34wpcV6FA7ngawB6g5Nu5Ek888/tBRSig==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.9.1",
@@ -26147,7 +26147,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.5",
-                "@aws/language-server-runtimes": "^0.2.40",
+                "@aws/language-server-runtimes": "^0.2.43",
                 "@aws/lsp-core": "^0.0.1",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -30,7 +30,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.5",
-        "@aws/language-server-runtimes": "^0.2.40",
+        "@aws/language-server-runtimes": "^0.2.43",
         "@aws/lsp-core": "^0.0.1",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/qDeveloperProfiles.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/qDeveloperProfiles.ts
@@ -1,5 +1,10 @@
-import { Logging, LSPErrorCodes, ResponseError } from '@aws/language-server-runtimes/server-interface'
-import { SsoConnectionType } from '../utils'
+import {
+    AWSInitializationOptions,
+    Logging,
+    LSPErrorCodes,
+    ResponseError,
+} from '@aws/language-server-runtimes/server-interface'
+import { isBool, isObject, SsoConnectionType } from '../utils'
 import { AWS_Q_ENDPOINTS } from '../../constants'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
 
@@ -94,4 +99,37 @@ async function fetchProfilesFromRegion(
 
         throw error
     }
+}
+
+const AWSQCapabilitiesKey = 'q'
+const developerProfilesEnabledKey = 'developerProfiles'
+
+/**
+ * @returns true if AWSInitializationOptions has the Q developer profiles flag set explicitly to true
+ *
+ * @example
+ * The function expects to receive the following structure:
+ * ```ts
+ * {
+ *  awsClientCapabilities?: {
+ *    q?: {
+ *        developerProfiles?: boolean
+ *    }
+ *  }
+ * }
+ * ```
+ */
+export function signalsAWSQDeveloperProfilesEnabled(initializationOptions: AWSInitializationOptions): boolean {
+    const qCapibilities = initializationOptions.awsClientCapabilities?.[AWSQCapabilitiesKey]
+
+    if (
+        isObject(qCapibilities) &&
+        !(qCapibilities instanceof Array) &&
+        developerProfilesEnabledKey in qCapibilities &&
+        isBool(qCapibilities[developerProfilesEnabledKey])
+    ) {
+        return qCapibilities[developerProfilesEnabledKey]
+    }
+
+    return false
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
@@ -6,110 +6,170 @@ import {
     Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION,
     QConfigurationServerToken,
     ServerConfigurationProvider,
+    signalsAWSQDeveloperProfilesEnabled,
 } from './qConfigurationServer'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
-import { Server } from '@aws/language-server-runtimes/server-interface'
+import { AWSInitializationOptions, Server } from '@aws/language-server-runtimes/server-interface'
 
-describe('QConfigurationServer', () => {
-    describe('OnGetConfigurationFromServer', () => {
-        let testFeatures: TestFeatures
-        let disposeServer: () => void
-        let listAvailableProfilesStub: sinon.SinonStub
-        let listAvailableCustomizationsStub: sinon.SinonStub
+describe('QConfigurationServerToken', () => {
+    let testFeatures: TestFeatures
+    let disposeServer: () => void
+    let listAvailableProfilesStub: sinon.SinonStub
+    let listAvailableCustomizationsStub: sinon.SinonStub
+    let qDeveloperProfilesEnabledPropertyStub: sinon.SinonStub
+    let qDeveloperProfilesEnabledSetterSpy: sinon.SinonSpy
 
-        beforeEach(() => {
-            testFeatures = new TestFeatures()
+    beforeEach(() => {
+        testFeatures = new TestFeatures()
 
-            const codeWhispererService = stubInterface<CodeWhispererServiceToken>()
-            const configurationServerFactory: Server = QConfigurationServerToken(() => codeWhispererService)
+        const codeWhispererService = stubInterface<CodeWhispererServiceToken>()
+        const configurationServerFactory: Server = QConfigurationServerToken(() => codeWhispererService)
 
-            listAvailableCustomizationsStub = sinon.stub(
-                ServerConfigurationProvider.prototype,
-                'listAvailableCustomizations'
-            )
-            listAvailableProfilesStub = sinon.stub(ServerConfigurationProvider.prototype, 'listAvailableProfiles')
+        listAvailableCustomizationsStub = sinon.stub(
+            ServerConfigurationProvider.prototype,
+            'listAvailableCustomizations'
+        )
+        listAvailableProfilesStub = sinon.stub(ServerConfigurationProvider.prototype, 'listAvailableProfiles')
+        qDeveloperProfilesEnabledSetterSpy = sinon.spy()
+        qDeveloperProfilesEnabledPropertyStub = sinon
+            .stub(ServerConfigurationProvider.prototype, 'qDeveloperProfilesEnabled')
+            .set(qDeveloperProfilesEnabledSetterSpy)
 
-            disposeServer = configurationServerFactory(testFeatures)
-        })
-
-        afterEach(() => {
-            sinon.restore()
-        })
-
-        // WIP: temporary test case until client can signal they support developer profiles
-        it(`calls all list methods when ${Q_CONFIGURATION_SECTION} is requested`, () => {
-            testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg({
-                section: Q_CONFIGURATION_SECTION,
-            })
-
-            sinon.assert.calledOnce(listAvailableCustomizationsStub)
-            sinon.assert.calledOnce(listAvailableProfilesStub)
-        })
-
-        it(`only calls listAvailableCustomizations when ${Q_CUSTOMIZATIONS_CONFIGURATION_SECTION} is requested`, () => {
-            testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg({
-                section: Q_CUSTOMIZATIONS_CONFIGURATION_SECTION,
-            })
-
-            sinon.assert.calledOnce(listAvailableCustomizationsStub)
-            sinon.assert.notCalled(listAvailableProfilesStub)
-        })
-
-        it(`only calls listAvailableProfiles when ${Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION} is requested`, () => {
-            testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg({
-                section: Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION,
-            })
-
-            sinon.assert.notCalled(listAvailableCustomizationsStub)
-            sinon.assert.calledOnce(listAvailableProfilesStub)
-        })
+        disposeServer = configurationServerFactory(testFeatures)
     })
 
-    describe('ServerConfigurationProvider', () => {
-        let serverConfigurationProvider: ServerConfigurationProvider
-        let codeWhispererService: StubbedInstance<CodeWhispererServiceToken>
-        let testFeatures: TestFeatures
-        let listAvailableProfilesHandlerSpy: sinon.SinonSpy
+    afterEach(() => {
+        sinon.restore()
+    })
 
-        beforeEach(() => {
-            codeWhispererService = stubInterface<CodeWhispererServiceToken>()
-            codeWhispererService.listAvailableCustomizations.resolves({
-                customizations: [],
-                $response: {} as any,
+    it(`enables Q developer profiles when signalled by client`, () => {
+        const initialize = (developerProfiles: boolean) => {
+            testFeatures.lsp.addInitializer.firstCall.firstArg({
+                initializationOptions: {
+                    aws: {
+                        awsClientCapabilities: {
+                            q: {
+                                developerProfiles,
+                            },
+                        },
+                    },
+                },
             })
+        }
 
-            testFeatures = new TestFeatures()
+        initialize(false)
+        sinon.assert.calledWith(qDeveloperProfilesEnabledSetterSpy.firstCall, false)
 
-            serverConfigurationProvider = new ServerConfigurationProvider(
-                codeWhispererService,
-                testFeatures.credentialsProvider,
-                testFeatures.logging,
-                () => codeWhispererService
-            )
+        initialize(true)
+        sinon.assert.calledWith(qDeveloperProfilesEnabledSetterSpy.secondCall, true)
+    })
 
-            listAvailableProfilesHandlerSpy = sinon.spy(
-                serverConfigurationProvider,
-                'listAllAvailableProfilesHandler' as keyof ServerConfigurationProvider
-            )
+    it(`calls all list methods when ${Q_CONFIGURATION_SECTION} is requested`, () => {
+        testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg({
+            section: Q_CONFIGURATION_SECTION,
         })
 
-        afterEach(() => {
-            sinon.restore()
+        sinon.assert.calledOnce(listAvailableCustomizationsStub)
+        sinon.assert.calledOnce(listAvailableProfilesStub)
+    })
+
+    it(`only calls listAvailableCustomizations when ${Q_CUSTOMIZATIONS_CONFIGURATION_SECTION} is requested`, () => {
+        testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg({
+            section: Q_CUSTOMIZATIONS_CONFIGURATION_SECTION,
         })
 
-        it(`calls corresponding API when listAvailableCustomizations is invoked`, async () => {
-            await serverConfigurationProvider.listAvailableCustomizations()
+        sinon.assert.calledOnce(listAvailableCustomizationsStub)
+        sinon.assert.notCalled(listAvailableProfilesStub)
+    })
 
-            sinon.assert.calledOnce(codeWhispererService.listAvailableCustomizations)
+    it(`only calls listAvailableProfiles when ${Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION} is requested`, () => {
+        testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg({
+            section: Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION,
         })
 
-        // WIP: alter test case when client can signal they support developer profiles
-        it(`does not use corresponding handler when listAvailableProfiles is invoked`, async () => {
-            const result = await serverConfigurationProvider.listAvailableProfiles()
+        sinon.assert.notCalled(listAvailableCustomizationsStub)
+        sinon.assert.calledOnce(listAvailableProfilesStub)
+    })
+})
 
-            sinon.assert.notCalled(listAvailableProfilesHandlerSpy)
-            assert.deepStrictEqual(result, [])
+describe('ServerConfigurationProvider', () => {
+    let serverConfigurationProvider: ServerConfigurationProvider
+    let codeWhispererService: StubbedInstance<CodeWhispererServiceToken>
+    let testFeatures: TestFeatures
+    let listAvailableProfilesHandlerSpy: sinon.SinonSpy
+
+    beforeEach(() => {
+        codeWhispererService = stubInterface<CodeWhispererServiceToken>()
+        codeWhispererService.listAvailableCustomizations.resolves({
+            customizations: [],
+            $response: {} as any,
+        })
+
+        testFeatures = new TestFeatures()
+
+        serverConfigurationProvider = new ServerConfigurationProvider(
+            codeWhispererService,
+            testFeatures.credentialsProvider,
+            testFeatures.logging,
+            () => codeWhispererService
+        )
+
+        listAvailableProfilesHandlerSpy = sinon.spy(
+            serverConfigurationProvider,
+            'listAllAvailableProfilesHandler' as keyof ServerConfigurationProvider
+        )
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    it(`calls corresponding API when listAvailableCustomizations is invoked`, async () => {
+        await serverConfigurationProvider.listAvailableCustomizations()
+
+        sinon.assert.calledOnce(codeWhispererService.listAvailableCustomizations)
+    })
+
+    it(`does not use listAvailableProfiles handler when developer profiles is disabled`, async () => {
+        const result = await serverConfigurationProvider.listAvailableProfiles()
+
+        sinon.assert.notCalled(listAvailableProfilesHandlerSpy)
+        assert.deepStrictEqual(result, [])
+    })
+
+    it(`uses listAvailableProfiles handler when developer profiles is enabled`, async () => {
+        serverConfigurationProvider.qDeveloperProfilesEnabled = true
+        await serverConfigurationProvider.listAvailableProfiles()
+
+        sinon.assert.called(listAvailableProfilesHandlerSpy)
+    })
+})
+
+describe('signalsAWSQDeveloperProfilesEnabled', () => {
+    const makeQCapability = (value?: any) => {
+        return value !== undefined ? { developerProfiles: value } : {}
+    }
+
+    const makeInitOptions = (value?: any): AWSInitializationOptions => {
+        return { awsClientCapabilities: { q: makeQCapability(value) } }
+    }
+
+    const TEST_CASES: { input: AWSInitializationOptions; expected: boolean }[] = [
+        { input: {}, expected: false },
+        { input: { awsClientCapabilities: {} }, expected: false },
+        { input: makeInitOptions(), expected: false },
+        { input: makeInitOptions([]), expected: false },
+        { input: makeInitOptions({}), expected: false },
+        { input: makeInitOptions(42), expected: false },
+        { input: makeInitOptions('some-string'), expected: false },
+        { input: makeInitOptions(false), expected: false },
+        { input: makeInitOptions(true), expected: true },
+    ]
+
+    TEST_CASES.forEach(testCase => {
+        it(`should return: ${testCase.expected} when passed: ${JSON.stringify(testCase.input)}`, () => {
+            assert.strictEqual(signalsAWSQDeveloperProfilesEnabled(testCase.input), testCase.expected)
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
@@ -6,11 +6,10 @@ import {
     Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION,
     QConfigurationServerToken,
     ServerConfigurationProvider,
-    signalsAWSQDeveloperProfilesEnabled,
 } from './qConfigurationServer'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
-import { AWSInitializationOptions, Server } from '@aws/language-server-runtimes/server-interface'
+import { Server } from '@aws/language-server-runtimes/server-interface'
 
 describe('QConfigurationServerToken', () => {
     let testFeatures: TestFeatures
@@ -143,33 +142,5 @@ describe('ServerConfigurationProvider', () => {
         await serverConfigurationProvider.listAvailableProfiles()
 
         sinon.assert.called(listAvailableProfilesHandlerSpy)
-    })
-})
-
-describe('signalsAWSQDeveloperProfilesEnabled', () => {
-    const makeQCapability = (value?: any) => {
-        return value !== undefined ? { developerProfiles: value } : {}
-    }
-
-    const makeInitOptions = (value?: any): AWSInitializationOptions => {
-        return { awsClientCapabilities: { q: makeQCapability(value) } }
-    }
-
-    const TEST_CASES: { input: AWSInitializationOptions; expected: boolean }[] = [
-        { input: {}, expected: false },
-        { input: { awsClientCapabilities: {} }, expected: false },
-        { input: makeInitOptions(), expected: false },
-        { input: makeInitOptions([]), expected: false },
-        { input: makeInitOptions({}), expected: false },
-        { input: makeInitOptions(42), expected: false },
-        { input: makeInitOptions('some-string'), expected: false },
-        { input: makeInitOptions(false), expected: false },
-        { input: makeInitOptions(true), expected: true },
-    ]
-
-    TEST_CASES.forEach(testCase => {
-        it(`should return: ${testCase.expected} when passed: ${JSON.stringify(testCase.input)}`, () => {
-            assert.strictEqual(signalsAWSQDeveloperProfilesEnabled(testCase.input), testCase.expected)
-        })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -1,5 +1,4 @@
 import {
-    AWSInitializationOptions,
     CancellationToken,
     CredentialsProvider,
     GetConfigurationFromServerParams,
@@ -18,9 +17,9 @@ import {
     AmazonQDeveloperProfile,
     getListAllAvailableProfilesHandler,
     ListAllAvailableProfilesHandler,
+    signalsAWSQDeveloperProfilesEnabled,
 } from '../amazonQServiceManager/qDeveloperProfiles'
 import { Customizations } from '../../client/token/codewhispererbearertokenclient'
-import { isBool, isObject } from '../utils'
 
 // The configuration section that the server will register and listen to
 export const Q_CONFIGURATION_SECTION = 'aws.q'
@@ -194,22 +193,4 @@ export class ServerConfigurationProvider {
         this.logging.error(`${message}: ${error}`)
         return new ResponseError(LSPErrorCodes.RequestFailed, message)
     }
-}
-
-const AWSQCapabilitiesKey = 'q'
-const developerProfilesEnabledKey = 'developerProfiles'
-
-export function signalsAWSQDeveloperProfilesEnabled(initializationOptions: AWSInitializationOptions): boolean {
-    const qCapibilities = initializationOptions.awsClientCapabilities?.[AWSQCapabilitiesKey]
-
-    if (
-        isObject(qCapibilities) &&
-        !(qCapibilities instanceof Array) &&
-        developerProfilesEnabledKey in qCapibilities &&
-        isBool(qCapibilities[developerProfilesEnabledKey])
-    ) {
-        return qCapibilities[developerProfilesEnabledKey]
-    }
-
-    return false
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -36,6 +36,10 @@ export function isNullish(value: unknown): value is null | undefined {
     return value === null || value === undefined
 }
 
+export function isBool(value: unknown): value is boolean {
+    return typeof value === 'boolean'
+}
+
 export function getCompletionType(suggestion: Suggestion): CodewhispererCompletionType {
     const nonBlankLines = suggestion.content.split('\n').filter(line => line.trim() !== '').length
 


### PR DESCRIPTION
## Problem

Currently, we have functionality for fetching and returning Q developer profiles, but by default we have it disabled. Instead, iff the client signals support for Q developer profiles, we should return them in the applicable `GetConfigurationFromServer` requests (`aws.q`, `aws.q.developerProfiles`)

## Solution

At initialization, we check the `AWSInitializationOptions` in `InitializationParams` for the structure:

```
q: {
  developerProfiles: boolean;
}
```

If these params are present, and the `developerProfiles` flag is explicitly set to true, we update the corresponding flag in `ServerConfigProvider`, which then in turn enables fetching and returning the Q developer profiles.



Testing: added unit tests that verify the flag-checking mechanism, as well as the initialize handler correctly setting the `qDeveloperProfilesEnabled` flag. Also tested E2E flow with bundled vs client by signalling `developerProfiles: true`
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
