### PR TITLE
[TEAM REVIEW] fix: update null check for net core compatibility version and path for private package support

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -159,25 +159,27 @@ export class ArtifactManager {
         var thirdPartyPackage = request.PackageReferences.find(
             p => p.IsPrivatePackage && reference.RelativePath.includes(p.Id)
         )
-        if (
-            thirdPartyPackage &&
-            thirdPartyPackage.NetCompatibleAssemblyRelativePath &&
-            thirdPartyPackage.NetCompatibleAssemblyPath
-        ) {
-            const privatePackageRelativePath = path
-                .join(
-                    referencesFolderName,
-                    thirdPartyPackageFolderName,
-                    thirdPartyPackage.NetCompatibleAssemblyRelativePath
-                )
-                .toLowerCase()
-            await this.copyFile(
-                thirdPartyPackage.NetCompatibleAssemblyPath,
-                this.getWorkspaceReferencePathFromRelativePath(privatePackageRelativePath)
-            )
+        if (thirdPartyPackage) {
             artifactReference.isThirdPartyPackage = true
-            artifactReference.netCompatibleRelativePath = privatePackageRelativePath
-            artifactReference.netCompatibleVersion = thirdPartyPackage.NetCompatiblePackageVersion
+
+            if (thirdPartyPackage.NetCompatibleAssemblyRelativePath && thirdPartyPackage.NetCompatibleAssemblyPath) {
+                const privatePackageRelativePath = path
+                    .join(
+                        referencesFolderName,
+                        thirdPartyPackageFolderName,
+                        thirdPartyPackage.NetCompatibleAssemblyRelativePath
+                    )
+                    .toLowerCase()
+                await this.copyFile(
+                    thirdPartyPackage.NetCompatibleAssemblyPath,
+                    this.getWorkspaceReferencePathFromRelativePath(privatePackageRelativePath)
+                )
+                artifactReference.netCompatibleRelativePath = privatePackageRelativePath
+            }
+
+            if (thirdPartyPackage.NetCompatiblePackageVersion) {
+                artifactReference.netCompatibleVersion = thirdPartyPackage.NetCompatiblePackageVersion
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

fix: update null check for net core compatibility version and path for private package support

## Solution

Null value handling added for NetCompatibleAssemblyRelativePath and NetCompatibleAssemblyPath

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
