### PR TITLE
feat(amazonq): add streaming client caching and inflight-request cancellation

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
+++ b/server/aws-lsp-codewhisperer/src/client/streamingClient/codewhispererStreamingClient.ts
@@ -2,6 +2,7 @@ import { CodeWhispererStreaming, CodeWhispererStreamingClientConfig } from '@amz
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { SDKInitializator } from '@aws/language-server-runtimes/server-interface'
 
+// TODO: refactor and combine with language-server/streamingClientService.ts when no longer in use
 export class StreamingClient {
     public async getStreamingClient(
         credentialsProvider: any,

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -154,7 +154,12 @@ describe('ChatController', () => {
         }
 
         telemetryService = new TelemetryService(amazonQServiceManager, mockCredentialsProvider, telemetry, logging)
-        chatController = new ChatController(chatSessionManagementService, testFeatures, telemetryService)
+        chatController = new ChatController(
+            chatSessionManagementService,
+            testFeatures,
+            telemetryService,
+            amazonQServiceManager
+        )
     })
 
     afterEach(() => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -40,15 +40,13 @@ import { getErrorMessage, isAwsError, isNullish, isObject } from '../../shared/u
 import { Metric } from '../../shared/telemetry/metric'
 import { QChatTriggerContext, TriggerContext } from './contexts/triggerContext'
 import { HELP_MESSAGE } from './constants'
-import { Q_CONFIGURATION_SECTION } from '../configuration/qConfigurationServer'
-import { textUtils } from '@aws/lsp-core'
 import {
     AmazonQServicePendingProfileError,
     AmazonQServicePendingSigninError,
 } from '../../shared/amazonQServiceManager/errors'
-import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { AmazonQWorkspaceConfig } from '../../shared/amazonQServiceManager/configurationUtils'
+import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -62,13 +60,13 @@ export class ChatController implements ChatHandlers {
     #triggerContext: QChatTriggerContext
     #customizationArn?: string
     #telemetryService: TelemetryService
-    #amazonQServiceManager?: AmazonQTokenServiceManager
+    #amazonQServiceManager: AmazonQTokenServiceManager
 
     constructor(
         chatSessionManagementService: ChatSessionManagementService,
         features: Features,
         telemetryService: TelemetryService,
-        amazonQServiceManager?: AmazonQTokenServiceManager
+        amazonQServiceManager: AmazonQTokenServiceManager
     ) {
         this.#features = features
         this.#chatSessionManagementService = chatSessionManagementService
@@ -116,13 +114,11 @@ export class ChatController implements ChatHandlers {
         const conversationIdentifier = session?.conversationId ?? 'New conversation'
         try {
             this.#log('Request for conversation id:', conversationIdentifier)
-            const profileArn = AmazonQTokenServiceManager.getInstance(this.#features).getActiveProfileArn()
             requestInput = this.#triggerContext.getChatParamsFromTrigger(
                 params,
                 triggerContext,
                 ChatTriggerType.MANUAL,
-                this.#customizationArn,
-                profileArn
+                this.#customizationArn
             )
 
             metric.recordStart()
@@ -237,18 +233,12 @@ export class ChatController implements ChatHandlers {
         let requestInput: SendMessageCommandInput
 
         try {
-            const profileArn = AmazonQTokenServiceManager.getInstance(this.#features).getActiveProfileArn()
             requestInput = this.#triggerContext.getChatParamsFromTrigger(
                 params,
                 triggerContext,
                 ChatTriggerType.INLINE_CHAT,
-                this.#customizationArn,
-                profileArn
+                this.#customizationArn
             )
-
-            if (!this.#amazonQServiceManager) {
-                throw new Error('amazonQServiceManager is not initialized')
-            }
 
             const client = this.#amazonQServiceManager.getStreamingClient()
             response = await client.sendMessage(requestInput)

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
@@ -1,19 +1,15 @@
-import {
-    CodeWhispererStreaming,
-    SendMessageCommandInput,
-    SendMessageCommandOutput,
-} from '@amzn/codewhisperer-streaming'
+import { SendMessageCommandInput, SendMessageCommandOutput } from '@amzn/codewhisperer-streaming'
 import * as assert from 'assert'
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
 import { ChatSessionService } from './chatSessionService'
-
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
+import { StreamingClientService } from '../../shared/streamingClientService'
 
 describe('Chat Session Service', () => {
-    let sendMessageStub: sinon.SinonStub<any, any>
     let abortStub: sinon.SinonStub<any, any>
     let chatSessionService: ChatSessionService
     let amazonQServiceManager: StubbedInstance<AmazonQTokenServiceManager>
+    let codeWhispererStreamingClient: StubbedInstance<StreamingClientService>
     const mockConversationId = 'mockConversationId'
 
     const mockRequestParams: SendMessageCommandInput = {
@@ -33,12 +29,11 @@ describe('Chat Session Service', () => {
     }
 
     beforeEach(() => {
-        sendMessageStub = sinon
-            .stub(CodeWhispererStreaming.prototype, 'sendMessage')
-            .callsFake(() => Promise.resolve(mockRequestResponse))
+        codeWhispererStreamingClient = stubInterface<StreamingClientService>()
+        codeWhispererStreamingClient.sendMessage.callsFake(() => Promise.resolve(mockRequestResponse))
 
         amazonQServiceManager = stubInterface<AmazonQTokenServiceManager>()
-        amazonQServiceManager.getStreamingClient.returns(new CodeWhispererStreaming())
+        amazonQServiceManager.getStreamingClient.returns(codeWhispererStreamingClient)
 
         abortStub = sinon.stub(AbortController.prototype, 'abort')
 
@@ -46,7 +41,6 @@ describe('Chat Session Service', () => {
     })
 
     afterEach(() => {
-        sendMessageStub.restore()
         abortStub.restore()
     })
 
@@ -62,8 +56,8 @@ describe('Chat Session Service', () => {
 
         it('should fill in conversationId in the request if exists', async () => {
             await chatSessionService.sendMessage(mockRequestParams)
-
-            sinon.assert.calledOnceWithExactly(sendMessageStub, mockRequestParams, sinon.match.object)
+            sinon.assert.calledOnce(codeWhispererStreamingClient.sendMessage)
+            sinon.assert.match(codeWhispererStreamingClient.sendMessage.firstCall.firstArg, mockRequestParams)
 
             chatSessionService.conversationId = mockConversationId
 
@@ -76,7 +70,10 @@ describe('Chat Session Service', () => {
                 },
             }
 
-            assert.ok(sendMessageStub.getCall(1).calledWithExactly(requestParamsWithConversationId, sinon.match.object))
+            sinon.assert.match(
+                codeWhispererStreamingClient.sendMessage.getCall(1).firstArg,
+                requestParamsWithConversationId
+            )
         })
     })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -38,9 +38,7 @@ export class ChatSessionService {
 
         const client = this.#amazonQServiceManager.getStreamingClient()
 
-        const response = await client.sendMessage(request, {
-            abortSignal: this.#abortController?.signal,
-        })
+        const response = await client.sendMessage(request, this.#abortController)
 
         return response
     }

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../constants'
 import * as qDeveloperProfilesFetcherModule from './qDeveloperProfiles'
 import { setCredentialsForAmazonQTokenServiceManagerFactory } from '../testUtils'
-import { CodeWhispererStreaming } from '@amzn/codewhisperer-streaming'
+import { StreamingClientService } from '../streamingClientService'
 
 export const mockedProfiles: qDeveloperProfilesFetcherModule.AmazonQDeveloperProfile[] = [
     {
@@ -233,7 +233,7 @@ describe('AmazonQTokenServiceManager', () => {
             assert.strictEqual(amazonQTokenServiceManager.getState(), 'INITIALIZED')
             assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'builderId')
 
-            assert(streamingClient instanceof CodeWhispererStreaming)
+            assert(streamingClient instanceof StreamingClientService)
             assert(codewhispererServiceStub.generateSuggestions.calledOnce)
         })
 
@@ -253,8 +253,11 @@ describe('AmazonQTokenServiceManager', () => {
             assert(codewhispererStubFactory.calledOnceWithExactly(testRegion, testEndpoint))
 
             const streamingClient = amazonQTokenServiceManager.getStreamingClient()
-            assert.strictEqual(await streamingClient.config.region(), testRegion)
-            assert.strictEqual((await streamingClient.config.endpoint()).hostname, 'some-endpoint-in-some-region')
+            assert.strictEqual(await streamingClient.client.config.region(), testRegion)
+            assert.strictEqual(
+                (await streamingClient.client.config.endpoint()).hostname,
+                'some-endpoint-in-some-region'
+            )
         })
 
         it('should initialize service with region set by runtime if not set by client', async () => {
@@ -265,8 +268,11 @@ describe('AmazonQTokenServiceManager', () => {
             assert(codewhispererStubFactory.calledOnceWithExactly('eu-central-1', TEST_ENDPOINT_EU_CENTRAL_1))
 
             const streamingClient = amazonQTokenServiceManager.getStreamingClient()
-            assert.strictEqual(await streamingClient.config.region(), 'eu-central-1')
-            assert.strictEqual((await streamingClient.config.endpoint()).hostname, 'amazon-q-in-eu-central-1-endpoint')
+            assert.strictEqual(await streamingClient.client.config.region(), 'eu-central-1')
+            assert.strictEqual(
+                (await streamingClient.client.config.endpoint()).hostname,
+                'amazon-q-in-eu-central-1-endpoint'
+            )
         })
 
         it('should initialize service with default region if not set by client and runtime', async () => {
@@ -275,9 +281,9 @@ describe('AmazonQTokenServiceManager', () => {
 
             assert(codewhispererStubFactory.calledOnceWithExactly(DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL))
 
-            assert.strictEqual(await streamingClient.config.region(), DEFAULT_AWS_Q_REGION)
+            assert.strictEqual(await streamingClient.client.config.region(), DEFAULT_AWS_Q_REGION)
             assert.strictEqual(
-                (await streamingClient.config.endpoint()).hostname,
+                (await streamingClient.client.config.endpoint()).hostname,
                 'codewhisperer.us-east-1.amazonaws.com'
             )
         })
@@ -300,7 +306,7 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'identityCenter')
                 assert(codewhispererServiceStub.generateSuggestions.calledOnce)
 
-                assert(streamingClient instanceof CodeWhispererStreaming)
+                assert(streamingClient instanceof StreamingClientService)
             })
         })
 
@@ -364,8 +370,8 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'identityCenter')
                 assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
 
-                assert(streamingClient instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient.config.region(), 'us-east-1')
+                assert(streamingClient instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient.client.config.region(), 'us-east-1')
             })
 
             it('handles Profile configuration request for valid profile & cancels the old in-flight update request', async () => {
@@ -440,8 +446,8 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-iad')
 
                 assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
-                assert(streamingClient1 instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient1.config.region(), 'us-east-1')
+                assert(streamingClient1 instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient1.client.config.region(), 'us-east-1')
 
                 // Profile change
 
@@ -464,9 +470,9 @@ describe('AmazonQTokenServiceManager', () => {
                 // CodeWhisperer Service was not recreated
                 assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
 
-                assert(streamingClient2 instanceof CodeWhispererStreaming)
-                assert.notStrictEqual(streamingClient1, streamingClient2)
-                assert.strictEqual(await streamingClient2.config.region(), 'us-east-1')
+                assert(streamingClient2 instanceof StreamingClientService)
+                assert.strictEqual(streamingClient1, streamingClient2)
+                assert.strictEqual(await streamingClient2.client.config.region(), 'us-east-1')
             })
 
             it('handles Profile configuration change to valid profile in different region', async () => {
@@ -494,8 +500,8 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-iad')
                 assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
 
-                assert(streamingClient1 instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient1.config.region(), 'us-east-1')
+                assert(streamingClient1 instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient1.client.config.region(), 'us-east-1')
 
                 // Profile change
 
@@ -523,9 +529,9 @@ describe('AmazonQTokenServiceManager', () => {
                 ])
 
                 // Streaming Client was recreated
-                assert(streamingClient2 instanceof CodeWhispererStreaming)
+                assert(streamingClient2 instanceof StreamingClientService)
                 assert.notStrictEqual(streamingClient1, streamingClient2)
-                assert.strictEqual(await streamingClient2.config.region(), 'eu-central-1')
+                assert.strictEqual(await streamingClient2.client.config.region(), 'eu-central-1')
             })
 
             it('handles Profile configuration change from valid to invalid profile', async () => {
@@ -553,8 +559,8 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-iad')
                 assert(codewhispererStubFactory.calledOnceWithExactly('us-east-1', TEST_ENDPOINT_US_EAST_1))
 
-                assert(streamingClient instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient.config.region(), 'us-east-1')
+                assert(streamingClient instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient.client.config.region(), 'us-east-1')
 
                 // Profile change to invalid profile
 
@@ -678,8 +684,8 @@ describe('AmazonQTokenServiceManager', () => {
                     TEST_ENDPOINT_EU_CENTRAL_1,
                 ])
 
-                assert(streamingClient instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient.config.region(), 'eu-central-1')
+                assert(streamingClient instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient.client.config.region(), 'eu-central-1')
             })
 
             it('prevents service usage while profile change is inflight when profile was set before', async () => {
@@ -713,8 +719,8 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), 'profile-iad')
                 assert.deepStrictEqual(codewhispererStubFactory.lastCall.args, ['us-east-1', TEST_ENDPOINT_US_EAST_1])
 
-                assert(streamingClient instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient.config.region(), 'us-east-1')
+                assert(streamingClient instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient.client.config.region(), 'us-east-1')
 
                 // Updaing profile
                 const pendingProfileUpdate = features.doUpdateConfiguration(
@@ -937,8 +943,8 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'builderId')
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), undefined)
 
-                assert(streamingClient instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient.config.region(), 'us-east-1')
+                assert(streamingClient instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient.client.config.region(), 'us-east-1')
 
                 setCredentials('identityCenter')
                 let service2 = amazonQTokenServiceManager.getCodewhispererService()
@@ -951,8 +957,8 @@ describe('AmazonQTokenServiceManager', () => {
                 assert(codewhispererStubFactory.calledTwice)
                 assert(codewhispererStubFactory.calledWithExactly(DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL))
 
-                assert(streamingClient2 instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient2.config.region(), DEFAULT_AWS_Q_REGION)
+                assert(streamingClient2 instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient2.client.config.region(), DEFAULT_AWS_Q_REGION)
             })
 
             it('should initialize service to PENDING_Q_PROFILE state when profile support is enabled', async () => {
@@ -967,8 +973,8 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'builderId')
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), undefined)
 
-                assert(streamingClient instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient.config.region(), 'us-east-1')
+                assert(streamingClient instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient.client.config.region(), 'us-east-1')
 
                 setCredentials('identityCenter')
 
@@ -1000,8 +1006,8 @@ describe('AmazonQTokenServiceManager', () => {
                 assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'identityCenter')
                 assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), undefined)
 
-                assert(streamingClient instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient.config.region(), 'us-east-1')
+                assert(streamingClient instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient.client.config.region(), 'us-east-1')
 
                 setCredentials('builderId')
                 let service2 = amazonQTokenServiceManager.getCodewhispererService()
@@ -1014,8 +1020,8 @@ describe('AmazonQTokenServiceManager', () => {
                 assert(codewhispererStubFactory.calledTwice)
                 assert(codewhispererStubFactory.calledWithExactly(DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL))
 
-                assert(streamingClient2 instanceof CodeWhispererStreaming)
-                assert.strictEqual(await streamingClient2.config.region(), 'us-east-1')
+                assert(streamingClient2 instanceof StreamingClientService)
+                assert.strictEqual(await streamingClient2.client.config.region(), 'us-east-1')
             })
         })
 

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.test.ts
@@ -1,0 +1,112 @@
+import { StreamingClientService } from './streamingClientService'
+import sinon from 'ts-sinon'
+import { expect } from 'chai'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { BearerCredentials } from '@aws/language-server-runtimes/server-interface'
+import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from './constants'
+import {
+    CodeWhispererStreaming,
+    SendMessageCommandInput,
+    SendMessageCommandOutput,
+} from '@amzn/codewhisperer-streaming'
+import { rejects } from 'assert'
+
+const TIME_TO_ADVANCE_MS = 100
+
+describe('StreamingClientService', () => {
+    let streamingClientService: StreamingClientService
+    let features: TestFeatures
+    let clock: sinon.SinonFakeTimers
+    let sendMessageStub: sinon.SinonStub
+    let abortStub: sinon.SinonStub
+
+    const MOCKED_TOKEN_ONE: BearerCredentials = { token: 'some-fake-token' }
+    const MOCKED_TOKEN_TWO: BearerCredentials = { token: 'some-other-fake-token' }
+
+    const MOCKED_SEND_MESSAGE_REQUEST: SendMessageCommandInput = {
+        conversationState: {
+            chatTriggerType: 'MANUAL',
+            currentMessage: {
+                userInputMessage: {
+                    content: 'some-content',
+                },
+            },
+        },
+    }
+
+    const MOCKED_SEND_MESSAGE_RESPONSE: SendMessageCommandOutput = {
+        $metadata: {},
+        sendMessageResponse: undefined,
+    }
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers({ now: new Date() })
+        features = new TestFeatures()
+
+        features.credentialsProvider.hasCredentials.withArgs('bearer').returns(true)
+        features.credentialsProvider.getCredentials.withArgs('bearer').returns(MOCKED_TOKEN_ONE)
+
+        sendMessageStub = sinon
+            .stub(CodeWhispererStreaming.prototype, 'sendMessage')
+            .callsFake(() => Promise.resolve(MOCKED_SEND_MESSAGE_RESPONSE))
+        streamingClientService = new StreamingClientService(
+            features.credentialsProvider,
+            features.sdkInitializator,
+            DEFAULT_AWS_Q_REGION,
+            DEFAULT_AWS_Q_ENDPOINT_URL,
+            'some-user-agent'
+        )
+
+        abortStub = sinon.stub(AbortController.prototype, 'abort')
+    })
+
+    afterEach(() => {
+        clock.restore()
+        sinon.restore()
+    })
+
+    it('provides the lastest token present in the credentials provider', async () => {
+        const tokenProvider = streamingClientService.client.config.token
+        expect(tokenProvider).not.to.be.undefined
+
+        const firstTokenPromise = (tokenProvider as any)()
+        await clock.tickAsync(TIME_TO_ADVANCE_MS)
+
+        const firstToken = await firstTokenPromise
+        expect(firstToken.token).to.deep.equal(MOCKED_TOKEN_ONE.token)
+
+        features.credentialsProvider.getCredentials.withArgs('bearer').returns(MOCKED_TOKEN_TWO)
+
+        const secondTokenPromise = (tokenProvider as any)()
+        await clock.tickAsync(TIME_TO_ADVANCE_MS)
+        const secondToken = await secondTokenPromise
+
+        expect(secondToken.token).to.deep.equal(MOCKED_TOKEN_TWO.token)
+    })
+
+    it('aborts in flight requests', async () => {
+        streamingClientService.sendMessage(MOCKED_SEND_MESSAGE_REQUEST)
+        streamingClientService.sendMessage(MOCKED_SEND_MESSAGE_REQUEST)
+
+        streamingClientService.abortInflightRequests()
+
+        sinon.assert.calledTwice(abortStub)
+        expect(streamingClientService['inflightRequests'].size).to.eq(0)
+    })
+
+    it('attaches known profileArn to request', async () => {
+        const mockedProfileArn = 'some-profile-arn'
+        streamingClientService.profileArn = mockedProfileArn
+        const expectedRequest: SendMessageCommandInput = {
+            ...MOCKED_SEND_MESSAGE_REQUEST,
+            profileArn: mockedProfileArn,
+        }
+        const promise = streamingClientService.sendMessage(MOCKED_SEND_MESSAGE_REQUEST)
+
+        await clock.tickAsync(TIME_TO_ADVANCE_MS)
+        await promise
+
+        sinon.assert.calledOnce(sendMessageStub)
+        sinon.assert.match(sendMessageStub.firstCall.firstArg, expectedRequest)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -1,0 +1,63 @@
+import {
+    CodeWhispererStreaming,
+    SendMessageCommandInput,
+    SendMessageCommandOutput,
+} from '@amzn/codewhisperer-streaming'
+import { CredentialsProvider, SDKInitializator } from '@aws/language-server-runtimes/server-interface'
+import { getBearerTokenFromProvider } from './utils'
+import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
+
+export class StreamingClientService {
+    client: CodeWhispererStreaming
+    private inflightRequests = new Set<AbortController>()
+    public profileArn?: string
+
+    constructor(
+        credentialsProvider: CredentialsProvider,
+        sdkInitializator: SDKInitializator,
+        region: string,
+        endpoint: string,
+        customUserAgent: string
+    ) {
+        const tokenProvider = async () => {
+            const token = getBearerTokenFromProvider(credentialsProvider)
+            // without setting expiration, the tokenProvider will only be called once
+            return { token, expiration: new Date() }
+        }
+
+        this.client = sdkInitializator(CodeWhispererStreaming, {
+            region,
+            endpoint,
+            token: tokenProvider,
+            retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
+            customUserAgent: customUserAgent,
+        })
+    }
+
+    public async sendMessage(
+        request: SendMessageCommandInput,
+        abortController?: AbortController
+    ): Promise<SendMessageCommandOutput> {
+        const controller: AbortController = abortController ?? new AbortController()
+
+        this.inflightRequests.add(controller)
+
+        const response = await this.client.sendMessage(
+            { ...request, profileArn: this.profileArn },
+            {
+                abortSignal: controller.signal,
+            }
+        )
+
+        this.inflightRequests.delete(controller)
+
+        return response
+    }
+
+    public abortInflightRequests() {
+        this.inflightRequests.forEach(abortController => {
+            abortController.abort()
+        })
+        this.inflightRequests.clear()
+    }
+}


### PR DESCRIPTION
## Problem

We need to cache the streaming client and be able to abort inflight requests on profile/connection changes.

## Solution

- initialize the streaming client with a token provider function that invokes the credentials provider before each request
- Add a wrapper around the streaming client that stores the abort controllers of inflight requests, similar to the solution for the regular codewhisperer service
    - This also allows us to add the active profile arn to incoming requests rather than making it the responsibility of the caller

Testing: new unit tests and validated chat still works in bundled minimial vs client.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
