### PR TITLE
feat(amazonq): optimize service manager reuse

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -45,14 +45,13 @@ import { Metric } from '../../shared/telemetry/metric'
 import { getErrorMessage, isAwsError, isNullish, isObject } from '../../shared/utils'
 import { QChatTriggerContext, TriggerContext } from '../chat/contexts/triggerContext'
 import { HELP_MESSAGE } from '../chat/constants'
-import { Q_CONFIGURATION_SECTION } from '../configuration/qConfigurationServer'
-import { textUtils } from '@aws/lsp-core'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import {
     AmazonQServicePendingProfileError,
     AmazonQServicePendingSigninError,
 } from '../../shared/amazonQServiceManager/errors'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
+import { AmazonQWorkspaceConfig } from '../../shared/amazonQServiceManager/configurationUtils'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -567,24 +566,18 @@ export class AgenticChatController implements ChatHandlers {
         return chatEventParser.getResult()
     }
 
-    updateConfiguration = async () => {
-        try {
-            const qConfig = await this.#features.lsp.workspace.getConfiguration(Q_CONFIGURATION_SECTION)
-            if (qConfig) {
-                this.#customizationArn = textUtils.undefinedIfEmpty(qConfig.customization)
-                this.#log(`Chat configuration updated to use ${this.#customizationArn}`)
-                /*
-                    The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
-                    configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
-                */
-                // const enableTelemetryEventsToDestination = true
-                // this.#telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
-                const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'
-                this.#telemetryService.updateOptOutPreference(optOutTelemetryPreference)
-            }
-        } catch (error) {
-            this.#log(`Error in GetConfiguration: ${error}`)
-        }
+    updateConfiguration = (newConfig: AmazonQWorkspaceConfig) => {
+        this.#customizationArn = newConfig.customizationArn
+        this.#log(`Chat configuration updated to use ${this.#customizationArn}`)
+        /*
+            The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
+            configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
+        */
+        // const enableTelemetryEventsToDestination = true
+        // this.#telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
+        const updatedOptOutPreference = newConfig.optOutTelemetryPreference
+        this.#telemetryService.updateOptOutPreference(updatedOptOutPreference)
+        this.#log(`Chat configuration telemetry preference to ${updatedOptOutPreference}`)
     }
 
     #log(...messages: string[]) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -41,8 +41,8 @@ export const QAgenticChatServer =
         })
 
         const updateConfigurationHandler = async () => {
-            await amazonQServiceManager.handleDidChangeConfiguration()
-            await chatController.updateConfiguration()
+            const amazonQConfig = await amazonQServiceManager.handleDidChangeConfiguration()
+            chatController.updateConfiguration(amazonQConfig)
         }
 
         lsp.onInitialized(async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/qChatServer.ts
@@ -36,8 +36,8 @@ export const QChatServer =
         })
 
         const updateConfigurationHandler = async () => {
-            await amazonQServiceManager.handleDidChangeConfiguration()
-            await chatController.updateConfiguration()
+            const amazonQConfig = await amazonQServiceManager.handleDidChangeConfiguration()
+            chatController.updateConfiguration(amazonQConfig)
         }
 
         lsp.onInitialized(async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
@@ -43,7 +43,7 @@ import {
 } from '../../shared/testUtils'
 import { CodeDiffTracker } from './codeDiffTracker'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
-import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
+import { initFallbackServiceManager } from '../../shared/amazonQServiceManager/factories'
 
 describe('CodeWhisperer Server', () => {
     const sandbox = sinon.createSandbox()
@@ -92,10 +92,13 @@ describe('CodeWhisperer Server', () => {
                 })
             )
 
-            server = CodewhispererServerFactory(_auth => service)
-
             // Initialize the features, but don't start server yet
             features = new TestFeatures()
+
+            server = CodewhispererServerFactory(() => initFallbackServiceManager(features, service))
+
+            //@ts-ignore
+            features.logging = console
             features.lsp.getClientInitializeParams.returns({} as InitializeParams)
 
             // Return no specific configuration for CodeWhisperer
@@ -528,16 +531,13 @@ describe('CodeWhisperer Server', () => {
                     })
                 )
 
-                const test_server = CodewhispererServerFactory(_auth => test_service)
-
-                // @ts-ignore
-                sinon.stub(AmazonQTokenServiceManager, 'getInstance').returns({
-                    getCodewhispererService: () => test_service,
-                    handleDidChangeConfiguration: () => Promise.resolve(),
-                })
-
                 // Initialize the features, but don't start server yet
                 const test_features = new TestFeatures()
+
+                const test_server = CodewhispererServerFactory(() =>
+                    initFallbackServiceManager(test_features, test_service)
+                )
+
                 features.lsp.getClientInitializeParams.returns({} as InitializeParams)
 
                 test_features.credentialsProvider.hasCredentials.returns(true)
@@ -636,10 +636,11 @@ describe('CodeWhisperer Server', () => {
                     responseContext: EXPECTED_RESPONSE_CONTEXT,
                 })
             )
-            server = CodewhispererServerFactory(_auth => service)
 
             // Initialize the features, but don't start server yet
             features = new TestFeatures()
+            server = CodewhispererServerFactory(() => initFallbackServiceManager(features, service))
+
             features.lsp.getClientInitializeParams.returns({} as InitializeParams)
         })
 
@@ -975,10 +976,10 @@ describe('CodeWhisperer Server', () => {
                 })
             )
 
-            server = CodewhispererServerFactory(_auth => service)
-
             // Initialize the features, but don't start server yet
             features = new TestFeatures()
+            server = CodewhispererServerFactory(() => initFallbackServiceManager(features, service))
+
             features.lsp.getClientInitializeParams.returns({} as InitializeParams)
 
             // Return no specific configuration for CodeWhisperer
@@ -1110,11 +1111,10 @@ describe('CodeWhisperer Server', () => {
         beforeEach(async () => {
             // Set up the server with a mock service, returning predefined recommendations
             service = stubInterface<CodeWhispererServiceBase>()
-
-            server = CodewhispererServerFactory(_auth => service)
-
             // Initialize the features, but don't start server yet
             features = new TestFeatures()
+            server = CodewhispererServerFactory(() => initFallbackServiceManager(features, service))
+
             features.lsp.getClientInitializeParams.returns({} as InitializeParams)
 
             // Start the server and open a document
@@ -1222,11 +1222,10 @@ describe('CodeWhisperer Server', () => {
                     responseContext: EXPECTED_RESPONSE_CONTEXT,
                 })
             )
-
-            server = CodewhispererServerFactory(_auth => service)
-
             // Initialize the features, but don't start server yet
             features = new TestFeatures()
+            server = CodewhispererServerFactory(() => initFallbackServiceManager(features, service))
+
             features.lsp.getClientInitializeParams.returns({} as InitializeParams)
             // Return no specific configuration for CodeWhisperer
             features.lsp.workspace.getConfiguration.returns(Promise.resolve({}))
@@ -1663,10 +1662,10 @@ describe('CodeWhisperer Server', () => {
                 })
             )
 
-            server = CodewhispererServerFactory(_auth => service)
-
             // Initialize the features, but don't start server yet
             features = new TestFeatures()
+            server = CodewhispererServerFactory(() => initFallbackServiceManager(features, service))
+
             features.lsp.getClientInitializeParams.returns({} as InitializeParams)
             // Return no specific configuration for CodeWhisperer
             features.lsp.workspace.getConfiguration.returns(Promise.resolve({}))

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
@@ -13,6 +13,7 @@ import { CodewhispererServerFactory } from './codeWhispererServer'
 import { CodeWhispererServiceBase, ResponseContext, Suggestion } from '../../shared/codeWhispererService'
 import { CodeWhispererSession, SessionManager } from './session/sessionManager'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
+import { initFallbackServiceManager } from '../../shared/amazonQServiceManager/factories'
 
 describe('Telemetry', () => {
     const sandbox = sinon.createSandbox()
@@ -175,10 +176,9 @@ describe('Telemetry', () => {
             service = stubInterface<CodeWhispererServiceBase>()
             setServiceResponse(DEFAULT_SUGGESTIONS, EXPECTED_RESPONSE_CONTEXT)
 
-            server = CodewhispererServerFactory(_auth => service)
-
             // Initialize the features, but don't start server yet
             features = new TestFeatures()
+            server = CodewhispererServerFactory(() => initFallbackServiceManager(features, service))
 
             // Return no specific configuration for CodeWhisperer
             features.lsp.workspace.getConfiguration.returns(Promise.resolve({}))

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -5,7 +5,7 @@ import { CodeWhispererServiceToken } from '../shared/codeWhispererService'
 import { QNetTransformServerToken } from './netTransform/netTransformServer'
 import { QChatServer } from './chat/qChatServer'
 import { QConfigurationServerToken } from './configuration/qConfigurationServer'
-import { initBaseIAMServiceManager, initBaseTokenServiceManager } from './amazonQServiceManager/factories'
+import { initBaseIAMServiceManager, initBaseTokenServiceManager } from '../shared/amazonQServiceManager/factories'
 
 export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(initBaseTokenServiceManager)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/proxy-server.ts
@@ -1,36 +1,15 @@
 import { QAgenticChatServer } from './agenticChat/qAgenticChatServer'
 import { SecurityScanServerToken } from './securityScan/codeWhispererSecurityScanServer'
 import { CodewhispererServerFactory } from './inline-completion/codeWhispererServer'
-import { CodeWhispererServiceIAM, CodeWhispererServiceToken } from '../shared/codeWhispererService'
+import { CodeWhispererServiceToken } from '../shared/codeWhispererService'
 import { QNetTransformServerToken } from './netTransform/netTransformServer'
 import { QChatServer } from './chat/qChatServer'
 import { QConfigurationServerToken } from './configuration/qConfigurationServer'
+import { initBaseIAMServiceManager, initBaseTokenServiceManager } from './amazonQServiceManager/factories'
 
-export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
-        return new CodeWhispererServiceToken(
-            credentialsProvider,
-            workspace,
-            awsQRegion,
-            awsQEndpointUrl,
-            sdkInitializator
-        )
-    },
-    'token'
-)
+export const CodeWhispererServerTokenProxy = CodewhispererServerFactory(initBaseTokenServiceManager)
 
-export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(
-    (credentialsProvider, workspace, awsQRegion, awsQEndpointUrl, sdkInitializator) => {
-        return new CodeWhispererServiceIAM(
-            credentialsProvider,
-            workspace,
-            awsQRegion,
-            awsQEndpointUrl,
-            sdkInitializator
-        )
-    },
-    'iam'
-)
+export const CodeWhispererServerIAMProxy = CodewhispererServerFactory(initBaseIAMServiceManager)
 
 export const CodeWhispererSecurityScanServerTokenProxy = SecurityScanServerToken()
 

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
@@ -63,9 +63,8 @@ describe('AmazonQTokenServiceManager', () => {
 
     beforeEach(() => {
         // Override endpoints for testing
-        AWS_Q_ENDPOINTS['us-east-1'] = TEST_ENDPOINT_US_EAST_1
-        // @ts-ignore
-        AWS_Q_ENDPOINTS['eu-central-1'] = TEST_ENDPOINT_EU_CENTRAL_1
+        AWS_Q_ENDPOINTS.set('us-east-1', TEST_ENDPOINT_US_EAST_1)
+        AWS_Q_ENDPOINTS.set('eu-central-1', TEST_ENDPOINT_EU_CENTRAL_1)
 
         sinon
             .stub(qDeveloperProfilesFetcherModule, 'getListAllAvailableProfilesHandler')
@@ -220,8 +219,7 @@ describe('AmazonQTokenServiceManager', () => {
 
             setCredentials('builderId')
 
-            // @ts-ignore
-            AWS_Q_ENDPOINTS[testRegion] = testEndpoint
+            AWS_Q_ENDPOINTS.set(testRegion, testEndpoint)
 
             features.lsp.getClientInitializeParams.reset()
         })

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -38,8 +38,8 @@ import {
 
 import { getBearerTokenFromProvider, isStringOrNull } from '../utils'
 import {
-    getAWSQRelatedWorkspaceConfigs,
-    getAWSQRegionAndEndpoint,
+    getAmazonQRelatedWorkspaceConfigs,
+    getAmazonQRegionAndEndpoint,
     AmazonQConfigurationCache,
     AmazonQWorkspaceConfig,
 } from './configurationUtils'
@@ -283,7 +283,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
 
     public async handleDidChangeConfiguration() {
         try {
-            const amazonQConfig = await getAWSQRelatedWorkspaceConfigs(this.features.lsp, this.features.logging)
+            const amazonQConfig = await getAmazonQRelatedWorkspaceConfigs(this.features.lsp, this.features.logging)
 
             if (this.cachedCodewhispererService) {
                 const { customizationArn, shareCodeWhispererContentWithAWS } = amazonQConfig
@@ -301,7 +301,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
 
             this.configurationCache.updateConfig(amazonQConfig)
         } catch (error) {
-            this.log(`Unexpected error in getAWSQRelatedWorkspaceConfigs: ${error}`)
+            this.log(`Unexpected error in getAmazonQRelatedWorkspaceConfigs: ${error}`)
         }
 
         return this.configurationCache.getConfig()
@@ -490,7 +490,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
     ) {
         this.logServiceState('Initializing CodewhispererService')
 
-        const { region, endpoint } = getAWSQRegionAndEndpoint(
+        const { region, endpoint } = getAmazonQRegionAndEndpoint(
             this.features.runtime,
             this.features.logging,
             clientOrProfileRegion

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -14,13 +14,6 @@ import {
     InitializeParams,
     CancellationTokenSource,
 } from '@aws/language-server-runtimes/server-interface'
-import {
-    DEFAULT_AWS_Q_ENDPOINT_URL,
-    DEFAULT_AWS_Q_REGION,
-    AWS_Q_ENDPOINTS,
-    AWS_Q_REGION_ENV_VAR,
-    AWS_Q_ENDPOINT_URL_ENV_VAR,
-} from '../constants'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
 import {
     AmazonQError,
@@ -35,7 +28,6 @@ import {
 } from './errors'
 import { BaseAmazonQServiceManager } from './BaseAmazonQServiceManager'
 import { Q_CONFIGURATION_SECTION } from '../../language-server/configuration/qConfigurationServer'
-import { textUtils } from '@aws/lsp-core'
 import { CodeWhispererStreaming } from '@amzn/codewhisperer-streaming'
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import {
@@ -45,6 +37,12 @@ import {
 } from './qDeveloperProfiles'
 
 import { getBearerTokenFromProvider, isStringOrNull } from '../utils'
+import {
+    getAWSQRelatedWorkspaceConfigs,
+    getAWSQRegionAndEndpoint,
+    AmazonQConfigurationCache,
+    AmazonQWorkspaceConfig,
+} from './configurationUtils'
 
 import { getUserAgent } from '../telemetryUtils'
 
@@ -89,7 +87,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
     private logging!: Logging
     private cachedCodewhispererService?: CodeWhispererServiceToken
     private enableDeveloperProfileSupport?: boolean
-    private configurationCache = new Map()
+    private configurationCache = new AmazonQConfigurationCache()
     private activeIdcProfile?: AmazonQDeveloperProfile
     private connectionType?: SsoConnectionType
     private profileChangeTokenSource: CancellationTokenSource | undefined
@@ -285,44 +283,14 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
 
     public async handleDidChangeConfiguration() {
         try {
-            const qConfig = await this.features.lsp.workspace.getConfiguration(Q_CONFIGURATION_SECTION)
-            if (qConfig) {
-                // aws.q.customizationArn - selected customization
-                const customizationArn = textUtils.undefinedIfEmpty(qConfig.customization)
-                this.log(`Read configuration customizationArn=${customizationArn}`)
-                this.configurationCache.set('customizationArn', customizationArn)
+            const amazonQConfig = await getAWSQRelatedWorkspaceConfigs(this.features.lsp, this.features.logging)
 
-                // aws.q.optOutTelemetry - telemetry optout option
-                const optOutTelemetryPreference = qConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN'
-                this.log(`Read configuration optOutTelemetryPreference=${optOutTelemetryPreference}`)
-                this.configurationCache.set('optOutTelemetryPreference', optOutTelemetryPreference)
+            if (this.cachedCodewhispererService) {
+                const { customizationArn, shareCodeWhispererContentWithAWS } = amazonQConfig
+                this.log(`Using customization=${customizationArn}`)
+                this.cachedCodewhispererService.customizationArn = customizationArn
 
-                if (this.cachedCodewhispererService) {
-                    this.log(`Using customization=${customizationArn}`)
-                    this.cachedCodewhispererService.customizationArn = customizationArn
-                }
-            }
-
-            const codeWhispererConfig = await this.features.lsp.workspace.getConfiguration('aws.codeWhisperer')
-            if (codeWhispererConfig) {
-                // aws.codeWhisperer.includeSuggestionsWithCodeReferences - return suggestions with code references
-                const includeSuggestionsWithCodeReferences =
-                    codeWhispererConfig['includeSuggestionsWithCodeReferences'] === true
-                this.log(
-                    `Read сonfiguration includeSuggestionsWithCodeReferences=${includeSuggestionsWithCodeReferences}`
-                )
-                this.configurationCache.set(
-                    'includeSuggestionsWithCodeReferences',
-                    includeSuggestionsWithCodeReferences
-                )
-
-                // aws.codeWhisperershareCodeWhispererContentWithAWS - share content with AWS
-                const shareCodeWhispererContentWithAWS =
-                    codeWhispererConfig['shareCodeWhispererContentWithAWS'] === true
-                this.log(`Read configuration shareCodeWhispererContentWithAWS=${shareCodeWhispererContentWithAWS}`)
-                this.configurationCache.set('shareCodeWhispererContentWithAWS', shareCodeWhispererContentWithAWS)
-
-                if (this.cachedCodewhispererService) {
+                if (shareCodeWhispererContentWithAWS !== undefined) {
                     this.log(
                         'Update shareCodeWhispererContentWithAWS setting on cachedCodewhispererService to ' +
                             shareCodeWhispererContentWithAWS
@@ -330,9 +298,17 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
                     this.cachedCodewhispererService.shareCodeWhispererContentWithAWS = shareCodeWhispererContentWithAWS
                 }
             }
+
+            this.configurationCache.updateConfig(amazonQConfig)
         } catch (error) {
-            this.log(`Error in GetConfiguration: ${error}`)
+            this.log(`Unexpected error in getAWSQRelatedWorkspaceConfigs: ${error}`)
         }
+
+        return this.configurationCache.getConfig()
+    }
+
+    public getConfiguration(): Readonly<AmazonQWorkspaceConfig> {
+        return this.configurationCache.getConfig()
     }
 
     private cancelActiveProfileChangeToken() {
@@ -504,54 +480,30 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
         this.cachedCodewhispererService?.abortInflightRequests()
         this.cachedCodewhispererService = undefined
         this.activeIdcProfile = undefined
+        this.region = undefined
+        this.endpoint = undefined
     }
 
-    private createCodewhispererServiceInstances(connectionType: 'builderId' | 'identityCenter', region?: string) {
+    private createCodewhispererServiceInstances(
+        connectionType: 'builderId' | 'identityCenter',
+        clientOrProfileRegion?: string
+    ) {
         this.logServiceState('Initializing CodewhispererService')
-        let awsQRegion: string
-        let awsQEndpoint: string | undefined
 
-        if (region) {
-            this.log(
-                `Selecting region (found: ${region}) provided by ${connectionType === 'builderId' ? 'client' : 'profile'}`
-            )
-            awsQRegion = region
-            // @ts-ignore
-            awsQEndpoint = AWS_Q_ENDPOINTS[awsQRegion]
-        } else {
-            const runtimeRegion = this.features.runtime.getConfiguration(AWS_Q_REGION_ENV_VAR)
-
-            if (runtimeRegion) {
-                this.log(`Selecting region (found: ${runtimeRegion}) provided by runtime`)
-                awsQRegion = runtimeRegion
-                // prettier-ignore
-                awsQEndpoint = // @ts-ignore
-                    this.features.runtime.getConfiguration(AWS_Q_ENDPOINT_URL_ENV_VAR) ?? AWS_Q_ENDPOINTS[awsQRegion]
-            } else {
-                this.log('Region not provided by caller or runtime, falling back to default region and endpoint')
-                awsQRegion = DEFAULT_AWS_Q_REGION
-                awsQEndpoint = DEFAULT_AWS_Q_ENDPOINT_URL
-            }
-        }
-
-        if (!awsQEndpoint) {
-            this.log(
-                `Unable to determine endpoint (found: ${awsQEndpoint}) for region: ${awsQRegion}, falling back to default region and endpoint`
-            )
-            awsQRegion = DEFAULT_AWS_Q_REGION
-            awsQEndpoint = DEFAULT_AWS_Q_ENDPOINT_URL
-        }
+        const { region, endpoint } = getAWSQRegionAndEndpoint(
+            this.features.runtime,
+            this.features.logging,
+            clientOrProfileRegion
+        )
 
         // Cache active region and endpoint selection
         this.connectionType = connectionType
-        this.region = awsQRegion
-        this.endpoint = awsQEndpoint
+        this.region = region
+        this.endpoint = endpoint
 
-        this.cachedCodewhispererService = this.serviceFactory(awsQRegion, awsQEndpoint)
+        this.cachedCodewhispererService = this.serviceFactory(region, endpoint)
 
-        this.log(
-            `CodeWhispererToken service for connection type ${connectionType} was initialized, region=${awsQRegion}`
-        )
+        this.log(`CodeWhispererToken service for connection type ${connectionType} was initialized, region=${region}`)
         this.logServiceState('CodewhispererService Initialization finished')
     }
 
@@ -574,10 +526,11 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
         service.updateClientConfig({
             customUserAgent: customUserAgent,
         })
-        service.customizationArn = textUtils.undefinedIfEmpty(this.configurationCache.get('customizationArn'))
+        service.customizationArn = this.configurationCache.getProperty('customizationArn')
         service.profileArn = this.activeIdcProfile?.arn
-        service.shareCodeWhispererContentWithAWS =
-            this.configurationCache.get('shareCodeWhispererContentWithAWS') === true
+        service.shareCodeWhispererContentWithAWS = this.configurationCache.getProperty(
+            'shareCodeWhispererContentWithAWS'
+        )
 
         this.log('Configured CodeWhispererServiceToken instance settings:')
         this.log(

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/BaseAmazonQServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/BaseAmazonQServiceManager.ts
@@ -1,6 +1,8 @@
 import { CodeWhispererServiceBase } from '../codeWhispererService'
+import { AmazonQWorkspaceConfig } from './configurationUtils'
 
 export interface BaseAmazonQServiceManager {
-    handleDidChangeConfiguration: () => Promise<void>
+    handleDidChangeConfiguration: () => Promise<Readonly<AmazonQWorkspaceConfig>>
     getCodewhispererService: () => CodeWhispererServiceBase
+    getConfiguration: () => Readonly<AmazonQWorkspaceConfig>
 }

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.test.ts
@@ -3,13 +3,13 @@ import {
     AmazonQConfigurationCache,
     AmazonQWorkspaceConfig,
     CODE_WHISPERER_CONFIGURATION_SECTION,
-    defaultAWSQWorkspaceConfigFactory,
-    getAWSQRelatedWorkspaceConfigs,
+    defaultAmazonQWorkspaceConfigFactory,
+    getAmazonQRelatedWorkspaceConfigs,
 } from './configurationUtils'
 import { Q_CONFIGURATION_SECTION } from '../../language-server/configuration/qConfigurationServer'
 import { deepStrictEqual, notDeepStrictEqual } from 'assert'
 
-describe('getAWSQRelatedWorkspaceConfigs', () => {
+describe('getAmazonQRelatedWorkspaceConfigs', () => {
     let features: TestFeatures
     let cache: AmazonQConfigurationCache
 
@@ -45,13 +45,13 @@ describe('getAWSQRelatedWorkspaceConfigs', () => {
             shareCodeWhispererContentWithAWS: MOCKED_AWS_CODEWHISPERER_SECTION.shareCodeWhispererContentWithAWS,
         }
 
-        const amazonQConfig = await getAWSQRelatedWorkspaceConfigs(features.lsp, features.logging)
+        const amazonQConfig = await getAmazonQRelatedWorkspaceConfigs(features.lsp, features.logging)
 
         deepStrictEqual(amazonQConfig, EXPECTED_CONFIG)
     })
 
     it('empty strings returned by q section are set to undefined', async () => {
-        const firstResult = await getAWSQRelatedWorkspaceConfigs(features.lsp, features.logging)
+        const firstResult = await getAmazonQRelatedWorkspaceConfigs(features.lsp, features.logging)
         deepStrictEqual(firstResult.customizationArn, MOCKED_AWS_Q_SECTION.customization)
         deepStrictEqual(
             firstResult.inlineSuggestions?.extraContext,
@@ -61,14 +61,14 @@ describe('getAWSQRelatedWorkspaceConfigs', () => {
         features.lsp.workspace.getConfiguration
             .withArgs(Q_CONFIGURATION_SECTION)
             .resolves({ customization: '', inlineSuggestions: { extraContext: '' } })
-        const secondResult = await getAWSQRelatedWorkspaceConfigs(features.lsp, features.logging)
+        const secondResult = await getAmazonQRelatedWorkspaceConfigs(features.lsp, features.logging)
 
         deepStrictEqual(secondResult.customizationArn, undefined)
         deepStrictEqual(secondResult.inlineSuggestions?.extraContext, undefined)
     })
 })
 
-describe('AWSQConfigurationCache', () => {
+describe('AmazonQConfigurationCache', () => {
     let cache: AmazonQConfigurationCache
 
     let mockedQConfig: AmazonQWorkspaceConfig
@@ -88,7 +88,7 @@ describe('AWSQConfigurationCache', () => {
     })
 
     it('initializes with the default configuration', () => {
-        deepStrictEqual(cache.getConfig(), defaultAWSQWorkspaceConfigFactory())
+        deepStrictEqual(cache.getConfig(), defaultAmazonQWorkspaceConfigFactory())
     })
 
     it('mutating the object used by setConfig does not alter the cached config ', () => {

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.test.ts
@@ -1,0 +1,103 @@
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import {
+    AmazonQConfigurationCache,
+    AmazonQWorkspaceConfig,
+    CODE_WHISPERER_CONFIGURATION_SECTION,
+    defaultAWSQWorkspaceConfigFactory,
+    getAWSQRelatedWorkspaceConfigs,
+} from './configurationUtils'
+import { Q_CONFIGURATION_SECTION } from '../../language-server/configuration/qConfigurationServer'
+import { deepStrictEqual, notDeepStrictEqual } from 'assert'
+
+describe('getAWSQRelatedWorkspaceConfigs', () => {
+    let features: TestFeatures
+    let cache: AmazonQConfigurationCache
+
+    const MOCKED_AWS_Q_SECTION = {
+        customization: 'some-customization-arn',
+        optOutTelemetry: true,
+        inlineSuggestions: {
+            extraContext: 'some-extra-context',
+        },
+    }
+
+    const MOCKED_AWS_CODEWHISPERER_SECTION = {
+        includeSuggestionsWithCodeReferences: true,
+        shareCodeWhispererContentWithAWS: true,
+    }
+
+    beforeEach(() => {
+        cache = new AmazonQConfigurationCache()
+        features = new TestFeatures()
+
+        features.lsp.workspace.getConfiguration.withArgs(Q_CONFIGURATION_SECTION).resolves(MOCKED_AWS_Q_SECTION)
+        features.lsp.workspace.getConfiguration
+            .withArgs(CODE_WHISPERER_CONFIGURATION_SECTION)
+            .resolves(MOCKED_AWS_CODEWHISPERER_SECTION)
+    })
+
+    it('fetches the configurations and returns them', async () => {
+        const EXPECTED_CONFIG: AmazonQWorkspaceConfig = {
+            customizationArn: MOCKED_AWS_Q_SECTION.customization,
+            optOutTelemetryPreference: 'OPTOUT',
+            inlineSuggestions: { extraContext: MOCKED_AWS_Q_SECTION.inlineSuggestions.extraContext },
+            includeSuggestionsWithCodeReferences: MOCKED_AWS_CODEWHISPERER_SECTION.includeSuggestionsWithCodeReferences,
+            shareCodeWhispererContentWithAWS: MOCKED_AWS_CODEWHISPERER_SECTION.shareCodeWhispererContentWithAWS,
+        }
+
+        const amazonQConfig = await getAWSQRelatedWorkspaceConfigs(features.lsp, features.logging)
+
+        deepStrictEqual(amazonQConfig, EXPECTED_CONFIG)
+    })
+
+    it('empty strings returned by q section are set to undefined', async () => {
+        const firstResult = await getAWSQRelatedWorkspaceConfigs(features.lsp, features.logging)
+        deepStrictEqual(firstResult.customizationArn, MOCKED_AWS_Q_SECTION.customization)
+        deepStrictEqual(
+            firstResult.inlineSuggestions?.extraContext,
+            MOCKED_AWS_Q_SECTION.inlineSuggestions.extraContext
+        )
+
+        features.lsp.workspace.getConfiguration
+            .withArgs(Q_CONFIGURATION_SECTION)
+            .resolves({ customization: '', inlineSuggestions: { extraContext: '' } })
+        const secondResult = await getAWSQRelatedWorkspaceConfigs(features.lsp, features.logging)
+
+        deepStrictEqual(secondResult.customizationArn, undefined)
+        deepStrictEqual(secondResult.inlineSuggestions?.extraContext, undefined)
+    })
+})
+
+describe('AWSQConfigurationCache', () => {
+    let cache: AmazonQConfigurationCache
+
+    let mockedQConfig: AmazonQWorkspaceConfig
+
+    beforeEach(() => {
+        cache = new AmazonQConfigurationCache()
+
+        mockedQConfig = {
+            customizationArn: 'some-arn',
+            optOutTelemetryPreference: 'OPTIN',
+            inlineSuggestions: {
+                extraContext: 'some-extra-context',
+            },
+            includeSuggestionsWithCodeReferences: false,
+            shareCodeWhispererContentWithAWS: true,
+        }
+    })
+
+    it('initializes with the default configuration', () => {
+        deepStrictEqual(cache.getConfig(), defaultAWSQWorkspaceConfigFactory())
+    })
+
+    it('mutating the object used by setConfig does not alter the cached config ', () => {
+        cache.updateConfig(mockedQConfig)
+        deepStrictEqual(cache.getConfig(), mockedQConfig)
+
+        mockedQConfig.customizationArn = undefined
+        mockedQConfig.inlineSuggestions = { extraContext: undefined }
+        notDeepStrictEqual(cache.getProperty('customizationArn'), mockedQConfig.customizationArn)
+        notDeepStrictEqual(cache.getProperty('inlineSuggestions'), mockedQConfig.inlineSuggestions)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
@@ -28,16 +28,14 @@ export function getAWSQRegionAndEndpoint(runtime: Runtime, logging: Logging, reg
     if (region) {
         logging.log(`Selecting region (found: ${region}) provided by caller`)
         awsQRegion = region
-        // @ts-ignore
-        awsQEndpoint = AWS_Q_ENDPOINTS[awsQRegion]
+        awsQEndpoint = AWS_Q_ENDPOINTS.get(awsQRegion)
     } else {
         const runtimeRegion = runtime.getConfiguration(AWS_Q_REGION_ENV_VAR)
 
         if (runtimeRegion) {
             logging.log(`Selecting region (found: ${runtimeRegion}) provided by runtime`)
             awsQRegion = runtimeRegion
-            // @ts-ignore
-            awsQEndpoint = runtime.getConfiguration(AWS_Q_ENDPOINT_URL_ENV_VAR) ?? AWS_Q_ENDPOINTS[awsQRegion]
+            awsQEndpoint = runtime.getConfiguration(AWS_Q_ENDPOINT_URL_ENV_VAR) ?? AWS_Q_ENDPOINTS.get(awsQRegion)
         } else {
             logging.log('Region not provided by caller or runtime, falling back to default region and endpoint')
             awsQRegion = DEFAULT_AWS_Q_REGION

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
@@ -9,7 +9,7 @@ import {
     DEFAULT_AWS_Q_REGION,
 } from '../constants'
 
-export interface AWSQRegionAndEndpoint {
+export interface AmazonQRegionAndEndpoint {
     region: string
     endpoint: string
 }
@@ -21,50 +21,56 @@ export interface AWSQRegionAndEndpoint {
  *
  * @returns region and endpoint for Q connection
  */
-export function getAWSQRegionAndEndpoint(runtime: Runtime, logging: Logging, region?: string): AWSQRegionAndEndpoint {
-    let awsQRegion: string
-    let awsQEndpoint: string | undefined
+export function getAmazonQRegionAndEndpoint(
+    runtime: Runtime,
+    logging: Logging,
+    region?: string
+): AmazonQRegionAndEndpoint {
+    let amazonQRegion: string
+    let amazonQEndpoint: string | undefined
 
     if (region) {
         logging.log(`Selecting region (found: ${region}) provided by caller`)
-        awsQRegion = region
-        awsQEndpoint = AWS_Q_ENDPOINTS.get(awsQRegion)
+        amazonQRegion = region
+        amazonQEndpoint = AWS_Q_ENDPOINTS.get(amazonQRegion)
     } else {
         const runtimeRegion = runtime.getConfiguration(AWS_Q_REGION_ENV_VAR)
 
         if (runtimeRegion) {
             logging.log(`Selecting region (found: ${runtimeRegion}) provided by runtime`)
-            awsQRegion = runtimeRegion
-            awsQEndpoint = runtime.getConfiguration(AWS_Q_ENDPOINT_URL_ENV_VAR) ?? AWS_Q_ENDPOINTS.get(awsQRegion)
+            amazonQRegion = runtimeRegion
+            amazonQEndpoint = runtime.getConfiguration(AWS_Q_ENDPOINT_URL_ENV_VAR) ?? AWS_Q_ENDPOINTS.get(amazonQRegion)
         } else {
-            logging.log('Region not provided by caller or runtime, falling back to default region and endpoint')
-            awsQRegion = DEFAULT_AWS_Q_REGION
-            awsQEndpoint = DEFAULT_AWS_Q_ENDPOINT_URL
+            logging.log(
+                `Region not provided by caller or runtime, falling back to default region (${DEFAULT_AWS_Q_REGION}) and endpoint`
+            )
+            amazonQRegion = DEFAULT_AWS_Q_REGION
+            amazonQEndpoint = DEFAULT_AWS_Q_ENDPOINT_URL
         }
     }
 
-    if (!awsQEndpoint) {
+    if (!amazonQEndpoint) {
         logging.log(
-            `Unable to determine endpoint (found: ${awsQEndpoint}) for region: ${awsQRegion}, falling back to default region and endpoint`
+            `Unable to determine endpoint (found: ${amazonQEndpoint}) for region: ${amazonQRegion}, falling back to default region (${DEFAULT_AWS_Q_REGION}) and endpoint`
         )
-        awsQRegion = DEFAULT_AWS_Q_REGION
-        awsQEndpoint = DEFAULT_AWS_Q_ENDPOINT_URL
+        amazonQRegion = DEFAULT_AWS_Q_REGION
+        amazonQEndpoint = DEFAULT_AWS_Q_ENDPOINT_URL
     }
 
     return {
-        region: awsQRegion,
-        endpoint: awsQEndpoint,
+        region: amazonQRegion,
+        endpoint: amazonQEndpoint,
     }
 }
 
-interface QInlineSuggestions {
+interface QInlineSuggestionsConfig {
     extraContext: string | undefined // aws.q.inlineSuggestions.extraContext
 }
 
 interface QConfigSection {
     customizationArn: string | undefined // aws.q.customizationArn - selected customization
     optOutTelemetryPreference: 'OPTOUT' | 'OPTIN' // aws.q.optOutTelemetry - telemetry optout option
-    inlineSuggestions: QInlineSuggestions
+    inlineSuggestions: QInlineSuggestionsConfig
 }
 
 interface CodeWhispererConfigSection {
@@ -83,7 +89,7 @@ export const CODE_WHISPERER_CONFIGURATION_SECTION = 'aws.codeWhisperer'
  *
  * and consolidates them into one configuration.
  */
-export async function getAWSQRelatedWorkspaceConfigs(
+export async function getAmazonQRelatedWorkspaceConfigs(
     lsp: Lsp,
     logging: Logging
 ): Promise<Readonly<Partial<AmazonQWorkspaceConfig>>> {
@@ -137,7 +143,7 @@ export async function getAWSQRelatedWorkspaceConfigs(
     }
 }
 
-export const defaultAWSQWorkspaceConfigFactory = (): AmazonQWorkspaceConfig => {
+export const defaultAmazonQWorkspaceConfigFactory = (): AmazonQWorkspaceConfig => {
     return {
         customizationArn: undefined,
         optOutTelemetryPreference: 'OPTIN',
@@ -153,7 +159,7 @@ export class AmazonQConfigurationCache {
     private _cachedConfig: AmazonQWorkspaceConfig
 
     constructor() {
-        this._cachedConfig = defaultAWSQWorkspaceConfigFactory()
+        this._cachedConfig = defaultAmazonQWorkspaceConfigFactory()
     }
 
     setProperty<K extends keyof AmazonQWorkspaceConfig>(key: K, newProperty: AmazonQWorkspaceConfig[K]) {

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
@@ -1,0 +1,179 @@
+import { Logging, Lsp, Runtime } from '@aws/language-server-runtimes/server-interface'
+import { Q_CONFIGURATION_SECTION } from '../../language-server/configuration/qConfigurationServer'
+import { textUtils } from '@aws/lsp-core'
+import {
+    AWS_Q_ENDPOINT_URL_ENV_VAR,
+    AWS_Q_ENDPOINTS,
+    AWS_Q_REGION_ENV_VAR,
+    DEFAULT_AWS_Q_ENDPOINT_URL,
+    DEFAULT_AWS_Q_REGION,
+} from '../constants'
+
+export interface AWSQRegionAndEndpoint {
+    region: string
+    endpoint: string
+}
+
+/**
+ * Determines Q region according to the following discovery chain:
+ *
+ * provided region (e.g. by client or profile) -> region set in runtime -> default region
+ *
+ * @returns region and endpoint for Q connection
+ */
+export function getAWSQRegionAndEndpoint(runtime: Runtime, logging: Logging, region?: string): AWSQRegionAndEndpoint {
+    let awsQRegion: string
+    let awsQEndpoint: string | undefined
+
+    if (region) {
+        logging.log(`Selecting region (found: ${region}) provided by caller`)
+        awsQRegion = region
+        // @ts-ignore
+        awsQEndpoint = AWS_Q_ENDPOINTS[awsQRegion]
+    } else {
+        const runtimeRegion = runtime.getConfiguration(AWS_Q_REGION_ENV_VAR)
+
+        if (runtimeRegion) {
+            logging.log(`Selecting region (found: ${runtimeRegion}) provided by runtime`)
+            awsQRegion = runtimeRegion
+            // @ts-ignore
+            awsQEndpoint = runtime.getConfiguration(AWS_Q_ENDPOINT_URL_ENV_VAR) ?? AWS_Q_ENDPOINTS[awsQRegion]
+        } else {
+            logging.log('Region not provided by caller or runtime, falling back to default region and endpoint')
+            awsQRegion = DEFAULT_AWS_Q_REGION
+            awsQEndpoint = DEFAULT_AWS_Q_ENDPOINT_URL
+        }
+    }
+
+    if (!awsQEndpoint) {
+        logging.log(
+            `Unable to determine endpoint (found: ${awsQEndpoint}) for region: ${awsQRegion}, falling back to default region and endpoint`
+        )
+        awsQRegion = DEFAULT_AWS_Q_REGION
+        awsQEndpoint = DEFAULT_AWS_Q_ENDPOINT_URL
+    }
+
+    return {
+        region: awsQRegion,
+        endpoint: awsQEndpoint,
+    }
+}
+
+interface QInlineSuggestions {
+    extraContext: string | undefined // aws.q.inlineSuggestions.extraContext
+}
+
+interface QConfigSection {
+    customizationArn: string | undefined // aws.q.customizationArn - selected customization
+    optOutTelemetryPreference: 'OPTOUT' | 'OPTIN' // aws.q.optOutTelemetry - telemetry optout option
+    inlineSuggestions: QInlineSuggestions
+}
+
+interface CodeWhispererConfigSection {
+    includeSuggestionsWithCodeReferences: boolean // aws.codeWhisperer.includeSuggestionsWithCodeReferences - return suggestions with code references
+    shareCodeWhispererContentWithAWS: boolean // aws.codeWhisperer.shareCodeWhispererContentWithAWS - share content with AWS
+}
+
+export type AmazonQWorkspaceConfig = QConfigSection & CodeWhispererConfigSection
+
+export const CODE_WHISPERER_CONFIGURATION_SECTION = 'aws.codeWhisperer'
+
+/**
+ * Attempts to fetch the workspace configurations set in:
+ *   - aws.q
+ *   - aws.codeWhisperer
+ *
+ * and consolidates them into one configuration.
+ */
+export async function getAWSQRelatedWorkspaceConfigs(
+    lsp: Lsp,
+    logging: Logging
+): Promise<Readonly<Partial<AmazonQWorkspaceConfig>>> {
+    let qConfig: Readonly<QConfigSection> | undefined = undefined
+    let codeWhispererConfig: Readonly<CodeWhispererConfigSection> | undefined = undefined
+
+    try {
+        logging.debug(`Calling getConfiguration(${Q_CONFIGURATION_SECTION})`)
+        const newQConfig = await lsp.workspace.getConfiguration(Q_CONFIGURATION_SECTION)
+
+        if (newQConfig) {
+            qConfig = {
+                customizationArn: textUtils.undefinedIfEmpty(newQConfig.customization),
+                optOutTelemetryPreference: newQConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN',
+                inlineSuggestions: {
+                    extraContext: textUtils.undefinedIfEmpty(newQConfig.inlineSuggestions?.extraContext),
+                },
+            }
+
+            logging.log(`Read configuration customizationArn=${qConfig.customizationArn}`)
+            logging.log(`Read configuration optOutTelemetryPreference=${qConfig.optOutTelemetryPreference}`)
+        }
+    } catch (error) {
+        logging.error(`Error in getConfiguration(${Q_CONFIGURATION_SECTION}): ${error}`)
+    }
+
+    try {
+        logging.debug(`Calling getConfiguration(${CODE_WHISPERER_CONFIGURATION_SECTION})`)
+        const newCodeWhispererConfig = await lsp.workspace.getConfiguration(CODE_WHISPERER_CONFIGURATION_SECTION)
+        if (newCodeWhispererConfig) {
+            codeWhispererConfig = {
+                includeSuggestionsWithCodeReferences:
+                    newCodeWhispererConfig['includeSuggestionsWithCodeReferences'] === true,
+                shareCodeWhispererContentWithAWS: newCodeWhispererConfig['shareCodeWhispererContentWithAWS'] === true,
+            }
+
+            logging.log(
+                `Read сonfiguration includeSuggestionsWithCodeReferences=${codeWhispererConfig.includeSuggestionsWithCodeReferences}`
+            )
+            logging.log(
+                `Read configuration shareCodeWhispererContentWithAWS=${codeWhispererConfig.shareCodeWhispererContentWithAWS}`
+            )
+        }
+    } catch (error) {
+        logging.error(`Error in getConfiguration(${CODE_WHISPERER_CONFIGURATION_SECTION}): ${error}`)
+    }
+
+    return {
+        ...qConfig,
+        ...codeWhispererConfig,
+    }
+}
+
+export const defaultAWSQWorkspaceConfigFactory = (): AmazonQWorkspaceConfig => {
+    return {
+        customizationArn: undefined,
+        optOutTelemetryPreference: 'OPTIN',
+        inlineSuggestions: {
+            extraContext: undefined,
+        },
+        includeSuggestionsWithCodeReferences: false,
+        shareCodeWhispererContentWithAWS: false,
+    }
+}
+
+export class AmazonQConfigurationCache {
+    private _cachedConfig: AmazonQWorkspaceConfig
+
+    constructor() {
+        this._cachedConfig = defaultAWSQWorkspaceConfigFactory()
+    }
+
+    setProperty<K extends keyof AmazonQWorkspaceConfig>(key: K, newProperty: AmazonQWorkspaceConfig[K]) {
+        this._cachedConfig[key] = typeof newProperty === 'object' ? { ...newProperty } : newProperty
+    }
+
+    getProperty<K extends keyof AmazonQWorkspaceConfig>(key: K): Readonly<AmazonQWorkspaceConfig[K]> {
+        const property = this._cachedConfig[key]
+        return typeof property === 'object' ? { ...property } : property
+    }
+
+    updateConfig(newConfig: Readonly<Partial<AmazonQWorkspaceConfig>>) {
+        Object.entries(newConfig).forEach(([key, value]) => {
+            this.setProperty(key as keyof AmazonQWorkspaceConfig, value)
+        })
+    }
+
+    getConfig(): Readonly<AmazonQWorkspaceConfig> {
+        return { ...this._cachedConfig }
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/factories.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/factories.test.ts
@@ -1,0 +1,58 @@
+import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
+import { deepStrictEqual, notDeepStrictEqual } from 'assert'
+import { AmazonQTokenServiceManager } from './AmazonQTokenServiceManager'
+import { initBaseTokenServiceManager, initFallbackServiceManager } from './factories'
+import { CodeWhispererServiceBase } from '../codeWhispererService'
+import { BaseAmazonQServiceManager } from './BaseAmazonQServiceManager'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+
+describe('initBaseServiceManager', () => {
+    let features: TestFeatures
+
+    beforeEach(() => {
+        features = new TestFeatures()
+    })
+
+    describe('initBaseTokenServiceManager', () => {
+        it('initializes token manager for bearer credentials type', () => {
+            const tokenManagerGetInstanceStub = sinon.stub(AmazonQTokenServiceManager, 'getInstance')
+
+            initBaseTokenServiceManager(features)
+
+            sinon.assert.calledOnce(tokenManagerGetInstanceStub)
+        })
+    })
+
+    describe('initFallbackServiceManager', () => {
+        let serviceStub: StubbedInstance<CodeWhispererServiceBase>
+        let serviceManager: BaseAmazonQServiceManager
+
+        beforeEach(() => {
+            serviceStub = stubInterface<CodeWhispererServiceBase>()
+            serviceStub.customizationArn = undefined
+
+            serviceManager = initFallbackServiceManager(features, serviceStub)
+        })
+
+        it('returns instantiated service', () => {
+            deepStrictEqual(serviceManager.getCodewhispererService(), serviceStub)
+        })
+
+        it('updates the cache and service when handleDidChangeConfiguration is called', async () => {
+            const initialConfig = serviceManager.getConfiguration()
+
+            deepStrictEqual(initialConfig.customizationArn, undefined)
+            deepStrictEqual(serviceStub.customizationArn, undefined)
+
+            features.lsp.workspace.getConfiguration.resolves({ customization: 'some-arn' })
+
+            await serviceManager.handleDidChangeConfiguration()
+
+            const updatedConfig = serviceManager.getConfiguration()
+            notDeepStrictEqual(updatedConfig, initialConfig)
+
+            deepStrictEqual(updatedConfig.customizationArn, 'some-arn')
+            deepStrictEqual(serviceStub.customizationArn, 'some-arn')
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/factories.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/factories.ts
@@ -3,8 +3,8 @@ import { BaseAmazonQServiceManager } from './BaseAmazonQServiceManager'
 import {
     AmazonQConfigurationCache,
     AmazonQWorkspaceConfig,
-    getAWSQRegionAndEndpoint,
-    getAWSQRelatedWorkspaceConfigs,
+    getAmazonQRegionAndEndpoint,
+    getAmazonQRelatedWorkspaceConfigs,
 } from './configurationUtils'
 import { CodeWhispererServiceBase, CodeWhispererServiceIAM } from '../codeWhispererService'
 
@@ -13,7 +13,7 @@ const initTokenServiceManager = (features: Features) => {
 }
 
 export const initFallbackServiceManager = (features: Features, serviceOverride?: CodeWhispererServiceBase) => {
-    const { region, endpoint } = getAWSQRegionAndEndpoint(features.runtime, features.logging)
+    const { region, endpoint } = getAmazonQRegionAndEndpoint(features.runtime, features.logging)
     const codeWhisperService =
         serviceOverride ??
         new CodeWhispererServiceIAM(
@@ -29,7 +29,7 @@ export const initFallbackServiceManager = (features: Features, serviceOverride?:
     return {
         handleDidChangeConfiguration: async (): Promise<Readonly<AmazonQWorkspaceConfig>> => {
             try {
-                const amazonQConfig = await getAWSQRelatedWorkspaceConfigs(features.lsp, features.logging)
+                const amazonQConfig = await getAmazonQRelatedWorkspaceConfigs(features.lsp, features.logging)
 
                 codeWhisperService.customizationArn = amazonQConfig.customizationArn
 

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/factories.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/factories.ts
@@ -1,0 +1,61 @@
+import { AmazonQTokenServiceManager, Features } from './AmazonQTokenServiceManager'
+import { BaseAmazonQServiceManager } from './BaseAmazonQServiceManager'
+import {
+    AmazonQConfigurationCache,
+    AmazonQWorkspaceConfig,
+    getAWSQRegionAndEndpoint,
+    getAWSQRelatedWorkspaceConfigs,
+} from './configurationUtils'
+import { CodeWhispererServiceBase, CodeWhispererServiceIAM } from '../codeWhispererService'
+
+const initTokenServiceManager = (features: Features) => {
+    return AmazonQTokenServiceManager.getInstance(features)
+}
+
+export const initFallbackServiceManager = (features: Features, serviceOverride?: CodeWhispererServiceBase) => {
+    const { region, endpoint } = getAWSQRegionAndEndpoint(features.runtime, features.logging)
+    const codeWhisperService =
+        serviceOverride ??
+        new CodeWhispererServiceIAM(
+            features.credentialsProvider,
+            features.workspace,
+            region,
+            endpoint,
+            features.sdkInitializator
+        )
+
+    const configurationCache = new AmazonQConfigurationCache()
+
+    return {
+        handleDidChangeConfiguration: async (): Promise<Readonly<AmazonQWorkspaceConfig>> => {
+            try {
+                const amazonQConfig = await getAWSQRelatedWorkspaceConfigs(features.lsp, features.logging)
+
+                codeWhisperService.customizationArn = amazonQConfig.customizationArn
+
+                if (amazonQConfig.shareCodeWhispererContentWithAWS !== undefined) {
+                    codeWhisperService.shareCodeWhispererContentWithAWS = amazonQConfig.shareCodeWhispererContentWithAWS
+                }
+
+                configurationCache.updateConfig(amazonQConfig)
+            } catch (error) {
+                features.logging.debug(`Unexpected error in getAWSQRelatedWorkspaceConfigs: ${error}`)
+            }
+
+            return configurationCache.getConfig()
+        },
+        getCodewhispererService: () => {
+            return codeWhisperService
+        },
+        getConfiguration: () => {
+            return configurationCache.getConfig()
+        },
+    }
+}
+
+export const initBaseTokenServiceManager = (features: Features): BaseAmazonQServiceManager => {
+    return initTokenServiceManager(features)
+}
+export const initBaseIAMServiceManager = (features: Features) => {
+    return initFallbackServiceManager(features)
+}

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.test.ts
@@ -14,15 +14,13 @@ import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../shared/c
 const SOME_Q_DEVELOPER_PROFILE_ARN = 'some-random-q-developer-profile-arn'
 const SOME_Q_DEVELOPER_PROFILE_NAME = 'some-random-q-developer-profile-name'
 const SOME_Q_ENDPOINT_URL = 'some-random-q-endpoint'
-const SOME_AWS_Q_ENDPOINT = {
-    [DEFAULT_AWS_Q_REGION]: DEFAULT_AWS_Q_ENDPOINT_URL,
-}
-const SOME_AWS_Q_ENDPOINTS = {
-    ...SOME_AWS_Q_ENDPOINT,
-    'eu-central-1': SOME_Q_ENDPOINT_URL,
-}
+const SOME_AWS_Q_ENDPOINT = new Map([[DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL]])
+const SOME_AWS_Q_ENDPOINTS = new Map([
+    [DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL],
+    ['eu-central-1', SOME_Q_ENDPOINT_URL],
+])
 
-const EXPECTED_DEVELOPER_PROFILES_LIST: AmazonQDeveloperProfile[] = Object.keys(SOME_AWS_Q_ENDPOINTS).map(region => ({
+const EXPECTED_DEVELOPER_PROFILES_LIST: AmazonQDeveloperProfile[] = Array.from(SOME_AWS_Q_ENDPOINTS.keys(), region => ({
     arn: SOME_Q_DEVELOPER_PROFILE_ARN,
     name: SOME_Q_DEVELOPER_PROFILE_NAME,
     identityDetails: {

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
@@ -21,7 +21,7 @@ interface IdentityDetails {
 export interface ListAllAvailableProfilesHandlerParams {
     connectionType: SsoConnectionType
     logging: Logging
-    endpoints?: { [region: string]: string } // override option for flexibility, we default to all (AWS_Q_ENDPOINTS)
+    endpoints?: Map<string, string> // override option for flexibility, we default to all (AWS_Q_ENDPOINTS)
 }
 
 export type ListAllAvailableProfilesHandler = (
@@ -43,7 +43,7 @@ export const getListAllAvailableProfilesHandler =
         const qEndpoints = endpoints ?? AWS_Q_ENDPOINTS
 
         const result = await Promise.allSettled(
-            Object.entries(qEndpoints).map(([region, endpoint]) => {
+            Array.from(qEndpoints.entries(), ([region, endpoint]) => {
                 const codeWhispererService = service(region, endpoint)
                 return fetchProfilesFromRegion(codeWhispererService, region, logging)
             })

--- a/server/aws-lsp-codewhisperer/src/shared/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/constants.ts
@@ -5,10 +5,10 @@ export const BUILDER_ID_START_URL = 'https://view.awsapps.com/start'
 export const DEFAULT_AWS_Q_ENDPOINT_URL = 'https://codewhisperer.us-east-1.amazonaws.com/'
 export const DEFAULT_AWS_Q_REGION = 'us-east-1'
 
-export const AWS_Q_ENDPOINTS = {
-    [DEFAULT_AWS_Q_REGION]: DEFAULT_AWS_Q_ENDPOINT_URL,
-    'eu-central-1': 'https://q.eu-central-1.amazonaws.com/',
-}
+export const AWS_Q_ENDPOINTS = new Map([
+    [DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL],
+    ['eu-central-1', 'https://q.eu-central-1.amazonaws.com/'],
+])
 
 export const AWS_Q_REGION_ENV_VAR = 'AWS_Q_REGION'
 export const AWS_Q_ENDPOINT_URL_ENV_VAR = 'AWS_Q_ENDPOINT_URL'

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetry.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetry.test.ts
@@ -11,6 +11,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 import { CodewhispererServerFactory } from '../../language-server/inline-completion/codeWhispererServer'
 import { CodeWhispererServiceBase, ResponseContext, Suggestion } from '../codeWhispererService'
 import { TelemetryService } from './telemetryService'
+import { initFallbackServiceManager } from '../amazonQServiceManager/factories'
 
 describe('CodeWhisperer Server', () => {
     const HELLO_WORLD_IN_CSHARP = `
@@ -52,10 +53,9 @@ class HelloWorld
                 })
             )
 
-            server = CodewhispererServerFactory(_auth => service)
-
             // Initialize the features, but don't start server yet
             features = new TestFeatures()
+            server = CodewhispererServerFactory(() => initFallbackServiceManager(features, service))
 
             // Return no specific configuration for CodeWhisperer
             features.lsp.workspace.getConfiguration.returns(Promise.resolve({}))


### PR DESCRIPTION
## Problem

We currently need to maintain a fallback codewhisperer service in the inline completions server because it supports both token and iam credentials. Refactoring this server would enable us to optimize the reuse of the new amazon q service manager.

## Solution

- Centralize workspace configurations within the service manager
    - By adding the `getConfiguration(): Readonly<AWSQWorkspaceConfigs>` method to `BaseAmazonQServiceManager` we can refer to the up-to-date workspace configurations maintained within the service manager
    - Introduce an `AWSQConfigurationCache` wrapper which orchestrates manipulation of the cached configuration within the service manager in a type-safe manner
    - Factor our handling configuration update events to a reusable function
    - Factor out region and endpoint discovery to reusable function
- Introduce a factory to initialize a base service manager based on the server's credentials type 

Testing: existing unit tests pass, added more unit tests

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
