### PR TITLE
fix(amazonq): select corrert Service manager mode in completion server factory

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/codeWhispererServer.ts
@@ -245,7 +245,8 @@ export const CodewhispererServerFactory =
             awsQRegion: string,
             awsQEndpointUrl: string,
             sdkInitializator: SDKInitializator
-        ) => CodeWhispererServiceBase
+        ) => CodeWhispererServiceBase,
+        serviceType?: 'token' | 'iam'
     ): Server =>
     ({ credentialsProvider, lsp, workspace, telemetry, logging, runtime, sdkInitializator }) => {
         let lastUserModificationTime: number
@@ -267,7 +268,6 @@ export const CodewhispererServerFactory =
         // AmazonQTokenServiceManager and TelemetryService are initialized in `onInitialized` handler to make sure Language Server connection is started
         let amazonQServiceManager: BaseAmazonQServiceManager
         let telemetryService: TelemetryService
-        const serviceType = fallbackCodeWhispererService.constructor.name
 
         lsp.addInitializer((params: InitializeParams) => {
             // TODO: Review configuration options expected in other features
@@ -646,7 +646,8 @@ export const CodewhispererServerFactory =
         }
 
         const onInitializedHandler = async () => {
-            if (serviceType === 'CodeWhispererServiceToken') {
+            if (serviceType === 'token') {
+                logging.log('Initialized Completion server with token service type')
                 amazonQServiceManager = AmazonQTokenServiceManager.getInstance({
                     lsp,
                     logging,
@@ -657,6 +658,7 @@ export const CodewhispererServerFactory =
                 })
             } else {
                 // Fallback to default passed service factory for IAM credentials type
+                logging.log('Initialized Completion server with default service type')
                 amazonQServiceManager = {
                     handleDidChangeConfiguration: async () => {},
                     getCodewhispererService: () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -14,7 +14,8 @@ export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(
             awsQEndpointUrl,
             sdkInitializator
         )
-    }
+    },
+    'token'
 )
 
 export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(
@@ -26,7 +27,8 @@ export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(
             awsQEndpointUrl,
             sdkInitializator
         )
-    }
+    },
+    'iam'
 )
 
 export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken()


### PR DESCRIPTION
## Problem
Current switch between Q Service manager type in InlineCompletions server does not work in code bundled in production mode with webpack.

## Solution
Use flag to explicitly set Service type for InlineCompletions server. This is temporary fix and will not be needed after refactoring in progress.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
