### PR TITLE
feat(amazonq): add support for setting profile to null

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -112,6 +112,10 @@
                 "title": "Update Amazon Q IDC Profile (Invalid)"
             },
             {
+                "command": "aws.sample-vscode-ext-amazonq.updateProfileNull",
+                "title": "Send Amazon Q IDC Null Profile (reset)"
+            },
+            {
                 "command": "aws.sample-vscode-ext-amazonq.getDeveloperProfiles",
                 "title": "Get developer profiles",
                 "category": "Test Amazon Q Extension"

--- a/client/vscode/src/selectQProfileActivation.ts
+++ b/client/vscode/src/selectQProfileActivation.ts
@@ -15,9 +15,10 @@ export async function registerQProfileSelection(languageClient: LanguageClient):
         'aws.sample-vscode-ext-amazonq.updateProfileInvalid',
         setProfile(languageClient, 'invalid-profile')
     )
+    commands.registerCommand('aws.sample-vscode-ext-amazonq.updateProfileNull', setProfile(languageClient, null))
 }
 
-function setProfile(languageClient: LanguageClient, profileArn: string) {
+function setProfile(languageClient: LanguageClient, profileArn: string | null) {
     return async () => {
         try {
             const result = await languageClient.sendRequest(updateConfigurationRequestType.method, {

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.test.ts
@@ -7,6 +7,7 @@ import {
     getUnmodifiedAcceptedTokens,
     getEndPositionForAcceptedSuggestion,
     safeGet,
+    isStringOrNull,
 } from './utils'
 import { expect } from 'chai'
 import { BUILDER_ID_START_URL } from './constants'
@@ -218,5 +219,24 @@ describe('safeGet', () => {
 
     it('throws when argument is undefined', () => {
         assert.throws(() => safeGet(getStringOrUndefined(false)))
+    })
+})
+
+describe('isStringOrNull', () => {
+    const testCases = [
+        { input: 0, expected: false },
+        { input: false, expected: false },
+        { input: [], expected: false },
+        { input: {}, expected: false },
+        { input: undefined, expected: false },
+        { input: 'some-string', expected: true },
+        { input: '', expected: true },
+        { input: null, expected: true },
+    ]
+
+    testCases.forEach(testCase => {
+        it(`should return: ${testCase.expected}, when passed: ${JSON.stringify(testCase.input)}`, () => {
+            assert(isStringOrNull(testCase.input) === testCase.expected)
+        })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/utils.ts
@@ -135,3 +135,7 @@ export function safeGet<T, E extends Error>(object: T | undefined, customError?:
 
     return object
 }
+
+export function isStringOrNull(object: any): object is string | null {
+    return typeof object === 'string' || object === null
+}


### PR DESCRIPTION
## Problem

We received the request to support uninitialising profile selection in `updateConfiguration` by sending empty profile.

## Solution

Instead of listening just for a `string` in `params.settings.profileArn`, we now also listen for `null`. When we receive `null`, the code whisperer service is reset and the state is set back to `PENDING_Q_PROFILE`.

Testing: 
- Added unit tests for transitions:
  - `INITIALIZED` ->(null) `PENDING_Q_PROFILE`
  - `PENDING_Q_PROFILE_UPDATE` ->(null) `PENDING_Q_PROFILE`
- Tested E2E flow with the bundled vs code client

Additional fixes:
- Added missing cancellation of on going profile updates when we receive credentials event
- Altered request cancellation handling to not restore state to avoid race conditions when e.g. cancellation is initiated by credential deletion or null.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
