### PR TITLE
test: expand fsWrite test suite and sync with VSC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13213,6 +13213,13 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/diff": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+            "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/eslint": {
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -30982,6 +30989,7 @@
                 "archiver": "^7.0.1",
                 "aws-sdk": "^2.1403.0",
                 "deepmerge": "^4.3.1",
+                "diff": "^7.0.0",
                 "fastest-levenshtein": "^1.0.16",
                 "got": "^11.8.5",
                 "hpagent": "^1.2.0",
@@ -30993,6 +31001,7 @@
             "devDependencies": {
                 "@types/adm-zip": "^0.5.5",
                 "@types/archiver": "^6.0.2",
+                "@types/diff": "^7.0.2",
                 "@types/uuid": "^9.0.8",
                 "assert": "^2.1.0",
                 "copyfiles": "^2.4.1",
@@ -31087,6 +31096,15 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "server/aws-lsp-codewhisperer/node_modules/diff": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "server/aws-lsp-identity": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -43,12 +43,14 @@
         "hpagent": "^1.2.0",
         "js-md5": "^0.8.3",
         "uuid": "^11.0.5",
+        "diff": "^7.0.0",
         "vscode-uri": "^3.1.0"
     },
     "devDependencies": {
         "@types/adm-zip": "^0.5.5",
         "@types/archiver": "^6.0.2",
         "@types/uuid": "^9.0.8",
+        "@types/diff": "^7.0.2",
         "assert": "^2.1.0",
         "copyfiles": "^2.4.1",
         "mock-fs": "^5.2.0",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.test.ts
@@ -50,6 +50,20 @@ describe('FsWrite Tool', function () {
         await tempFolder.delete()
     })
 
+    it('writes a empty space to updates stream', async function () {
+        const fsRead = new FsWrite(features)
+        const chunks: string[] = []
+        const stream = new WritableStream({
+            write: c => {
+                chunks.push(c)
+            },
+        })
+        await fsRead.queueDescription(stream)
+        assert.strictEqual(chunks.length, 1)
+        assert.ok(chunks[0], ' ')
+        assert.ok(!stream.locked)
+    })
+
     describe('handleCreate', function () {
         it('creates a new file with fileText content', async function () {
             const filePath = path.join(tempFolder.path, 'file1.txt')
@@ -413,6 +427,121 @@ describe('FsWrite Tool', function () {
 
             const fsWrite = new FsWrite(features)
             await assert.rejects(() => fsWrite.invoke(params), /no such file or directory/)
+        })
+    })
+
+    describe('getDiffChanges', function () {
+        beforeEach(async () => {
+            tempFolder.clear()
+        })
+
+        it('handles create case', async function () {
+            const testContent = 'newFileText'
+            const fsWrite = new FsWrite(features)
+
+            const filepath = path.join(tempFolder.path, 'testFile.txt')
+
+            const result = await fsWrite.getDiffChanges({ command: 'create', path: filepath, fileText: testContent })
+            assert.deepStrictEqual(result, [
+                {
+                    added: true,
+                    count: 1,
+                    removed: false,
+                    value: testContent,
+                },
+            ])
+            const result2 = await fsWrite.getDiffChanges({ command: 'create', path: filepath })
+            assert.deepStrictEqual(result2, [])
+        })
+
+        it('handles replace case', async function () {
+            const fsWrite = new FsWrite(features)
+            const content = 'replace this old word'
+            const filepath = await tempFolder.write('testFile.txt', content)
+
+            const result = await fsWrite.getDiffChanges({
+                command: 'strReplace',
+                path: filepath,
+                oldStr: 'old',
+                newStr: 'new',
+            })
+            assert.deepStrictEqual(result, [
+                {
+                    added: false,
+                    count: 1,
+                    removed: true,
+                    value: content,
+                },
+                {
+                    added: true,
+                    count: 1,
+                    removed: false,
+                    value: content.replace('old', 'new'),
+                },
+            ])
+        })
+
+        it('handles insert case', async function () {
+            const fsWrite = new FsWrite(features)
+            const content = 'line1 \n line2 \n line3'
+            const filepath = await tempFolder.write('testFile.txt', content)
+
+            const result = await fsWrite.getDiffChanges({
+                command: 'insert',
+                path: filepath,
+                insertLine: 2,
+                newStr: 'new text',
+            })
+
+            assert.deepStrictEqual(result, [
+                {
+                    added: false,
+                    count: 2,
+                    removed: false,
+                    value: 'line1 \n line2 \n',
+                },
+                {
+                    added: true,
+                    count: 1,
+                    removed: false,
+                    value: 'new text\n',
+                },
+                {
+                    added: false,
+                    count: 1,
+                    removed: false,
+                    value: ' line3',
+                },
+            ])
+        })
+
+        it('handles append case', async function () {
+            const fsWrite = new FsWrite(features)
+            const content = 'line1 \n line2'
+            const filepath = await tempFolder.write('testFile.txt', content)
+
+            const result = await fsWrite.getDiffChanges({ command: 'append', path: filepath, newStr: 'line3' })
+
+            assert.deepStrictEqual(result, [
+                {
+                    added: false,
+                    count: 1,
+                    removed: false,
+                    value: 'line1 \n',
+                },
+                {
+                    added: false,
+                    count: 1,
+                    removed: true,
+                    value: ' line2',
+                },
+                {
+                    added: true,
+                    count: 2,
+                    removed: false,
+                    value: ' line2\nline3',
+                },
+            ])
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -49,6 +49,32 @@ export class FsWrite {
         this.workspace = features.workspace
     }
 
+    public async validate(params: FsWriteParams): Promise<void> {
+        switch (params.command) {
+            case 'create':
+                if (!params.path) {
+                    throw new Error('Path must not be empty')
+                }
+                break
+            case 'strReplace':
+            case 'insert': {
+                const fileExists = await this.workspace.fs.exists(params.path)
+                if (!fileExists) {
+                    throw new Error('The provided path must exist in order to replace or insert contents into it')
+                }
+                break
+            }
+            case 'append':
+                if (!params.path) {
+                    throw new Error('Path must not be empty')
+                }
+                if (!params.newStr) {
+                    throw new Error('Content to append must not be empty')
+                }
+                break
+        }
+    }
+
     public async invoke(params: FsWriteParams): Promise<InvokeOutput> {
         const sanitizedPath = sanitize(params.path)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -1,8 +1,9 @@
 import { InvokeOutput } from './toolShared'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
+import { Change, diffLines } from 'diff'
 
-// Port of https://github.com/aws/aws-toolkit-vscode/blob/10bb1c7dc45f128df14d749d95905c0e9b808096/packages/core/src/codewhispererChat/tools/fsWrite.ts#L42
+// Port of https://github.com/aws/aws-toolkit-vscode/blob/8e00eefa33f4eee99eed162582c32c270e9e798e/packages/core/src/codewhispererChat/tools/fsWrite.ts#L42
 
 interface BaseParams {
     path: string
@@ -32,6 +33,12 @@ export interface AppendParams extends BaseParams {
 }
 
 export type FsWriteParams = CreateParams | StrReplaceParams | InsertParams | AppendParams
+
+export interface FsWriteBackup {
+    filePath: string
+    content: string
+    isNew: boolean
+}
 
 export class FsWrite {
     private readonly logging: Features['logging']
@@ -66,6 +73,91 @@ export class FsWrite {
                 content: '',
             },
         }
+    }
+
+    public async queueDescription(updates: WritableStream): Promise<void> {
+        const updateWriter = updates.getWriter()
+        // Write an empty string because FsWrite should only show a chat message with header
+        await updateWriter.write(' ')
+        await updateWriter.close()
+        updateWriter.releaseLock()
+    }
+
+    public async getDiffChanges(params: FsWriteParams): Promise<Change[]> {
+        let newContent
+        const { filePath: sanitizedPath, content: oldContent } = await this.getBackup(params)
+        switch (params.command) {
+            case 'create':
+                newContent = this.getCreateCommandText(params)
+                break
+            case 'strReplace':
+                newContent = await this.getStrReplaceContent(params, sanitizedPath)
+                break
+            case 'insert':
+                newContent = await this.getInsertContent(params, sanitizedPath)
+                break
+            case 'append':
+                newContent = await this.getAppendContent(params, sanitizedPath)
+                break
+        }
+        return diffLines(oldContent, newContent)
+    }
+
+    public async getBackup(params: FsWriteParams): Promise<FsWriteBackup> {
+        const sanitizedPath = sanitize(params.path)
+        let oldContent
+        let isNew
+        try {
+            oldContent = await this.workspace.fs.readFile(sanitizedPath)
+            isNew = false
+        } catch (err) {
+            oldContent = ''
+            isNew = true
+        }
+        return { filePath: sanitizedPath, content: oldContent, isNew }
+    }
+
+    private async getStrReplaceContent(params: StrReplaceParams, sanitizedPath: string): Promise<string> {
+        const fileContent = await this.workspace.fs.readFile(sanitizedPath)
+
+        const matches = [...fileContent.matchAll(new RegExp(this.escapeRegExp(params.oldStr), 'g'))]
+
+        if (matches.length === 0) {
+            throw new Error(`No occurrences of "${params.oldStr}" were found`)
+        }
+        if (matches.length > 1) {
+            throw new Error(`${matches.length} occurrences of oldStr were found when only 1 is expected`)
+        }
+
+        return fileContent.replace(params.oldStr, params.newStr)
+    }
+
+    private async getAppendContent(params: AppendParams, sanitizedPath: string): Promise<string> {
+        const fileContent = await this.workspace.fs.readFile(sanitizedPath)
+        const needsNewline = fileContent.length !== 0 && !fileContent.endsWith('\n')
+
+        let contentToAppend = params.newStr
+        if (needsNewline) {
+            contentToAppend = '\n' + contentToAppend
+        }
+
+        return fileContent + contentToAppend
+    }
+
+    private async getInsertContent(params: InsertParams, sanitizedPath: string): Promise<string> {
+        const fileContent = await this.workspace.fs.readFile(sanitizedPath)
+        const lines = fileContent.split('\n')
+
+        const numLines = lines.length
+        const insertLine = Math.max(0, Math.min(params.insertLine, numLines))
+
+        let newContent: string
+        if (insertLine === 0) {
+            newContent = params.newStr + '\n' + fileContent
+        } else {
+            newContent = [...lines.slice(0, insertLine), params.newStr, ...lines.slice(insertLine)].join('\n')
+        }
+        return newContent
     }
 
     private async handleCreate(params: CreateParams, sanitizedPath: string): Promise<void> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -12,7 +12,12 @@ export const FsToolsServer: Server = ({ workspace, logging, agent }) => {
 
     agent.addTool(fsReadTool.getSpec(), (input: FsReadParams) => fsReadTool.invoke(input))
 
-    agent.addTool(fsWriteTool.getSpec(), (input: FsWriteParams) => fsWriteTool.invoke(input))
+    agent.addTool(fsWriteTool.getSpec(), async (input: FsWriteParams) => {
+        // TODO: fill in logic for handling invalid tool invocations
+        // TODO: implement chat streaming via queueDescription.
+        await fsWriteTool.validate(input)
+        await fsWriteTool.invoke(input)
+    })
 
     agent.addTool(listDirectoryTool.getSpec(), (input: ListDirectoryParams) => listDirectoryTool.invoke(input))
 


### PR DESCRIPTION
## Problem
There have been significant changes to the `fsWrite` tool since it was originally ported in https://github.com/aws/language-servers/pull/894. 

Additionally, the test suite is missing coverage for some core components and it has the properly that tests are dependent on each other. 

For example, one test creates a file that the next test uses. This is problematic because the tests become coupled and changes to one test could trickle down and cause unclear side effects. 


## Solution
- Port fsWrite latest changes from VSC. (as of https://github.com/aws/aws-toolkit-vscode/blob/8e00eefa33f4eee99eed162582c32c270e9e798e/packages/core/src/codewhispererChat/tools/fsWrite.ts#L42). 
- refactor tests so that they are isolated. 
- add coverage for the new diff mechanism. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
