### PR TITLE
feat(amazonq): accept extra context for Q Inline Suggestions

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -231,7 +231,7 @@
                     "type": "string",
                     "description": "The selected Q customization"
                 },
-                "aws.q.extracontext": {
+                "aws.q.extraContext": {
                     "scope": "resource",
                     "type": "string",
                     "description": "Extra context for Q Inline Suggestions"

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -231,7 +231,7 @@
                     "type": "string",
                     "description": "The selected Q customization"
                 },
-                "aws.q.extraContext": {
+                "aws.q.inlineSuggestions.extraContext": {
                     "scope": "resource",
                     "type": "string",
                     "description": "Extra context for Q Inline Suggestions"

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -231,6 +231,11 @@
                     "type": "string",
                     "description": "The selected Q customization"
                 },
+                "aws.q.extracontext": {
+                    "scope": "resource",
+                    "type": "string",
+                    "description": "Extra context for Q Inline Suggestions"
+                },
                 "aws.q.optOutTelemetry": {
                     "scope": "resource",
                     "type": "boolean",

--- a/server/aws-lsp-codewhisperer/README.md
+++ b/server/aws-lsp-codewhisperer/README.md
@@ -93,4 +93,4 @@ const params: InitializeParams = {
 ```
 
 ### Extra context for Q Inline Suggestions
-In cases when the client runs in a specific environment that requires customized suggestions, the server supports a `aws.q.extracontext` workspace configuration. This extra context will be passed to the left file content of the request in the beginning of the file.
+In cases when the client runs in a specific environment that requires customized suggestions, the server supports a `aws.q.extraContext` workspace configuration. This extra context will be passed to the left file content of the request in the beginning of the file.

--- a/server/aws-lsp-codewhisperer/README.md
+++ b/server/aws-lsp-codewhisperer/README.md
@@ -91,3 +91,6 @@ const params: InitializeParams = {
   }
 }
 ```
+
+### Extra context for Q Inline Suggestions
+In cases when the client runs in a specific environment that requires customized suggestions, the server supports a `aws.q.extracontext` workspace configuration. This extra context will be passed to the left file content of the request in the beginning of the file.

--- a/server/aws-lsp-codewhisperer/README.md
+++ b/server/aws-lsp-codewhisperer/README.md
@@ -93,4 +93,4 @@ const params: InitializeParams = {
 ```
 
 ### Extra context for Q Inline Suggestions
-In cases when the client runs in a specific environment that requires customized suggestions, the server supports a `aws.q.extraContext` workspace configuration. This extra context will be passed to the left file content of the request in the beginning of the file.
+In cases when the client runs in a specific environment that requires customized suggestions, the server supports a `aws.q.inlineSuggestions.extraContext` workspace configuration. This extra context will be passed to the left file content of the request in the beginning of the file.

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -243,7 +243,13 @@ describe('CodeWhisperer Server', () => {
 
         it('should include extra context in recommendation request when extraContext is configured', async () => {
             const extraContext = 'Additional context for test'
-            features.lsp.workspace.getConfiguration.returns(Promise.resolve({ extraContext }))
+            features.lsp.workspace.getConfiguration.returns(
+                Promise.resolve({
+                    inlineSuggestions: {
+                        extraContext,
+                    },
+                })
+            )
 
             await features.openDocument(SOME_FILE).doChangeConfiguration()
 

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.test.ts
@@ -241,7 +241,7 @@ describe('CodeWhisperer Server', () => {
             sinon.assert.notCalled(service.generateSuggestions)
         })
 
-        it.only('should include extra context in recommendation request when extraContext is configured', async () => {
+        it('should include extra context in recommendation request when extraContext is configured', async () => {
             const extraContext = 'Additional context for test'
             features.lsp.workspace.getConfiguration.returns(Promise.resolve({ extraContext }))
 

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -250,6 +250,7 @@ export const CodewhispererServerFactory =
     ({ credentialsProvider, lsp, workspace, telemetry, logging, runtime, sdkInitializator }) => {
         let lastUserModificationTime: number
         let timeSinceLastUserModification: number = 0
+        let extraContext: string | undefined = undefined
 
         const sessionManager = SessionManager.getInstance()
 
@@ -323,6 +324,7 @@ export const CodewhispererServerFactory =
                 const selectionRange = params.context.selectedCompletionInfo?.range
                 const fileContext = getFileContext({ textDocument, inferredLanguageId, position: params.position })
 
+
                 // TODO: Can we get this derived from a keyboard event in the future?
                 // This picks the last non-whitespace character, if any, before the cursor
                 const triggerCharacter = fileContext.leftFileContent.trim().at(-1) ?? ''
@@ -395,6 +397,10 @@ export const CodewhispererServerFactory =
                     customizationArn: textUtils.undefinedIfEmpty(codeWhispererService.customizationArn),
                 })
 
+                // Add extra context to request context
+                if (extraContext) {
+                    requestContext.fileContext.leftFileContent = extraContext + '\n' + requestContext.fileContext.leftFileContent
+                }
                 return codeWhispererService.generateSuggestions({
                         ...requestContext,
                         fileContext: {
@@ -618,6 +624,7 @@ export const CodewhispererServerFactory =
                     // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
                     const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'
                     telemetryService.updateOptOutPreference(optOutTelemetryPreference)
+                    extraContext = qConfig['extracontext']
                 }
 
                 const config = await lsp.workspace.getConfiguration('aws.codeWhisperer')

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -624,7 +624,7 @@ export const CodewhispererServerFactory =
                     // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
                     const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'
                     telemetryService.updateOptOutPreference(optOutTelemetryPreference)
-                    extraContext = qConfig['extracontext']
+                    extraContext = qConfig['extraContext']
                 }
 
                 const config = await lsp.workspace.getConfiguration('aws.codeWhisperer')

--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -624,7 +624,7 @@ export const CodewhispererServerFactory =
                     // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
                     const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'
                     telemetryService.updateOptOutPreference(optOutTelemetryPreference)
-                    extraContext = qConfig['extraContext']
+                    extraContext = qConfig.inlineSuggestions?.extraContext
                 }
 
                 const config = await lsp.workspace.getConfiguration('aws.codeWhisperer')


### PR DESCRIPTION
## Problem
In some use cases, the client has more information about the context in which the code is being edited. For example, when the editor is run in a web environment on a specific page. Then providing this additional information to Q improves quality of the suggestions. And without the context the recommendations can be barely useful, especially when editing an empty file. 

## Solution
The additional information will be added to the file's left content of the request. If no extra context is passed, the left content is not modified.  
The extra context is passed to the server as workspace configuration under `aws.q.inlineSuggestions.extraContext`. 

Using the supplemental context field was considered, but it was later discovered that it's supported not for all languages. Thus, modifying the left content before making a request is a more reliable approach. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
