### PR TITLE
fix(amazonq): use relative path of document with chat params

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentContext.ts
@@ -4,6 +4,8 @@ import { Range, TextDocument } from 'vscode-languageserver-textdocument'
 import { getLanguageId } from '../../languageDetection'
 import { Features } from '../../types'
 import { getExtendedCodeBlockRange, getSelectionWithinExtendedRange } from './utils'
+import path = require('path')
+import { URI } from 'vscode-uri'
 
 export type DocumentContext = CwsprTextDocument & {
     cursorState?: EditorState['cursorState']
@@ -13,6 +15,7 @@ export type DocumentContext = CwsprTextDocument & {
 
 export interface DocumentContextExtractorConfig {
     logger?: Features['logging']
+    workspace?: Features['workspace']
     characterLimits?: number
 }
 
@@ -21,9 +24,11 @@ export class DocumentContextExtractor {
 
     #characterLimits: number
     #logger?: Features['logging']
+    #workspace?: Features['workspace']
 
     constructor(config?: DocumentContextExtractorConfig) {
         this.#logger = config?.logger
+        this.#workspace = config?.workspace
         this.#characterLimits = config?.characterLimits ?? DocumentContextExtractor.DEFAULT_CHARACTER_LIMIT
     }
 
@@ -44,15 +49,26 @@ export class DocumentContextExtractor {
 
         const rangeWithinCodeBlock = getSelectionWithinExtendedRange(targetRange, codeBlockRange)
 
+        const relativePath = this.getRelativePath(document)
+
         const languageId = getLanguageId(document)
 
         return {
             cursorState: rangeWithinCodeBlock ? { range: rangeWithinCodeBlock } : undefined,
             text: document.getText(codeBlockRange),
             programmingLanguage: languageId ? { languageName: languageId } : undefined,
-            relativeFilePath: document.uri,
+            relativeFilePath: relativePath,
             hasCodeSnippet: Boolean(rangeWithinCodeBlock),
             totalEditorCharacters: document.getText().length,
         }
+    }
+
+    private getRelativePath(document: TextDocument): string {
+        const documentUri = URI.parse(document.uri)
+        const workspaceFolder = this.#workspace?.getWorkspaceFolder?.(document.uri)
+        const workspaceUri = workspaceFolder?.uri
+        const workspaceRoot = workspaceUri ? URI.parse(workspaceUri).fsPath : process.cwd()
+        const absolutePath = documentUri.fsPath
+        return path.relative(workspaceRoot, absolutePath)
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
@@ -17,7 +17,7 @@ export class QChatTriggerContext {
 
     constructor(workspace: Features['workspace'], logger: Features['logging']) {
         this.#workspace = workspace
-        this.#documentContextExtractor = new DocumentContextExtractor({ logger })
+        this.#documentContextExtractor = new DocumentContextExtractor({ logger, workspace })
     }
 
     async getNewTriggerContext(params: ChatParams): Promise<TriggerContext> {


### PR DESCRIPTION
## Description
This change addresses a bug where full/absolute path of the active text document is being sent instead of the relative Path expected with a ChatPromptRequest. 
See [here for payload shape ](https://github.com/aws/language-servers/blob/ee04afc7775e83bfa3868b4b661cf59ff3c7f949/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts#L54) which expects relativePath in the request.

Validated that chat can answer questions related to active file with this change
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
