### PR TITLE
fix(amazonq): call custom and default handlers for onTabAdd

### DIFF
--- a/chat-client/src/client/withAdapter.ts
+++ b/chat-client/src/client/withAdapter.ts
@@ -34,7 +34,10 @@ export const withAdapter = (
     }
 
     const eventHandlerWithAdapter: ChatEventHandler = {
-        onTabAdd: addDefaultRouting('onTabAdd'),
+        onTabAdd: (tabID: string) => {
+            customEventHandler.onTabAdd?.(tabID)
+            defaultEventHandler.onTabAdd?.(tabID)
+        },
         onTabChange: addDefaultRouting('onTabChange'),
         onBeforeTabRemove: addDefaultRouting('onBeforeTabRemove', true),
         onTabRemove: addDefaultRouting('onTabRemove'),


### PR DESCRIPTION
## Problem
When a user enters a quick action command in hybrid chat (e.g. `/dev`) the custom event handler will never be called.
This is because when the quick action gets handled, the tab never gets added to [VSCode's tabsStorage](https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/amazonq/webview/ui/storages/tabsStorage.ts#L52), which is used to determine whether the [tab is supported or not](https://github.com/aws/language-servers/blob/main/chat-client/src/client/withAdapter.ts#L26) by VSCode's hybrid connector

## Solution
Call both the custom event handler, which will add the new tab into VSCode's internal tabsStorage, and the default event handler, which will add the tab to mynahUI

## Alternative solutions
We could try to handle adding the tab to tabStorage from within the quick action handler but it seems risky, since it has the potential to have a lot of side effects

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
