### PR TITLE
fix(amazonq): add missing paginator to list profiles call

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
@@ -75,6 +75,7 @@ async function fetchProfilesFromRegion(
 
             const response = await service.listAvailableProfiles({
                 maxResults: MAX_Q_DEVELOPER_PROFILES_PER_PAGE,
+                nextToken: nextToken,
             })
 
             const profiles = response.profiles.map(profile => ({


### PR DESCRIPTION
## Problem

If an account that has more than one developer profile queries `aws.q.developerProfiles`, the response is a list containing the first profile ten times. A paginator is missing in the call to list all profiles.

## Solution

Add the missing `nextToken` paginator.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
