### PR TITLE
chore: bump the version of runtimes

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -11,7 +11,7 @@
         "start": "cross-env NODE_OPTIONS=--max_old_space_size=8172 webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-partiql": "^0.0.5"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.50"
+        "@aws/language-server-runtimes": "^0.2.52"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -323,7 +323,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.7",
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -77,7 +77,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -104,7 +104,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -112,7 +112,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -132,7 +132,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -140,7 +140,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-partiql": "^0.0.5"
             },
             "devDependencies": {
@@ -176,7 +176,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -196,7 +196,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -218,7 +218,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.50"
+                "@aws/language-server-runtimes": "^0.2.52"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -262,7 +262,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.7",
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -6464,14 +6464,15 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.50",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.50.tgz",
-            "integrity": "sha512-M4HDcP+KBgK3tEH9KhmXBtHkA1Gw0dip7Iz1EuwzFEikVJqeiKBQXyvNa92A+4OMQxRY5iX6Q66jXfq8KDbldQ==",
+            "version": "0.2.52",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.52.tgz",
+            "integrity": "sha512-WzxhJJXkiN5O76vH7T5Zyfl8jcODp50ZphA6g1nQgQXOYMTrhCwgkFdZ8PFlsLrEVwlWLbUpQ05XuQVWgYJ5Fg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.9.3",
                 "@aws-crypto/sha256-js": "^5.2.0",
                 "@aws-sdk/client-cognito-identity": "^3.758.0",
-                "@aws/language-server-runtimes-types": "^0.1.7",
+                "@aws/language-server-runtimes-types": "^0.1.9",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
                 "@opentelemetry/resources": "^1.30.1",
@@ -6498,9 +6499,10 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.7.tgz",
-            "integrity": "sha512-q+VtDat62oZoR7zEc4gyubqqH1HlFDPpzquAJJf01t/mmKG6zsv0zUwKmMtjg2Qx4lMDrOWnZcTVNorvSSdW3A==",
+            "version": "0.1.9",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.9.tgz",
+            "integrity": "sha512-aIaqnYNFBT9ROFyFu6hxnsVqBwleNskpySQmYSJ4/8gqv3H+fLOlip8Zko6ApodQPicR2lwumM87XvnSVErHMw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"
@@ -26348,7 +26350,7 @@
             "version": "0.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-core": "^0.0.2"
             },
             "devDependencies": {
@@ -26419,7 +26421,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.7",
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-core": "^0.0.2",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
@@ -26539,7 +26541,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-core": "^0.0.2",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -26614,7 +26616,7 @@
             "version": "0.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-core": "^0.0.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -26628,7 +26630,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-core": "0.0.2",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -26657,7 +26659,7 @@
             "version": "0.0.6",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -26690,7 +26692,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-core": "^0.0.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -26704,7 +26706,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -26715,7 +26717,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.50",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-core": "^0.0.2"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -30,7 +30,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.7",
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-core": "^0.0.2",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-core": "^0.0.2",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-core": "^0.0.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-core": "0.0.2",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "@aws/lsp-core": "^0.0.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.50",
+        "@aws/language-server-runtimes": "^0.2.52",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem
Bump the version of runtimes to 0.2.52 to be able to populate the requestId in the InlineChat response structure for the [PR](https://github.com/aws/language-servers/pull/897)

## Solution

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
