### PR TITLE
fix: revert tsconfig changes in codewhisperer-runtimes

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/src/main.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/src/main.ts
@@ -44,4 +44,4 @@ const worker = new Worker(
 
 // Start Language Client
 const client = new LanguageClient(worker)
-await client.start()
+// await client.start()

--- a/app/aws-lsp-codewhisperer-runtimes/tsconfig.json
+++ b/app/aws-lsp-codewhisperer-runtimes/tsconfig.json
@@ -2,12 +2,7 @@
     "extends": "../../tsconfig.packages.json",
     "compilerOptions": {
         "rootDir": "./src",
-        "outDir": "./out",
-        "esModuleInterop": true,
-        "allowJs": true,
-        "checkJs": true,
-        "module": "ESNext",
-        "target": "ES2022"
+        "outDir": "./out"
     },
     "include": ["src"]
 }


### PR DESCRIPTION
## Problem
quick fix to revert breaking changes in aws-lsp-codewhisperer-runtimes that caused the token standalone to break.
See https://github.com/aws/language-servers/pull/883/files#r2022907628

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
