### PR TITLE
feat(amazonq): add auth follow up for pending profile selection

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -144,24 +144,6 @@ export class AgenticChatController implements ChatHandlers {
                 this.#telemetryController.emitMessageResponseError(params.tabId, metric.metric)
             }
 
-            if (err instanceof AmazonQServicePendingSigninError) {
-                this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
-
-                return createAuthFollowUpResult('full-auth')
-            }
-
-            if (err instanceof AmazonQServicePendingProfileError) {
-                this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
-
-                const followUpResult = createAuthFollowUpResult('use-supported-auth')
-                // Access first element in array
-                if (followUpResult.followUp?.options) {
-                    followUpResult.followUp.options[0].pillText = 'Select Q Developer Profile'
-                }
-
-                return followUpResult
-            }
-
             const authFollowType = getAuthFollowUpType(err)
 
             if (authFollowType) {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.test.ts
@@ -27,6 +27,12 @@ import * as utils from './utils'
 import { DEFAULT_HELP_FOLLOW_UP_PROMPT, HELP_MESSAGE } from './constants'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
+import {
+    AmazonQError,
+    AmazonQServicePendingProfileError,
+    AmazonQServicePendingSigninError,
+} from '../../shared/amazonQServiceManager/errors'
+import { MISSING_BEARER_TOKEN_ERROR } from '../../shared/constants'
 
 describe('ChatController', () => {
     const mockTabId = 'tab-1'
@@ -321,21 +327,38 @@ describe('ChatController', () => {
             assert.ok(chatResult instanceof ResponseError)
         })
 
-        it('returns a auth follow up action if sendMessage returns an auth error', async () => {
-            sendMessageStub.callsFake(() => {
-                throw new Error('Error')
+        const authFollowUpTestCases = [
+            {
+                expectedAuthFollowUp: 'full-auth',
+                error: new Error(MISSING_BEARER_TOKEN_ERROR),
+            },
+            {
+                expectedAuthFollowUp: 'full-auth',
+                error: new AmazonQServicePendingSigninError(),
+            },
+            {
+                expectedAuthFollowUp: 'use-supported-auth',
+                error: new AmazonQServicePendingProfileError(),
+            },
+        ]
+
+        authFollowUpTestCases.forEach(testCase => {
+            it(`returns ${testCase.expectedAuthFollowUp} follow up action when sendMessage throws ${testCase.error instanceof AmazonQError ? testCase.error.code : testCase.error.message}`, async () => {
+                sendMessageStub.callsFake(() => {
+                    throw testCase.error
+                })
+
+                const chatResultPromise = chatController.onChatPrompt(
+                    { tabId: mockTabId, prompt: { prompt: 'Hello' }, partialResultToken: 1 },
+                    mockCancellationToken
+                )
+
+                const chatResult = await chatResultPromise
+
+                sinon.assert.callCount(testFeatures.lsp.sendProgress, 0)
+                // @ts-ignore
+                assert.deepStrictEqual(chatResult, utils.createAuthFollowUpResult(testCase.expectedAuthFollowUp))
             })
-
-            sinon.stub(utils, 'getAuthFollowUpType').returns('full-auth')
-            const chatResultPromise = chatController.onChatPrompt(
-                { tabId: mockTabId, prompt: { prompt: 'Hello' }, partialResultToken: 1 },
-                mockCancellationToken
-            )
-
-            const chatResult = await chatResultPromise
-
-            sinon.assert.callCount(testFeatures.lsp.sendProgress, 0)
-            assert.deepStrictEqual(chatResult, utils.createAuthFollowUpResult('full-auth'))
         })
 
         it('returns a ResponseError if response streams return an error event', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -137,24 +137,6 @@ export class ChatController implements ChatHandlers {
                 this.#telemetryController.emitMessageResponseError(params.tabId, metric.metric)
             }
 
-            if (err instanceof AmazonQServicePendingSigninError) {
-                this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
-
-                return createAuthFollowUpResult('full-auth')
-            }
-
-            if (err instanceof AmazonQServicePendingProfileError) {
-                this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
-
-                const followUpResult = createAuthFollowUpResult('use-supported-auth')
-                // Access first element in array
-                if (followUpResult.followUp?.options) {
-                    followUpResult.followUp.options[0].pillText = 'Select Q Developer Profile'
-                }
-
-                return followUpResult
-            }
-
             const authFollowType = getAuthFollowUpType(err)
 
             if (authFollowType) {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/utils.ts
@@ -2,12 +2,18 @@ import { ChatResult } from '@aws/language-server-runtimes/server-interface'
 import { GENERIC_UNAUTHORIZED_ERROR, INVALID_TOKEN, MISSING_BEARER_TOKEN_ERROR } from '../../shared/constants'
 import { DEFAULT_HELP_FOLLOW_UP_PROMPT, HELP_MESSAGE } from './constants'
 import { v4 as uuid } from 'uuid'
+import {
+    AmazonQError,
+    AmazonQServicePendingProfileError,
+    AmazonQServicePendingProfileUpdateError,
+    AmazonQServicePendingSigninError,
+} from '../../shared/amazonQServiceManager/errors'
 
 type AuthFollowUpType = 'full-auth' | 're-auth' | 'missing_scopes' | 'use-supported-auth'
 
-type AuthErrorDefinition = { match: (err: Error) => boolean; authFollowType: AuthFollowUpType }
+type AuthErrorDefinition<E extends Error> = { match: (err: E) => boolean; authFollowType: AuthFollowUpType }
 
-const AUTH_ERROR_DEFINITION_LIST: AuthErrorDefinition[] = [
+const AUTH_ERROR_DEFINITION_LIST: AuthErrorDefinition<Error>[] = [
     {
         match: (err: Error) => err.message.startsWith(MISSING_BEARER_TOKEN_ERROR),
         authFollowType: 'full-auth',
@@ -22,10 +28,23 @@ const AUTH_ERROR_DEFINITION_LIST: AuthErrorDefinition[] = [
     },
 ]
 
+const AMAZON_Q_ERROR_DEFINITION_LIST: AuthErrorDefinition<AmazonQError>[] = [
+    {
+        match: (err: AmazonQError) => err instanceof AmazonQServicePendingProfileError,
+        authFollowType: 'use-supported-auth',
+    },
+    {
+        match: (err: AmazonQError) => err instanceof AmazonQServicePendingSigninError,
+        authFollowType: 'full-auth',
+    },
+]
+
 export function getAuthFollowUpType(err: unknown): AuthFollowUpType | undefined {
-    return err instanceof Error
-        ? AUTH_ERROR_DEFINITION_LIST.find(definition => definition.match(err))?.authFollowType
-        : undefined
+    return err instanceof AmazonQError
+        ? AMAZON_Q_ERROR_DEFINITION_LIST.find(definition => definition.match(err))?.authFollowType
+        : err instanceof Error
+          ? AUTH_ERROR_DEFINITION_LIST.find(definition => definition.match(err))?.authFollowType
+          : undefined
 }
 
 export function createAuthFollowUpResult(authType: AuthFollowUpType): ChatResult {
@@ -35,6 +54,8 @@ export function createAuthFollowUpResult(authType: AuthFollowUpType): ChatResult
             pillText = 'Authenticate'
             break
         case 'use-supported-auth':
+            pillText = 'Select Q Developer Profile'
+            break
         case 'missing_scopes':
             pillText = 'Enable Amazon Q'
             break


### PR DESCRIPTION
## Problem

`createAuthFollowUpResult` and `getAuthFollowUpType` do not recognize the recently introduced `AmazonQ` errors, while we would want to use these methods to detect the `AuthFollowUpType` and create the follow up result accordingly.

## Solution

Extend the existing functions with handling for `AmazonQServicePendingSigninError` and `AmazonQServicePendingProfileError`. Also updated the related unit test(s).

Testing: Verified that attempting to chat while signed in but no profile selected displays `Select Q Developer Profile` as follow up result

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
