### PR TITLE
chore: added auth listener to reset the service manager state in case of bearer token signout

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -10,6 +10,7 @@ import {
     LSPErrorCodes,
     SsoConnectionType,
     CancellationToken,
+    ExecuteCommandParams,
 } from '@aws/language-server-runtimes/server-interface'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION, AWS_Q_ENDPOINTS } from '../../constants'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
@@ -123,7 +124,19 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
     }
 
     private setupAuthListener(): void {
-        // TODO: listen on changes to credentials and signout events from client to manage state correctly.
+        this.features.lsp.onExecuteCommand(
+            async (params: ExecuteCommandParams, _token: CancellationToken): Promise<any> => {
+                this.log(`Received command: ${params.command}`)
+                switch (params.command) {
+                    case 'bearerCredentialsDeleteCommand':
+                        this.cachedCodewhispererService = undefined
+                        this.activeIdcProfile = undefined
+                        this.connectionType = 'none'
+                        break
+                }
+                return
+            }
+        )
     }
 
     private setupConfigurationListeners(): void {

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -305,7 +305,11 @@ export const CodewhispererServerFactory =
             })
             telemetryService.updateUserContext(makeUserContextObject(params, runtime.platform, 'INLINE'))
             return {
-                capabilities: {},
+                capabilities: {
+                    executeCommandProvider: {
+                        commands: ['bearerCredentialsDeleteCommand'],
+                    },
+                },
             }
         })
 
@@ -393,7 +397,7 @@ export const CodewhispererServerFactory =
                 }
 
                 const codeWhispererService = AmazonQServiceManager.getCodewhispererService()
-                
+
                 // supplementalContext available only via token authentication
                 const supplementalContextPromise =
                     codeWhispererService instanceof CodeWhispererServiceToken


### PR DESCRIPTION
Listener to update the local state of AmazonQTokenServiceManager class, so bearer token signout can reset the state to avoid any kind of race conditions.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
