### PR TITLE
feat: add context transparency feature

### DIFF
--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -207,7 +207,7 @@ describe('Chat', () => {
         })
         window.dispatchEvent(chatEvent)
 
-        assert.calledOnceWithExactly(updateLastChatAnswerStub, tabId, { body })
+        assert.calledOnceWithExactly(updateLastChatAnswerStub, tabId, { body, header: undefined })
         assert.notCalled(endMessageStreamStub)
         assert.notCalled(updateStoreStub)
     })

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -306,10 +306,41 @@ export const createMynahUi = (
 
     const addChatResponse = (chatResult: ChatResult, tabId: string, isPartialResult: boolean) => {
         const { type, ...chatResultWithoutType } = chatResult
+        let header = undefined
+
+        if (chatResult.contextList !== undefined) {
+            header = {
+                fileList: {
+                    fileTreeTitle: '',
+                    filePaths: chatResult.contextList.filePaths?.map(file => file),
+                    rootFolderTitle: 'Context',
+                    flatList: true,
+                    collapsed: true,
+                    hideFileCount: true,
+                    details: Object.fromEntries(
+                        Object.entries(chatResult.contextList.details || {}).map(([filePath, fileDetails]) => [
+                            filePath,
+                            {
+                                label:
+                                    fileDetails.lineRanges
+                                        ?.map(range =>
+                                            range.first === -1 || range.second === -1
+                                                ? ''
+                                                : `line ${range.first} - ${range.second}`
+                                        )
+                                        .join(', ') || '',
+                                description: filePath,
+                                clickable: true,
+                            },
+                        ])
+                    ),
+                },
+            }
+        }
 
         if (isPartialResult) {
             // type for MynahUI differs from ChatResult types so we ignore it
-            mynahUi.updateLastChatAnswer(tabId, { ...chatResultWithoutType })
+            mynahUi.updateLastChatAnswer(tabId, { ...chatResultWithoutType, header: header })
             return
         }
 
@@ -345,6 +376,7 @@ export const createMynahUi = (
             : {}
 
         mynahUi.updateLastChatAnswer(tabId, {
+            header: header,
             body: chatResult.body,
             messageId: chatResult.messageId,
             followUp: followUps,

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.53",
+                "@aws/language-server-runtimes": "^0.2.52",
                 "@aws/lsp-partiql": "^0.0.5"
             },
             "devDependencies": {


### PR DESCRIPTION
## Problem
Q response can provide a context with file list. This feature is not available in chat client

## Solution
Added the above to chat client
<img width="406" alt="image" src="https://github.com/user-attachments/assets/d247e23d-104d-4698-8d05-df6eb6f97c46" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
