### PR TITLE
deps: always install current monorepo dependencies

### DIFF
--- a/app/aws-lsp-buildspec-runtimes/package.json
+++ b/app/aws-lsp-buildspec-runtimes/package.json
@@ -7,6 +7,6 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/lsp-buildspec": "^0.0.1"
+        "@aws/lsp-buildspec": "*"
     }
 }

--- a/app/aws-lsp-cloudformation-runtimes/package.json
+++ b/app/aws-lsp-cloudformation-runtimes/package.json
@@ -7,6 +7,6 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/lsp-cloudformation": "^0.0.1"
+        "@aws/lsp-cloudformation": "*"
     }
 }

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -8,6 +8,6 @@
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.48",
-        "@aws/lsp-identity": "^0.0.1"
+        "@aws/lsp-identity": "*"
     }
 }

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -8,6 +8,6 @@
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.48",
-        "@aws/lsp-notification": "^0.0.1"
+        "@aws/lsp-notification": "*"
     }
 }

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.48",
-        "@aws/lsp-partiql": "^0.0.5"
+        "@aws/lsp-partiql": "*"
     },
     "devDependencies": {
         "ts-loader": "^9.4.4",

--- a/app/aws-lsp-s3-runtimes/package.json
+++ b/app/aws-lsp-s3-runtimes/package.json
@@ -10,6 +10,6 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/lsp-s3": "^0.0.1"
+        "@aws/lsp-s3": "*"
     }
 }

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -14,7 +14,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/hello-world-lsp": "^0.0.1",
+        "@aws/hello-world-lsp": "*",
         "@aws/language-server-runtimes": "^0.2.48"
     },
     "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,14 +63,14 @@
             "name": "@aws/lsp-buildspec-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/lsp-buildspec": "^0.0.1"
+                "@aws/lsp-buildspec": "*"
             }
         },
         "app/aws-lsp-cloudformation-runtimes": {
             "name": "@aws/lsp-cloudformation-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/lsp-cloudformation": "^0.0.1"
+                "@aws/lsp-cloudformation": "*"
             }
         },
         "app/aws-lsp-codewhisperer-runtimes": {
@@ -99,7 +99,7 @@
             "version": "0.1.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.48",
-                "@aws/lsp-identity": "^0.0.1"
+                "@aws/lsp-identity": "*"
             }
         },
         "app/aws-lsp-json-runtimes": {
@@ -127,7 +127,7 @@
             "version": "0.1.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.48",
-                "@aws/lsp-notification": "^0.0.1"
+                "@aws/lsp-notification": "*"
             }
         },
         "app/aws-lsp-partiql-runtimes": {
@@ -135,7 +135,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.48",
-                "@aws/lsp-partiql": "^0.0.5"
+                "@aws/lsp-partiql": "*"
             },
             "devDependencies": {
                 "ts-loader": "^9.4.4",
@@ -148,7 +148,7 @@
             "name": "@aws/lsp-s3-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/lsp-s3": "^0.0.1"
+                "@aws/lsp-s3": "*"
             },
             "bin": {
                 "aws-lsp-s3-binary": "out/index.js"
@@ -199,7 +199,7 @@
             "name": "@aws/hello-world-lsp-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/hello-world-lsp": "^0.0.1",
+                "@aws/hello-world-lsp": "*",
                 "@aws/language-server-runtimes": "^0.2.48"
             },
             "devDependencies": {
@@ -26076,7 +26076,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.48",
-                "@aws/lsp-core": "^0.0.2"
+                "@aws/lsp-core": "*"
             },
             "devDependencies": {
                 "@babel/plugin-transform-modules-commonjs": "^7.24.1",
@@ -26147,7 +26147,7 @@
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.7",
                 "@aws/language-server-runtimes": "^0.2.48",
-                "@aws/lsp-core": "^0.0.2",
+                "@aws/lsp-core": "*",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
                 "archiver": "^7.0.1",
@@ -26267,7 +26267,7 @@
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
                 "@aws/language-server-runtimes": "^0.2.48",
-                "@aws/lsp-core": "^0.0.2",
+                "@aws/lsp-core": "*",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
                 "https-proxy-agent": "^7.0.5",
@@ -26342,7 +26342,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.48",
-                "@aws/lsp-core": "^0.0.2",
+                "@aws/lsp-core": "*",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
             },
@@ -26356,7 +26356,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.48",
-                "@aws/lsp-core": "0.0.2",
+                "@aws/lsp-core": "*",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -26406,7 +26406,7 @@
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.623.0",
                 "@aws-sdk/types": "^3.734.0",
-                "@aws/lsp-core": "^0.0.2",
+                "@aws/lsp-core": "*",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
             }
@@ -26418,7 +26418,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.48",
-                "@aws/lsp-core": "^0.0.2",
+                "@aws/lsp-core": "*",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
                 "yaml-language-server": "1.13.0"

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.48",
-        "@aws/lsp-core": "^0.0.2"
+        "@aws/lsp-core": "*"
     },
     "peerDependencies": {
         "antlr4-c3": ">=3.4 < 4",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -31,7 +31,7 @@
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.7",
         "@aws/language-server-runtimes": "^0.2.48",
-        "@aws/lsp-core": "^0.0.2",
+        "@aws/lsp-core": "*",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",
         "archiver": "^7.0.1",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -24,7 +24,7 @@
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
         "@aws/language-server-runtimes": "^0.2.48",
-        "@aws/lsp-core": "^0.0.2",
+        "@aws/lsp-core": "*",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",
         "https-proxy-agent": "^7.0.5",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.48",
-        "@aws/lsp-core": "^0.0.2",
+        "@aws/lsp-core": "*",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"
     },

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.48",
-        "@aws/lsp-core": "0.0.2",
+        "@aws/lsp-core": "*",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/aws-lsp-s3/package.json
+++ b/server/aws-lsp-s3/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.623.0",
         "@aws-sdk/types": "^3.734.0",
-        "@aws/lsp-core": "^0.0.2",
+        "@aws/lsp-core": "*",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"
     }

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.48",
-        "@aws/lsp-core": "^0.0.2",
+        "@aws/lsp-core": "*",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",
         "yaml-language-server": "1.13.0"


### PR DESCRIPTION
## Problem
Some packages declare dependencies on specific version range of other packages in this monorepo. When package version starts zeros for MAJOR and MINOR version parts (e.g. 0.0.1), npm threats them as major versions, and fails to install dependencies when version changes. This breaks automated release process, when packages with `0.0.x` versions are updated, ex. https://github.com/aws/language-servers/actions/runs/14081622706/job/39435699667?pr=851

## Solution

Use `*` to declare dependency version on subpackages in monorepo.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
