### PR TITLE
chore: sync FsWrite tool with vsc version

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.test.ts
@@ -96,39 +96,6 @@ describe('FsWrite Tool', function () {
 
             assert.deepStrictEqual(output, expectedOutput)
         })
-
-        it('uses newStr when fileText is not provided', async function () {
-            const filePath = path.join(tempFolder.path, 'file2.txt')
-
-            const params: CreateParams = {
-                command: 'create',
-                newStr: 'Hello World',
-                path: filePath,
-            }
-            const fsWrite = new FsWrite(features)
-            const output = await fsWrite.invoke(params)
-
-            const content = await features.workspace.fs.readFile(filePath)
-            assert.strictEqual(content, 'Hello World')
-
-            assert.deepStrictEqual(output, expectedOutput)
-        })
-
-        it('creates an empty file when no content is provided', async function () {
-            const filePath = path.join(tempFolder.path, 'file3.txt')
-
-            const params: CreateParams = {
-                command: 'create',
-                path: filePath,
-            }
-            const fsWrite = new FsWrite(features)
-            const output = await fsWrite.invoke(params)
-
-            const content = await features.workspace.fs.readFile(filePath)
-            assert.strictEqual(content, '')
-
-            assert.deepStrictEqual(output, expectedOutput)
-        })
     })
 
     describe('handleStrReplace', async function () {
@@ -442,8 +409,6 @@ describe('FsWrite Tool', function () {
                     value: testContent,
                 },
             ])
-            const result2 = await fsWrite.getDiffChanges({ command: 'create', path: filepath })
-            assert.deepStrictEqual(result2, [])
         })
 
         it('handles replace case', async function () {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -3,10 +3,11 @@ import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
 import { Change, diffLines } from 'diff'
 
-// Port of https://github.com/aws/aws-toolkit-vscode/blob/8e00eefa33f4eee99eed162582c32c270e9e798e/packages/core/src/codewhispererChat/tools/fsWrite.ts#L42
+// Port of https://github.com/aws/aws-toolkit-vscode/blob/4cc64fcf279f47b1bd2ecd64de803abfed623c6d/packages/core/src/codewhispererChat/tools/fsWrite.ts#L42
 
 interface BaseParams {
     path: string
+    explanation?: string
 }
 
 export interface CreateParams extends BaseParams {
@@ -259,7 +260,15 @@ export class FsWrite {
         return {
             name: 'fsWrite',
             description:
-                'A tool for creating and editing a file.\n * The `create` command will override the file at `path` if it already exists as a file, and otherwise create a new file\n * The `append` command will add content to the end of an existing file, automatically adding a newline if the file does not end with one. The file must exist.\n Notes for using the `strReplace` command:\n * The `oldStr` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!\n * If the `oldStr` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `oldStr` to make it unique\n * The `newStr` parameter should contain the edited lines that should replace the `oldStr`. The `insert` command will insert `newStr` after `insertLine` and place it on its own line.',
+                'A tool for creating and editing a file.\n * The `create` command will override the file at `path` if it already exists as a file, \
+                and otherwise create a new file\n * The `append` command will add content to the end of an existing file, \
+                automatically adding a newline if the file does not end with one. \
+                The file must exist.\n Notes for using the `strReplace` command:\n * \
+                The `oldStr` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!\n * \
+                If the `oldStr` parameter is not unique in the file, the replacement will not be performed. \
+                Make sure to include enough context in `oldStr` to make it unique\n * \
+                The `newStr` parameter should contain the edited lines that should replace the `oldStr`. \
+                The `insert` command will insert `newStr` after `insertLine` and place it on its own line.',
             inputSchema: {
                 type: 'object',
                 properties: {
@@ -268,6 +277,11 @@ export class FsWrite {
                         enum: commands,
                         description:
                             'The commands to run. Allowed options are: `create`, `strReplace`, `insert`, `append`.',
+                    },
+                    explanation: {
+                        description:
+                            'One sentence explanation as to why this tool is being used, and how it contributes to the goal.',
+                        type: 'string',
                     },
                     fileText: {
                         description:


### PR DESCRIPTION
## Problem
There have been recent changes to the VSC implementation that are not reflected here. 

## Solution
Sync up to most recent changes: https://github.com/aws/aws-toolkit-vscode/blob/16aa8768834f41ae512522473a6a962bb96abe51/packages/core/src/codewhispererChat/tools/fsWrite.ts#L42
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
