### PR TITLE
fix: correct the return type to fix internal build

### DIFF
--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -206,7 +206,7 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri, 
                     const result = await responsePromise
 
                     if (result?.success) {
-                        return { tabId: result.result.tabId }
+                        return result.result
                     } else {
                         return new ResponseError(
                             mapErrorType(result?.error.type),


### PR DESCRIPTION
correct the return type in the chatActivation file to fix one of the broken internal build errors.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
