### PR TITLE
feat: update artifact manager for qct .net to include private package support

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -153,7 +153,7 @@ export class ArtifactManager {
         } as RequirementJson
     }
 
-    private processPrivatePackages(
+    processPrivatePackages(
         request: StartTransformRequest,
         reference: ExternalReference,
         artifactReference: References

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -169,6 +169,9 @@ export class ArtifactManager {
         reference: ExternalReference,
         artifactReference: References
     ) {
+        if (!request.PackageReferences) {
+            return
+        }
         var thirdPartyPackage = request.PackageReferences.find(
             p => p.IsPrivatePackage && reference.RelativePath.includes(p.Id)
         )

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -23,21 +23,10 @@ export class ArtifactManager {
     }
 
     async createZip(request: StartTransformRequest): Promise<string> {
-        this.logging.log('Starting createZip process...')
-
-        this.logging.log('Creating requirement.json...')
         await this.createRequirementJson(request)
-
-        this.logging.log('Copying solution config files...')
         await this.copySolutionConfigFiles(request)
-
-        this.logging.log('Removing duplicate NuGet packages folder...')
         await this.removeDuplicateNugetPackagesFolder(request)
-
-        this.logging.log('Creating final zip file...')
         const zipPath = await this.zipArtifact()
-
-        this.logging.log(`Zip creation completed. Path: ${zipPath}`)
         return zipPath
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -109,9 +109,23 @@ export class ArtifactManager {
                         reference.AssemblyFullPath,
                         this.getWorkspaceReferencePathFromRelativePath(relativePath)
                     )
+                    var thirdPartyPackage = project.ThirdPartyPackages.find(
+                        p => p.FrameworkRelativePath == reference.RelativePath
+                    )
+                    if (thirdPartyPackage) {
+                        this.copyFile(
+                            thirdPartyPackage.CoreCompatibleRelativePath,
+                            this.getWorkspaceReferencePathFromRelativePath(thirdPartyPackage.CoreCompatibleRelativePath)
+                        )
+                    }
                     references.push({
                         includedInArtifact: reference.IncludedInArtifact,
                         relativePath: relativePath,
+                        isThirdPartyPackage: thirdPartyPackage ? true : false,
+                        netCompatibleRelativePath: thirdPartyPackage
+                            ? thirdPartyPackage.CoreCompatibleRelativePath
+                            : undefined,
+                        netCompatibleVersion: thirdPartyPackage ? thirdPartyPackage.CoreCompatbileVersion : undefined,
                     })
                 } catch (error) {
                     this.logging.log('Failed to process file: ' + error + reference.AssemblyFullPath)

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -85,6 +85,12 @@ export interface ExternalReference {
     IncludedInArtifact: boolean
 }
 
+export interface ThirdPartyPackage {
+    FrameworkRelativePath: string
+    CoreCompatibleRelativePath: string
+    CoreCompatbileVersion: string
+}
+
 export interface TransformProjectMetadata {
     Name: string
     ProjectTargetFramework: string
@@ -93,6 +99,7 @@ export interface TransformProjectMetadata {
     ProjectLanguage: string
     ProjectType: string
     ExternalReferences: ExternalReference[]
+    ThirdPartyPackages: ThirdPartyPackage[]
 }
 
 export interface Project {
@@ -110,4 +117,7 @@ export interface CodeFile {
 export interface References {
     includedInArtifact: boolean
     relativePath: string
+    isThirdPartyPackage: boolean
+    netCompatibleRelativePath?: string
+    netCompatibleVersion?: string
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -10,7 +10,7 @@ export interface StartTransformRequest extends ExecuteCommandParams {
     SolutionConfigPaths: string[]
     ProjectMetadata: TransformProjectMetadata[]
     TransformNetStandardProjects: boolean
-    PackageReferences: PackageReferenceMetadata[]
+    PackageReferences?: PackageReferenceMetadata[]
 }
 
 export interface StartTransformResponse {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -10,6 +10,7 @@ export interface StartTransformRequest extends ExecuteCommandParams {
     SolutionConfigPaths: string[]
     ProjectMetadata: TransformProjectMetadata[]
     TransformNetStandardProjects: boolean
+    PackageReferences: PackageReferenceMetadata[]
 }
 
 export interface StartTransformResponse {
@@ -76,6 +77,7 @@ export interface RequirementJson {
     SolutionPath: string
     Projects: Project[]
     TransformNetStandardProjects: boolean
+    PackageReferences: PackageReferenceMetadata[]
 }
 
 export interface ExternalReference {
@@ -120,4 +122,12 @@ export interface References {
     isThirdPartyPackage: boolean
     netCompatibleRelativePath?: string
     netCompatibleVersion?: string
+}
+
+export interface PackageReferenceMetadata {
+    Id: string
+    Versions: string[]
+    IsPrivatePackage: boolean
+    NetCompatiblePackageDirectory?: string
+    NetCompatiblePackageVersion?: string
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -77,7 +77,6 @@ export interface RequirementJson {
     SolutionPath: string
     Projects: Project[]
     TransformNetStandardProjects: boolean
-    PackageReferences: PackageReferenceMetadata[]
 }
 
 export interface ExternalReference {
@@ -85,12 +84,6 @@ export interface ExternalReference {
     RelativePath: string
     AssemblyFullPath: string
     IncludedInArtifact: boolean
-}
-
-export interface ThirdPartyPackage {
-    FrameworkRelativePath: string
-    CoreCompatibleRelativePath: string
-    CoreCompatbileVersion: string
 }
 
 export interface TransformProjectMetadata {
@@ -101,7 +94,6 @@ export interface TransformProjectMetadata {
     ProjectLanguage: string
     ProjectType: string
     ExternalReferences: ExternalReference[]
-    ThirdPartyPackages: ThirdPartyPackage[]
 }
 
 export interface Project {
@@ -128,6 +120,7 @@ export interface PackageReferenceMetadata {
     Id: string
     Versions: string[]
     IsPrivatePackage: boolean
-    NetCompatiblePackageDirectory?: string
     NetCompatiblePackageVersion?: string
+    NetCompatibleAssemblyPath?: string
+    NetCompatibleAssemblyRelativePath?: string
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/artifactManager.processPrivatePackages.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/artifactManager.processPrivatePackages.test.ts
@@ -1,0 +1,179 @@
+import { expect } from 'chai'
+import { Workspace, Logging } from '@aws/language-server-runtimes/server-interface'
+import { StartTransformRequest, ExternalReference, References, PackageReferenceMetadata } from '../models'
+import { ArtifactManager } from '../artifactManager'
+import path = require('path')
+import { StubbedInstance, default as simon, stubInterface } from 'ts-sinon'
+import { EXAMPLE_REQUEST } from './mockData'
+
+describe('ArtifactManager - processPrivatePackages', () => {
+    let workspace: StubbedInstance<Workspace>
+    let artifactManager: ArtifactManager
+    let sampleStartTransformRequest: StartTransformRequest
+    let sampleExternalReference: ExternalReference
+    let sampleArtifactReference: References
+    const mockedLogging = stubInterface<Logging>()
+
+    beforeEach(() => {
+        workspace = stubInterface<Workspace>()
+        // Create new instance of ArtifactManager before each test
+        artifactManager = new ArtifactManager(workspace, mockedLogging, '')
+
+        // Mock internal methods that might be called
+        artifactManager.copyFile = (source: string, destination: string) => {
+            // Mock implementation if needed
+        }
+        artifactManager.getWorkspaceReferencePathFromRelativePath = (relativePath: string) => {
+            return path.join('mock/workspace/path', relativePath)
+        }
+
+        // Setup initial test data
+        sampleStartTransformRequest = EXAMPLE_REQUEST
+
+        sampleExternalReference = {
+            ProjectPath: '',
+            RelativePath: '',
+            AssemblyFullPath: '',
+            IncludedInArtifact: true,
+        }
+        sampleArtifactReference = {
+            includedInArtifact: true,
+            relativePath: '',
+            isThirdPartyPackage: false,
+        }
+    })
+
+    it('should do nothing when PackageReferences is undefined', () => {
+        sampleStartTransformRequest.PackageReferences = undefined
+        artifactManager.processPrivatePackages(
+            sampleStartTransformRequest,
+            sampleExternalReference,
+            sampleArtifactReference
+        )
+        expect(sampleArtifactReference.isThirdPartyPackage).to.equal(false)
+        expect(sampleArtifactReference.netCompatibleRelativePath).to.equal(undefined)
+        expect(sampleArtifactReference.netCompatibleVersion).to.equal(undefined)
+    })
+
+    it('should process private package when all conditions are met', () => {
+        // Spy on the copyFile method
+        let copyFileCalled = false
+        artifactManager.copyFile = (source: string, destination: string) => {
+            copyFileCalled = true
+        }
+
+        const privatePackage: PackageReferenceMetadata = {
+            Id: 'test-package',
+            Versions: [],
+            IsPrivatePackage: true,
+            NetCompatibleAssemblyRelativePath: 'path/to/assembly',
+            NetCompatibleAssemblyPath: 'full/path/to/assembly',
+            NetCompatiblePackageVersion: '2.0.0',
+        }
+
+        sampleStartTransformRequest.PackageReferences = [privatePackage]
+        sampleExternalReference.RelativePath = 'some/path/test-package/more/path'
+
+        artifactManager.processPrivatePackages(
+            sampleStartTransformRequest,
+            sampleExternalReference,
+            sampleArtifactReference
+        )
+
+        expect(copyFileCalled).to.be.true
+        expect(sampleArtifactReference.isThirdPartyPackage).to.equal(true)
+        expect(sampleArtifactReference.netCompatibleRelativePath).to.equal(
+            path.join('references', 'thirdpartypackages', 'path/to/assembly').toLowerCase()
+        )
+        expect(sampleArtifactReference.netCompatibleVersion).to.equal('2.0.0')
+    })
+
+    it('should not process when package is not private', () => {
+        let copyFileCalled = false
+        artifactManager.copyFile = (source: string, destination: string) => {
+            copyFileCalled = true
+        }
+
+        const nonPrivatePackage = {
+            Id: 'test-package',
+            IsPrivatePackage: false,
+            NetCompatibleAssemblyRelativePath: 'path/to/assembly',
+            NetCompatibleAssemblyPath: 'full/path/to/assembly',
+            NetCompatiblePackageVersion: '1.0.0',
+            Versions: [],
+        }
+
+        sampleStartTransformRequest.PackageReferences = [nonPrivatePackage]
+        sampleExternalReference.RelativePath = 'some/path/test-package/more/path'
+
+        artifactManager.processPrivatePackages(
+            sampleStartTransformRequest,
+            sampleExternalReference,
+            sampleArtifactReference
+        )
+
+        expect(copyFileCalled).to.be.false
+        expect(sampleArtifactReference.isThirdPartyPackage).to.equal(false)
+        expect(sampleArtifactReference.netCompatibleRelativePath).to.equal(undefined)
+        expect(sampleArtifactReference.netCompatibleVersion).to.equal(undefined)
+    })
+
+    it('should not process when package ID is not in reference path', () => {
+        let copyFileCalled = false
+        artifactManager.copyFile = (source: string, destination: string) => {
+            copyFileCalled = true
+        }
+
+        const privatePackage = {
+            Id: 'test-package',
+            IsPrivatePackage: true,
+            NetCompatibleAssemblyRelativePath: 'path/to/assembly',
+            NetCompatibleAssemblyPath: 'full/path/to/assembly',
+            NetCompatiblePackageVersion: '1.0.0',
+            Versions: [],
+        }
+
+        sampleStartTransformRequest.PackageReferences = [privatePackage]
+        sampleExternalReference.RelativePath = 'some/path/different-package/more/path'
+
+        artifactManager.processPrivatePackages(
+            sampleStartTransformRequest,
+            sampleExternalReference,
+            sampleArtifactReference
+        )
+
+        expect(copyFileCalled).to.be.false
+        expect(sampleArtifactReference.isThirdPartyPackage).to.equal(false)
+        expect(sampleArtifactReference.netCompatibleRelativePath).to.equal(undefined)
+        expect(sampleArtifactReference.netCompatibleVersion).to.equal(undefined)
+    })
+
+    it('should not process when NetCompatibleAssemblyRelativePath is missing', () => {
+        let copyFileCalled = false
+        artifactManager.copyFile = (source: string, destination: string) => {
+            copyFileCalled = true
+        }
+
+        const privatePackage = {
+            Id: 'test-package',
+            IsPrivatePackage: true,
+            NetCompatibleAssemblyPath: 'full/path/to/assembly',
+            NetCompatiblePackageVersion: '1.0.0',
+            Versions: [],
+        }
+
+        sampleStartTransformRequest.PackageReferences = [privatePackage]
+        sampleExternalReference.RelativePath = 'some/path/test-package/more/path'
+
+        artifactManager.processPrivatePackages(
+            sampleStartTransformRequest,
+            sampleExternalReference,
+            sampleArtifactReference
+        )
+
+        expect(copyFileCalled).to.be.false
+        expect(sampleArtifactReference.isThirdPartyPackage).to.equal(false)
+        expect(sampleArtifactReference.netCompatibleRelativePath).to.equal(undefined)
+        expect(sampleArtifactReference.netCompatibleVersion).to.equal(undefined)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
@@ -54,7 +54,6 @@ const sampleUserInputRequest: StartTransformRequest = {
             ExternalReferences: [],
             ProjectTargetFramework: '',
             SourceCodeFilePaths: [],
-            ThirdPartyPackages: [],
         },
     ],
     TransformNetStandardProjects: false,

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
@@ -54,10 +54,12 @@ const sampleUserInputRequest: StartTransformRequest = {
             ExternalReferences: [],
             ProjectTargetFramework: '',
             SourceCodeFilePaths: [],
+            ThirdPartyPackages: [],
         },
     ],
     TransformNetStandardProjects: false,
     command: '',
+    PackageReferences: [],
 }
 
 function safeSet(obj: any, path: string[], value: any): void {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/mockData.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/mockData.ts
@@ -1,19 +1,14 @@
-export const EXAMPLE_REQUEST = {
+import { StartTransformRequest } from '../models'
+
+export const EXAMPLE_REQUEST: StartTransformRequest = {
+    SolutionFilePath: 'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\CoreMVC.sln',
+    SolutionConfigPaths: [],
+    TransformNetStandardProjects: true,
     SolutionRootPath: 'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC',
     TargetFramework: 'net8.0',
     ProgramLanguage: 'csharp',
     SelectedProjectPath:
         'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\CoreMVC.csproj',
-    SourceCodeFilePaths: [
-        'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\appsettings.Development.json',
-        'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\appsettings.json',
-        'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\CoreMVC.csproj',
-        'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\Program.cs',
-        'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\Startup.cs',
-        'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC.sln',
-        'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\PortSolutionResult.json',
-        'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\PortSolutionResult.txt',
-    ],
     ProjectMetadata: [
         {
             Name: 'CoreMVC',
@@ -29,9 +24,19 @@ export const EXAMPLE_REQUEST = {
                         'references\\packages\\microsoft.aspnetcore.app.ref\\3.1.10\\ref\\netcoreapp3.1\\Microsoft.Extensions.Http.dll',
                     AssemblyFullPath:
                         'C:\\.nuget\\packages\\microsoft.aspnetcore.app.ref\\3.1.10\\ref\\netcoreapp3.1\\Microsoft.Extensions.Http.dll',
-                    TargetFrameworkId: '',
                     IncludedInArtifact: true,
                 },
+            ],
+            ProjectTargetFramework: 'net8.0',
+            SourceCodeFilePaths: [
+                'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\appsettings.Development.json',
+                'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\appsettings.json',
+                'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\CoreMVC.csproj',
+                'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\Program.cs',
+                'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC\\Startup.cs',
+                'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\CoreMVC.sln',
+                'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\PortSolutionResult.json',
+                'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC\\PortSolutionResult.txt',
             ],
         },
         {
@@ -47,7 +52,6 @@ export const EXAMPLE_REQUEST = {
                         'references\\Reference Assemblies\\Microsoft\\Framework\\.NETFramework\\v4.0\\System.Drawing.dll',
                     AssemblyFullPath:
                         'C:\\Program Files (x86)\\Reference Assemblies\\Microsoft\\Framework\\.NETFramework\\v4.0\\System.Drawing.dll',
-                    TargetFrameworkId: 'netframework4.0',
                     IncludedInArtifact: false,
                 },
                 {
@@ -57,10 +61,11 @@ export const EXAMPLE_REQUEST = {
                         'references\\Reference Assemblies\\Microsoft\\Framework\\.NETFramework\\v4.0\\System.Web.dll',
                     AssemblyFullPath:
                         'C:\\Program Files (x86)\\Reference Assemblies\\Microsoft\\Framework\\.NETFramework\\v4.0\\System.Web.dll',
-                    TargetFrameworkId: 'netframework4.0',
                     IncludedInArtifact: false,
                 },
             ],
+            ProjectTargetFramework: 'net8.0',
+            SourceCodeFilePaths: [],
         },
     ],
     command: 'aws/qNetTransform/startTransform',

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
@@ -16,6 +16,7 @@ const sampleStartTransformRequest: StartTransformRequest = {
     ProjectMetadata: [],
     TransformNetStandardProjects: false,
     command: '',
+    PackageReferences: [],
 }
 const mockedLogging = stubInterface<Logging>()
 
@@ -54,6 +55,7 @@ describe('Test validation functionality', () => {
             ProjectLanguage: '',
             ProjectType: 'AspNetCoreMvc',
             ExternalReferences: [],
+            ThirdPartyPackages: [],
         }
         mockStartTransformationRequest.ProjectMetadata.push(mockProjectMeta)
 
@@ -70,6 +72,7 @@ describe('Test validation functionality', () => {
             ProjectLanguage: '',
             ProjectType: 'not supported',
             ExternalReferences: [],
+            ThirdPartyPackages: [],
         }
         mockStartTransformationRequest.ProjectMetadata = []
         mockStartTransformationRequest.ProjectMetadata.push(mockProjectMeta)
@@ -87,6 +90,7 @@ describe('Test validation functionality', () => {
             ProjectLanguage: '',
             ProjectType: 'AspNetCoreMvc',
             ExternalReferences: [],
+            ThirdPartyPackages: [],
         }
         mockStartTransformationRequest.ProjectMetadata = []
         mockStartTransformationRequest.ProjectMetadata.push(mockProjectMeta)

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
@@ -55,7 +55,6 @@ describe('Test validation functionality', () => {
             ProjectLanguage: '',
             ProjectType: 'AspNetCoreMvc',
             ExternalReferences: [],
-            ThirdPartyPackages: [],
         }
         mockStartTransformationRequest.ProjectMetadata.push(mockProjectMeta)
 
@@ -72,7 +71,6 @@ describe('Test validation functionality', () => {
             ProjectLanguage: '',
             ProjectType: 'not supported',
             ExternalReferences: [],
-            ThirdPartyPackages: [],
         }
         mockStartTransformationRequest.ProjectMetadata = []
         mockStartTransformationRequest.ProjectMetadata.push(mockProjectMeta)
@@ -90,7 +88,6 @@ describe('Test validation functionality', () => {
             ProjectLanguage: '',
             ProjectType: 'AspNetCoreMvc',
             ExternalReferences: [],
-            ThirdPartyPackages: [],
         }
         mockStartTransformationRequest.ProjectMetadata = []
         mockStartTransformationRequest.ProjectMetadata.push(mockProjectMeta)


### PR DESCRIPTION
## Problem
Update artifact manager for qct .net to include private package support

## Solution

ArtifactManager Updates:

- store core compatible assembly files in thirdpartypackages folder under references
- update the requirement.json created with relative path to files in the above folder.

## Testing
Testing positive case, verify artifact.zip was created properly

example artifact.zip after change.
[artifact.zip](https://github.com/user-attachments/files/19558786/artifact.zip)

![Screenshot 2025-04-01 at 4 00 04 PM](https://github.com/user-attachments/assets/a2fcbfc2-3a8b-4909-9f2c-1325632f953d)

![Screenshot 2025-04-01 at 4 00 22 PM](https://github.com/user-attachments/assets/aa6ab2c7-ee89-4f3f-90a6-a2ed6ed3d3cf)

![Screenshot 2025-04-01 at 4 00 33 PM](https://github.com/user-attachments/assets/e383b18a-a344-4755-8ec4-b8a7eff2e68f)

Also test negative case where PackageReferences not provided in the request, make sure requirement.json and artifact content still created properly.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
