### PR TITLE
feat(identity): refreshingSsoCache expiration errors

### DIFF
--- a/server/aws-lsp-identity/src/language-server/ssoTokenAutoRefresher.test.ts
+++ b/server/aws-lsp-identity/src/language-server/ssoTokenAutoRefresher.test.ts
@@ -4,8 +4,8 @@ import { SSOToken } from '@smithy/shared-ini-file-loader'
 import { StubbedInstance, stubInterface } from 'ts-sinon'
 import { SsoClientRegistration, RefreshingSsoCache } from '../sso'
 import { restore, spy } from 'sinon'
-import { Logging, Telemetry } from '@aws/language-server-runtimes/server-interface'
-import { Observability } from '@aws/lsp-core'
+import { AwsErrorCodes, Logging, Telemetry } from '@aws/language-server-runtimes/server-interface'
+import { AwsError, Observability } from '@aws/lsp-core'
 
 // eslint-disable-next-line
 use(require('chai-as-promised'))
@@ -46,7 +46,9 @@ function createSsoToken(expiresAsOffsetMillis: number): SSOToken {
 function stubSsoCache(clientRegistration?: SsoClientRegistration, ssoToken?: SSOToken): RefreshingSsoCache {
     return stubInterface<RefreshingSsoCache>({
         getSsoClientRegistration: Promise.resolve(clientRegistration),
-        getSsoToken: Promise.resolve(ssoToken),
+        getSsoToken: ssoToken
+            ? Promise.resolve(ssoToken)
+            : Promise.reject(new AwsError('Test: No SSO Token', AwsErrorCodes.E_INVALID_SSO_TOKEN)),
     })
 }
 


### PR DESCRIPTION
Emit expired errors instead of returning undefined so that the client can more easily understand what is going on.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
