### PR TITLE
feat(amazonq): add regionalization support to security scan server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/constants.ts
@@ -4,3 +4,6 @@ export const DEFAULT_AWS_Q_REGION = 'us-east-1'
 export const AWS_Q_ENDPOINTS = {
     [DEFAULT_AWS_Q_REGION]: DEFAULT_AWS_Q_ENDPOINT_URL,
 }
+
+export const AWS_Q_REGION_ENV_VAR = 'AWS_Q_REGION'
+export const AWS_Q_ENDPOINT_URL_ENV_VAR = 'AWS_Q_ENDPOINT_URL'

--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
@@ -15,7 +15,13 @@ import {
     LSPErrorCodes,
     ResponseError,
 } from '@aws/language-server-runtimes/protocol'
-import { AWS_Q_ENDPOINTS, DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../constants'
+import {
+    AWS_Q_ENDPOINT_URL_ENV_VAR,
+    AWS_Q_ENDPOINTS,
+    AWS_Q_REGION_ENV_VAR,
+    DEFAULT_AWS_Q_ENDPOINT_URL,
+    DEFAULT_AWS_Q_REGION,
+} from '../../constants'
 import * as qDeveloperProfilesFetcherModule from './qDeveloperProfiles'
 import { setCredentialsForAmazonQTokenServiceManagerFactory } from '../testUtils'
 import { CodeWhispererStreaming } from '@amzn/codewhisperer-streaming'
@@ -215,8 +221,8 @@ describe('AmazonQTokenServiceManager', () => {
         })
 
         it('should initialize service with region set by runtime if not set by client', async () => {
-            features.runtime.getConfiguration.withArgs('AWS_Q_REGION').returns('eu-central-1')
-            features.runtime.getConfiguration.withArgs('AWS_Q_ENDPOINT_URL').returns(TEST_ENDPOINT_EU_CENTRAL_1)
+            features.runtime.getConfiguration.withArgs(AWS_Q_REGION_ENV_VAR).returns('eu-central-1')
+            features.runtime.getConfiguration.withArgs(AWS_Q_ENDPOINT_URL_ENV_VAR).returns(TEST_ENDPOINT_EU_CENTRAL_1)
 
             amazonQTokenServiceManager.getCodewhispererService()
             assert(codewhispererStubFactory.calledOnceWithExactly('eu-central-1', TEST_ENDPOINT_EU_CENTRAL_1))

--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -14,7 +14,13 @@ import {
     CredentialsType,
     InitializeParams,
 } from '@aws/language-server-runtimes/server-interface'
-import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION, AWS_Q_ENDPOINTS } from '../../constants'
+import {
+    DEFAULT_AWS_Q_ENDPOINT_URL,
+    DEFAULT_AWS_Q_REGION,
+    AWS_Q_ENDPOINTS,
+    AWS_Q_REGION_ENV_VAR,
+    AWS_Q_ENDPOINT_URL_ENV_VAR,
+} from '../../constants'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
 import {
     AmazonQError,
@@ -448,14 +454,30 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
 
     private createCodewhispererServiceInstances(connectionType: 'builderId' | 'identityCenter', region?: string) {
         this.logServiceState('Initializing CodewhispererService')
-        let awsQRegion = this.features.runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION
-        let awsQEndpoint: string | undefined =
-            this.features.runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+        let awsQRegion: string
+        let awsQEndpoint: string | undefined
 
         if (region) {
+            this.log(
+                `Selecting region (found: ${region}) provided by ${connectionType === 'builderId' ? 'client' : 'profile'}`
+            )
             awsQRegion = region
             // @ts-ignore
-            awsQEndpoint = AWS_Q_ENDPOINTS[region]
+            awsQEndpoint = AWS_Q_ENDPOINTS[awsQRegion]
+        } else {
+            const runtimeRegion = this.features.runtime.getConfiguration(AWS_Q_REGION_ENV_VAR)
+
+            if (runtimeRegion) {
+                this.log(`Selecting region (found: ${runtimeRegion}) provided by runtime`)
+                awsQRegion = runtimeRegion
+                // prettier-ignore
+                awsQEndpoint = // @ts-ignore
+                    this.features.runtime.getConfiguration(AWS_Q_ENDPOINT_URL_ENV_VAR) ?? AWS_Q_ENDPOINTS[awsQRegion]
+            } else {
+                this.log('Region not provided by caller or runtime, falling back to default region and endpoint')
+                awsQRegion = DEFAULT_AWS_Q_REGION
+                awsQEndpoint = DEFAULT_AWS_Q_ENDPOINT_URL
+            }
         }
 
         if (!awsQEndpoint) {

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererSecurityScanServer.ts
@@ -20,30 +20,18 @@ import { getErrorMessage, parseJson } from './utils'
 import { getUserAgent } from './utilities/telemetryUtils'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../constants'
 import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
+import { AmazonQTokenServiceManager } from './amazonQServiceManager/AmazonQTokenServiceManager'
 
 const RunSecurityScanCommand = 'aws/codewhisperer/runSecurityScan'
 const CancelSecurityScanCommand = 'aws/codewhisperer/cancelSecurityScan'
 
 export const SecurityScanServerToken =
-    (
-        service: (
-            credentialsProvider: CredentialsProvider,
-            workspace: Workspace,
-            awsQRegion: string,
-            awsQEndpointUrl: string,
-            sdkInitializator: SDKInitializator
-        ) => CodeWhispererServiceToken
-    ): Server =>
+    (): Server =>
     ({ credentialsProvider, workspace, logging, lsp, telemetry, runtime, sdkInitializator }) => {
-        const codewhispererclient = service(
-            credentialsProvider,
-            workspace,
-            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
-            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
-            sdkInitializator
-        )
+        let amazonQServiceManager: AmazonQTokenServiceManager
+        let scanHandler: SecurityScanHandler
+
         const diagnosticsProvider = new SecurityScanDiagnosticsProvider(lsp, logging)
-        const scanHandler = new SecurityScanHandler(codewhispererclient, workspace, logging)
 
         const runSecurityScan = async (params: SecurityScanRequestParams, token: CancellationToken) => {
             logging.log(`Starting security scan`)
@@ -228,10 +216,6 @@ export const SecurityScanServerToken =
             return
         }
         const onInitializeHandler = (params: InitializeParams) => {
-            codewhispererclient.updateClientConfig({
-                customUserAgent: getUserAgent(params, runtime.serverInfo),
-            })
-
             return {
                 capabilities: {
                     executeCommandProvider: {
@@ -241,8 +225,21 @@ export const SecurityScanServerToken =
             }
         }
 
+        const onInitializedHandler = () => {
+            amazonQServiceManager = AmazonQTokenServiceManager.getInstance({
+                lsp,
+                logging,
+                runtime,
+                credentialsProvider,
+                sdkInitializator,
+                workspace,
+            })
+            scanHandler = new SecurityScanHandler(amazonQServiceManager, workspace, logging)
+        }
+
         lsp.onExecuteCommand(onExecuteCommandHandler)
         lsp.addInitializer(onInitializeHandler)
+        lsp.onInitialized(onInitializedHandler)
         lsp.onDidChangeTextDocument(async p => {
             const textDocument = await workspace.getTextDocument(p.textDocument.uri)
             const languageId = getSupportedLanguageId(textDocument, supportedSecurityScanLanguages)
@@ -265,6 +262,6 @@ export const SecurityScanServerToken =
 
         return () => {
             // dispose function
-            scanHandler.tokenSource.dispose()
+            scanHandler?.tokenSource.dispose()
         }
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -38,7 +38,12 @@ import { fetchSupplementalContext } from './utilities/supplementalContextUtil/su
 import { textUtils } from '@aws/lsp-core'
 import { TelemetryService } from './telemetryService'
 import { AcceptedSuggestionEntry, CodeDiffTracker } from './telemetry/codeDiffTracker'
-import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../constants'
+import {
+    AWS_Q_ENDPOINT_URL_ENV_VAR,
+    AWS_Q_REGION_ENV_VAR,
+    DEFAULT_AWS_Q_ENDPOINT_URL,
+    DEFAULT_AWS_Q_REGION,
+} from '../constants'
 import { AmazonQTokenServiceManager } from './amazonQServiceManager/AmazonQTokenServiceManager'
 import { AmazonQError, AmazonQServiceInitializationError } from './amazonQServiceManager/errors'
 import { BaseAmazonQServiceManager } from './amazonQServiceManager/BaseAmazonQServiceManager'
@@ -248,8 +253,8 @@ export const CodewhispererServerFactory =
 
         const sessionManager = SessionManager.getInstance()
 
-        const awsQRegion = runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION
-        const awsQEndpointUrl = runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL
+        const awsQRegion = runtime.getConfiguration(AWS_Q_REGION_ENV_VAR) ?? DEFAULT_AWS_Q_REGION
+        const awsQEndpointUrl = runtime.getConfiguration(AWS_Q_ENDPOINT_URL_ENV_VAR) ?? DEFAULT_AWS_Q_ENDPOINT_URL
         const fallbackCodeWhispererService = service(
             credentialsProvider,
             workspace,

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransformServer.ts
@@ -45,7 +45,12 @@ const PollTransformForPlanCommand = 'aws/qNetTransform/pollTransformForPlan'
 const GetTransformPlanCommand = 'aws/qNetTransform/getTransformPlan'
 const CancelTransformCommand = 'aws/qNetTransform/cancelTransform'
 const DownloadArtifactsCommand = 'aws/qNetTransform/downloadArtifacts'
-import { DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL } from '../constants'
+import {
+    DEFAULT_AWS_Q_REGION,
+    DEFAULT_AWS_Q_ENDPOINT_URL,
+    AWS_Q_REGION_ENV_VAR,
+    AWS_Q_ENDPOINT_URL_ENV_VAR,
+} from '../constants'
 import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
 /**
@@ -67,8 +72,8 @@ export const QNetTransformServerToken =
         const codewhispererclient = service(
             credentialsProvider,
             workspace,
-            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
-            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
+            runtime.getConfiguration(AWS_Q_REGION_ENV_VAR) ?? DEFAULT_AWS_Q_REGION,
+            runtime.getConfiguration(AWS_Q_ENDPOINT_URL_ENV_VAR) ?? DEFAULT_AWS_Q_ENDPOINT_URL,
             sdkInitializator
         )
         const transformHandler = new TransformHandler(codewhispererclient, workspace, logging, runtime)
@@ -126,8 +131,8 @@ export const QNetTransformServerToken =
                         const cwStreamingClientInstance = new StreamingClient()
                         const cwStreamingClient = await cwStreamingClientInstance.getStreamingClient(
                             credentialsProvider,
-                            runtime.getConfiguration('AWS_Q_REGION') ?? DEFAULT_AWS_Q_REGION,
-                            runtime.getConfiguration('AWS_Q_ENDPOINT_URL') ?? DEFAULT_AWS_Q_ENDPOINT_URL,
+                            runtime.getConfiguration(AWS_Q_REGION_ENV_VAR) ?? DEFAULT_AWS_Q_REGION,
+                            runtime.getConfiguration(AWS_Q_ENDPOINT_URL_ENV_VAR) ?? DEFAULT_AWS_Q_ENDPOINT_URL,
                             sdkInitializator,
                             customCWClientConfig
                         )

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -29,17 +29,7 @@ export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(
     }
 )
 
-export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
-        return new CodeWhispererServiceToken(
-            credentialsProvider,
-            workspace,
-            awsQRegion,
-            awsQEndpointUrl,
-            sdkInitializator
-        )
-    }
-)
+export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken()
 
 export const QNetTransformServerTokenProxy = QNetTransformServerToken(
     (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.test.ts
@@ -8,6 +8,7 @@ import { StartCodeAnalysisRequest } from '../../client/token/codewhispererbearer
 import { CodeWhispererServiceToken } from '../codeWhispererService'
 import { SecurityScanHandler } from './securityScanHandler'
 import { RawCodeScanIssue } from './types'
+import { AmazonQTokenServiceManager } from '../amazonQServiceManager/AmazonQTokenServiceManager'
 
 const mockCodeScanFindings = JSON.stringify([
     {
@@ -54,9 +55,11 @@ describe('securityScanHandler', () => {
     const mockedLogging = stubInterface<Logging>()
     beforeEach(async () => {
         // Set up the server with a mock service
+        const serviceManager = stubInterface<AmazonQTokenServiceManager>()
         client = stubInterface<CodeWhispererServiceToken>()
+        serviceManager.getCodewhispererService.returns(client)
         workspace = stubInterface<Workspace>()
-        securityScanhandler = new SecurityScanHandler(client, workspace, mockedLogging)
+        securityScanhandler = new SecurityScanHandler(serviceManager, workspace, mockedLogging)
     })
 
     describe('Test createCodeResourcePresignedUrlHandler', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/securityScan/securityScanHandler.ts
@@ -16,18 +16,18 @@ import {
     ListCodeAnalysisFindingsRequest,
     StartCodeAnalysisRequest,
 } from '../../client/token/codewhispererbearertokenclient'
-import { CodeWhispererServiceToken } from '../codeWhispererService'
 import { sleep } from '../dependencyGraph/commonUtil'
 import { AggregatedCodeScanIssue, RawCodeScanIssue } from './types'
+import { AmazonQTokenServiceManager } from '../amazonQServiceManager/AmazonQTokenServiceManager'
 
 export class SecurityScanHandler {
-    private client: CodeWhispererServiceToken
+    private serviceManager: AmazonQTokenServiceManager
     private workspace: Workspace
     private logging: Logging
     public tokenSource: CancellationTokenSource
 
-    constructor(client: CodeWhispererServiceToken, workspace: Workspace, logging: Logging) {
-        this.client = client
+    constructor(serviceManager: AmazonQTokenServiceManager, workspace: Workspace, logging: Logging) {
+        this.serviceManager = serviceManager
         this.workspace = workspace
         this.logging = logging
         this.tokenSource = new CancellationTokenSource()
@@ -56,7 +56,7 @@ export class SecurityScanHandler {
         }
         try {
             this.logging.log('Prepare for uploading src context...')
-            const response = await this.client.createUploadUrl(request)
+            const response = await this.serviceManager.getCodewhispererService().createUploadUrl(request)
             this.logging.log(`Request id: ${response.$response.requestId}`)
             this.logging.log(`Complete Getting presigned Url for uploading src context.`)
             this.logging.log(`Uploading src context...`)
@@ -107,7 +107,7 @@ export class SecurityScanHandler {
         }
         this.logging.log(`Creating scan job...`)
         try {
-            const resp = await this.client.startCodeAnalysis(req)
+            const resp = await this.serviceManager.getCodewhispererService().startCodeAnalysis(req)
             this.logging.log(`Request id: ${resp.$response.requestId}`)
             return resp
         } catch (error) {
@@ -126,7 +126,7 @@ export class SecurityScanHandler {
             const req: GetCodeAnalysisRequest = {
                 jobId: jobId,
             }
-            const resp = await this.client.getCodeAnalysis(req)
+            const resp = await this.serviceManager.getCodewhispererService().getCodeAnalysis(req)
             this.logging.log(`Request id: ${resp.$response.requestId}`)
 
             if (resp.status !== 'Pending') {
@@ -151,7 +151,7 @@ export class SecurityScanHandler {
             jobId,
             codeAnalysisFindingsSchema: 'codeanalysis/findings/1.0',
         }
-        const response = await this.client.listCodeAnalysisFindings(request)
+        const response = await this.serviceManager.getCodewhispererService().listCodeAnalysisFindings(request)
         this.logging.log(`Request id: ${response.$response.requestId}`)
 
         const aggregatedCodeScanIssueList = await this.mapToAggregatedList(response.codeAnalysisFindings, projectPath)


### PR DESCRIPTION
## Problem

The security scan server should use the correct region based on either the selected Q developer profile, or in case of the `builderID` connection type, use the correct region based on the expected discovery chain.

## Solution

Integrate with the security scan server with the amazon q service manager, using only the codewhisperer client provided by this singleton. The service manager is setup to select the correct region based on the above mentioned requirements, so using this client ensures the security scan server meets the region selection requirements as well.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
