### PR TITLE
test: skip flaky child process tracker test

### DIFF
--- a/core/aws-lsp-core/src/util/processUtils.test.ts
+++ b/core/aws-lsp-core/src/util/processUtils.test.ts
@@ -357,7 +357,7 @@ describe('ChildProcessTracker', function () {
         await tempFolder.delete()
     })
 
-    it(`removes stopped processes every ${ChildProcessTracker.pollingInterval / 1000} seconds`, async function () {
+    it.skip(`removes stopped processes every ${ChildProcessTracker.pollingInterval / 1000} seconds`, async function () {
         const runningProcess = await startTestProcess(tempFolder, logging)
         tracker.add(runningProcess.childProcess)
         assert.strictEqual(tracker.has(runningProcess.childProcess), true, 'failed to add test command')


### PR DESCRIPTION
## Problem
This test is flaky and is failing CI on unrelated changes. Ex. https://github.com/aws/language-servers/actions/runs/14414451928/job/40491802663#step:5:1583

The cause is not immediately clear, and requires some investigation. Not able to reproduce locally by repeating the test suggesting it is related to either bleed-through from another test or a CI specific. 


## Solution
- Skip the test to avoid blocking other work while root-sourcing the issue. 
- This test is non-critical, as it related to the child process logging functionality. 
- Follow up with a longer term fix and attempt to root cause the issue. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
