### PR TITLE
feat(amazonq): update initialization flow for AmazonQTokenServiceManager

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/BaseAmazonQServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/BaseAmazonQServiceManager.ts
@@ -2,6 +2,5 @@ import { CodeWhispererServiceBase } from '../codeWhispererService'
 
 export interface BaseAmazonQServiceManager {
     handleDidChangeConfiguration: () => Promise<void>
-    updateClientConfig: (config: { userAgent: string }) => void
     getCodewhispererService: () => CodeWhispererServiceBase
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/errors.ts
@@ -8,6 +8,13 @@ export class AmazonQError extends Error {
     }
 }
 
+export class AmazonQServiceInitializationError extends AmazonQError {
+    constructor(message: string = 'Amazon Q service manager initilization error') {
+        super(message, 'E_AMAZON_Q_INITIALIZATION_ERROR')
+        this.name = 'AmazonQServiceInitializationError'
+    }
+}
+
 export class AmazonQServiceNotInitializedError extends AmazonQError {
     constructor(message: string = 'Amazon Q service SDK is not initialized') {
         super(message, 'E_AMAZON_Q_NOT_INITIALIZED')

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -258,27 +258,9 @@ export const CodewhispererServerFactory =
             sdkInitializator
         )
 
-        let AmazonQServiceManager: BaseAmazonQServiceManager
+        // AmazonQTokenServiceManager is initialized in `onInitialized` handler to make sure Language Server connection is started
+        let amazonQServiceManager: BaseAmazonQServiceManager
         const serviceType = fallbackCodeWhispererService.constructor.name
-        if (serviceType === 'CodeWhispererServiceToken') {
-            AmazonQServiceManager = AmazonQTokenServiceManager.getInstance({
-                lsp,
-                logging,
-                credentialsProvider,
-                sdkInitializator,
-                workspace,
-                runtime,
-            })
-        } else {
-            // Fallback to default passed service factory for IAM credentials type
-            AmazonQServiceManager = {
-                handleDidChangeConfiguration: async () => {},
-                updateClientConfig: () => {},
-                getCodewhispererService: () => {
-                    return fallbackCodeWhispererService
-                },
-            }
-        }
 
         const telemetryService = new TelemetryService(
             credentialsProvider,
@@ -292,10 +274,6 @@ export const CodewhispererServerFactory =
         )
 
         lsp.addInitializer((params: InitializeParams) => {
-            AmazonQServiceManager.updateClientConfig({
-                userAgent: getUserAgent(params, runtime.serverInfo),
-            })
-
             // TODO: Review configuration options expected in other features
             fallbackCodeWhispererService.updateClientConfig({
                 customUserAgent: getUserAgent(params, runtime.serverInfo),
@@ -392,7 +370,7 @@ export const CodewhispererServerFactory =
                     return EMPTY_RESULT
                 }
 
-                const codeWhispererService = AmazonQServiceManager.getCodewhispererService()
+                const codeWhispererService = amazonQServiceManager.getCodewhispererService()
                 
                 // supplementalContext available only via token authentication
                 const supplementalContextPromise =
@@ -647,7 +625,7 @@ export const CodewhispererServerFactory =
                 // Currently can't hook AmazonQTokenServiceManager.handleDidChangeConfiguration to lsp listenre directly
                 // as it will override listeners from each consuming Server.
                 // TODO: refactor configuration listener in Server and AmazonQTokenServiceManager in runtimes.
-                await AmazonQServiceManager.handleDidChangeConfiguration()
+                await amazonQServiceManager.handleDidChangeConfiguration()
 
                 const qConfig = await lsp.workspace.getConfiguration(Q_CONFIGURATION_SECTION)
                 if (qConfig) {
@@ -684,9 +662,32 @@ export const CodewhispererServerFactory =
             }
         }
 
+        const onInitializedHandler = async () => {
+            if (serviceType === 'CodeWhispererServiceToken') {
+                amazonQServiceManager = AmazonQTokenServiceManager.getInstance({
+                    lsp,
+                    logging,
+                    credentialsProvider,
+                    sdkInitializator,
+                    workspace,
+                    runtime,
+                })
+            } else {
+                // Fallback to default passed service factory for IAM credentials type
+                amazonQServiceManager = {
+                    handleDidChangeConfiguration: async () => {},
+                    getCodewhispererService: () => {
+                        return fallbackCodeWhispererService
+                    },
+                }
+            }
+
+            await updateConfiguration()
+        }
+
         lsp.extensions.onInlineCompletionWithReferences(onInlineCompletionHandler)
         lsp.extensions.onLogInlineCompletionSessionResults(onLogInlineCompletionSessionResultsHandler)
-        lsp.onInitialized(updateConfiguration)
+        lsp.onInitialized(onInitializedHandler)
         lsp.didChangeConfiguration(updateConfiguration)
 
         lsp.onDidChangeTextDocument(async p => {

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererService.ts
@@ -52,6 +52,7 @@ export abstract class CodeWhispererServiceBase {
     protected readonly codeWhispererEndpoint
     public shareCodeWhispererContentWithAWS = false
     public customizationArn?: string
+    public profileArn?: string
     abstract client: CodeWhispererSigv4Client | CodeWhispererTokenClient
 
     abstract getCredentialsType(): CredentialsType
@@ -166,6 +167,9 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
         // add cancellation check
         // add error check
         if (this.customizationArn) request = { ...request, customizationArn: this.customizationArn }
+        if (this.profileArn) {
+            request.profileArn = this.profileArn
+        }
 
         const response = await this.client.generateCompletions(request).promise()
         const responseContext = {


### PR DESCRIPTION
Updating initialization flow for AmazonQTokenServiceManager:

1. Now it must be initialized in consuming Server inside as part of `lsp.onInitialized` handler, to ensure that LSP connection was initialized and `InitializeParams` are cached in `lsp` feature.
2. Reading `q. developerProfiles` initialization option from cached `InitializeParams` to toggle Developer Profiles support in manager instead of passing a flag. 
3. Computing `customUserAgent` from cached `InitializeParams` instead of using setter in consuming code.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
