### PR TITLE
fix(amazonq): await for recordMetric in CodeDiff tracker

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/telemetry/codeDiffTracker.ts
@@ -37,7 +37,11 @@ export class CodeDiffTracker<T extends AcceptedSuggestionEntry = AcceptedSuggest
     #interval?: NodeJS.Timeout
     #workspace: Features['workspace']
     #logging: Features['logging']
-    #recordMetric: (entry: T, codeModificationPercentage: number, unmodifiedAcceptedCharacterCount: number) => void
+    #recordMetric: (
+        entry: T,
+        codeModificationPercentage: number,
+        unmodifiedAcceptedCharacterCount: number
+    ) => Promise<void>
     #flushInterval: number
     #timeElapsedThreshold: number
     #maxQueueSize: number
@@ -60,7 +64,11 @@ export class CodeDiffTracker<T extends AcceptedSuggestionEntry = AcceptedSuggest
     constructor(
         workspace: Features['workspace'],
         logging: Features['logging'],
-        recordMetric: (entry: T, codeModificationPercentage: number, unmodifiedAcceptedCharacterCount: number) => void,
+        recordMetric: (
+            entry: T,
+            codeModificationPercentage: number,
+            unmodifiedAcceptedCharacterCount: number
+        ) => Promise<void>,
         options?: CodeDiffTrackerOptions
     ) {
         this.#eventQueue = []
@@ -133,7 +141,7 @@ export class CodeDiffTracker<T extends AcceptedSuggestionEntry = AcceptedSuggest
                     suggestion.originalString,
                     currString
                 )
-                this.#recordMetric(suggestion, percentage, unmodifiedAcceptedCharacterCount)
+                await this.#recordMetric(suggestion, percentage, unmodifiedAcceptedCharacterCount)
             }
         } catch (e) {
             this.#logging.log(`Exception Thrown from CodeDiffTracker: ${e}`)


### PR DESCRIPTION
## Problem
CodeDiffTracker does not await for recordMetric callback when it's async method, which may result in uncaughtRejection and crash node process.

## Solution
Await for recordMetric call to catch rejections

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
