### PR TITLE
ci: move release-please last release pointer commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
     "bootstrap-sha": "ea570718da2b32b552b4308de1b4b3c2ee444b2b",
+    "last-release-sha": "307f5a961ebcaa0dfd86edca85a8374f797163ed",
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "always-link-local": false,


### PR DESCRIPTION
## Problem
New release-please PR included already released changes https://github.com/aws/language-servers/pull/880.
Apparently release-please looked back at the oldest release for 2 packages that didn't change and used that point in time to collect change log. This resulted in already release changes being processed again.

## Solution
Move last release sha to previous release to skip released changes.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
