### PR TITLE
chore: initial flare migration for /test

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/agents/shared/model.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/agents/shared/model.ts
@@ -1,0 +1,25 @@
+export interface Reference {
+    licenseName?: string
+    repository?: string
+    url?: string
+    recommendationContentSpan?: {
+        start: number
+        end: number
+    }
+}
+
+// TODO: remove ShortAnswer because it will be deprecated
+export interface ShortAnswer {
+    testFilePath: string
+    buildCommands: string[]
+    planSummary: string
+    sourceFilePath?: string
+    testFramework?: string
+    executionCommands?: string[]
+    testCoverage?: number
+    stopIteration?: string
+    errorMessage?: string
+    // TODO: from codewhisper model
+    // codeReferences?: References
+    numberOfTestMethods?: number
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/agents/testgen/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/agents/testgen/constants.ts
@@ -1,0 +1,188 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ProgressField, MynahIcons, ChatItemButton } from '@aws/mynah-ui'
+// TODO: added ButtonActions enum to this file
+// import { ButtonActions } from '../chat/controller/messenger/messengerUtils'
+// TODO: added TestGenerationBuildStep enum to this file
+// import { TestGenerationBuildStep } from '../../codewhisperer/models/constants'
+// TODO: will ChatSessionManager still exist?
+// import { ChatSessionManager } from '../chat/storages/chatSession'
+import { BuildStatus } from './session'
+
+// For uniquely identifiying which chat messages should be routed to Test
+export const testChat = 'testChat'
+
+export const maxUserPromptLength = 4096 // user prompt character limit from MPS and API model.
+
+// TODO: adding ButtonActions enum to this file for now
+// These enums map to string IDs
+export enum ButtonActions {
+    ACCEPT = 'Accept',
+    MODIFY = 'Modify',
+    REJECT = 'Reject',
+    VIEW_DIFF = 'View-Diff',
+    STOP_TEST_GEN = 'Stop-Test-Generation',
+    STOP_BUILD = 'Stop-Build-Process',
+    PROVIDE_FEEDBACK = 'Provide-Feedback',
+}
+
+// TODO: adding TestGenerationBuildStep enum to this file for now
+export enum TestGenerationBuildStep {
+    START_STEP,
+    INSTALL_DEPENDENCIES,
+    RUN_BUILD,
+    RUN_EXECUTION_TESTS,
+    FIXING_TEST_CASES,
+    PROCESS_TEST_RESULTS,
+}
+
+// TODO: Refactor the common functionality between Transform, FeatureDev, CWSPRChat, Scan and UTG to a new Folder.
+
+export default class MessengerUtils {
+    static stringToEnumValue = <T extends { [key: string]: string }, K extends keyof T & string>(
+        enumObject: T,
+        value: `${T[K]}`
+    ): T[K] => {
+        if (Object.values(enumObject).includes(value)) {
+            return value as unknown as T[K]
+        } else {
+            throw new Error('Value provided was not found in Enum')
+        }
+    }
+}
+
+export const cancelTestGenButton: ChatItemButton = {
+    id: ButtonActions.STOP_TEST_GEN,
+    text: 'Cancel',
+    icon: 'cancel' as MynahIcons,
+}
+
+export const testGenProgressField: ProgressField = {
+    status: 'default',
+    value: -1,
+    text: 'Generating unit tests...',
+    actions: [cancelTestGenButton],
+}
+
+export const testGenCompletedField: ProgressField = {
+    status: 'success',
+    value: 100,
+    text: 'Complete...',
+    actions: [],
+}
+
+export const cancellingProgressField: ProgressField = {
+    status: 'warning',
+    text: 'Cancelling...',
+    value: -1,
+    actions: [],
+}
+
+export const cancelBuildProgressButton: ChatItemButton = {
+    id: ButtonActions.STOP_BUILD,
+    text: 'Cancel',
+    icon: 'cancel' as MynahIcons,
+}
+
+export const buildProgressField: ProgressField = {
+    status: 'default',
+    value: -1,
+    text: 'Executing...',
+    actions: [cancelBuildProgressButton],
+}
+
+export const errorProgressField: ProgressField = {
+    status: 'error',
+    text: 'Error...Input needed',
+    value: -1,
+    actions: [cancelBuildProgressButton],
+}
+
+export const testGenSummaryMessage = (
+    fileName: string,
+    planSummary?: string
+) => `Sure. This may take a few minutes. I'll share updates here as I work on this.
+
+**Generating unit tests for the following methods in \`${fileName}\`**
+${planSummary ? `\n\n${planSummary}` : ''}
+`
+
+const checkIcons = {
+    wait: '&#9744;',
+    current: '&#9744;',
+    done: '<span style="color: green;">&#10004;</span>',
+    error: '&#10060;',
+}
+
+interface StepStatus {
+    step: TestGenerationBuildStep
+    status: 'wait' | 'current' | 'done' | 'error'
+}
+
+const stepStatuses: StepStatus[] = []
+
+// TODO: Added session as a paramter, since no instance of ChatSessionManager
+export const testGenBuildProgressMessage = (currentStep: TestGenerationBuildStep, session: any, status?: string) => {
+    // const session = ChatSessionManager.Instance.getSession()
+    const statusText = BuildStatus[session.buildStatus].toLowerCase()
+    const icon = session.buildStatus === BuildStatus.SUCCESS ? checkIcons['done'] : checkIcons['error']
+    let message = `Sure. This may take a few minutes and I'll share updates on my progress here.
+**Progress summary**\n\n`
+
+    if (currentStep === TestGenerationBuildStep.START_STEP) {
+        return message.trim()
+    }
+
+    updateStepStatuses(currentStep, status)
+
+    if (currentStep >= TestGenerationBuildStep.RUN_BUILD) {
+        message += `${getIconForStep(TestGenerationBuildStep.RUN_BUILD)} Started build execution\n`
+    }
+
+    if (currentStep >= TestGenerationBuildStep.RUN_EXECUTION_TESTS) {
+        message += `${getIconForStep(TestGenerationBuildStep.RUN_EXECUTION_TESTS)} Executing tests\n`
+    }
+
+    if (currentStep >= TestGenerationBuildStep.FIXING_TEST_CASES && session.buildStatus === BuildStatus.FAILURE) {
+        message += `${getIconForStep(TestGenerationBuildStep.FIXING_TEST_CASES)} Fixing errors in tests\n\n`
+    }
+
+    if (currentStep > TestGenerationBuildStep.PROCESS_TEST_RESULTS) {
+        message += `**Test case summary**
+${session.shortAnswer?.testCoverage ? `- Unit test coverage ${session.shortAnswer?.testCoverage}%` : ``}
+${icon} Build ${statusText}
+${icon} Assertion ${statusText}`
+        // TODO: Update Assertion %
+    }
+
+    return message.trim()
+}
+// TODO: Work on UX to show the build error in the progress message
+const updateStepStatuses = (currentStep: TestGenerationBuildStep, status?: string) => {
+    for (let step = TestGenerationBuildStep.INSTALL_DEPENDENCIES; step <= currentStep; step++) {
+        const stepStatus: StepStatus = {
+            step: step,
+            status: 'wait',
+        }
+
+        if (step === currentStep) {
+            stepStatus.status = status === 'failed' ? 'error' : 'current'
+        } else if (step < currentStep) {
+            stepStatus.status = 'done'
+        }
+
+        const existingIndex = stepStatuses.findIndex(s => s.step === step)
+        if (existingIndex !== -1) {
+            stepStatuses[existingIndex] = stepStatus
+        } else {
+            stepStatuses.push(stepStatus)
+        }
+    }
+}
+
+const getIconForStep = (step: TestGenerationBuildStep) => {
+    const stepStatus = stepStatuses.find(s => s.step === step)
+    return stepStatus ? checkIcons[stepStatus.status] : checkIcons.wait
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/agents/testgen/error.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/agents/testgen/error.ts
@@ -1,0 +1,69 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// import { ToolkitError } from '../shared/errors'
+
+export const technicalErrorCustomerFacingMessage =
+    'I am experiencing technical difficulties at the moment. Please try again in a few minutes.'
+const defaultTestGenErrorMessage = 'Amazon Q encountered an error while generating tests. Try again later.'
+
+// TODO: should extend ToolkitError
+export class TestGenError {
+    constructor(
+        error: string,
+        code: string,
+        public uiMessage: string
+    ) {
+        // super(error, { code })
+    }
+}
+export class ProjectZipError extends TestGenError {
+    constructor(error: string) {
+        super(error, 'ProjectZipError', defaultTestGenErrorMessage)
+    }
+}
+export class InvalidSourceZipError extends TestGenError {
+    constructor() {
+        super('Failed to create valid source zip', 'InvalidSourceZipError', defaultTestGenErrorMessage)
+    }
+}
+export class CreateUploadUrlError extends TestGenError {
+    constructor(errorMessage: string) {
+        super(errorMessage, 'CreateUploadUrlError', technicalErrorCustomerFacingMessage)
+    }
+}
+export class UploadTestArtifactToS3Error extends TestGenError {
+    constructor(error: string) {
+        super(error, 'UploadTestArtifactToS3Error', technicalErrorCustomerFacingMessage)
+    }
+}
+export class CreateTestJobError extends TestGenError {
+    constructor(error: string) {
+        super(error, 'CreateTestJobError', technicalErrorCustomerFacingMessage)
+    }
+}
+export class TestGenTimedOutError extends TestGenError {
+    constructor() {
+        super(
+            'Test generation failed. Amazon Q timed out.',
+            'TestGenTimedOutError',
+            technicalErrorCustomerFacingMessage
+        )
+    }
+}
+export class TestGenStoppedError extends TestGenError {
+    constructor() {
+        super('Unit test generation cancelled.', 'TestGenCancelled', 'Unit test generation cancelled.')
+    }
+}
+export class TestGenFailedError extends TestGenError {
+    constructor(error?: string) {
+        super(error ?? 'Test generation failed', 'TestGenFailedError', error ?? technicalErrorCustomerFacingMessage)
+    }
+}
+export class ExportResultsArchiveError extends TestGenError {
+    constructor(error?: string) {
+        super(error ?? 'Test generation failed', 'ExportResultsArchiveError', technicalErrorCustomerFacingMessage)
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/agents/testgen/session.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/agents/testgen/session.ts
@@ -1,0 +1,79 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ShortAnswer, Reference } from '../shared/model'
+// TODO: how is codewhisperer client model generated in flare?
+// import { TargetFileInfo, TestGenerationJob } from '../../../codewhisperer/client/codewhispereruserclient'
+
+export enum ConversationState {
+    IDLE,
+    JOB_SUBMITTED,
+    WAITING_FOR_INPUT,
+    WAITING_FOR_BUILD_COMMMAND_INPUT,
+    WAITING_FOR_REGENERATE_INPUT,
+    IN_PROGRESS,
+}
+
+export enum BuildStatus {
+    SUCCESS,
+    FAILURE,
+    CANCELLED,
+}
+
+export class Session {
+    // Used to keep track of whether or not the current session is currently authenticating/needs authenticating
+    public isAuthenticating: boolean = false
+
+    // A tab may or may not be currently open
+    public tabID: string | undefined
+
+    // This is unique per each test generation cycle
+    public testGenerationJobGroupName: string | undefined = undefined
+    public listOfTestGenerationJobId: string[] = []
+    public startTestGenerationRequestId: string | undefined = undefined
+    // public testGenerationJob: TestGenerationJob | undefined // TODO
+
+    // Start Test generation
+    public isSupportedLanguage: boolean = false
+    public conversationState: ConversationState = ConversationState.IDLE
+    public shortAnswer: ShortAnswer | undefined
+    public sourceFilePath: string = ''
+    public generatedFilePath: string = ''
+    public projectRootPath: string = ''
+    public fileLanguage: string | undefined = 'plaintext'
+    public stopIteration: boolean = false
+    // TODO: from codewhisper model
+    // public targetFileInfo: TargetFileInfo | undefined
+    public jobSummary: string = ''
+
+    // Telemetry
+    public testGenerationStartTime: number = 0
+    public hasUserPromptSupplied: boolean = false
+    public isCodeBlockSelected: boolean = false
+    public srcPayloadSize: number = 0
+    public srcZipFileSize: number = 0
+    public artifactsUploadDuration: number = 0
+    public numberOfTestsGenerated: number = 0
+    public linesOfCodeGenerated: number = 0
+    public linesOfCodeAccepted: number = 0
+    public charsOfCodeGenerated: number = 0
+    public charsOfCodeAccepted: number = 0
+    public latencyOfTestGeneration: number = 0
+
+    // TODO: Take values from ShortAnswer or TestGenerationJob
+    // Build loop
+    public buildStatus: BuildStatus = BuildStatus.SUCCESS
+    public updatedBuildCommands: string[] | undefined = undefined
+    public testCoveragePercentage: number = 90
+    public isInProgress: boolean = false
+    public acceptedJobId = ''
+    public references: Reference[] = []
+
+    constructor() {}
+
+    public isTabOpen(): boolean {
+        return this.tabID !== undefined
+    }
+}


### PR DESCRIPTION
## Problem
- Initial migration for /test to flare

TODOs: 
- added enums to constants.ts
- will ChatSessionManager still exist?
- Added session as a paramter, since no instance of ChatSessionManager
- should extend ToolkitError
- how is codewhisperer client model generated in flare?

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
