### PR TITLE
fix(amazonq): do not throw when receiving null profile while client not connected

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
@@ -305,6 +305,26 @@ describe('AmazonQTokenServiceManager', () => {
         })
 
         describe('Developer Profiles Support is enabled', () => {
+            it('should not throw when receiving null profile arn in PENDING_CONNECTION state', async () => {
+                setupServiceManager(true)
+                assert.strictEqual(amazonQTokenServiceManager.getState(), 'PENDING_CONNECTION')
+
+                await assert.doesNotReject(
+                    features.doUpdateConfiguration(
+                        {
+                            section: 'aws.q',
+                            settings: {
+                                profileArn: null,
+                            },
+                        },
+                        {} as CancellationToken
+                    )
+                )
+
+                assert.strictEqual(amazonQTokenServiceManager.getActiveProfileArn(), undefined)
+                assert.strictEqual(amazonQTokenServiceManager.getState(), 'PENDING_CONNECTION')
+            })
+
             it('should initialize to PENDING_Q_PROFILE state when IdentityCenter Connection is set', async () => {
                 setupServiceManager(true)
                 assert.strictEqual(amazonQTokenServiceManager.getState(), 'PENDING_CONNECTION')

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -340,7 +340,12 @@ export class AmazonQTokenServiceManager implements BaseAmazonQServiceManager {
         this.handleSsoConnectionChange()
 
         if (this.connectionType === 'none') {
-            throw new AmazonQServicePendingSigninError()
+            if (newProfileArn !== null) {
+                throw new AmazonQServicePendingSigninError()
+            }
+
+            this.logServiceState('Received null profile while not connected, ignoring request')
+            return
         }
 
         if (this.connectionType !== 'identityCenter') {


### PR DESCRIPTION
## Problem

Clients should be able to send null profile to server when client is not connected without receiving an error.

## Solution

When connection type is `none`, only throw an error in `handleProfileChange` when profileArn is not null.

Testing: added new unit test and send a null profile in bundle client

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
