### PR TITLE
fix: remove duplicate property

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -328,17 +328,6 @@ export const createMynahUi = (
             }
             return false
         },
-
-        // Noop not-implemented handlers
-        onBeforeTabRemove: undefined,
-        onFileActionClick: undefined,
-        onStopChatResponse: undefined,
-        onQuickCommandGroupActionClick: undefined,
-        onChatItemEngagement: undefined,
-        onShowMoreWebResultsClick: undefined,
-        onFormLinkClick: undefined,
-        onFormModifierEnterPress: undefined,
-        onTabBarButtonClick: undefined,
     }
 
     const mynahUiProps: MynahUIProps = {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -333,7 +333,6 @@ export const createMynahUi = (
         onBeforeTabRemove: undefined,
         onFileActionClick: undefined,
         onStopChatResponse: undefined,
-        onFileClick: undefined,
         onQuickCommandGroupActionClick: undefined,
         onChatItemEngagement: undefined,
         onShowMoreWebResultsClick: undefined,


### PR DESCRIPTION
## Problem
Main branch is failing build caused by a compile error https://github.com/aws/language-servers/actions/runs/14333867432/job/40175897377.

This likely happened because the `onFileClick` property was implemented in two different commits (-([this](https://github.com/aws/language-servers/pull/919) and [this](https://github.com/aws/language-servers/commit/b95fe1e1a63f6df469bcd0c5e58a66c0819feb55#diff-b68ed2121e608d8cb0c35bb3021bfdc77a4fc0bd423d7b79cbead1e290c15300R32-R330)) and was not detected as a conflict by github.

## Solution
Remove the duplicate property

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
