### PR TITLE
fix: handle undefined workspace folders in context controller

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
@@ -13,10 +13,6 @@ export const LocalProjectContextServer = (): Server => features => {
     let telemetryService: TelemetryService
 
     lsp.addInitializer((params: InitializeParams) => {
-        if (!params.workspaceFolders) {
-            throw new Error('Workspace folders are required')
-        }
-
         amazonQServiceManager = AmazonQTokenServiceManager.getInstance(features)
         telemetryService = new TelemetryService(amazonQServiceManager, credentialsProvider, telemetry, logging)
 


### PR DESCRIPTION
## Problem
In some cases workspace folders will be null. Currently this causes an exception to be thrown by the context server's initializer and crashes the server.

## Solution
Removed an unnecessary exception raised when workspace folders is not provided. This is already handled by subsequent code which passes an empty array in this case.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
