### PR TITLE
feat: context data selection support in chat-client

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -11,7 +11,7 @@
         "start": "cross-env NODE_OPTIONS=--max_old_space_size=8172 webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.52"
+        "@aws/language-server-runtimes": "^0.2.53"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -21,9 +21,9 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.1.7",
-        "@aws/language-server-runtimes-types": "^0.1.5",
-        "@aws/mynah-ui": "^4.25.0"
+        "@aws/chat-client-ui-types": "^0.1.12",
+        "@aws/language-server-runtimes-types": "^0.1.10",
+        "@aws/mynah-ui": "^4.26.1"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -30,9 +30,11 @@ describe('Chat', () => {
     let clientApi: { postMessage: sinon.SinonStub }
 
     before(() => {
-        // Mock global ResizeObserver for test environment
+        // Mock global observers for test environment
         // @ts-ignore
         global.ResizeObserver = null
+        // @ts-ignore
+        global.IntersectionObserver = null
     })
 
     beforeEach(() => {

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -21,7 +21,9 @@ import {
 } from '@aws/chat-client-ui-types'
 import {
     CHAT_REQUEST_METHOD,
+    CONTEXT_COMMAND_NOTIFICATION_METHOD,
     ChatParams,
+    ContextCommandParams,
     FEEDBACK_NOTIFICATION_METHOD,
     FOLLOW_UP_CLICK_NOTIFICATION_METHOD,
     FeedbackParams,
@@ -93,14 +95,16 @@ export const createChat = (
             case ERROR_MESSAGE:
                 mynahApi.showError((message as ErrorMessage).params)
                 break
+            case CONTEXT_COMMAND_NOTIFICATION_METHOD:
+                mynahApi.sendContextCommand(message.params as ContextCommandParams)
+                break
             case CHAT_OPTIONS: {
                 const params = (message as ChatOptionsMessage).params
                 const chatConfig: ChatClientConfig = params?.quickActions?.quickActionsCommandGroups
                     ? {
                           quickActionCommands: params.quickActions.quickActionsCommandGroups,
-                          disclaimerAcknowledged: config?.disclaimerAcknowledged ?? false,
                       }
-                    : { disclaimerAcknowledged: config?.disclaimerAcknowledged ?? false }
+                    : {}
 
                 tabFactory.updateDefaultTabData(chatConfig)
 

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -96,7 +96,7 @@ export const createChat = (
                 mynahApi.showError((message as ErrorMessage).params)
                 break
             case CONTEXT_COMMAND_NOTIFICATION_METHOD:
-                mynahApi.sendContextCommand(message.params as ContextCommandParams)
+                mynahApi.sendContextCommands(message.params as ContextCommandParams)
                 break
             case CHAT_OPTIONS: {
                 const params = (message as ChatOptionsMessage).params

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -34,7 +34,7 @@ export interface InboundChatApi {
     sendGenericCommand(params: GenericCommandParams): void
     showError(params: ErrorParams): void
     openTab(params: OpenTabParams): void
-    sendContextCommand(params: ContextCommandParams): void
+    sendContextCommands(params: ContextCommandParams): void
 }
 
 type ContextCommandGroups = MynahUIDataModel['contextCommands']
@@ -429,7 +429,7 @@ ${params.message}`,
         }
     }
 
-    const sendContextCommand = (params: ContextCommandParams) => {
+    const sendContextCommands = (params: ContextCommandParams) => {
         contextCommandGroups = params.contextCommandGroups
 
         Object.keys(mynahUi.getAllTabs()).forEach(tabId => {
@@ -445,7 +445,7 @@ ${params.message}`,
         sendGenericCommand: sendGenericCommand,
         showError: showError,
         openTab: openTab,
-        sendContextCommand: sendContextCommand,
+        sendContextCommands: sendContextCommands,
     }
 
     return [mynahUi, api]

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -327,8 +327,8 @@
     "devDependencies": {
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
-        "@aws/chat-client-ui-types": "^0.1.7",
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/chat-client-ui-types": "^0.1.12",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -17,6 +17,7 @@ import {
     InlineChatParams,
     InlineChatResult,
     inlineChatRequestType,
+    contextCommandsNotificationType,
 } from '@aws/language-server-runtimes/protocol'
 import { v4 as uuidv4 } from 'uuid'
 import { Uri, ViewColumn, Webview, WebviewPanel, commands, window } from 'vscode'
@@ -54,6 +55,13 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri, 
 
     languageClient.onTelemetry(e => {
         languageClient.info(`[VSCode Client] Received telemetry event from server ${JSON.stringify(e)}`)
+    })
+
+    languageClient.onNotification(contextCommandsNotificationType, params => {
+        panel.webview.postMessage({
+            command: contextCommandsNotificationType.method,
+            params: params,
+        })
     })
 
     panel.webview.onDidReceiveMessage(async message => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "eslint": "^8.42.0",
                 "eslint-plugin-import": "^2.29.1",
                 "eslint-plugin-unused-imports": "^4.1.4",
-                "husky": "^9.1.1",
+                "husky": "^9.1.7",
                 "node-loader": "^2.1.0",
                 "prettier": "^3.3.3",
                 "pretty-quick": "^4.0.0",
@@ -40,7 +40,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -77,7 +77,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -104,7 +104,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -112,7 +112,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -132,7 +132,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -140,7 +140,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-partiql": "^0.0.5"
             },
             "devDependencies": {
@@ -176,7 +176,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -196,7 +196,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -218,7 +218,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.52"
+                "@aws/language-server-runtimes": "^0.2.53"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -238,9 +238,9 @@
             "version": "0.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.1.7",
-                "@aws/language-server-runtimes-types": "^0.1.5",
-                "@aws/mynah-ui": "^4.25.0"
+                "@aws/chat-client-ui-types": "^0.1.12",
+                "@aws/language-server-runtimes-types": "^0.1.10",
+                "@aws/mynah-ui": "^4.26.1"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -261,8 +261,8 @@
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
-                "@aws/chat-client-ui-types": "^0.1.7",
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/chat-client-ui-types": "^0.1.12",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -6447,12 +6447,12 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.7.tgz",
-            "integrity": "sha512-VDaLgddfH5mZgoXeYSCUU/ZVu04xkWZFsR/uyHs1EwLvhmjPtO3plD8syQXbSTX1Fo3oVZM2aFnA0Myy5MVCHg==",
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.12.tgz",
+            "integrity": "sha512-2yfRwElcJOwJ8dBR8aLcWAy9HlULRluaVCerCHXV+LstiIvkS0cd92l248Y+RQlKAvbGZXpnEzUOrlkNWVa80Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.5"
+                "@aws/language-server-runtimes-types": "^0.1.10"
             }
         },
         "node_modules/@aws/hello-world-lsp": {
@@ -6464,15 +6464,15 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.52",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.52.tgz",
-            "integrity": "sha512-WzxhJJXkiN5O76vH7T5Zyfl8jcODp50ZphA6g1nQgQXOYMTrhCwgkFdZ8PFlsLrEVwlWLbUpQ05XuQVWgYJ5Fg==",
+            "version": "0.2.53",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.53.tgz",
+            "integrity": "sha512-Tt2iPKJoGs/zWN3rU+BDh4w3IUPHp6Qju//qoQETjDxRMesFk86LliXirMAM2GTFFzy+hBtwTHftmFMvcJ6bYg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.9.3",
                 "@aws-crypto/sha256-js": "^5.2.0",
                 "@aws-sdk/client-cognito-identity": "^3.758.0",
-                "@aws/language-server-runtimes-types": "^0.1.9",
+                "@aws/language-server-runtimes-types": "^0.1.10",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
                 "@opentelemetry/resources": "^1.30.1",
@@ -6499,9 +6499,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.9",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.9.tgz",
-            "integrity": "sha512-aIaqnYNFBT9ROFyFu6hxnsVqBwleNskpySQmYSJ4/8gqv3H+fLOlip8Zko6ApodQPicR2lwumM87XvnSVErHMw==",
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.10.tgz",
+            "integrity": "sha512-SIzwtSKG0IFrQFDREVdIIzpMOCVbcV45Nk/LufXIux523KlNSvxpQViIIQThqO4KmoyOZZ3ZWsUELdzpxc//iQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -6597,10 +6597,11 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.25.0.tgz",
-            "integrity": "sha512-bWFvV80UkNlyEE+3adXBsVu44TkKK4MVU9bH5w3q1jZ3T5c08dGvHDtW8423fa884x6bJdALR6Q+kFrEYrAIDw==",
+            "version": "4.26.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.26.1.tgz",
+            "integrity": "sha512-qUgQ6NVmiCSp6qF43cM6522U8QtBTBbqDv5yKS/5tl9cEQuZJSfKDq2zFUstQNZmsw0GE8p/NboTDo3mRv4sSQ==",
             "hasInstallScript": true,
+            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "highlight.js": "^11.11.0",
@@ -26350,7 +26351,7 @@
             "version": "0.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-core": "^0.0.2"
             },
             "devDependencies": {
@@ -26420,8 +26421,8 @@
             "dependencies": {
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
                 "@aws-sdk/util-retry": "^3.374.0",
-                "@aws/chat-client-ui-types": "^0.1.7",
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/chat-client-ui-types": "^0.1.12",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-core": "^0.0.2",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
@@ -26541,7 +26542,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-core": "^0.0.2",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -26616,7 +26617,7 @@
             "version": "0.1.2",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-core": "^0.0.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -26630,7 +26631,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-core": "0.0.2",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -26659,7 +26660,7 @@
             "version": "0.0.6",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -26692,7 +26693,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "@aws/lsp-core": "^0.0.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -26706,7 +26707,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -26717,7 +26718,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.52",
+                "@aws/language-server-runtimes": "^0.2.53",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "eslint": "^8.42.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-unused-imports": "^4.1.4",
-        "husky": "^9.1.1",
+        "husky": "^9.1.7",
         "node-loader": "^2.1.0",
         "prettier": "^3.3.3",
         "pretty-quick": "^4.0.0",

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-core": "^0.0.2"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -29,8 +29,8 @@
     "dependencies": {
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
         "@aws-sdk/util-retry": "^3.374.0",
-        "@aws/chat-client-ui-types": "^0.1.7",
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/chat-client-ui-types": "^0.1.12",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-core": "^0.0.2",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -54,7 +54,10 @@ import {
 } from '../../shared/amazonQServiceManager/errors'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 
-type ChatHandlers = Omit<LspHandlers<Chat>, 'openTab' | 'sendChatUpdate' | 'onFileClicked'>
+type ChatHandlers = Omit<
+    LspHandlers<Chat>,
+    'openTab' | 'sendChatUpdate' | 'onFileClicked' | 'onInlineChatPrompt' | 'sendContextCommands' | 'onCreatePrompt'
+>
 
 export class AgenticChatController implements ChatHandlers {
     #features: Features

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -49,7 +49,10 @@ import {
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 
-type ChatHandlers = Omit<LspHandlers<Chat>, 'openTab' | 'sendChatUpdate' | 'onFileClicked'>
+type ChatHandlers = Omit<
+    LspHandlers<Chat>,
+    'openTab' | 'sendChatUpdate' | 'onFileClicked' | 'onInlineChatPrompt' | 'sendContextCommands' | 'onCreatePrompt'
+>
 
 export class ChatController implements ChatHandlers {
     #features: Features

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-core": "^0.0.2",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-core": "^0.0.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-core": "0.0.2",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "@aws/lsp-core": "^0.0.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.52",
+        "@aws/language-server-runtimes": "^0.2.53",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem

We need to support context commands sent from server to chat-client. This is expected to work through 'aws/chat/sendContextCommands' protocol.

## Solution

- Upgrade to the latest "@aws/language-server-runtimes" package
- Show context commands as quick actions in chat client (available via `@`)

Tested with fake data:
<img width="676" alt="Screenshot 2025-04-02 at 14 45 36" src="https://github.com/user-attachments/assets/a552ea97-074d-491d-bd66-8bbd63502693" />

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
