### PR TITLE
feat(identity): enable device code

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -10,7 +10,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.40",
+        "@aws/language-server-runtimes": "^0.2.41",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "crypto-browserify": "^3.12.1",

--- a/app/aws-lsp-codewhisperer-runtimes/src/token-standalone.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/src/token-standalone.ts
@@ -7,6 +7,7 @@ import {
     QConfigurationServerTokenProxy,
     QNetTransformServerTokenProxy,
 } from '@aws/lsp-codewhisperer/out/language-server/proxy-server'
+import { IdentityServer } from '@aws/lsp-identity'
 
 const MAJOR = 0
 const MINOR = 1
@@ -21,6 +22,7 @@ const props: RuntimeProps = {
         QConfigurationServerTokenProxy,
         QNetTransformServerTokenProxy,
         QChatServerProxy,
+        IdentityServer.create,
     ],
     name: 'AWS CodeWhisperer',
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.40",
+                "@aws/language-server-runtimes": "^0.2.41",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "crypto-browserify": "^3.12.1",

--- a/server/aws-lsp-identity/src/language-server/identityServer.ts
+++ b/server/aws-lsp-identity/src/language-server/identityServer.ts
@@ -9,14 +9,15 @@ import {
     InvalidateSsoTokenParams,
     InitializeParams,
     PartialInitializeResult,
+    ShowMessageRequestParams,
 } from '@aws/language-server-runtimes/server-interface'
 import { SharedConfigProfileStore } from './profiles/sharedConfigProfileStore'
 import { IdentityService } from './identityService'
 import { FileSystemSsoCache, RefreshingSsoCache } from '../sso/cache'
 import { SsoTokenAutoRefresher } from './ssoTokenAutoRefresher'
-import { ShowUrl } from '../sso'
 import { AwsError, ServerBase } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { ShowUrl, ShowMessageRequest, ShowProgress } from '../sso/utils'
 
 export class IdentityServer extends ServerBase {
     constructor(features: Features) {
@@ -34,6 +35,9 @@ export class IdentityServer extends ServerBase {
         // Callbacks for server->client JSON-RPC calls
         const showUrl: ShowUrl = (url: URL) =>
             this.features.lsp.window.showDocument({ uri: url.toString(), external: true })
+        const showMessageRequest: ShowMessageRequest = (params: ShowMessageRequestParams) =>
+            this.features.lsp.window.showMessageRequest(params)
+        const showProgress: ShowProgress = this.features.lsp.sendProgress
 
         // Initialize dependencies
         const profileStore = new SharedConfigProfileStore(this.observability)
@@ -50,7 +54,7 @@ export class IdentityServer extends ServerBase {
             profileStore,
             ssoCache,
             autoRefresher,
-            showUrl,
+            { showUrl, showMessageRequest, showProgress },
             this.getClientName(params),
             this.observability
         )

--- a/server/aws-lsp-identity/src/language-server/identityService.test.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.test.ts
@@ -1,12 +1,16 @@
 import { expect, use } from 'chai'
 import { StubbedInstance, stubInterface } from 'ts-sinon'
 import { awsBuilderIdReservedName, SsoCache, SsoClientRegistration } from '../sso'
-import * as acp from '../sso/authorizationCodePkce/authorizationCodePkceFlow'
 import { IdentityService } from './identityService'
 import { ProfileData, ProfileStore } from './profiles/profileService'
 import { SsoTokenAutoRefresher } from './ssoTokenAutoRefresher'
-import { createStubInstance, restore, stub } from 'sinon'
-import { CancellationToken, ProfileKind, SsoTokenSourceKind } from '@aws/language-server-runtimes/protocol'
+import { createStubInstance, restore, spy, SinonSpy } from 'sinon'
+import {
+    AuthorizationFlowKind,
+    CancellationToken,
+    ProfileKind,
+    SsoTokenSourceKind,
+} from '@aws/language-server-runtimes/protocol'
 import { SSOToken } from '@smithy/shared-ini-file-loader'
 import { Logging, Telemetry } from '@aws/language-server-runtimes/server-interface'
 import { Observability } from '@aws/lsp-core'
@@ -20,6 +24,7 @@ let profileStore: StubbedInstance<ProfileStore>
 let ssoCache: StubbedInstance<SsoCache>
 let autoRefresher: StubbedInstance<SsoTokenAutoRefresher>
 let observability: StubbedInstance<Observability>
+let authFlowFn: SinonSpy
 
 describe('IdentityService', () => {
     beforeEach(() => {
@@ -55,6 +60,7 @@ describe('IdentityService', () => {
                 issuedAt: new Date(Date.now()).toISOString(),
                 scopes: ['sso:account:access'],
             } satisfies SsoClientRegistration),
+            getSsoToken: Promise.resolve(undefined),
             removeSsoToken: Promise.resolve(),
             setSsoToken: Promise.resolve(),
         })
@@ -64,7 +70,7 @@ describe('IdentityService', () => {
             unwatch: undefined,
         }) as StubbedInstance<SsoTokenAutoRefresher>
 
-        stub(acp, 'authorizationCodePkceFlow').returns(
+        authFlowFn = spy(() =>
             Promise.resolve({
                 accessToken: 'my-access-token',
                 expiresAt: new Date(Date.now() + 10 * 1000).toISOString(),
@@ -75,7 +81,22 @@ describe('IdentityService', () => {
         observability.logging = stubInterface<Logging>()
         observability.telemetry = stubInterface<Telemetry>()
 
-        sut = new IdentityService(profileStore, ssoCache, autoRefresher, _ => {}, 'My Client', observability)
+        sut = new IdentityService(
+            profileStore,
+            ssoCache,
+            autoRefresher,
+            {
+                showUrl: _ => {},
+                showMessageRequest: _ => Promise.resolve({ title: 'client-response' }),
+                showProgress: _ => Promise.resolve(),
+            },
+            'My Client',
+            observability,
+            {
+                [AuthorizationFlowKind.Pkce]: authFlowFn,
+                [AuthorizationFlowKind.DeviceCode]: authFlowFn,
+            }
+        )
     })
 
     afterEach(() => {
@@ -109,6 +130,53 @@ describe('IdentityService', () => {
             expect(actual.ssoToken.id).to.equal('my-sso-session')
             expect(actual.ssoToken.accessToken).to.equal('my-access-token')
             expect(autoRefresher.watch.calledOnce).to.be.true
+        })
+
+        it('Can login with different auth flows.', async () => {
+            await sut.getSsoToken(
+                {
+                    clientName: 'my-client',
+                    source: { kind: SsoTokenSourceKind.IamIdentityCenter, profileName: 'my-profile' },
+                    options: {
+                        authorizationFlow: 'DeviceCode',
+                    },
+                },
+                CancellationToken.None
+            )
+            expect(authFlowFn.calledOnce).to.be.true
+
+            await sut.getSsoToken(
+                {
+                    clientName: 'my-client',
+                    source: { kind: SsoTokenSourceKind.IamIdentityCenter, profileName: 'my-profile' },
+                    options: {
+                        authorizationFlow: 'Pkce',
+                    },
+                },
+                CancellationToken.None
+            )
+            expect(authFlowFn.calledTwice).to.be.true
+        })
+
+        it('Throws when auth flow is invalid.', async () => {
+            const error = await expect(
+                sut.getSsoToken(
+                    {
+                        clientName: 'my-client',
+                        source: {
+                            kind: SsoTokenSourceKind.AwsBuilderId,
+                            ssoRegistrationScopes: ['sso:account:access'],
+                        },
+                        options: {
+                            authorizationFlow: 'unknown' as any,
+                        },
+                    },
+                    CancellationToken.None
+                )
+            ).rejectedWith(Error)
+
+            expect(error.message).to.equal('Unsupported authorization flow requested: unknown')
+            expect(autoRefresher.watch.calledOnce).to.be.false
         })
 
         it('Throws when no SSO token cached and loginOnInvalidToken is false.', async () => {

--- a/server/aws-lsp-identity/src/language-server/identityService.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.ts
@@ -1,4 +1,5 @@
 import {
+    AuthorizationFlowKind,
     AwsBuilderIdSsoTokenSource,
     AwsErrorCodes,
     CancellationToken,
@@ -13,23 +14,37 @@ import {
     SsoTokenSourceKind,
 } from '@aws/language-server-runtimes/server-interface'
 import { normalizeSettingList, ProfileStore } from './profiles/profileService'
-import { authorizationCodePkceFlow, awsBuilderIdReservedName, awsBuilderIdSsoRegion, ShowUrl } from '../sso'
+import { authorizationCodePkceFlow, awsBuilderIdReservedName, awsBuilderIdSsoRegion } from '../sso'
 import { SsoCache, SsoClientRegistration } from '../sso/cache'
 import { SsoTokenAutoRefresher } from './ssoTokenAutoRefresher'
-import { throwOnInvalidClientRegistration, throwOnInvalidSsoSession, throwOnInvalidSsoSessionName } from '../sso/utils'
+import {
+    throwOnInvalidClientRegistration,
+    throwOnInvalidSsoSession,
+    throwOnInvalidSsoSessionName,
+    SsoFlowParams,
+} from '../sso/utils'
 import { AwsError, Observability } from '@aws/lsp-core'
 import { __ServiceException } from '@aws-sdk/client-sso-oidc/dist-types/models/SSOOIDCServiceException'
+import { deviceCodeFlow } from '../sso/deviceCode/deviceCodeFlow'
+import { SSOToken } from '@smithy/shared-ini-file-loader'
 
 type SsoTokenSource = IamIdentityCenterSsoTokenSource | AwsBuilderIdSsoTokenSource
+type AuthFlows = Record<AuthorizationFlowKind, (params: SsoFlowParams) => Promise<SSOToken>>
+
+const flows: AuthFlows = {
+    [AuthorizationFlowKind.DeviceCode]: deviceCodeFlow,
+    [AuthorizationFlowKind.Pkce]: authorizationCodePkceFlow,
+}
 
 export class IdentityService {
     constructor(
         private readonly profileStore: ProfileStore,
         private readonly ssoCache: SsoCache,
         private readonly autoRefresher: SsoTokenAutoRefresher,
-        private readonly showUrl: ShowUrl,
+        private readonly handlers: SsoFlowParams['handlers'],
         private readonly clientName: string,
-        private readonly observability: Observability
+        private readonly observability: Observability,
+        private readonly authFlows: AuthFlows = flows
     ) {}
 
     async getSsoToken(params: GetSsoTokenParams, token: CancellationToken): Promise<GetSsoTokenResult> {
@@ -64,14 +79,25 @@ export class IdentityService {
                 clientRegistration = await this.ssoCache.getSsoClientRegistration(this.clientName, ssoSession)
                 throwOnInvalidClientRegistration(clientRegistration)
 
-                ssoToken = await authorizationCodePkceFlow(
-                    this.clientName,
+                const flowOpts: SsoFlowParams = {
+                    clientName: this.clientName,
                     clientRegistration,
                     ssoSession,
-                    this.showUrl,
+                    handlers: this.handlers,
                     token,
-                    this.observability
-                ).catch(reason => {
+                    observability: this.observability,
+                }
+
+                const flowKind = params.options?.authorizationFlow ?? getSsoTokenOptionsDefaults.authorizationFlow
+                if (!Object.keys(this.authFlows).includes(flowKind)) {
+                    throw new AwsError(
+                        `Unsupported authorization flow requested: ${flowKind}`,
+                        AwsErrorCodes.E_CANNOT_CREATE_SSO_TOKEN
+                    )
+                }
+
+                const flow = this.authFlows[flowKind]
+                ssoToken = await flow(flowOpts).catch(reason => {
                     throw AwsError.wrap(reason, AwsErrorCodes.E_CANNOT_CREATE_SSO_TOKEN)
                 })
 

--- a/server/aws-lsp-identity/src/sso/deviceCode/deviceCodeFlow.test.ts
+++ b/server/aws-lsp-identity/src/sso/deviceCode/deviceCodeFlow.test.ts
@@ -143,8 +143,8 @@ describe('deviceCodeFlow', () => {
         params.handlers.showMessageRequest = async () => {
             throw errorToThrow
         }
-        const err = await expect(deviceCodeFlow(params)).to.be.rejectedWith(errorToThrow)
-        expect(err).to.equal(errorToThrow)
+
+        await expect(deviceCodeFlow(params)).to.be.rejectedWith(errorToThrow)
     })
 
     it('Throws error if authorization expires', async () => {


### PR DESCRIPTION
- Add device code as selectable auth flow
- Refactor PKCE flow to use params structure
- Add IdentityServer to cw lsp activation and update version
- Add example message handlers in the sample vscode app

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
