### PR TITLE
fix(amazonq): add cancel support to loading developer profiles

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -80,7 +80,7 @@ export const QConfigurationServerToken =
                         case Q_CONFIGURATION_SECTION:
                             ;[customizations, developerProfiles] = await Promise.all([
                                 serverConfigurationProvider.listAvailableCustomizations(),
-                                serverConfigurationProvider.listAvailableProfiles(),
+                                serverConfigurationProvider.listAvailableProfiles(token),
                             ])
 
                             return amazonQServiceManager.getEnableDeveloperProfileSupport()
@@ -91,7 +91,7 @@ export const QConfigurationServerToken =
 
                             return customizations
                         case Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION:
-                            developerProfiles = await serverConfigurationProvider.listAvailableProfiles()
+                            developerProfiles = await serverConfigurationProvider.listAvailableProfiles(token)
 
                             return developerProfiles
                         default:
@@ -130,7 +130,7 @@ export class ServerConfigurationProvider {
         )
     }
 
-    async listAvailableProfiles(): Promise<AmazonQDeveloperProfile[]> {
+    async listAvailableProfiles(token: CancellationToken): Promise<AmazonQDeveloperProfile[]> {
         if (!this.serviceManager.getEnableDeveloperProfileSupport()) {
             this.logging.debug('Q developer profiles disabled - returning empty list')
             return []
@@ -140,6 +140,7 @@ export class ServerConfigurationProvider {
             const profiles = await this.listAllAvailableProfilesHandler({
                 connectionType: this.credentialsProvider.getConnectionType(),
                 logging: this.logging,
+                token: token,
             })
 
             return profiles

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -83,6 +83,8 @@ export const QConfigurationServerToken =
                                 serverConfigurationProvider.listAvailableProfiles(token),
                             ])
 
+                            throwIfCancelled(token)
+
                             return amazonQServiceManager.getEnableDeveloperProfileSupport()
                                 ? { customizations, developerProfiles }
                                 : { customizations }
@@ -92,6 +94,8 @@ export const QConfigurationServerToken =
                             return customizations
                         case Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION:
                             developerProfiles = await serverConfigurationProvider.listAvailableProfiles(token)
+
+                            throwIfCancelled(token)
 
                             return developerProfiles
                         default:
@@ -114,6 +118,12 @@ export const QConfigurationServerToken =
         logging.log('Amazon Q Configuration server has been initialised')
         return () => {}
     }
+
+function throwIfCancelled(token: CancellationToken) {
+    if (token.isCancellationRequested) {
+        throw new ResponseError(LSPErrorCodes.RequestCancelled, 'Request cancelled')
+    }
+}
 
 const ON_GET_CONFIGURATION_FROM_SERVER_ERROR_PREFIX = 'Failed to fetch: '
 

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -305,6 +305,7 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<CodeWh
         const profiles = await getListAllAvailableProfilesHandler(this.serviceFactory)({
             connectionType: 'identityCenter',
             logging: this.logging,
+            token: token,
         })
 
         this.handleTokenCancellationRequest(token)

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.test.ts
@@ -2,7 +2,11 @@ import * as assert from 'assert'
 import { StubbedInstance, stubInterface } from 'ts-sinon'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
 import { SsoConnectionType } from '../utils'
-import { AWSInitializationOptions, Logging } from '@aws/language-server-runtimes/server-interface'
+import {
+    AWSInitializationOptions,
+    CancellationTokenSource,
+    Logging,
+} from '@aws/language-server-runtimes/server-interface'
 import {
     AmazonQDeveloperProfile,
     getListAllAvailableProfilesHandler,
@@ -35,6 +39,7 @@ describe('ListAllAvailableProfiles Handler', () => {
 
     let codeWhispererService: StubbedInstance<CodeWhispererServiceToken>
     let handler: ListAllAvailableProfilesHandler
+    let tokenSource: CancellationTokenSource
 
     const listAvailableProfilesResponse = {
         profiles: [
@@ -57,6 +62,7 @@ describe('ListAllAvailableProfiles Handler', () => {
         codeWhispererService.listAvailableProfiles.resolves(listAvailableProfilesResponse)
 
         handler = getListAllAvailableProfilesHandler(() => codeWhispererService)
+        tokenSource = new CancellationTokenSource()
     })
 
     it('should aggregrate profiles retrieved from different regions', async () => {
@@ -64,6 +70,7 @@ describe('ListAllAvailableProfiles Handler', () => {
             connectionType: 'identityCenter',
             logging,
             endpoints: SOME_AWS_Q_ENDPOINTS,
+            token: tokenSource.token,
         })
 
         assert.strictEqual(
@@ -78,6 +85,7 @@ describe('ListAllAvailableProfiles Handler', () => {
             const profiles = await handler({
                 connectionType,
                 logging,
+                token: tokenSource.token,
             })
 
             assert.deepStrictEqual(profiles, [])
@@ -102,6 +110,7 @@ describe('ListAllAvailableProfiles Handler', () => {
                 connectionType: 'identityCenter',
                 logging,
                 endpoints: SOME_AWS_Q_ENDPOINT,
+                token: tokenSource.token,
             })
 
             assert.strictEqual(codeWhispererService.listAvailableProfiles.callCount, EXPECTED_CALLS)
@@ -115,6 +124,7 @@ describe('ListAllAvailableProfiles Handler', () => {
                 connectionType: 'identityCenter',
                 logging,
                 endpoints: SOME_AWS_Q_ENDPOINT,
+                token: tokenSource.token,
             })
 
             assert.strictEqual(codeWhispererService.listAvailableProfiles.callCount, MAX_EXPECTED_PAGES)


### PR DESCRIPTION
## Problem

There can be some latency while loading developer profiles, caused by either a poor internet connection, a sluggish backend, or both. Clients need a way to cancel the request for loading profiles.

## Solution

Wire in support for the Cancellation Token.

This change is being done in tandem with VS Toolkit change https://github.com/aws/aws-toolkit-visual-studio-staging/pull/2443

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
