### PR TITLE
fix(amazonq): specify code analysis scope and scan name when running scans

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/constants.ts
@@ -1,0 +1,5 @@
+export const projectScanUploadIntent = 'FULL_PROJECT_SECURITY_SCAN'
+
+export const standardScanTimeoutMs = 900_000 // 15 minutes
+
+export const projectCodeAnalysisScope = 'PROJECT'

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.test.ts
@@ -8,6 +8,7 @@ import { StartCodeAnalysisRequest } from '../../client/token/codewhispererbearer
 import { CodeWhispererServiceToken } from '../codeWhispererService'
 import { SecurityScanHandler } from './securityScanHandler'
 import { RawCodeScanIssue } from './types'
+import * as ScanConstants from './constants'
 
 const mockCodeScanFindings = JSON.stringify([
     {
@@ -99,6 +100,8 @@ describe('securityScanHandler', () => {
             const requestParams: StartCodeAnalysisRequest = {
                 artifacts: { SourceCode: 'dummy-upload-id' },
                 programmingLanguage: { languageName: 'csharp' },
+                scope: ScanConstants.projectCodeAnalysisScope,
+                codeScanName: 'dummy-scan-name',
             }
             const res = await securityScanhandler.createScanJob(artifactMap, 'csharp', 'dummy-scan-name')
             simon.assert.calledOnceWithExactly(client.startCodeAnalysis, requestParams)

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.test.ts
@@ -74,7 +74,10 @@ describe('securityScanHandler', () => {
 
         it('returns correct source code', async () => {
             const expectedSourceCode = 'dummy-upload-id'
-            const res = await securityScanhandler.createCodeResourcePresignedUrlHandler(Buffer.from('dummy-data'))
+            const res = await securityScanhandler.createCodeResourcePresignedUrlHandler(
+                Buffer.from('dummy-data'),
+                'dummy-scan-name'
+            )
             simon.assert.callCount(putStub, 1)
             assert.equal(res.SourceCode, expectedSourceCode)
         })
@@ -97,7 +100,7 @@ describe('securityScanHandler', () => {
                 artifacts: { SourceCode: 'dummy-upload-id' },
                 programmingLanguage: { languageName: 'csharp' },
             }
-            const res = await securityScanhandler.createScanJob(artifactMap, 'csharp')
+            const res = await securityScanhandler.createScanJob(artifactMap, 'csharp', 'dummy-scan-name')
             simon.assert.calledOnceWithExactly(client.startCodeAnalysis, requestParams)
             assert.equal(res.jobId, 'dummy-job-id')
             assert.equal(res.status, 'Pending')

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.ts
@@ -7,6 +7,7 @@ import {
 import got from 'got'
 import { md5 } from 'js-md5'
 import * as path from 'path'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
     ArtifactMap,
@@ -99,11 +100,14 @@ export class SecurityScanHandler {
     }
 
     async createScanJob(artifactMap: ArtifactMap, languageName: string) {
+        const scanName = uuidv4()
         const req: StartCodeAnalysisRequest = {
             artifacts: artifactMap,
             programmingLanguage: {
                 languageName,
             },
+            scope: `PROJECT`,
+            codeScanName: scanName,
         }
         this.logging.log(`Creating scan job...`)
         try {
@@ -120,7 +124,7 @@ export class SecurityScanHandler {
         let status = 'Pending'
         let timer = 0
         const codeScanJobPollingIntervalSeconds = 1
-        const codeScanJobTimeoutSeconds = 50
+        const codeScanJobTimeoutSeconds = 900
         // eslint-disable-next-line no-constant-condition
         while (true) {
             const req: GetCodeAnalysisRequest = {


### PR DESCRIPTION
## Problem
Q developer scans were failing to execute due to a couple of issues. This change adds fixes to address them.
## Solution
Changes included:
* Scans were timing out due to a lower timeout limit. It has now been updated to 15mins matching other IDE's timeout limits for project scans. Reference [VSCode timeout](https://github.com/aws/aws-toolkit-vscode/blob/b048f97449b6265d97a51676acc3464aeefa4c06/packages/core/src/codewhisperer/models/constants.ts#L264)
* Missing parameters specifying the scope of the scan has now been added to the `UploadToS3` call and the `CreateScanJob` call of the scan process. At this time only `PROJECT` scope is supported. Support for file auto scans is out of scope. Reference [VSCode request](https://github.com/aws/aws-toolkit-vscode/blob/b048f97449b6265d97a51676acc3464aeefa4c06/packages/core/src/codewhisperer/service/securityScanHandler.ts#L293)
* A bug related to the presence of kms key in the upload call has been fixed.  
   * The null and undefined check for kmsKey always returned a true, that has now been fixed as an AND conditional check
   * The `CreateUploadUrlResponse` 's requestHeaders is defaulted  first to pick the request Headers. Reference [VSCode logic](https://github.com/aws/aws-toolkit-vscode/blob/b048f97449b6265d97a51676acc3464aeefa4c06/packages/core/src/codewhisperer/service/securityScanHandler.ts#L390).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
