### PR TITLE
feat(amazonq): add eu-central-1 endpoint

### DIFF
--- a/server/aws-lsp-codewhisperer/src/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/constants.ts
@@ -3,6 +3,7 @@ export const DEFAULT_AWS_Q_REGION = 'us-east-1'
 
 export const AWS_Q_ENDPOINTS = {
     [DEFAULT_AWS_Q_REGION]: DEFAULT_AWS_Q_ENDPOINT_URL,
+    'eu-central-1': 'https://q.eu-central-1.amazonaws.com/',
 }
 
 export const AWS_Q_REGION_ENV_VAR = 'AWS_Q_REGION'


### PR DESCRIPTION
## Problem
Amazon Q launches support for new FRA region

## Solution
Adding eu-central-1 endpoint to list of supported endpoints

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
