### PR TITLE
fix: disable slack notifications for PRs from forks

### DIFF
--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     notify:
         name: Slack notification
-        if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.draft == false
+        if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
         runs-on: [ubuntu-latest]
         steps:
             - name: Post message


### PR DESCRIPTION
## Problem
The Slack notification workflow fails on PRs from forked repositories. These failures are false positives and create unnecessary noise in our CI pipeline.
Reason is that GitHub Secrets are not passed to the runner when a workflow is triggered from a forked repository, because of security reasons.

## Solution
Disabling slack notification workflow for PRs coming from forks. We could think of some better solution that will work with forks in the future.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
