### PR TITLE
fix: update @aws/language-server-runtimes to 0.2.48

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -10,7 +10,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "crypto-browserify": "^3.12.1",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.34",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-partiql": "^0.0.5"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.47"
+        "@aws/language-server-runtimes": "^0.2.48"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -318,7 +318,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.7",
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -77,7 +77,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "crypto-browserify": "^3.12.1",
@@ -98,7 +98,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -106,7 +106,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -126,7 +126,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -134,7 +134,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.34",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-partiql": "^0.0.5"
             },
             "devDependencies": {
@@ -158,7 +158,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -178,7 +178,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -200,7 +200,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.47"
+                "@aws/language-server-runtimes": "^0.2.48"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -244,7 +244,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.7",
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -6446,15 +6446,15 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.47",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.47.tgz",
-            "integrity": "sha512-uelALNgwDS2DC7m+PMd0NbZBUCI5i+QYmGICz/7S/djf+dWAG0atFB+1TLjjLZvmo15ySKsyTVt89pDrLhlE/Q==",
+            "version": "0.2.48",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.48.tgz",
+            "integrity": "sha512-uKB7uiz3Naq6PGtg+1iQlUrkRKNJ4DUZijNrbUSH2OTvwQTErmMB/Ltu7M3To5IdNCi+Guk44qwaLMUx/6gJ8w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@apidevtools/json-schema-ref-parser": "^11.9.1",
+                "@apidevtools/json-schema-ref-parser": "^11.9.3",
                 "@aws-crypto/sha256-js": "^5.2.0",
                 "@aws-sdk/client-cognito-identity": "^3.758.0",
-                "@aws/language-server-runtimes-types": "^0.1.5",
+                "@aws/language-server-runtimes-types": "^0.1.6",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
                 "@opentelemetry/resources": "^1.30.1",
@@ -6467,11 +6467,11 @@
                 "@smithy/signature-v4": "^5.0.1",
                 "ajv": "^8.17.1",
                 "aws-sdk": "^2.1692.0",
-                "axios": "^1.8.2",
+                "axios": "^1.8.4",
                 "hpagent": "^1.2.0",
                 "jose": "^5.9.6",
                 "mac-ca": "^3.1.1",
-                "rxjs": "^7.8.1",
+                "rxjs": "^7.8.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-protocol": "^3.17.5",
                 "win-ca": "^3.5.1"
@@ -6481,9 +6481,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.5.tgz",
-            "integrity": "sha512-QOT4eoZSsFuablRniG+uijdBGo1+6jTnf117h2a8CvQuTGX085Y8lc34izs98Qw/szDr6Oi/D6wrlhsAXomRDQ==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.6.tgz",
+            "integrity": "sha512-D8BukMtJRauOw2h/VHOMq7xZxXtCui1zNPzfoU8p6NAAveQL2+eJiLb0l+eYfAB/F1BfWGDcCU/T6cuYg3A/Ng==",
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -13304,9 +13304,9 @@
             "link": true
         },
         "node_modules/axios": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
-            "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+            "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
@@ -26075,7 +26075,7 @@
             "version": "0.1.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-core": "^0.0.2"
             },
             "devDependencies": {
@@ -26146,7 +26146,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.7",
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-core": "^0.0.2",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
@@ -26266,7 +26266,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-core": "^0.0.2",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -26341,7 +26341,7 @@
             "version": "0.1.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-core": "^0.0.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -26355,7 +26355,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-core": "0.0.2",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -26384,7 +26384,7 @@
             "version": "0.0.5",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -26417,7 +26417,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "@aws/lsp-core": "^0.0.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -26431,7 +26431,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -26442,7 +26442,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.47",
+                "@aws/language-server-runtimes": "^0.2.48",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-core": "^0.0.2"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -30,7 +30,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.7",
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-core": "^0.0.2",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-core": "^0.0.2",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-core": "^0.0.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-core": "0.0.2",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "@aws/lsp-core": "^0.0.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.47",
+        "@aws/language-server-runtimes": "^0.2.48",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Update @aws/language-server-runtimes to latest 0.2.48 version.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
