### PR TITLE
chore: bump runtimes version and add empty onInlineChatPrompt implementation

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -11,7 +11,7 @@
         "start": "cross-env NODE_OPTIONS=--max_old_space_size=8172 webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-partiql": "^0.0.5"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.48"
+        "@aws/language-server-runtimes": "^0.2.50"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -323,7 +323,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.7",
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -77,7 +77,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -104,7 +104,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -112,7 +112,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -132,7 +132,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -140,7 +140,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-partiql": "^0.0.5"
             },
             "devDependencies": {
@@ -176,7 +176,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -196,7 +196,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -218,7 +218,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.48"
+                "@aws/language-server-runtimes": "^0.2.50"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -262,7 +262,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.7",
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -6464,15 +6464,14 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.48",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.48.tgz",
-            "integrity": "sha512-uKB7uiz3Naq6PGtg+1iQlUrkRKNJ4DUZijNrbUSH2OTvwQTErmMB/Ltu7M3To5IdNCi+Guk44qwaLMUx/6gJ8w==",
-            "license": "Apache-2.0",
+            "version": "0.2.50",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.50.tgz",
+            "integrity": "sha512-M4HDcP+KBgK3tEH9KhmXBtHkA1Gw0dip7Iz1EuwzFEikVJqeiKBQXyvNa92A+4OMQxRY5iX6Q66jXfq8KDbldQ==",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.9.3",
                 "@aws-crypto/sha256-js": "^5.2.0",
                 "@aws-sdk/client-cognito-identity": "^3.758.0",
-                "@aws/language-server-runtimes-types": "^0.1.6",
+                "@aws/language-server-runtimes-types": "^0.1.7",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
                 "@opentelemetry/resources": "^1.30.1",
@@ -6499,10 +6498,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.6.tgz",
-            "integrity": "sha512-D8BukMtJRauOw2h/VHOMq7xZxXtCui1zNPzfoU8p6NAAveQL2+eJiLb0l+eYfAB/F1BfWGDcCU/T6cuYg3A/Ng==",
-            "license": "Apache-2.0",
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.7.tgz",
+            "integrity": "sha512-q+VtDat62oZoR7zEc4gyubqqH1HlFDPpzquAJJf01t/mmKG6zsv0zUwKmMtjg2Qx4lMDrOWnZcTVNorvSSdW3A==",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"
@@ -26350,7 +26348,7 @@
             "version": "0.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-core": "^0.0.2"
             },
             "devDependencies": {
@@ -26421,7 +26419,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.7",
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-core": "^0.0.2",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
@@ -26541,7 +26539,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-core": "^0.0.2",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -26616,7 +26614,7 @@
             "version": "0.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-core": "^0.0.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -26630,7 +26628,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-core": "0.0.2",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -26659,7 +26657,7 @@
             "version": "0.0.6",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -26692,7 +26690,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "@aws/lsp-core": "^0.0.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -26706,7 +26704,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -26717,7 +26715,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.48",
+                "@aws/language-server-runtimes": "^0.2.50",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-core": "^0.0.2"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -30,7 +30,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.7",
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-core": "^0.0.2",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -12,6 +12,7 @@ import {
     TextDocumentEdit,
     TextEdit,
     chatRequestType,
+    InlineChatParams,
 } from '@aws/language-server-runtimes/protocol'
 import {
     CancellationToken,
@@ -213,6 +214,13 @@ export class AgenticChatController implements ChatHandlers {
                 err instanceof Error ? err.message : 'Unknown error occured during response stream'
             )
         }
+    }
+
+    async onInlineChatPrompt(
+        params: InlineChatParams,
+        token: CancellationToken
+    ): Promise<ChatResult | ResponseError<ChatResult>> {
+        return {}
     }
 
     async onCodeInsertToCursorPosition(params: InsertToCursorPositionParams) {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -3,6 +3,7 @@ import {
     ApplyWorkspaceEditParams,
     ErrorCodes,
     FeedbackParams,
+    InlineChatParams,
     InsertToCursorPositionParams,
     TextDocumentEdit,
     TextEdit,
@@ -208,6 +209,13 @@ export class ChatController implements ChatHandlers {
                 err instanceof Error ? err.message : 'Unknown error occured during response stream'
             )
         }
+    }
+
+    async onInlineChatPrompt(
+        params: InlineChatParams,
+        token: CancellationToken
+    ): Promise<ChatResult | ResponseError<ChatResult>> {
+        return {}
     }
 
     async onCodeInsertToCursorPosition(params: InsertToCursorPositionParams) {

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-core": "^0.0.2",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-core": "^0.0.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-core": "0.0.2",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "@aws/lsp-core": "^0.0.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.48",
+        "@aws/language-server-runtimes": "^0.2.50",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem
bump runtimes and comply to new version of ChatHandlers protocol (see [PR](https://github.com/aws/language-server-runtimes/pull/391/files#diff-3b7ccc3150a65fa49ffbc0f6d5f2beb4a487251387f744a5a58a75768fde5de0R129)) by adding an empty implemenetation for the new `onInlineChatPrompt` in the classes using Chat.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
