### PR TITLE
fix: update null check for net core compatibility version and path fo…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -159,25 +159,27 @@ export class ArtifactManager {
         var thirdPartyPackage = request.PackageReferences.find(
             p => p.IsPrivatePackage && reference.RelativePath.includes(p.Id)
         )
-        if (
-            thirdPartyPackage &&
-            thirdPartyPackage.NetCompatibleAssemblyRelativePath &&
-            thirdPartyPackage.NetCompatibleAssemblyPath
-        ) {
-            const privatePackageRelativePath = path
-                .join(
-                    referencesFolderName,
-                    thirdPartyPackageFolderName,
-                    thirdPartyPackage.NetCompatibleAssemblyRelativePath
-                )
-                .toLowerCase()
-            await this.copyFile(
-                thirdPartyPackage.NetCompatibleAssemblyPath,
-                this.getWorkspaceReferencePathFromRelativePath(privatePackageRelativePath)
-            )
+        if (thirdPartyPackage) {
             artifactReference.isThirdPartyPackage = true
-            artifactReference.netCompatibleRelativePath = privatePackageRelativePath
-            artifactReference.netCompatibleVersion = thirdPartyPackage.NetCompatiblePackageVersion
+
+            if (thirdPartyPackage.NetCompatibleAssemblyRelativePath && thirdPartyPackage.NetCompatibleAssemblyPath) {
+                const privatePackageRelativePath = path
+                    .join(
+                        referencesFolderName,
+                        thirdPartyPackageFolderName,
+                        thirdPartyPackage.NetCompatibleAssemblyRelativePath
+                    )
+                    .toLowerCase()
+                await this.copyFile(
+                    thirdPartyPackage.NetCompatibleAssemblyPath,
+                    this.getWorkspaceReferencePathFromRelativePath(privatePackageRelativePath)
+                )
+                artifactReference.netCompatibleRelativePath = privatePackageRelativePath
+            }
+
+            if (thirdPartyPackage.NetCompatiblePackageVersion) {
+                artifactReference.netCompatibleVersion = thirdPartyPackage.NetCompatiblePackageVersion
+            }
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/artifactManager.processPrivatePackages.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/artifactManager.processPrivatePackages.test.ts
@@ -150,33 +150,34 @@ describe('ArtifactManager - processPrivatePackages', () => {
         expect(sampleArtifactReference.netCompatibleVersion).to.equal(undefined)
     })
 
-    it('should not process when NetCompatibleAssemblyRelativePath is missing', async () => {
+    it('should mark as third party package but not copy when paths are null', async () => {
         let copyFileCalled = false
         artifactManager.copyFile = async (source: string, destination: string): Promise<void> => {
             copyFileCalled = true
             return Promise.resolve()
         }
 
-        const privatePackage = {
+        const privatePackage: PackageReferenceMetadata = {
             Id: 'test-package',
-            IsPrivatePackage: true,
-            NetCompatibleAssemblyPath: 'full/path/to/assembly',
-            NetCompatiblePackageVersion: '1.0.0',
             Versions: [],
+            IsPrivatePackage: true,
+            NetCompatibleAssemblyRelativePath: undefined,
+            NetCompatibleAssemblyPath: undefined,
+            NetCompatiblePackageVersion: undefined,
         }
 
         sampleStartTransformRequest.PackageReferences = [privatePackage]
         sampleExternalReference.RelativePath = 'some/path/test-package/more/path'
 
-        artifactManager.processPrivatePackages(
+        await artifactManager.processPrivatePackages(
             sampleStartTransformRequest,
             sampleExternalReference,
             sampleArtifactReference
         )
 
         expect(copyFileCalled).to.be.false
-        expect(sampleArtifactReference.isThirdPartyPackage).to.equal(false)
-        expect(sampleArtifactReference.netCompatibleRelativePath).to.equal(undefined)
-        expect(sampleArtifactReference.netCompatibleVersion).to.equal(undefined)
+        expect(sampleArtifactReference.isThirdPartyPackage).to.equal(true)
+        expect(sampleArtifactReference.netCompatibleRelativePath).to.be.undefined
+        expect(sampleArtifactReference.netCompatibleVersion).to.be.undefined
     })
 })


### PR DESCRIPTION
## Problem

fix: update null check for net core compatibility version and path for private package support

## Solution

Null value handling added for NetCompatibleAssemblyRelativePath and NetCompatibleAssemblyPath

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
