### PR TITLE
feat: Cancel inflight update requests

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -91,7 +91,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
     private configurationCache = new Map()
     private activeIdcProfile?: AmazonQDeveloperProfile
     private connectionType?: SsoConnectionType
-    public profileChangeTokenSource: CancellationTokenSource | undefined
+    private profileChangeTokenSource: CancellationTokenSource | undefined
     private region?: string
     private endpoint?: string
     /**


### PR DESCRIPTION
The PR introduces changes to cancel in-flight update profile requests, so only the recent request is honored whereas the old request in progress gets cancelled. This is implemented using CancellationTokenSource, calling cancel() on the source instance changes the isCancellationRequested property of the token to true, hence enabling us to return an error for the old request.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
