### PR TITLE
fix: add onTabBarAction and getSerializedChat to Omit list of Chat handlers

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -74,6 +74,8 @@ type ChatHandlers = Omit<
     | 'onCreatePrompt'
     | 'onListConversations'
     | 'onConversationClick'
+    | 'onTabBarAction'
+    | 'getSerializedChat'
 >
 
 export class AgenticChatController implements ChatHandlers {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -58,6 +58,8 @@ type ChatHandlers = Omit<
     | 'onCreatePrompt'
     | 'onListConversations'
     | 'onConversationClick'
+    | 'onTabBarAction'
+    | 'getSerializedChat'
 >
 
 export class ChatController implements ChatHandlers {


### PR DESCRIPTION
Add **onTabBarAction** and **getSerializedChat** to Omit list of Chat handlers so internal build do not fail. This is temporary and can be removed post actual implementation of the methods in both of these classes. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
