### PR TITLE
fix(amazonq): reduce noisy logging from Q Service Manager

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -234,7 +234,7 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
         // Connection type hasn't change.
 
         if (newConnectionType === this.connectionType) {
-            this.log('Connection type did not change.')
+            this.logging.debug(`Connection type did not change: ${this.connectionType}`)
 
             return
         }


### PR DESCRIPTION
## Problem
Logging in is AmazonQTokenServiceManager.ts noisy.

## Solution
Switch noisy log to debug loglevel

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
