### PR TITLE
test: add tests for q chat server IAM

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/qChatServerIAM.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/qChatServerIAM.test.ts
@@ -4,14 +4,14 @@ import sinon from 'ts-sinon'
 import { ChatController } from './chatController'
 import { ChatSessionManagementService } from './chatSessionManagementService'
 import { QChatServerFactory } from './qChatServer'
-import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
+import { AmazonQIAMServiceManager } from '../../shared/amazonQServiceManager/AmazonQIAMServiceManager'
 
-describe('QChatServer', () => {
+describe('QChatServerIAM', () => {
     const mockTabId = 'mockTabId'
     let disposeStub: sinon.SinonStub
     let withAmazonQServiceManagerSpy: sinon.SinonSpy
     let testFeatures: TestFeatures
-    let amazonQServiceManager: AmazonQTokenServiceManager
+    let amazonQServiceManager: AmazonQIAMServiceManager
     let disposeServer: () => void
     let chatSessionManagementService: ChatSessionManagementService
 
@@ -31,7 +31,7 @@ describe('QChatServer', () => {
         }
         testFeatures.lsp.getClientInitializeParams.returns(cachedInitializeParams)
 
-        amazonQServiceManager = AmazonQTokenServiceManager.getInstance(testFeatures)
+        amazonQServiceManager = AmazonQIAMServiceManager.getInstance(testFeatures)
 
         disposeStub = sinon.stub(ChatSessionManagementService.prototype, 'dispose')
         chatSessionManagementService = ChatSessionManagementService.getInstance()
@@ -51,7 +51,7 @@ describe('QChatServer', () => {
         testFeatures.dispose()
     })
 
-    it('should initialize ChatSessionManagementService with AmazonQTokenServiceManager instance', () => {
+    it('should initialize ChatSessionManagementService with AmazonQIAMServiceManager instance', () => {
         sinon.assert.calledOnceWithExactly(withAmazonQServiceManagerSpy, amazonQServiceManager)
     })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/qChatServerToken.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/qChatServerToken.test.ts
@@ -1,0 +1,113 @@
+import { CancellationToken, Server } from '@aws/language-server-runtimes/server-interface'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import sinon from 'ts-sinon'
+import { ChatController } from './chatController'
+import { ChatSessionManagementService } from './chatSessionManagementService'
+import { QChatServerFactory } from './qChatServer'
+import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
+
+describe('QChatServerToken', () => {
+    const mockTabId = 'mockTabId'
+    let disposeStub: sinon.SinonStub
+    let withAmazonQServiceManagerSpy: sinon.SinonSpy
+    let testFeatures: TestFeatures
+    let amazonQServiceManager: AmazonQTokenServiceManager
+    let disposeServer: () => void
+    let chatSessionManagementService: ChatSessionManagementService
+
+    beforeEach(async () => {
+        testFeatures = new TestFeatures()
+        // @ts-ignore
+        const cachedInitializeParams: InitializeParams = {
+            initializationOptions: {
+                aws: {
+                    awsClientCapabilities: {
+                        q: {
+                            developerProfiles: false,
+                        },
+                    },
+                },
+            },
+        }
+        testFeatures.lsp.getClientInitializeParams.returns(cachedInitializeParams)
+
+        amazonQServiceManager = AmazonQTokenServiceManager.getInstance(testFeatures)
+
+        disposeStub = sinon.stub(ChatSessionManagementService.prototype, 'dispose')
+        chatSessionManagementService = ChatSessionManagementService.getInstance()
+        withAmazonQServiceManagerSpy = sinon.spy(chatSessionManagementService, 'withAmazonQServiceManager')
+
+        const chatServerFactory: Server = QChatServerFactory(() => amazonQServiceManager)
+
+        disposeServer = chatServerFactory(testFeatures)
+
+        // Trigger initialize notification
+        await testFeatures.lsp.onInitialized.firstCall.firstArg()
+    })
+
+    afterEach(() => {
+        sinon.restore()
+        ChatSessionManagementService.reset()
+        testFeatures.dispose()
+    })
+
+    it('should initialize ChatSessionManagementService with AmazonQTokenServiceManager instance', () => {
+        sinon.assert.calledOnceWithExactly(withAmazonQServiceManagerSpy, amazonQServiceManager)
+    })
+
+    it('dispose should dispose all chat session services', () => {
+        disposeServer()
+
+        sinon.assert.calledOnce(disposeStub)
+    })
+
+    it('calls the corresponding controller when tabAdd notification is received', () => {
+        const tabAddStub = sinon.stub(ChatController.prototype, 'onTabAdd')
+
+        testFeatures.chat.onTabAdd.firstCall.firstArg({ tabId: mockTabId })
+
+        sinon.assert.calledOnce(tabAddStub)
+    })
+
+    it('calls the corresponding controller when tabRemove notification is received', () => {
+        const tabRemoveStub = sinon.stub(ChatController.prototype, 'onTabRemove')
+
+        testFeatures.chat.onTabRemove.firstCall.firstArg({ tabId: mockTabId })
+
+        sinon.assert.calledOnce(tabRemoveStub)
+    })
+
+    it('calls the corresponding controller when endChat request is received', () => {
+        const endChatStub = sinon.stub(ChatController.prototype, 'onEndChat')
+
+        testFeatures.chat.onEndChat.firstCall.firstArg({ tabId: mockTabId })
+
+        sinon.assert.calledOnce(endChatStub)
+    })
+
+    it('calls the corresponding controller when chatPrompt request is received', () => {
+        const chatPromptStub = sinon.stub(ChatController.prototype, 'onChatPrompt')
+
+        testFeatures.chat.onChatPrompt.firstCall.firstArg({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, {})
+
+        sinon.assert.calledOnce(chatPromptStub)
+    })
+
+    it('calls the corresponding controller when inlineChatPrompt request is received', () => {
+        const inlineChatPromptStub = sinon.stub(ChatController.prototype, 'onInlineChatPrompt')
+        const mockCancellationToken: CancellationToken = {
+            isCancellationRequested: false,
+            onCancellationRequested: () => ({ dispose: () => {} }),
+        }
+        testFeatures.chat.onInlineChatPrompt.firstCall.firstArg({ prompt: { prompt: 'Hello' } }, mockCancellationToken)
+
+        sinon.assert.calledOnce(inlineChatPromptStub)
+        sinon.assert.calledWith(
+            inlineChatPromptStub,
+            {
+                prompt: { prompt: 'Hello' },
+            },
+            mockCancellationToken
+        )
+    })
+})


### PR DESCRIPTION
## Problem
this PR is a folllowup of https://github.com/aws/language-servers/pull/945, which adds some basic tests for the IAM client for q chat server.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
