### PR TITLE
feat: support create prompt form in chat-client

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.12",
         "@aws/language-server-runtimes-types": "^0.1.10",
-        "@aws/mynah-ui": "^4.26.1"
+        "@aws/mynah-ui": "^4.28.0"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -22,8 +22,10 @@ import {
 import {
     CHAT_REQUEST_METHOD,
     CONTEXT_COMMAND_NOTIFICATION_METHOD,
+    CREATE_PROMPT_NOTIFICATION_METHOD,
     ChatParams,
     ContextCommandParams,
+    CreatePromptParams,
     FEEDBACK_NOTIFICATION_METHOD,
     FOLLOW_UP_CLICK_NOTIFICATION_METHOD,
     FeedbackParams,
@@ -191,6 +193,9 @@ export const createChat = (
                     },
                 })
             }
+        },
+        createPrompt: (params: CreatePromptParams) => {
+            sendMessageToClient({ command: CREATE_PROMPT_NOTIFICATION_METHOD, params })
         },
     }
 

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -14,6 +14,7 @@ import {
 } from '@aws/chat-client-ui-types'
 import {
     ChatParams,
+    CreatePromptParams,
     FeedbackParams,
     FollowUpClickParams,
     InfoLinkClickParams,
@@ -61,6 +62,7 @@ export interface OutboundChatApi {
     uiReady(): void
     disclaimerAcknowledged(): void
     onOpenTab(result: OpenTabResult | ErrorResult): void
+    createPrompt(params: CreatePromptParams): void
 }
 
 export class Messager {
@@ -158,5 +160,9 @@ export class Messager {
 
     onOpenTab = (result: OpenTabResult | ErrorResult): void => {
         this.chatApi.onOpenTab(result)
+    }
+
+    onCreatePrompt = (promptName: string): void => {
+        this.chatApi.createPrompt({ promptName })
     }
 }

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -41,6 +41,7 @@ describe('MynahUI', () => {
             uiReady: sinon.stub(),
             disclaimerAcknowledged: sinon.stub(),
             onOpenTab: sinon.stub(),
+            createPrompt: sinon.stub(),
         }
 
         messager = new Messager(outboundChatApi)

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -39,6 +39,13 @@ export interface InboundChatApi {
 
 type ContextCommandGroups = MynahUIDataModel['contextCommands']
 
+const ContextPrompt = {
+    CreateItemId: 'create-saved-prompt',
+    CancelButtonId: 'cancel-create-prompt',
+    SubmitButtonId: 'submit-create-prompt',
+    PromptNameFieldId: 'prompt-name',
+} as const
+
 export const handleChatPrompt = (
     mynahUi: MynahUI,
     tabId: string,
@@ -267,12 +274,12 @@ export const createMynahUi = (
             }
         },
         onContextSelected: (contextItem, tabId) => {
-            if (contextItem.id === 'create-saved-prompt') {
+            if (contextItem.id === ContextPrompt.CreateItemId) {
                 mynahUi.showCustomForm(
                     tabId,
                     [
                         {
-                            id: 'prompt-name',
+                            id: ContextPrompt.PromptNameFieldId,
                             type: 'textinput',
                             mandatory: true,
                             autoFocus: true,
@@ -282,8 +289,8 @@ export const createMynahUi = (
                         },
                     ],
                     [
-                        { id: 'cancel-create-prompt', text: 'Cancel', status: 'clear' },
-                        { id: 'submit-create-prompt', text: 'Create', status: 'main' },
+                        { id: ContextPrompt.CancelButtonId, text: 'Cancel', status: 'clear' },
+                        { id: ContextPrompt.SubmitButtonId, text: 'Create', status: 'main' },
                     ],
                     `Create a saved prompt`
                 )
@@ -292,14 +299,14 @@ export const createMynahUi = (
             return true
         },
         onCustomFormAction: (tabId, action) => {
-            if (action.id === 'submit-create-prompt') {
-                messager.onCreatePrompt(action.formItemValues?.['prompt-name'] ?? '')
+            if (action.id === ContextPrompt.SubmitButtonId) {
+                messager.onCreatePrompt(action.formItemValues![ContextPrompt.PromptNameFieldId])
             }
         },
         onFormTextualItemKeyPress: (event: KeyboardEvent, formData: Record<string, string>, itemId: string) => {
-            if (itemId === 'prompt-name' && event.key === 'Enter') {
+            if (itemId === ContextPrompt.PromptNameFieldId && event.key === 'Enter') {
                 event.preventDefault()
-                messager.onCreatePrompt(formData?.['prompt-name'])
+                messager.onCreatePrompt(formData[ContextPrompt.PromptNameFieldId])
                 return true
             }
             return false

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -266,6 +266,44 @@ export const createMynahUi = (
                 })
             }
         },
+        onContextSelected: (contextItem, tabId) => {
+            if (contextItem.id === 'create-saved-prompt') {
+                mynahUi.showCustomForm(
+                    tabId,
+                    [
+                        {
+                            id: 'prompt-name',
+                            type: 'textinput',
+                            mandatory: true,
+                            autoFocus: true,
+                            title: 'Prompt name',
+                            placeholder: 'Enter prompt name',
+                            description: "Use this prompt by typing '@' followed by the prompt name.",
+                        },
+                    ],
+                    [
+                        { id: 'cancel-create-prompt', text: 'Cancel', status: 'clear' },
+                        { id: 'submit-create-prompt', text: 'Create', status: 'main' },
+                    ],
+                    `Create a saved prompt`
+                )
+                return false
+            }
+            return true
+        },
+        onCustomFormAction: (tabId, action) => {
+            if (action.id === 'submit-create-prompt') {
+                messager.onCreatePrompt(action.formItemValues?.['prompt-name'] ?? '')
+            }
+        },
+        onFormTextualItemKeyPress: (event: KeyboardEvent, formData: Record<string, string>, itemId: string) => {
+            if (itemId === 'prompt-name' && event.key === 'Enter') {
+                event.preventDefault()
+                messager.onCreatePrompt(formData?.['prompt-name'])
+                return true
+            }
+            return false
+        },
         tabs: {
             [initialTabId]: {
                 isSelected: true,

--- a/chat-client/src/contracts/serverContracts.ts
+++ b/chat-client/src/contracts/serverContracts.ts
@@ -21,6 +21,8 @@ import {
     QUICK_ACTION_REQUEST_METHOD,
     OpenTabResult,
     OPEN_TAB_REQUEST_METHOD,
+    CreatePromptParams,
+    CREATE_PROMPT_NOTIFICATION_METHOD,
 } from '@aws/language-server-runtimes-types'
 
 export const TELEMETRY = 'telemetry/event'
@@ -39,6 +41,7 @@ export type ServerMessageCommand =
     | typeof INFO_LINK_CLICK_NOTIFICATION_METHOD
     | typeof QUICK_ACTION_REQUEST_METHOD
     | typeof OPEN_TAB_REQUEST_METHOD
+    | typeof CREATE_PROMPT_NOTIFICATION_METHOD
 
 export interface Message {
     command: ServerMessageCommand
@@ -65,3 +68,4 @@ export type ServerMessageParams =
     | SourceLinkClickParams
     | FollowUpClickParams
     | OpenTabResult
+    | CreatePromptParams

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,7 +246,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.12",
                 "@aws/language-server-runtimes-types": "^0.1.10",
-                "@aws/mynah-ui": "^4.26.1"
+                "@aws/mynah-ui": "^4.28.0"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -6603,9 +6603,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.26.1.tgz",
-            "integrity": "sha512-qUgQ6NVmiCSp6qF43cM6522U8QtBTBbqDv5yKS/5tl9cEQuZJSfKDq2zFUstQNZmsw0GE8p/NboTDo3mRv4sSQ==",
+            "version": "4.28.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.28.0.tgz",
+            "integrity": "sha512-HKL65KBOMap7ZZrQs/Ol08zfj48A7paPWzm/vNsAYeL/dE25EmXYkkS3YIZSveaYF0ltYUt7hzyQnNWl/18KKA==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {


### PR DESCRIPTION
## Problem

Custom form needs to be supported in chat-client as a UI to create prompt files.

## Solution

- If context item is selected with `'create-saved-prompt'` id, show the create prompt form
- If Submit button or corresponding "enter" key was pressed, send `createPrompt` request to extension/chat server.
<img width="629" alt="Screenshot 2025-04-03 at 18 16 52" src="https://github.com/user-attachments/assets/6180acef-128d-416c-9ec2-ae6ac97c7c35" />


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
