### PR TITLE
[Team review] : fix for file not found issue

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/transformHandler.test.ts
@@ -28,6 +28,8 @@ import sinon = require('sinon')
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../../constants'
 import { Service } from 'aws-sdk'
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service'
+import path = require('path')
+import { IZipEntry } from 'adm-zip'
 
 const mocked$Response = {
     $response: {
@@ -317,6 +319,181 @@ describe('Test Transform handler ', () => {
                     'ProgressUpdateName 1 for PlanStep 1'
                 )
             }
+        })
+    })
+
+    describe('extractAllEntriesTo', () => {
+        let sandbox: sinon.SinonSandbox
+        let mkdirStub: sinon.SinonStub
+        let writeFileStub: sinon.SinonStub
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox()
+
+            sandbox.stub(path, 'join').callsFake((...args) => args.join('/'))
+            sandbox.stub(path, 'dirname').callsFake(p => p.split('/').slice(0, -1).join('/'))
+            mkdirStub = sinon.stub(fs.promises, 'mkdir')
+            writeFileStub = sinon.stub(fs.promises, 'writeFile')
+        })
+
+        afterEach(() => {
+            sandbox.restore()
+            if (mkdirStub?.restore) {
+                mkdirStub.restore()
+            }
+            if (writeFileStub?.restore) {
+                writeFileStub.restore()
+            }
+        })
+
+        function createMockZipEntry(entryName: string, isDirectory: boolean, content?: string): IZipEntry {
+            return {
+                entryName,
+                isDirectory,
+                getData: content ? () => Buffer.from(content) : () => Buffer.from(''),
+                header: {} as any,
+                attr: 0,
+                getCompressedData: () => Buffer.from(''),
+                name: entryName,
+                rawEntryName: Buffer.from(entryName),
+                extra: Buffer.from(''),
+                comment: '',
+                getCompressedDataAsync: function (callback: (data: Buffer) => void): void {
+                    throw new Error('Function not implemented.')
+                },
+                setData: function (value: string | Buffer): void {
+                    throw new Error('Function not implemented.')
+                },
+                getDataAsync: function (callback: (data: Buffer, err: string) => void): void {
+                    throw new Error('Function not implemented.')
+                },
+                packHeader: function (): Buffer {
+                    throw new Error('Function not implemented.')
+                },
+                toString: function (): string {
+                    throw new Error('Function not implemented.')
+                },
+            }
+        }
+
+        it('should create directories and extract files successfully', async () => {
+            const pathContainingArchive = '/test/path'
+            const zipEntries = [
+                createMockZipEntry('dir1/', true),
+                createMockZipEntry('dir1/file1.txt', false, 'content1'),
+                createMockZipEntry('file2.txt', false, 'content2'),
+            ]
+
+            await transformHandler.extractAllEntriesTo(pathContainingArchive, zipEntries)
+
+            sinon.assert.calledThrice(mkdirStub)
+            sinon.assert.calledTwice(writeFileStub)
+        })
+
+        it('should handle ENOENT errors gracefully', async () => {
+            const pathContainingArchive = '/test/path'
+            const enoentError = new Error('ENOENT') as NodeJS.ErrnoException
+            enoentError.code = 'ENOENT'
+
+            const zipEntries = [createMockZipEntry('file1.txt', false)]
+            zipEntries[0].getData = () => {
+                throw enoentError
+            }
+
+            await transformHandler.extractAllEntriesTo(pathContainingArchive, zipEntries)
+
+            expect(mockedLogging.log.args.flat()).to.include('ENOENT error was ignored for entry: file1.txt')
+        })
+
+        it('should throw non-ENOENT errors', async () => {
+            const pathContainingArchive = '/test/path'
+            const otherError = new Error('Some other error')
+
+            const zipEntries = [createMockZipEntry('file1.txt', false)]
+            zipEntries[0].getData = () => {
+                throw otherError
+            }
+
+            return transformHandler
+                .extractAllEntriesTo(pathContainingArchive, zipEntries)
+                .then(() => {
+                    expect.fail('Expected "Some other error" to be thrown, but no error was thrown.')
+                })
+                .catch(error => {
+                    expect(error.message).to.equal('Some other error')
+                })
+        })
+
+        it('should handle nested directory structures', async () => {
+            const pathContainingArchive = '/test/path'
+            const zipEntries = [
+                createMockZipEntry('dir1/', true),
+                createMockZipEntry('dir1/dir2/', true),
+                createMockZipEntry('dir1/dir2/file1.txt', false, 'content1'),
+            ]
+
+            await transformHandler.extractAllEntriesTo(pathContainingArchive, zipEntries)
+
+            sinon.assert.calledThrice(mkdirStub)
+            sinon.assert.calledOnce(writeFileStub)
+            sinon.assert.calledWith(writeFileStub, '/test/path/dir1/dir2/file1.txt')
+        })
+
+        it('should handle empty entry list', async () => {
+            const pathContainingArchive = '/test/path'
+            const zipEntries: IZipEntry[] = []
+
+            await transformHandler.extractAllEntriesTo(pathContainingArchive, zipEntries)
+
+            sinon.assert.notCalled(mkdirStub)
+            sinon.assert.notCalled(writeFileStub)
+        })
+
+        it('should handle files without directories', async () => {
+            const pathContainingArchive = '/test/path'
+            const zipEntries = [
+                createMockZipEntry('file1.txt', false, 'content1'),
+                createMockZipEntry('file2.txt', false, 'content2'),
+            ]
+
+            await transformHandler.extractAllEntriesTo(pathContainingArchive, zipEntries)
+
+            sinon.assert.calledTwice(mkdirStub)
+            sinon.assert.calledTwice(writeFileStub)
+        })
+
+        it('should handle mixed content with files and directories', async () => {
+            const pathContainingArchive = '/test/path'
+            const zipEntries = [
+                createMockZipEntry('dir1/', true),
+                createMockZipEntry('file1.txt', false, 'content1'),
+                createMockZipEntry('dir1/file2.txt', false, 'content2'),
+            ]
+
+            await transformHandler.extractAllEntriesTo(pathContainingArchive, zipEntries)
+
+            sinon.assert.calledThrice(mkdirStub)
+            sinon.assert.calledTwice(writeFileStub)
+            sinon.assert.calledWith(mkdirStub, '/test/path/dir1')
+        })
+
+        it('should handle invalid entry paths', async () => {
+            const pathContainingArchive = '/test/path'
+            const invalidError = new Error('Invalid path') as NodeJS.ErrnoException
+            invalidError.code = 'EINVAL'
+
+            const zipEntries = [createMockZipEntry('invalid/../../file.txt', false, 'content')]
+
+            ;(fs.promises.mkdir as sinon.SinonStub).rejects(invalidError)
+
+            return transformHandler
+                .extractAllEntriesTo(pathContainingArchive, zipEntries)
+                .then(() => {
+                    expect.fail('Expected "Invalid path" to be thrown, but no error was thrown.')
+                })
+                .catch(error => {
+                    expect(error.message).to.equal('Invalid path')
+                })
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -373,6 +373,7 @@ export class TransformHandler {
                 }
             }
             const saveToWorkspace = path.join(saveToDir, workspaceFolderName)
+            this.logging.log(`Identified path of directory to save artifacts is ${saveToDir}`)
             const pathContainingArchive = await this.archivePathGenerator(exportId, buffer, saveToWorkspace)
             this.logging.log('PathContainingArchive :' + pathContainingArchive)
             return {
@@ -386,16 +387,44 @@ export class TransformHandler {
         }
     }
 
+    async extractAllEntriesTo(pathContainingArchive: string, zipEntries: AdmZip.IZipEntry[]) {
+        for (const entry of zipEntries) {
+            try {
+                const entryPath = path.join(pathContainingArchive, entry.entryName)
+                if (entry.isDirectory) {
+                    await fs.promises.mkdir(entryPath, { recursive: true })
+                } else {
+                    const parentDir = path.dirname(entryPath)
+                    await fs.promises.mkdir(parentDir, { recursive: true })
+                    await fs.promises.writeFile(entryPath, entry.getData())
+                }
+            } catch (extractError: any) {
+                if (extractError instanceof Error && 'code' in extractError && extractError.code === 'ENOENT') {
+                    this.logging.log(`ENOENT error was ignored for entry: ${entry.entryName}`)
+                } else {
+                    throw extractError
+                }
+            }
+        }
+    }
+
     async archivePathGenerator(exportId: string, buffer: Uint8Array[], saveToDir: string) {
-        const tempDir = path.join(saveToDir, exportId)
-        const pathToArchive = path.join(tempDir, 'ExportResultsArchive.zip')
-        await this.directoryExists(tempDir)
-        await fs.writeFileSync(pathToArchive, Buffer.concat(buffer))
-        let pathContainingArchive = ''
-        pathContainingArchive = path.dirname(pathToArchive)
-        const zip = new AdmZip(pathToArchive)
-        zip.extractAllTo(pathContainingArchive)
-        return pathContainingArchive
+        try {
+            const tempDir = path.join(saveToDir, exportId)
+            const pathToArchive = path.join(tempDir, 'ExportResultsArchive.zip')
+            await this.directoryExists(tempDir)
+            await fs.writeFileSync(pathToArchive, Buffer.concat(buffer))
+            let pathContainingArchive = ''
+            pathContainingArchive = path.dirname(pathToArchive)
+            const zip = new AdmZip(pathToArchive)
+            const zipEntries = zip.getEntries()
+
+            await this.extractAllEntriesTo(pathContainingArchive, zipEntries)
+            return pathContainingArchive
+        } catch (error) {
+            this.logging.log(`error received ${JSON.stringify(error)}`)
+            return ''
+        }
     }
 
     async directoryExists(directoryPath: any) {
@@ -403,6 +432,7 @@ export class TransformHandler {
             await fs.accessSync(directoryPath)
         } catch (error) {
             // Directory doesn't exist, create it
+            this.logging.log(`Directory doesn't exist, creating it ${directoryPath}`)
             await fs.mkdirSync(directoryPath, { recursive: true })
         }
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -400,7 +400,7 @@ export class TransformHandler {
                 }
             } catch (extractError: any) {
                 if (extractError instanceof Error && 'code' in extractError && extractError.code === 'ENOENT') {
-                    this.logging.log(`ENOENT error was ignored for entry: ${entry.entryName}`)
+                    this.logging.log(`File not found(ENOENT) error was ignored for file path : ${entry.entryName}`)
                 } else {
                     throw extractError
                 }
@@ -418,7 +418,6 @@ export class TransformHandler {
             pathContainingArchive = path.dirname(pathToArchive)
             const zip = new AdmZip(pathToArchive)
             const zipEntries = zip.getEntries()
-
             await this.extractAllEntriesTo(pathContainingArchive, zipEntries)
             return pathContainingArchive
         } catch (error) {


### PR DESCRIPTION
## Problem
When post-transformation artifacts are downloaded, there may be some files with wrong relative path and could not be found/ could not be extracted in` /artifactWorkspace/transformation-id/` folder
typical example can be file like - 
<img width="654" alt="image" src="https://github.com/user-attachments/assets/5380ec26-5f82-4e82-9207-4e19e0e9a7b8" />
this file can throw file not found error and entirely stop downloading artifacts and return error to user


## Solution
In case we identify such file, we can log the ENOENT errored file and still continue extracting results and unblock customers. 


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
