### PR TITLE
feat: add proper windows support for executeBash (WIP)

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
@@ -2,10 +2,8 @@ import { strict as assert } from 'assert'
 import * as mockfs from 'mock-fs'
 import * as sinon from 'sinon'
 import { ExecuteBash } from './executeBash'
-import { processUtils } from '@aws/lsp-core'
 import { Logging } from '@aws/language-server-runtimes/server-interface'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
-import { Writable } from 'stream'
 
 describe('ExecuteBash Tool', () => {
     let logging: Logging

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -305,7 +305,11 @@ export class ExecuteBash {
     }
 
     private static async whichCommand(logger: Logging, cmd: string): Promise<string> {
-        const cp = new processUtils.ChildProcess(logger, 'which', [cmd], {
+        const { command, args } =
+            process.platform === 'win32'
+                ? { command: 'where', args: [cmd] }
+                : { command: 'sh', args: ['-c', `command -v ${cmd} || which ${cmd}`] }
+        const cp = new processUtils.ChildProcess(logger, command, args, {
             collect: true,
             waitForStreams: true,
         })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -305,7 +305,8 @@ export class ExecuteBash {
     }
 
     private static async whichCommand(logger: Logging, cmd: string): Promise<string> {
-        const cp = new processUtils.ChildProcess(logger, 'which', [cmd], {
+        // use 'command -v' instead as which isn't POSIX
+        const cp = new processUtils.ChildProcess(logger, 'command', ['-v', cmd], {
             collect: true,
             waitForStreams: true,
         })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -305,10 +305,10 @@ export class ExecuteBash {
     }
 
     private static async whichCommand(logger: Logging, cmd: string): Promise<string> {
-        const { command, args } =
-            process.platform === 'win32'
-                ? { command: 'where', args: [cmd] }
-                : { command: 'sh', args: ['-c', `command -v ${cmd}`] }
+        const isWindows = process.platform === 'win32'
+        const { command, args } = isWindows
+            ? { command: 'where', args: [cmd] }
+            : { command: 'sh', args: ['-c', `command -v ${cmd}`] }
         const cp = new processUtils.ChildProcess(logger, command, args, {
             collect: true,
             waitForStreams: true,
@@ -321,7 +321,7 @@ export class ExecuteBash {
 
         const output = result.stdout.trim()
         if (!output) {
-            throw new Error(`Command '${cmd}' found but 'which' returned empty output.`)
+            throw new Error(`Command '${cmd}' found but '${command} ${args.join(' ')}' returned empty output.`)
         }
         return output
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -308,7 +308,7 @@ export class ExecuteBash {
         const { command, args } =
             process.platform === 'win32'
                 ? { command: 'where', args: [cmd] }
-                : { command: 'sh', args: ['-c', `command -v ${cmd} || which ${cmd}`] }
+                : { command: 'sh', args: ['-c', `command -v ${cmd}`] }
         const cp = new processUtils.ChildProcess(logger, command, args, {
             collect: true,
             waitForStreams: true,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -305,8 +305,7 @@ export class ExecuteBash {
     }
 
     private static async whichCommand(logger: Logging, cmd: string): Promise<string> {
-        // use 'command -v' instead as which isn't POSIX
-        const cp = new processUtils.ChildProcess(logger, 'command', ['-v', cmd], {
+        const cp = new processUtils.ChildProcess(logger, 'which', [cmd], {
             collect: true,
             waitForStreams: true,
         })


### PR DESCRIPTION
Built on https://github.com/aws/language-servers/pull/934

## Problem
After removing the mocks for executeBash the tests still pass on windows. I suspect this is because Git for Windows includes Git Bash which includes `which` and other unix utilities. However, this may not be the case on customer machines.

## Solution
- add proper windows support by using `where` instead. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
