### PR TITLE
chore: sync fsRead with VSC branch. 

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.test.ts
@@ -43,9 +43,24 @@ describe('FsRead Tool', () => {
         tempFolder.clear()
     })
 
-    it('throws if path is empty', async () => {
+    it('invalidates empty path', async () => {
         const fsRead = new FsRead(features)
-        await assert.rejects(() => fsRead.invoke({ path: '' }))
+        await assert.rejects(
+            fsRead.validate({ path: '' }),
+            /Path cannot be empty/i,
+            'Expected an error about empty path'
+        )
+    })
+
+    it('invalidates non-existent paths', async () => {
+        const filePath = path.join(tempFolder.path, 'no_such_file.txt')
+        const fsRead = new FsRead(features)
+
+        await assert.rejects(
+            fsRead.validate({ path: filePath }),
+            /does not exist or cannot be accessed/i,
+            'Expected an error indicating the path does not exist'
+        )
     })
 
     it('reads entire file', async () => {
@@ -68,27 +83,6 @@ describe('FsRead Tool', () => {
 
         assert.strictEqual(result.output.kind, 'text')
         assert.strictEqual(result.output.content, 'B\nC\nD')
-    })
-
-    it('throws error if path does not exist', async () => {
-        const filePath = path.join(tempFolder.path, 'no_such_file.txt')
-        const fsRead = new FsRead(features)
-
-        await assert.rejects(fsRead.invoke({ path: filePath }))
-    })
-
-    it('throws error if content exceeds 30KB', async function () {
-        const bigContent = 'x'.repeat(35_000)
-
-        const filePath = await tempFolder.write('bigFile.txt', bigContent)
-
-        const fsRead = new FsRead(features)
-
-        await assert.rejects(
-            fsRead.invoke({ path: filePath }),
-            /This tool only supports reading \d+ bytes at a time/i,
-            'Expected a size-limit error'
-        )
     })
 
     it('invalid line range', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.test.ts
@@ -94,4 +94,17 @@ describe('FsRead Tool', () => {
         assert.strictEqual(result.output.kind, 'text')
         assert.strictEqual(result.output.content, '')
     })
+
+    it('updates the stream', async () => {
+        const fsRead = new FsRead(features)
+        const chunks = []
+        const stream = new WritableStream({
+            write: c => {
+                chunks.push(c)
+            },
+        })
+        await fsRead.queueDescription({ path: 'this/is/my/path' }, stream)
+        assert.ok(chunks.length > 0)
+        assert.ok(!stream.locked)
+    })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
@@ -113,7 +113,7 @@ export class FsRead {
         return {
             name: 'fsRead',
             description:
-                'A tool for reading a file. \n* This tool returns the contents of a file, and the optional `readRange` determines what range of lines will be read from the specified file.',
+                'A tool for reading a file.\n * This tool returns the contents of a file, and the optional `readRange` determines what range of lines will be read from the specified file',
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -123,7 +123,7 @@ export class FsRead {
                     },
                     readRange: {
                         description:
-                            'Optional parameter when reading files.\n* If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[startLine, -1]` shows all lines from `startLine` to the end of the file.',
+                            'Optional parameter when reading files.\n * If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[startLine, -1]` shows all lines from `startLine` to the end of the file.',
                         type: 'array',
                         items: {
                             type: 'number',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
@@ -49,6 +49,8 @@ export class FsRead {
         } else {
             await updateWriter.write('all lines')
         }
+        await updateWriter.close()
+        updateWriter.releaseLock()
     }
 
     public async invoke(params: FsReadParams): Promise<InvokeOutput> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -10,7 +10,12 @@ export const FsToolsServer: Server = ({ workspace, logging, agent }) => {
 
     const listDirectoryTool = new ListDirectory({ workspace, logging })
 
-    agent.addTool(fsReadTool.getSpec(), (input: FsReadParams) => fsReadTool.invoke(input))
+    agent.addTool(fsReadTool.getSpec(), async (input: FsReadParams) => {
+        // TODO: fill in logic for handling invalid tool invocations
+        // TODO: implement chat streaming via queueDescription.
+        await fsReadTool.validate(input)
+        await fsReadTool.invoke(input)
+    })
 
     agent.addTool(fsWriteTool.getSpec(), (input: FsWriteParams) => fsWriteTool.invoke(input))
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -1,5 +1,3 @@
-export const maxToolResponseSize = 30720 // 30KB
-
 export interface InvokeOutput {
     output:
         | {


### PR DESCRIPTION
## Problem
The fsRead tool has had changes since https://github.com/aws/language-servers/pull/894 was merged. Additionally, the `validate` and `invoke` methods were combined previously, but have been separated here until the final implementation is more stable, and refactoring can be done with less churn. 

## Solution
- sync up to https://github.com/aws/aws-toolkit-vscode/blob/8e00eefa33f4eee99eed162582c32c270e9e798e/packages/core/src/codewhispererChat/tools/fsRead.ts#L17
- add TODO comments as hints for where work is still needed to integrate the tool to mirror its VSC implementation. 
- add a test for working with the `queueDescription` function. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
