### PR TITLE
feat(amazonq): integrate q service manager with configuration server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
@@ -16,7 +16,6 @@ import {
     ResponseError,
 } from '@aws/language-server-runtimes/protocol'
 import { AWS_Q_ENDPOINTS, DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
-import { SsoConnectionType } from '@aws/language-server-runtimes/server-interface'
 import * as qDeveloperProfilesFetcherModule from './qDeveloperProfiles'
 import { setCredentialsForAmazonQTokenServiceManagerFactory } from '../testUtils'
 
@@ -506,10 +505,7 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getState(), 'INITIALIZED')
                 assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'identityCenter')
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-iad')
-                assert.deepStrictEqual(codewhispererStubFactory.lastCall.args, [
-                    'us-east-1',
-                    'amazon-q-in-us-east-1-endpoint',
-                ])
+                assert.deepStrictEqual(codewhispererStubFactory.lastCall.args, ['us-east-1', TEST_ENDPOINT_US_EAST_1])
 
                 // Updaing profile
                 const pendingProfileUpdate = features.doUpdateConfiguration(

--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
@@ -18,6 +18,7 @@ import {
 import { AWS_Q_ENDPOINTS, DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
 import { SsoConnectionType } from '@aws/language-server-runtimes/server-interface'
 import * as qDeveloperProfilesFetcherModule from './qDeveloperProfiles'
+import { setCredentialsForAmazonQTokenServiceManagerFactory } from '../testUtils'
 
 export const mockedProfiles: qDeveloperProfilesFetcherModule.AmazonQDeveloperProfile[] = [
     {
@@ -43,6 +44,9 @@ export const mockedProfiles: qDeveloperProfilesFetcherModule.AmazonQDeveloperPro
     },
 ]
 
+const TEST_ENDPOINT_US_EAST_1 = 'amazon-q-in-us-east-1-endpoint'
+const TEST_ENDPOINT_EU_CENTRAL_1 = 'amazon-q-in-eu-central-1-endpoint'
+
 describe('AmazonQTokenServiceManager', () => {
     let codewhispererServiceStub: StubbedInstance<CodeWhispererServiceToken>
     let codewhispererStubFactory: sinon.SinonStub<any[], StubbedInstance<CodeWhispererServiceToken>>
@@ -52,9 +56,9 @@ describe('AmazonQTokenServiceManager', () => {
 
     beforeEach(() => {
         // Override endpoints for testing
-        AWS_Q_ENDPOINTS['us-east-1'] = 'amazon-q-in-us-east-1-endpoint'
+        AWS_Q_ENDPOINTS['us-east-1'] = TEST_ENDPOINT_US_EAST_1
         // @ts-ignore
-        AWS_Q_ENDPOINTS['eu-central-1'] = 'amazon-q-in-eu-central-1-endpoint'
+        AWS_Q_ENDPOINTS['eu-central-1'] = TEST_ENDPOINT_EU_CENTRAL_1
 
         sinon
             .stub(qDeveloperProfilesFetcherModule, 'getListAllAvailableProfilesHandler')
@@ -102,13 +106,7 @@ describe('AmazonQTokenServiceManager', () => {
         amazonQTokenServiceManager.setServiceFactory(codewhispererStubFactory)
     }
 
-    const setCredentials = (connectionType: SsoConnectionType) => {
-        features.credentialsProvider.hasCredentials.returns(true)
-        features.credentialsProvider.getConnectionType.returns(connectionType)
-        features.credentialsProvider.getCredentials.returns({
-            token: 'test-token',
-        })
-    }
+    const setCredentials = setCredentialsForAmazonQTokenServiceManagerFactory(() => features)
 
     const clearCredentials = () => {
         features.credentialsProvider.hasCredentials.returns(false)
@@ -129,12 +127,26 @@ describe('AmazonQTokenServiceManager', () => {
     })
 
     describe('BuilderId support', () => {
-        it('should be INITIALIZED with BuilderId Connection', async () => {
+        const testRegion = 'some-region'
+        const testEndpoint = 'some-endpoint-in-some-region'
+
+        beforeEach(() => {
             setupServiceManager()
             assert.strictEqual(amazonQTokenServiceManager.getState(), 'PENDING_CONNECTION')
 
             setCredentials('builderId')
 
+            // @ts-ignore
+            AWS_Q_ENDPOINTS[testRegion] = testEndpoint
+
+            features.lsp.getClientInitializeParams.reset()
+        })
+
+        afterEach(() => {
+            AmazonQTokenServiceManager.resetInstance()
+        })
+
+        it('should be INITIALIZED with BuilderId Connection', async () => {
             const service = amazonQTokenServiceManager.getCodewhispererService()
             await service.generateSuggestions({} as GenerateSuggestionsRequest)
 
@@ -142,6 +154,35 @@ describe('AmazonQTokenServiceManager', () => {
             assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'builderId')
 
             assert(codewhispererServiceStub.generateSuggestions.calledOnce)
+        })
+
+        it('should initialize service with region set by client', () => {
+            features.lsp.getClientInitializeParams.returns({
+                processId: 0,
+                rootUri: 'some-root-uri',
+                capabilities: {},
+                initializationOptions: {
+                    aws: {
+                        region: testRegion,
+                    },
+                },
+            })
+
+            amazonQTokenServiceManager.getCodewhispererService()
+            assert(codewhispererStubFactory.calledOnceWithExactly(testRegion, testEndpoint))
+        })
+
+        it('should initialize service with region set by runtime if not set by client', () => {
+            features.runtime.getConfiguration.withArgs('AWS_Q_REGION').returns('eu-central-1')
+            features.runtime.getConfiguration.withArgs('AWS_Q_ENDPOINT_URL').returns(TEST_ENDPOINT_EU_CENTRAL_1)
+
+            amazonQTokenServiceManager.getCodewhispererService()
+            assert(codewhispererStubFactory.calledOnceWithExactly('eu-central-1', TEST_ENDPOINT_EU_CENTRAL_1))
+        })
+
+        it('should initialize service with default region if not set by client and runtime', () => {
+            amazonQTokenServiceManager.getCodewhispererService()
+            assert(codewhispererStubFactory.calledOnceWithExactly(DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL))
         })
     })
 
@@ -199,7 +240,7 @@ describe('AmazonQTokenServiceManager', () => {
 
                 assert.strictEqual(amazonQTokenServiceManager.getState(), 'INITIALIZED')
                 assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'identityCenter')
-                assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', 'amazon-q-in-us-east-1-endpoint'))
+                assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
             })
 
             it('handles Profile configuration change to valid profile in same region', async () => {
@@ -225,7 +266,7 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'identityCenter')
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-iad')
 
-                assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', 'amazon-q-in-us-east-1-endpoint'))
+                assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
 
                 // Profile change
 
@@ -245,7 +286,7 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-iad-2')
 
                 // CodeWhisperer Service was not recreated
-                assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', 'amazon-q-in-us-east-1-endpoint'))
+                assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
             })
 
             it('handles Profile configuration change to valid profile in different region', async () => {
@@ -270,7 +311,7 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getState(), 'INITIALIZED')
                 assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'identityCenter')
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-iad')
-                assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', 'amazon-q-in-us-east-1-endpoint'))
+                assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
 
                 // Profile change
 
@@ -293,7 +334,7 @@ describe('AmazonQTokenServiceManager', () => {
                 assert(codewhispererStubFactory.calledTwice)
                 assert.deepStrictEqual(codewhispererStubFactory.lastCall.args, [
                     'eu-central-1',
-                    'amazon-q-in-eu-central-1-endpoint',
+                    TEST_ENDPOINT_EU_CENTRAL_1,
                 ])
             })
 
@@ -319,7 +360,7 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getState(), 'INITIALIZED')
                 assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'identityCenter')
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-iad')
-                assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', 'amazon-q-in-us-east-1-endpoint'))
+                assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
 
                 // Profile change to invalid profile
 
@@ -349,10 +390,7 @@ describe('AmazonQTokenServiceManager', () => {
 
                 // CodeWhisperer Service was not recreated
                 assert(codewhispererStubFactory.calledOnce)
-                assert.deepStrictEqual(codewhispererStubFactory.lastCall.args, [
-                    'us-east-1',
-                    'amazon-q-in-us-east-1-endpoint',
-                ])
+                assert.deepStrictEqual(codewhispererStubFactory.lastCall.args, ['us-east-1', TEST_ENDPOINT_US_EAST_1])
             })
 
             it('handles invalid profile selection', async () => {
@@ -436,7 +474,7 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-fra')
                 assert.deepStrictEqual(codewhispererStubFactory.lastCall.args, [
                     'eu-central-1',
-                    'amazon-q-in-eu-central-1-endpoint',
+                    TEST_ENDPOINT_EU_CENTRAL_1,
                 ])
             })
 
@@ -537,7 +575,7 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-fra')
                 assert.deepStrictEqual(codewhispererStubFactory.lastCall.args, [
                     'eu-central-1',
-                    'amazon-q-in-eu-central-1-endpoint',
+                    TEST_ENDPOINT_EU_CENTRAL_1,
                 ])
             })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -421,12 +421,21 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
     private createCodewhispererServiceInstance(connectionType: 'builderId' | 'identityCenter', region?: string) {
         this.logServiceState('Initializing CodewhispererService')
         let awsQRegion = this.features.runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION
-        let awsQEndpointUrl = this.features.runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+        let awsQEndpointUrl: string | undefined =
+            this.features.runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
 
         if (region) {
             awsQRegion = region
             // @ts-ignore
             awsQEndpointUrl = AWS_Q_ENDPOINTS[region]
+        }
+
+        if (!awsQEndpointUrl) {
+            this.log(
+                `Unable to determine endpoint (found: ${awsQEndpointUrl}) for region: ${awsQRegion}, falling back to default region and endpoint`
+            )
+            awsQRegion = DEFAULT_AWS_Q_REGION
+            awsQEndpointUrl = DEFAULT_AWS_Q_ENDPOINT_URL
         }
 
         this.cachedCodewhispererService = this.serviceFactory(awsQRegion, awsQEndpointUrl)
@@ -514,7 +523,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
         return this.serviceFactory
     }
 
-    public getEnableDeveloperProfileSupport(): boolean | undefined {
-        return this.enableDeveloperProfileSupport
+    public getEnableDeveloperProfileSupport(): boolean {
+        return this.enableDeveloperProfileSupport === undefined ? false : this.enableDeveloperProfileSupport
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/qDeveloperProfiles.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/qDeveloperProfiles.test.ts
@@ -10,7 +10,6 @@ import {
     signalsAWSQDeveloperProfilesEnabled,
 } from './qDeveloperProfiles'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
-import { isBool, isObject } from '../utils'
 
 const SOME_Q_DEVELOPER_PROFILE_ARN = 'some-random-q-developer-profile-arn'
 const SOME_Q_DEVELOPER_PROFILE_NAME = 'some-random-q-developer-profile-name'

--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/qDeveloperProfiles.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/qDeveloperProfiles.ts
@@ -87,10 +87,9 @@ async function fetchProfilesFromRegion(
 
             allRegionalProfiles.push(...profiles)
 
+            logging.debug(`Fetched profiles from ${region}: ${JSON.stringify(response)} (iteration: ${numberOfPages})`)
             nextToken = response.nextToken
             numberOfPages++
-
-            logging.debug(`Fetched profiles from ${region}: ${JSON.stringify(response)} (iteration: ${numberOfPages})`)
         } while (nextToken !== undefined && numberOfPages < MAX_Q_DEVELOPER_PROFILE_PAGES)
 
         return allRegionalProfiles
@@ -120,15 +119,15 @@ const developerProfilesEnabledKey = 'developerProfiles'
  * ```
  */
 export function signalsAWSQDeveloperProfilesEnabled(initializationOptions: AWSInitializationOptions): boolean {
-    const qCapibilities = initializationOptions.awsClientCapabilities?.[AWSQCapabilitiesKey]
+    const qCapabilities = initializationOptions.awsClientCapabilities?.[AWSQCapabilitiesKey]
 
     if (
-        isObject(qCapibilities) &&
-        !(qCapibilities instanceof Array) &&
-        developerProfilesEnabledKey in qCapibilities &&
-        isBool(qCapibilities[developerProfilesEnabledKey])
+        isObject(qCapabilities) &&
+        !(qCapabilities instanceof Array) &&
+        developerProfilesEnabledKey in qCapabilities &&
+        isBool(qCapabilities[developerProfilesEnabledKey])
     ) {
-        return qCapibilities[developerProfilesEnabledKey]
+        return qCapabilities[developerProfilesEnabledKey]
     }
 
     return false

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
@@ -9,59 +9,60 @@ import {
 } from './qConfigurationServer'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
-import { Server } from '@aws/language-server-runtimes/server-interface'
+import { InitializeParams, Server } from '@aws/language-server-runtimes/server-interface'
+import { AmazonQTokenServiceManager } from '../amazonQServiceManager/AmazonQTokenServiceManager'
+import { setCredentialsForAmazonQTokenServiceManagerFactory } from '../testUtils'
+
+const getInitializeParams = (developerProfiles = true): InitializeParams => {
+    return {
+        processId: 0,
+        rootUri: 'some-root-uri',
+        capabilities: {},
+        initializationOptions: {
+            aws: {
+                awsClientCapabilities: {
+                    q: {
+                        developerProfiles,
+                    },
+                },
+            },
+        },
+    }
+}
 
 describe('QConfigurationServerToken', () => {
     let testFeatures: TestFeatures
+    let amazonQServiceManager: AmazonQTokenServiceManager
     let disposeServer: () => void
     let listAvailableProfilesStub: sinon.SinonStub
     let listAvailableCustomizationsStub: sinon.SinonStub
-    let qDeveloperProfilesEnabledPropertyStub: sinon.SinonStub
-    let qDeveloperProfilesEnabledSetterSpy: sinon.SinonSpy
 
     beforeEach(() => {
         testFeatures = new TestFeatures()
+        testFeatures.lsp.getClientInitializeParams.returns(getInitializeParams())
+
+        amazonQServiceManager = AmazonQTokenServiceManager.getInstance(testFeatures)
 
         const codeWhispererService = stubInterface<CodeWhispererServiceToken>()
-        const configurationServerFactory: Server = QConfigurationServerToken(() => codeWhispererService)
+        const configurationServerFactory: Server = QConfigurationServerToken()
+
+        amazonQServiceManager.setServiceFactory(sinon.stub().returns(codeWhispererService))
 
         listAvailableCustomizationsStub = sinon.stub(
             ServerConfigurationProvider.prototype,
             'listAvailableCustomizations'
         )
         listAvailableProfilesStub = sinon.stub(ServerConfigurationProvider.prototype, 'listAvailableProfiles')
-        qDeveloperProfilesEnabledSetterSpy = sinon.spy()
-        qDeveloperProfilesEnabledPropertyStub = sinon
-            .stub(ServerConfigurationProvider.prototype, 'qDeveloperProfilesEnabled')
-            .set(qDeveloperProfilesEnabledSetterSpy)
 
         disposeServer = configurationServerFactory(testFeatures)
+        // trigger initialize notification
+        testFeatures.lsp.onInitialized.firstCall.firstArg()
     })
 
     afterEach(() => {
         sinon.restore()
-    })
-
-    it(`enables Q developer profiles when signalled by client`, () => {
-        const initialize = (developerProfiles: boolean) => {
-            testFeatures.lsp.addInitializer.firstCall.firstArg({
-                initializationOptions: {
-                    aws: {
-                        awsClientCapabilities: {
-                            q: {
-                                developerProfiles,
-                            },
-                        },
-                    },
-                },
-            })
-        }
-
-        initialize(false)
-        sinon.assert.calledWith(qDeveloperProfilesEnabledSetterSpy.firstCall, false)
-
-        initialize(true)
-        sinon.assert.calledWith(qDeveloperProfilesEnabledSetterSpy.secondCall, true)
+        testFeatures.dispose()
+        AmazonQTokenServiceManager.resetInstance()
     })
 
     it(`calls all list methods when ${Q_CONFIGURATION_SECTION} is requested`, () => {
@@ -94,9 +95,31 @@ describe('QConfigurationServerToken', () => {
 
 describe('ServerConfigurationProvider', () => {
     let serverConfigurationProvider: ServerConfigurationProvider
+    let amazonQServiceManager: AmazonQTokenServiceManager
     let codeWhispererService: StubbedInstance<CodeWhispererServiceToken>
     let testFeatures: TestFeatures
     let listAvailableProfilesHandlerSpy: sinon.SinonSpy
+
+    const setCredentials = setCredentialsForAmazonQTokenServiceManagerFactory(() => testFeatures)
+
+    const setupServerConfigurationProvider = (developerProfiles = true) => {
+        testFeatures.lsp.getClientInitializeParams.returns(getInitializeParams(developerProfiles))
+
+        AmazonQTokenServiceManager.resetInstance()
+
+        amazonQServiceManager = AmazonQTokenServiceManager.getInstance(testFeatures)
+        amazonQServiceManager.setServiceFactory(sinon.stub().returns(codeWhispererService))
+        serverConfigurationProvider = new ServerConfigurationProvider(
+            amazonQServiceManager,
+            testFeatures.credentialsProvider,
+            testFeatures.logging
+        )
+
+        listAvailableProfilesHandlerSpy = sinon.spy(
+            serverConfigurationProvider,
+            'listAllAvailableProfilesHandler' as keyof ServerConfigurationProvider
+        )
+    }
 
     beforeEach(() => {
         codeWhispererService = stubInterface<CodeWhispererServiceToken>()
@@ -104,33 +127,34 @@ describe('ServerConfigurationProvider', () => {
             customizations: [],
             $response: {} as any,
         })
+        codeWhispererService.listAvailableProfiles.resolves({
+            profiles: [],
+            $response: {} as any,
+        })
 
         testFeatures = new TestFeatures()
 
-        serverConfigurationProvider = new ServerConfigurationProvider(
-            codeWhispererService,
-            testFeatures.credentialsProvider,
-            testFeatures.logging,
-            () => codeWhispererService
-        )
+        setCredentials('identityCenter')
 
-        listAvailableProfilesHandlerSpy = sinon.spy(
-            serverConfigurationProvider,
-            'listAllAvailableProfilesHandler' as keyof ServerConfigurationProvider
-        )
+        setupServerConfigurationProvider()
     })
 
     afterEach(() => {
         sinon.restore()
+        testFeatures.dispose()
     })
 
     it(`calls corresponding API when listAvailableCustomizations is invoked`, async () => {
+        setCredentials('builderId')
+
         await serverConfigurationProvider.listAvailableCustomizations()
 
         sinon.assert.calledOnce(codeWhispererService.listAvailableCustomizations)
     })
 
     it(`does not use listAvailableProfiles handler when developer profiles is disabled`, async () => {
+        setupServerConfigurationProvider(false)
+
         const result = await serverConfigurationProvider.listAvailableProfiles()
 
         sinon.assert.notCalled(listAvailableProfilesHandlerSpy)
@@ -138,9 +162,8 @@ describe('ServerConfigurationProvider', () => {
     })
 
     it(`uses listAvailableProfiles handler when developer profiles is enabled`, async () => {
-        serverConfigurationProvider.qDeveloperProfilesEnabled = true
         await serverConfigurationProvider.listAvailableProfiles()
 
-        sinon.assert.called(listAvailableProfilesHandlerSpy)
+        sinon.assert.calledOnce(listAvailableProfilesHandlerSpy)
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -77,7 +77,7 @@ export const QConfigurationServerToken =
                                 serverConfigurationProvider.listAvailableProfiles(),
                             ])
 
-                            return serverConfigurationProvider.isQDeveloperProfilesEnabled()
+                            return amazonQServiceManager.getEnableDeveloperProfileSupport()
                                 ? { customizations, developerProfiles }
                                 : { customizations }
                         case Q_CUSTOMIZATIONS_CONFIGURATION_SECTION:
@@ -124,14 +124,8 @@ export class ServerConfigurationProvider {
         )
     }
 
-    public isQDeveloperProfilesEnabled(): boolean {
-        const enableDeveloperProfileSupport = this.serviceManager.getEnableDeveloperProfileSupport()
-
-        return enableDeveloperProfileSupport !== undefined ? enableDeveloperProfileSupport : false
-    }
-
     async listAvailableProfiles(): Promise<AmazonQDeveloperProfile[]> {
-        if (!this.isQDeveloperProfilesEnabled()) {
+        if (!this.serviceManager.getEnableDeveloperProfileSupport()) {
             this.logging.debug('Q developer profiles disabled - returning empty list')
             return []
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -62,14 +62,4 @@ export const QChatServerProxy = QChatServer((credentialsProvider, awsQRegion, aw
         .withSdkRuntimeConfigurator(sdkInitializator)
 })
 
-export const QConfigurationServerTokenProxy = QConfigurationServerToken(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
-        return new CodeWhispererServiceToken(
-            credentialsProvider,
-            workspace,
-            awsQRegion,
-            awsQEndpointUrl,
-            sdkInitializator
-        )
-    }
-)
+export const QConfigurationServerTokenProxy = QConfigurationServerToken()

--- a/server/aws-lsp-codewhisperer/src/language-server/testUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/testUtils.ts
@@ -1,5 +1,7 @@
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { ResponseContext, Suggestion } from './codeWhispererService'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { SsoConnectionType } from './utils'
 
 export const HELLO_WORLD_IN_CSHARP = `class HelloWorld
 {
@@ -205,4 +207,15 @@ export function shuffleList<T>(list: T[]): T[] {
     }
 
     return shuffledList
+}
+
+export const setCredentialsForAmazonQTokenServiceManagerFactory = (getFeatures: () => TestFeatures) => {
+    return (connectionType: SsoConnectionType) => {
+        const features = getFeatures()
+        features.credentialsProvider.hasCredentials.returns(true)
+        features.credentialsProvider.getConnectionType.returns(connectionType)
+        features.credentialsProvider.getCredentials.returns({
+            token: 'test-token',
+        })
+    }
 }


### PR DESCRIPTION
## Problem

The Q Configuration server should use the correct regional endpoints for fetching customizations. When connection type is `builderId`, the region and endpoint should be discovered in the following order:

the region set by the client -> the region set in runtime -> the default region

In case of connection type being `identityCenter`, the region determined by the selected Q developer profile should be used instead

## Solution

1. Use the new `AmazonQTokenServiceManager` and its cached codewhisperer service in `ServerConfigurationProvider`, which already handles the underlying connection type differentiation. This also allows us to remove the service factory.
2. Extend `AmazonQTokenServiceManager` to setup the cached codewhisperer service according to the aforementioned region discovery chain in case of the `builderId` connection type.

Testing: 
1. added unit tests for the `builderId` region discovery
2. Used the bundled minimal vs code client to E2E test the `identityCenter` flow

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
