### PR TITLE
feat(amazonq): intergrate regionalization support into Q Chat server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
@@ -43,8 +43,8 @@ export const mockedProfiles: qDeveloperProfilesFetcherModule.AmazonQDeveloperPro
     },
 ]
 
-const TEST_ENDPOINT_US_EAST_1 = 'amazon-q-in-us-east-1-endpoint'
-const TEST_ENDPOINT_EU_CENTRAL_1 = 'amazon-q-in-eu-central-1-endpoint'
+const TEST_ENDPOINT_US_EAST_1 = 'http://amazon-q-in-us-east-1-endpoint'
+const TEST_ENDPOINT_EU_CENTRAL_1 = 'http://amazon-q-in-eu-central-1-endpoint'
 
 describe('AmazonQTokenServiceManager', () => {
     let codewhispererServiceStub: StubbedInstance<CodeWhispererServiceToken>
@@ -155,7 +155,7 @@ describe('AmazonQTokenServiceManager', () => {
 
     describe('BuilderId support', () => {
         const testRegion = 'some-region'
-        const testEndpoint = 'some-endpoint-in-some-region'
+        const testEndpoint = 'http://some-endpoint-in-some-region'
 
         beforeEach(() => {
             setupServiceManager()

--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
@@ -47,7 +47,7 @@ export const mockedProfiles: qDeveloperProfilesFetcherModule.AmazonQDeveloperPro
 const TEST_ENDPOINT_US_EAST_1 = 'http://amazon-q-in-us-east-1-endpoint'
 const TEST_ENDPOINT_EU_CENTRAL_1 = 'http://amazon-q-in-eu-central-1-endpoint'
 
-describe.only('AmazonQTokenServiceManager', () => {
+describe('AmazonQTokenServiceManager', () => {
     let codewhispererServiceStub: StubbedInstance<CodeWhispererServiceToken>
     let codewhispererStubFactory: sinon.SinonStub<any[], StubbedInstance<CodeWhispererServiceToken>>
     let sdkInitializatorSpy: sinon.SinonSpy
@@ -161,7 +161,6 @@ describe.only('AmazonQTokenServiceManager', () => {
             assert.strictEqual(amazonQTokenServiceManager.getState(), 'INITIALIZED')
             assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'builderId')
             assert(!(amazonQTokenServiceManager['cachedCodewhispererService'] === undefined))
-            assert(!(amazonQTokenServiceManager['cachedStreamingClient'] === undefined))
             assert.strictEqual((amazonQTokenServiceManager as any)['activeIdcProfile'], undefined)
         })
     })
@@ -356,7 +355,7 @@ describe.only('AmazonQTokenServiceManager', () => {
                 assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
 
                 assert(streamingClient2 instanceof CodeWhispererStreaming)
-                assert.strictEqual(streamingClient1, streamingClient2)
+                assert.notStrictEqual(streamingClient1, streamingClient2)
                 assert.strictEqual(await streamingClient2.config.region(), 'us-east-1')
             })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -220,7 +220,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
             // region set by client -> runtime region -> default region
             const clientParams = this.features.lsp.getClientInitializeParams()
 
-            this.createCodewhispererServiceInstance('builderId', clientParams?.initializationOptions?.aws?.region)
+            this.createCodewhispererServiceInstances('builderId', clientParams?.initializationOptions?.aws?.region)
             this.state = 'INITIALIZED'
             this.log('Initialized Amazon Q service with builderId connection')
 
@@ -242,7 +242,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
                 return
             }
 
-            this.createCodewhispererServiceInstance('identityCenter')
+            this.createCodewhispererServiceInstances('identityCenter')
             this.state = 'INITIALIZED'
             this.log('Initialized Amazon Q service with identityCenter connection')
 
@@ -354,7 +354,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
 
         if (!this.activeIdcProfile) {
             this.activeIdcProfile = newProfile
-            this.createCodewhispererServiceInstance('identityCenter', newProfile.identityDetails.region)
+            this.createCodewhispererServiceInstances('identityCenter', newProfile.identityDetails.region)
             this.state = 'INITIALIZED'
             this.log(
                 `Initialized identityCenter connection to region ${newProfile.identityDetails.region} for profile ${newProfile.arn}`
@@ -396,7 +396,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
         this.resetCodewhispererService()
 
         this.activeIdcProfile = newProfile
-        this.createCodewhispererServiceInstance('identityCenter', newProfile.identityDetails.region)
+        this.createCodewhispererServiceInstances('identityCenter', newProfile.identityDetails.region)
         this.state = 'INITIALIZED'
 
         return
@@ -445,7 +445,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
         this.activeIdcProfile = undefined
     }
 
-    private createCodewhispererServiceInstance(connectionType: 'builderId' | 'identityCenter', region?: string) {
+    private createCodewhispererServiceInstances(connectionType: 'builderId' | 'identityCenter', region?: string) {
         this.logServiceState('Initializing CodewhispererService')
         let awsQRegion = this.features.runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION
         let awsQEndpoint: string | undefined =

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.test.ts
@@ -1,20 +1,10 @@
-import {
-    CredentialsProvider,
-    SDKInitializator,
-    SDKClientConstructorV2,
-    SDKClientConstructorV3,
-} from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import sinon from 'ts-sinon'
 import { ChatSessionManagementService } from './chatSessionManagementService'
 import { ChatSessionService } from './chatSessionService'
-import { Service } from 'aws-sdk'
-import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
 
 describe('ChatSessionManagementService', () => {
     const mockSessionId = 'mockSessionId'
-    const mockAwsQRegion: string = 'mock-aws-q-region'
-    const mockAwsQEndpointUrl: string = 'mock-aws-q-endpoint-url'
 
     it('getInstance should return the same instance if initialized', () => {
         const instance = ChatSessionManagementService.getInstance()
@@ -23,44 +13,14 @@ describe('ChatSessionManagementService', () => {
         assert.strictEqual(instance, instance2)
     })
 
-    it('creating a session without credentials provider should throw an error', () => {
-        const createSessionResult = ChatSessionManagementService.getInstance().createSession(mockSessionId)
-
-        sinon.assert.match(createSessionResult, { success: false, error: sinon.match.string })
-    })
-
     describe('Session interface', () => {
-        const mockCredentialsProvider: CredentialsProvider = {
-            hasCredentials: sinon.stub().returns(true),
-            getCredentials: sinon.stub().returns(Promise.resolve({ token: 'mockToken' })),
-            getConnectionMetadata: sinon.stub(),
-            getConnectionType: sinon.stub(),
-            onCredentialsDeleted: sinon.stub(),
-        }
-
         const mockSessionId2 = 'mockSessionId2'
         let disposeStub: sinon.SinonStub
         let chatSessionManagementService: ChatSessionManagementService
 
-        const mockSdkRuntimeConfigurator: SDKInitializator = Object.assign(
-            // Default callable function for v3 clients
-            <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T => new Ctor({ ...current_config }),
-            // Property for v2 clients
-            {
-                v2: <T extends Service, P extends ServiceConfigurationOptions>(
-                    Ctor: SDKClientConstructorV2<T, P>,
-                    current_config: P
-                ): T => new Ctor({ ...current_config }),
-            }
-        )
-
         beforeEach(() => {
             disposeStub = sinon.stub(ChatSessionService.prototype, 'dispose')
             chatSessionManagementService = ChatSessionManagementService.getInstance()
-                .withCredentialsProvider(mockCredentialsProvider)
-                .withCodeWhispererRegion(mockAwsQRegion)
-                .withCodeWhispererEndpoint(mockAwsQEndpointUrl)
-                .withSdkRuntimeConfigurator(mockSdkRuntimeConfigurator)
         })
 
         afterEach(() => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionManagementService.ts
@@ -1,16 +1,11 @@
-import { CredentialsProvider, SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 import { Result } from '../types'
-import { ChatSessionService, ChatSessionServiceConfig } from './chatSessionService'
+import { ChatSessionService } from './chatSessionService'
+import { AmazonQTokenServiceManager } from '../amazonQServiceManager/AmazonQTokenServiceManager'
 
 export class ChatSessionManagementService {
     static #instance?: ChatSessionManagementService
     #sessionByTab: Map<string, ChatSessionService> = new Map<string, any>()
-    #credentialsProvider?: CredentialsProvider
-    #clientConfig?: ChatSessionServiceConfig | (() => ChatSessionServiceConfig) = {}
-    #customUserAgent?: string = '%Amazon-Q-For-LanguageServers%'
-    #codeWhispererRegion?: string
-    #codeWhispererEndpoint?: string
-    #sdkInitializator?: SDKInitializator
+    #amazonQServiceManager?: AmazonQTokenServiceManager
 
     public static getInstance() {
         if (!ChatSessionManagementService.#instance) {
@@ -26,38 +21,10 @@ export class ChatSessionManagementService {
 
     private constructor() {}
 
-    public withConfig(clientConfig?: ChatSessionServiceConfig | (() => ChatSessionServiceConfig)) {
-        this.#clientConfig = clientConfig
+    public withAmazonQServiceManager(amazonQServiceManager: AmazonQTokenServiceManager) {
+        this.#amazonQServiceManager = amazonQServiceManager
 
         return this
-    }
-
-    public withCredentialsProvider(credentialsProvider: CredentialsProvider) {
-        this.#credentialsProvider = credentialsProvider
-
-        return this
-    }
-
-    public withCodeWhispererRegion(codeWhispererRegion: string) {
-        this.#codeWhispererRegion = codeWhispererRegion
-
-        return this
-    }
-
-    public withCodeWhispererEndpoint(codeWhispererEndpoint: string) {
-        this.#codeWhispererEndpoint = codeWhispererEndpoint
-
-        return this
-    }
-
-    public withSdkRuntimeConfigurator(sdkInitializator: SDKInitializator) {
-        this.#sdkInitializator = sdkInitializator
-
-        return this
-    }
-
-    public setCustomUserAgent(customUserAgent: string) {
-        this.#customUserAgent = customUserAgent
     }
 
     public hasSession(tabId: string): boolean {
@@ -65,44 +32,14 @@ export class ChatSessionManagementService {
     }
 
     public createSession(tabId: string): Result<ChatSessionService, string> {
-        if (!this.#credentialsProvider) {
-            return {
-                success: false,
-                error: 'Credentials provider is not set',
-            }
-        } else if (!this.#codeWhispererRegion) {
-            return {
-                success: false,
-                error: 'CodeWhispererRegion is not set',
-            }
-        } else if (!this.#codeWhispererEndpoint) {
-            return {
-                success: false,
-                error: 'CodeWhispererEndpoint is not set',
-            }
-        } else if (!this.#sdkInitializator) {
-            return {
-                success: false,
-                error: 'SdkInitializator is not set',
-            }
-        } else if (this.#sessionByTab.has(tabId)) {
+        if (this.#sessionByTab.has(tabId)) {
             return {
                 success: true,
                 data: this.#sessionByTab.get(tabId)!,
             }
         }
 
-        const clientConfig = typeof this.#clientConfig === 'function' ? this.#clientConfig() : this.#clientConfig
-        const newSession = new ChatSessionService(
-            this.#credentialsProvider,
-            this.#codeWhispererRegion,
-            this.#codeWhispererEndpoint,
-            this.#sdkInitializator,
-            {
-                ...clientConfig,
-                customUserAgent: this.#customUserAgent,
-            }
-        )
+        const newSession = new ChatSessionService(this.#amazonQServiceManager)
 
         this.#sessionByTab.set(tabId, newSession)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
@@ -3,45 +3,17 @@ import {
     SendMessageCommandInput,
     SendMessageCommandOutput,
 } from '@amzn/codewhisperer-streaming'
-import {
-    CredentialsProvider,
-    SDKInitializator,
-    SDKClientConstructorV2,
-    SDKClientConstructorV3,
-} from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
-import sinon from 'ts-sinon'
+import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
 import { ChatSessionService } from './chatSessionService'
-import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
-import { Service } from 'aws-sdk'
-import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
+import { AmazonQTokenServiceManager } from '../amazonQServiceManager/AmazonQTokenServiceManager'
 
 describe('Chat Session Service', () => {
     let sendMessageStub: sinon.SinonStub<any, any>
     let abortStub: sinon.SinonStub<any, any>
     let chatSessionService: ChatSessionService
-    const mockCredentialsProvider: CredentialsProvider = {
-        hasCredentials: sinon.stub().returns(true),
-        getCredentials: sinon.stub().returns(Promise.resolve({ token: 'mockToken ' })),
-        getConnectionMetadata: sinon.stub(),
-        getConnectionType: sinon.stub(),
-        onCredentialsDeleted: sinon.stub(),
-    }
-    const awsQRegion: string = DEFAULT_AWS_Q_REGION
-    const awsQEndpointUrl: string = DEFAULT_AWS_Q_ENDPOINT_URL
+    let amazonQServiceManager: StubbedInstance<AmazonQTokenServiceManager>
     const mockConversationId = 'mockConversationId'
-
-    const mockSdkRuntimeConfigurator: SDKInitializator = Object.assign(
-        // Default callable function for v3 clients
-        <T, P>(Ctor: SDKClientConstructorV3<T, P>, current_config: P): T => new Ctor({ ...current_config }),
-        // Property for v2 clients
-        {
-            v2: <T extends Service, P extends ServiceConfigurationOptions>(
-                Ctor: SDKClientConstructorV2<T, P>,
-                current_config: P
-            ): T => new Ctor({ ...current_config }),
-        }
-    )
 
     const mockRequestParams: SendMessageCommandInput = {
         conversationState: {
@@ -60,18 +32,16 @@ describe('Chat Session Service', () => {
     }
 
     beforeEach(() => {
-        abortStub = sinon.stub(AbortController.prototype, 'abort')
-
         sendMessageStub = sinon
             .stub(CodeWhispererStreaming.prototype, 'sendMessage')
             .callsFake(() => Promise.resolve(mockRequestResponse))
 
-        chatSessionService = new ChatSessionService(
-            mockCredentialsProvider,
-            awsQRegion,
-            awsQEndpointUrl,
-            mockSdkRuntimeConfigurator
-        )
+        amazonQServiceManager = stubInterface<AmazonQTokenServiceManager>()
+        amazonQServiceManager.getStreamingClient.returns(new CodeWhispererStreaming())
+
+        abortStub = sinon.stub(AbortController.prototype, 'abort')
+
+        chatSessionService = new ChatSessionService(amazonQServiceManager)
     })
 
     afterEach(() => {
@@ -80,6 +50,15 @@ describe('Chat Session Service', () => {
     })
 
     describe('calling SendMessage', () => {
+        it('throws error is AmazonQTokenServiceManager is not initialized', async () => {
+            chatSessionService = new ChatSessionService(undefined)
+
+            await assert.rejects(
+                chatSessionService.sendMessage(mockRequestParams),
+                new Error('amazonQServiceManager is not initialized')
+            )
+        })
+
         it('should fill in conversationId in the request if exists', async () => {
             await chatSessionService.sendMessage(mockRequestParams)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -1,24 +1,16 @@
 import {
-    CodeWhispererStreaming,
     CodeWhispererStreamingClientConfig,
     SendMessageCommandInput,
     SendMessageCommandOutput,
 } from '@amzn/codewhisperer-streaming'
-import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
-import { CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
-import { getBearerTokenFromProvider } from '../utils'
-import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
+import { AmazonQTokenServiceManager } from '../amazonQServiceManager/AmazonQTokenServiceManager'
 
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
-    readonly #codeWhispererRegion: string
-    readonly #codeWhispererEndpoint: string
-    #sdkInitializator: SDKInitializator
     #abortController?: AbortController
-    #credentialsProvider: CredentialsProvider
-    #config?: CodeWhispererStreamingClientConfig
     #conversationId?: string
+    #amazonQServiceManager?: AmazonQTokenServiceManager
 
     public get conversationId(): string | undefined {
         return this.#conversationId
@@ -28,18 +20,8 @@ export class ChatSessionService {
         this.#conversationId = value
     }
 
-    constructor(
-        credentialsProvider: CredentialsProvider,
-        codeWhispererRegion: string,
-        codeWhispererEndpoint: string,
-        sdkInitializator: SDKInitializator,
-        config?: CodeWhispererStreamingClientConfig
-    ) {
-        this.#credentialsProvider = credentialsProvider
-        this.#codeWhispererRegion = codeWhispererRegion
-        this.#codeWhispererEndpoint = codeWhispererEndpoint
-        this.#sdkInitializator = sdkInitializator
-        this.#config = config
+    constructor(amazonQServiceManager?: AmazonQTokenServiceManager) {
+        this.#amazonQServiceManager = amazonQServiceManager
     }
 
     public async sendMessage(request: SendMessageCommandInput): Promise<SendMessageCommandOutput> {
@@ -49,13 +31,11 @@ export class ChatSessionService {
             request.conversationState.conversationId = this.#conversationId
         }
 
-        const client = this.#sdkInitializator(CodeWhispererStreaming, {
-            region: this.#codeWhispererRegion,
-            endpoint: this.#codeWhispererEndpoint,
-            token: () => Promise.resolve({ token: getBearerTokenFromProvider(this.#credentialsProvider) }),
-            retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
-            ...this.#config,
-        })
+        if (!this.#amazonQServiceManager) {
+            throw new Error('amazonQServiceManager is not initialized')
+        }
+
+        const client = this.#amazonQServiceManager.getStreamingClient()
 
         const response = await client.sendMessage(request, {
             abortSignal: this.#abortController?.signal,

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
@@ -32,7 +32,8 @@ export class QChatTriggerContext {
     getChatParamsFromTrigger(
         params: ChatParams,
         triggerContext: TriggerContext,
-        customizationArn?: string
+        customizationArn?: string,
+        profileArn?: string
     ): SendMessageCommandInput {
         const { prompt } = params
 
@@ -60,6 +61,7 @@ export class QChatTriggerContext {
                 },
                 customizationArn,
             },
+            profileArn,
         }
 
         return data

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -1,4 +1,3 @@
-import { ChatSessionManagementService } from './chat/chatSessionManagementService'
 import { SecurityScanServerToken } from './codeWhispererSecurityScanServer'
 import { CodewhispererServerFactory } from './codeWhispererServer'
 import { CodeWhispererServiceIAM, CodeWhispererServiceToken } from './codeWhispererService'
@@ -54,12 +53,6 @@ export const QNetTransformServerTokenProxy = QNetTransformServerToken(
     }
 )
 
-export const QChatServerProxy = QChatServer((credentialsProvider, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
-    return ChatSessionManagementService.getInstance()
-        .withCredentialsProvider(credentialsProvider)
-        .withCodeWhispererEndpoint(awsQEndpointUrl)
-        .withCodeWhispererRegion(awsQRegion)
-        .withSdkRuntimeConfigurator(sdkInitializator)
-})
+export const QChatServerProxy = QChatServer()
 
 export const QConfigurationServerTokenProxy = QConfigurationServerToken()

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -1,15 +1,9 @@
-import {
-    BearerCredentials,
-    CredentialsProvider,
-    Position,
-    Workspace,
-} from '@aws/language-server-runtimes/server-interface'
+import { BearerCredentials, CredentialsProvider, Position } from '@aws/language-server-runtimes/server-interface'
 import { AWSError } from 'aws-sdk'
 import { distance } from 'fastest-levenshtein'
 import { Suggestion } from './codeWhispererService'
 import { CodewhispererCompletionType } from './telemetry/types'
 import { BUILDER_ID_START_URL, MISSING_BEARER_TOKEN_ERROR } from './constants'
-import { ServerInfo } from '@aws/language-server-runtimes/server-interface/runtime'
 export type SsoConnectionType = 'builderId' | 'identityCenter' | 'none'
 
 export function isAwsError(error: unknown): error is AWSError {


### PR DESCRIPTION
## Problem
We need to add regionalization support to Q Chat Server.

## Solution
* Extend AmazonQTokenServiceManager to expose factory method to create instance of `CodeWhispererStreaming` client with currently active region and endpoint
* Integrate Q Chat server to use new method
* Remove obsolete configuration passed in various Q Chat server service classes.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
