### PR TITLE
fix: disable timeout for tests in aws-lsp-codewhisperer and core sub-folders

### DIFF
--- a/core/aws-lsp-core/package.json
+++ b/core/aws-lsp-core/package.json
@@ -21,7 +21,7 @@
     "scripts": {
         "compile": "tsc --build",
         "test": "npm run test-unit",
-        "test-unit": "mocha \"./out/**/*.test.js\"",
+        "test-unit": "mocha --timeout 0 \"./out/**/*.test.js\"",
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -21,7 +21,7 @@
         "lint": "npm run lint:src",
         "lint:bundle:webworker": "webpack --config webpack.lint.config.js && eslint bundle/aws-lsp-codewhisperer-webworker.js # Verify compatibility with web runtime target",
         "lint:src": "eslint src/ --ext .ts,.tsx",
-        "test:unit": "ts-mocha -b \"./src/**/*.test.ts\"",
+        "test:unit": "ts-mocha --timeout 0 -b \"./src/**/*.test.ts\"",
         "test": "npm run lint && npm run test:unit",
         "prepack": "npm run compile && ts-node ../../script/link_bundled_dependencies.ts",
         "postinstall": "node ./script/install_transitive_dep.js"


### PR DESCRIPTION
## Problem
The new tests added recently in the recent PRs containing the ones defined in aws-lsp-codewhisperer and core packages, sometimes take more than 2s to execute (2s is the default mocha timeout). Tests taking more than 2s fails. 

## Solution

Mocha has a default timeout of 2000ms per test case. Mocha provides us the capability to override this timeout value or even disable timeout when we provide 0 value to the timeout function. https://mochajs.org/#test-level
Raising this PR to disable the timeout for the mentioned sub folders above.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
