### PR TITLE
chore: sync executeBash tool with vsc version

### DIFF
--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -79,3 +79,9 @@ export function formatListing(entry: Dirent): string {
 export function getEntryPath(entry: Dirent) {
     return path.join(entry.parentPath, entry.name)
 }
+
+// TODO: port this to runtimes?
+export async function inWorkspace(workspace: Features['workspace'], filepath: string) {
+    const r = await workspace.getTextDocument(filepath)
+    return r !== undefined
+}

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -82,6 +82,5 @@ export function getEntryPath(entry: Dirent) {
 
 // TODO: port this to runtimes?
 export async function inWorkspace(workspace: Features['workspace'], filepath: string) {
-    const r = await workspace.getTextDocument(filepath)
-    return r !== undefined
+    return (await workspace.getTextDocument(filepath)) !== undefined
 }

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+import { URI } from 'vscode-uri'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 
 type ElementType<T> = T extends (infer U)[] ? U : never
@@ -82,5 +83,5 @@ export function getEntryPath(entry: Dirent) {
 
 // TODO: port this to runtimes?
 export async function inWorkspace(workspace: Features['workspace'], filepath: string) {
-    return (await workspace.getTextDocument(filepath)) !== undefined
+    return (await workspace.getTextDocument(URI.file(filepath).toString())) !== undefined
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
@@ -2,14 +2,15 @@ import { strict as assert } from 'assert'
 import * as mockfs from 'mock-fs'
 import * as sinon from 'sinon'
 import { ExecuteBash } from './executeBash'
-import { Logging } from '@aws/language-server-runtimes/server-interface'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 
 describe('ExecuteBash Tool', () => {
-    let logging: Logging
+    let features: Features
 
     before(function () {
-        logging = new TestFeatures().logging
+        features = new TestFeatures()
     })
 
     beforeEach(() => {
@@ -21,47 +22,100 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('pass validation for a safe command (read-only)', async () => {
-        const execBash = new ExecuteBash(logging)
-        await execBash.validate(logging, 'ls')
+        const execBash = new ExecuteBash(features)
+        await execBash.validate('ls')
     })
 
     it('fail validation if the command is empty', async () => {
-        const execBash = new ExecuteBash(logging)
+        const execBash = new ExecuteBash(features)
         await assert.rejects(
-            execBash.validate(logging, '   '),
+            execBash.validate('   '),
             /Bash command cannot be empty/i,
             'Expected an error for empty command'
         )
     })
 
-    it('set requiresAcceptance=true if the command has dangerous patterns', () => {
-        const execBash = new ExecuteBash(logging)
-        const validation = execBash.requiresAcceptance('ls && rm -rf /')
+    it('set requiresAcceptance=true if the command has dangerous patterns', async () => {
+        const execBash = new ExecuteBash(features)
+        const validation = await execBash.requiresAcceptance({ command: 'ls && rm -rf /' })
         assert.equal(validation.requiresAcceptance, true, 'Should require acceptance for dangerous pattern')
     })
 
-    it('set requiresAcceptance=false if it is a read-only command', () => {
-        const execBash = new ExecuteBash(logging)
-        const validation = execBash.requiresAcceptance('cat file.txt')
+    it('set requiresAcceptance=false if it is a read-only command', async () => {
+        const execBash = new ExecuteBash(features)
+        const validation = await execBash.requiresAcceptance({ command: 'cat file.txt' })
         assert.equal(validation.requiresAcceptance, false, 'Read-only command should not require acceptance')
     })
 
     it('whichCommand cannot find the first arg', async () => {
-        const execBash = new ExecuteBash(logging)
+        const execBash = new ExecuteBash(features)
         await assert.rejects(
-            execBash.validate(logging, 'noSuchCmd'),
+            execBash.validate('noSuchCmd'),
             /not found on PATH/i,
             'Expected not found error from whichCommand'
         )
     })
 
     it('validate and invokes the command', async () => {
-        const execBash = new ExecuteBash(logging)
+        const execBash = new ExecuteBash(features)
 
         const writable = new WritableStream()
         const result = await execBash.invoke({ command: 'ls' }, writable)
         assert.strictEqual(result.output.kind, 'json')
         assert.ok('exitStatus' in result.output.content)
         assert.ok('stdout' in result.output.content && typeof result.output.content.stdout === 'string')
+    })
+
+    it('requires acceptance if the command references an absolute file path outside the workspace', async () => {
+        // Stub workspace folders to simulate a workspace at '/workspace/folder'
+        const execBash = new ExecuteBash({
+            ...features,
+            workspace: {
+                ...features.workspace,
+                getTextDocument: async s => undefined,
+            },
+        })
+        const result = await execBash.requiresAcceptance({
+            command: 'cat /not/in/workspace/file.txt',
+            cwd: '/workspace/folder',
+        })
+
+        assert.equal(
+            result.requiresAcceptance,
+            true,
+            'Should require acceptance for an absolute path outside of workspace'
+        )
+    })
+
+    it('does NOT require acceptance if the command references a relative file path inside the workspace', async () => {
+        // Command references a relative path that resolves within the workspace
+        const execBash = new ExecuteBash({
+            ...features,
+            workspace: {
+                ...features.workspace,
+                getTextDocument: async s => ({}) as TextDocument,
+            },
+        })
+        const result = await execBash.requiresAcceptance({ command: 'cat ./file.txt', cwd: '/workspace/folder' })
+
+        assert.equal(result.requiresAcceptance, false, 'Relative path inside workspace should not require acceptance')
+    })
+
+    it('does NOT require acceptance if there is no path-like token in the command', async () => {
+        // Stub workspace folders (even though they are not used in this case)
+        const execBash = new ExecuteBash({
+            ...features,
+            workspace: {
+                ...features.workspace,
+                getTextDocument: async s => ({}) as TextDocument,
+            },
+        })
+        const result = await execBash.requiresAcceptance({ command: 'echo hello world', cwd: '/workspace/folder' })
+
+        assert.equal(
+            result.requiresAcceptance,
+            false,
+            'A command without any path-like token should not require acceptance'
+        )
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
@@ -67,7 +67,6 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('requires acceptance if the command references an absolute file path outside the workspace', async () => {
-        // Stub workspace folders to simulate a workspace at '/workspace/folder'
         const execBash = new ExecuteBash({
             ...features,
             workspace: {
@@ -102,7 +101,6 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('does NOT require acceptance if there is no path-like token in the command', async () => {
-        // Stub workspace folders (even though they are not used in this case)
         const execBash = new ExecuteBash({
             ...features,
             workspace: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -1,4 +1,4 @@
-// Port from VSC https://github.com/aws/aws-toolkit-vscode/blob/093d5bcbce777c88cf18c76b52738610263d1fc0/packages/core/src/codewhispererChat/tools/executeBash.ts#L134
+// Port from VSC https://github.com/aws/aws-toolkit-vscode/blob/741c2c481bcf0dca2d9554e32dc91d8514b1b1d1/packages/core/src/codewhispererChat/tools/executeBash.ts#L134
 
 import { InvokeOutput } from './toolShared'
 import { split } from 'shlex'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -3,16 +3,20 @@
 import { InvokeOutput } from './toolShared'
 import { split } from 'shlex'
 import { Logging } from '@aws/language-server-runtimes/server-interface'
-import { processUtils } from '@aws/lsp-core'
+import { processUtils, workspaceUtils } from '@aws/lsp-core'
+import { CancellationToken } from 'vscode-languageserver'
 import { getUserHomeDir, sanitize } from '@aws/lsp-core/out/util/path'
+import { ChildProcess, ChildProcessOptions } from '@aws/lsp-core/out/util/processUtils'
+// eslint-disable-next-line import/no-nodejs-modules
+import { isAbsolute, join } from 'path' // Safe to import on web since this is part of path-browserify
+import { Features } from '../../types'
 
 export enum CommandCategory {
     ReadOnly,
-    HighRisk,
+    Mutate,
     Destructive,
 }
 
-export const dangerousPatterns = new Set(['<(', '$(', '`'])
 export const splitOperators = new Set(['|', '&&', '||', '>'])
 export const splitOperatorsArray = Array.from(splitOperators)
 export const commandCategories = new Map<string, CommandCategory>([
@@ -43,45 +47,37 @@ export const commandCategories = new Map<string, CommandCategory>([
     ['netstat', CommandCategory.ReadOnly],
     ['ss', CommandCategory.ReadOnly],
     ['dig', CommandCategory.ReadOnly],
-    ['grep', CommandCategory.ReadOnly],
     ['wc', CommandCategory.ReadOnly],
     ['sort', CommandCategory.ReadOnly],
     ['diff', CommandCategory.ReadOnly],
     ['head', CommandCategory.ReadOnly],
     ['tail', CommandCategory.ReadOnly],
 
-    // HighRisk commands
-    ['chmod', CommandCategory.HighRisk],
-    ['chown', CommandCategory.HighRisk],
-    ['mv', CommandCategory.HighRisk],
-    ['cp', CommandCategory.HighRisk],
-    ['ln', CommandCategory.HighRisk],
-    ['mount', CommandCategory.HighRisk],
-    ['umount', CommandCategory.HighRisk],
-    ['kill', CommandCategory.HighRisk],
-    ['killall', CommandCategory.HighRisk],
-    ['pkill', CommandCategory.HighRisk],
-    ['iptables', CommandCategory.HighRisk],
-    ['route', CommandCategory.HighRisk],
-    ['systemctl', CommandCategory.HighRisk],
-    ['service', CommandCategory.HighRisk],
-    ['crontab', CommandCategory.HighRisk],
-    ['at', CommandCategory.HighRisk],
-    ['tar', CommandCategory.HighRisk],
-    ['awk', CommandCategory.HighRisk],
-    ['sed', CommandCategory.HighRisk],
-    ['wget', CommandCategory.HighRisk],
-    ['curl', CommandCategory.HighRisk],
-    ['nc', CommandCategory.HighRisk],
-    ['ssh', CommandCategory.HighRisk],
-    ['scp', CommandCategory.HighRisk],
-    ['ftp', CommandCategory.HighRisk],
-    ['sftp', CommandCategory.HighRisk],
-    ['rsync', CommandCategory.HighRisk],
-    ['chroot', CommandCategory.HighRisk],
-    ['lsof', CommandCategory.HighRisk],
-    ['strace', CommandCategory.HighRisk],
-    ['gdb', CommandCategory.HighRisk],
+    // Mutable commands
+    ['chmod', CommandCategory.Mutate],
+    ['curl', CommandCategory.Mutate],
+    ['mount', CommandCategory.Mutate],
+    ['umount', CommandCategory.Mutate],
+    ['systemctl', CommandCategory.Mutate],
+    ['service', CommandCategory.Mutate],
+    ['crontab', CommandCategory.Mutate],
+    ['at', CommandCategory.Mutate],
+    ['nc', CommandCategory.Mutate],
+    ['ssh', CommandCategory.Mutate],
+    ['scp', CommandCategory.Mutate],
+    ['ftp', CommandCategory.Mutate],
+    ['sftp', CommandCategory.Mutate],
+    ['rsync', CommandCategory.Mutate],
+    ['chroot', CommandCategory.Mutate],
+    ['strace', CommandCategory.Mutate],
+    ['gdb', CommandCategory.Mutate],
+    ['apt', CommandCategory.Mutate],
+    ['yum', CommandCategory.Mutate],
+    ['dnf', CommandCategory.Mutate],
+    ['pacman', CommandCategory.Mutate],
+    ['exec', CommandCategory.Mutate],
+    ['eval', CommandCategory.Mutate],
+    ['xargs', CommandCategory.Mutate],
 
     // Destructive commands
     ['rm', CommandCategory.Destructive],
@@ -100,26 +96,29 @@ export const commandCategories = new Map<string, CommandCategory>([
     ['insmod', CommandCategory.Destructive],
     ['rmmod', CommandCategory.Destructive],
     ['modprobe', CommandCategory.Destructive],
-    ['apt', CommandCategory.Destructive],
-    ['yum', CommandCategory.Destructive],
-    ['dnf', CommandCategory.Destructive],
-    ['pacman', CommandCategory.Destructive],
-    ['perl', CommandCategory.Destructive],
-    ['python', CommandCategory.Destructive],
-    ['bash', CommandCategory.Destructive],
-    ['sh', CommandCategory.Destructive],
-    ['exec', CommandCategory.Destructive],
-    ['eval', CommandCategory.Destructive],
-    ['xargs', CommandCategory.Destructive],
+    ['kill', CommandCategory.Destructive],
+    ['killall', CommandCategory.Destructive],
+    ['pkill', CommandCategory.Destructive],
+    ['iptables', CommandCategory.Destructive],
+    ['route', CommandCategory.Destructive],
+    ['chown', CommandCategory.Destructive],
 ])
 export const maxBashToolResponseSize: number = 1024 * 1024 // 1MB
 export const lineCount: number = 1024
 export const destructiveCommandWarningMessage = '⚠️ WARNING: Destructive command detected:\n\n'
-export const highRiskCommandWarningMessage = '⚠️ WARNING: High risk command detected:\n\n'
+export const mutateCommandWarningMessage = 'Mutation command:\n\n'
 
 export interface ExecuteBashParams {
     command: string
     cwd?: string
+    explanation?: string
+}
+
+interface TimestampedChunk {
+    timestamp: number
+    isStdout: boolean
+    content: string
+    isFirst: boolean
 }
 
 export interface CommandValidation {
@@ -128,9 +127,15 @@ export interface CommandValidation {
 }
 
 export class ExecuteBash {
-    constructor(private readonly logger: Logging) {}
+    private childProcess?: ChildProcess
+    private readonly workspace: Features['workspace']
+    private readonly logging: Features['logging']
+    constructor(features: Pick<Features, 'logging' | 'workspace'> & Partial<Features>) {
+        this.workspace = features.workspace
+        this.logging = features.logging
+    }
 
-    public async validate(logging: Logging, command: string): Promise<void> {
+    public async validate(command: string): Promise<void> {
         if (!command.trim()) {
             throw new Error('Bash command cannot be empty.')
         }
@@ -141,15 +146,26 @@ export class ExecuteBash {
         }
 
         try {
-            await ExecuteBash.whichCommand(logging, args[0])
+            await ExecuteBash.whichCommand(this.logging, args[0])
         } catch {
             throw new Error(`Command '${args[0]}' not found on PATH.`)
         }
     }
 
-    public requiresAcceptance(command: string): CommandValidation {
+    private static handleTimestampedChunk(
+        chunk: TimestampedChunk,
+        stdoutBuffer: string[],
+        stderrBuffer: string[],
+        writer?: WritableStreamDefaultWriter
+    ): void {
+        const buffer = chunk.isStdout ? stdoutBuffer : stderrBuffer
+        const content = chunk.isFirst ? '```console\n' + chunk.content : chunk.content
+        ExecuteBash.handleChunk(content, buffer, writer)
+    }
+
+    public async requiresAcceptance(params: ExecuteBashParams): Promise<CommandValidation> {
         try {
-            const args = split(command)
+            const args = split(params.command)
             if (!args || args.length === 0) {
                 return { requiresAcceptance: true }
             }
@@ -180,76 +196,161 @@ export class ExecuteBash {
                     return { requiresAcceptance: true }
                 }
 
+                // For each command, validate arguments for path safety within workspace
+                for (const arg of cmdArgs) {
+                    if (this.looksLikePath(arg)) {
+                        // If not absolute, resolve using workingDirectory if available.
+                        const fullPath = !isAbsolute(arg) && params.cwd ? join(params.cwd, arg) : arg
+                        const isInWorkspace = await workspaceUtils.inWorkspace(this.workspace, fullPath)
+                        if (!isInWorkspace) {
+                            return { requiresAcceptance: true, warning: destructiveCommandWarningMessage }
+                        }
+                    }
+                }
+
                 const command = cmdArgs[0]
                 const category = commandCategories.get(command)
 
                 switch (category) {
                     case CommandCategory.Destructive:
                         return { requiresAcceptance: true, warning: destructiveCommandWarningMessage }
-                    case CommandCategory.HighRisk:
-                        return {
-                            requiresAcceptance: true,
-                            warning: highRiskCommandWarningMessage,
-                        }
+                    case CommandCategory.Mutate:
+                        return { requiresAcceptance: true, warning: mutateCommandWarningMessage }
                     case CommandCategory.ReadOnly:
-                        if (cmdArgs.some(arg => Array.from(dangerousPatterns).some(pattern => arg.includes(pattern)))) {
-                            return { requiresAcceptance: true, warning: highRiskCommandWarningMessage }
-                        }
                         continue
                     default:
-                        return { requiresAcceptance: true, warning: highRiskCommandWarningMessage }
+                        return { requiresAcceptance: true }
                 }
             }
             return { requiresAcceptance: false }
         } catch (error) {
-            this.logger.warn(`Error while checking acceptance: ${(error as Error).message}`)
+            this.logging.warn(`Error while checking acceptance: ${(error as Error).message}`)
             return { requiresAcceptance: true }
         }
     }
 
-    public async invoke(params: ExecuteBashParams, updates?: WritableStream): Promise<InvokeOutput> {
-        await this.validate(this.logger, params.command)
-        const cwd = params.cwd ? sanitize(params.cwd) : getUserHomeDir()
-        this.logger.info(`Invoking bash command: '${params.command}' in cwd: '${cwd}'`)
+    private looksLikePath(arg: string): boolean {
+        return arg.startsWith('/') || arg.startsWith('./') || arg.startsWith('../')
+    }
+
+    public async invoke(
+        params: ExecuteBashParams,
+        updates?: WritableStream,
+        cancellationToken?: CancellationToken
+    ): Promise<InvokeOutput> {
+        this.logging.info(`Invoking bash command: "${params.command}" in cwd: "${params.cwd}"`)
 
         return new Promise(async (resolve, reject) => {
-            this.logger.debug(`Spawning process with command: bash -c '${params.command}' (cwd=${cwd})`)
+            // Check if cancelled before starting
+            if (cancellationToken?.isCancellationRequested) {
+                this.logging.debug('Bash command execution cancelled before starting')
+                reject(new Error('Command execution cancelled'))
+                return
+            }
+
+            this.logging.debug(`Spawning process with command: bash -c "${params.command}" (cwd=${params.cwd})`)
 
             const stdoutBuffer: string[] = []
             const stderrBuffer: string[] = []
 
-            let firstChunk = true
-            let firstStderrChunk = true
+            // Use a closure boolean value firstChunk and a function to get and set its value
+            let isFirstChunk = true
+            const getAndSetFirstChunk = (newValue: boolean): boolean => {
+                const oldValue = isFirstChunk
+                isFirstChunk = newValue
+                return oldValue
+            }
+
+            // Use a queue to maintain chronological order of chunks
+            // This ensures that the output is processed in the exact order it was generated by the child process.
+            const outputQueue: TimestampedChunk[] = []
+            let processingQueue = false
+
             const writer = updates?.getWriter()
-            const childProcessOptions: processUtils.ChildProcessOptions = {
+            // Process the queue in order
+            const processQueue = () => {
+                if (processingQueue || outputQueue.length === 0) {
+                    return
+                }
+
+                processingQueue = true
+
+                try {
+                    // Sort by timestamp to ensure chronological order
+                    outputQueue.sort((a, b) => a.timestamp - b.timestamp)
+
+                    while (outputQueue.length > 0) {
+                        const chunk = outputQueue.shift()!
+                        ExecuteBash.handleTimestampedChunk(chunk, stdoutBuffer, stderrBuffer, writer)
+                    }
+                } finally {
+                    processingQueue = false
+                }
+            }
+
+            const childProcessOptions: ChildProcessOptions = {
                 spawnOptions: {
-                    cwd: cwd,
+                    cwd: params.cwd,
                     stdio: ['pipe', 'pipe', 'pipe'],
                 },
                 collect: false,
                 waitForStreams: true,
-                onStdout: (chunk: string) => {
-                    ExecuteBash.handleChunk(firstChunk ? '```console\n' + chunk : chunk, stdoutBuffer, writer)
-                    firstChunk = false
+                onStdout: async (chunk: string) => {
+                    if (cancellationToken?.isCancellationRequested) {
+                        this.logging.debug('Bash command execution cancelled during stderr processing')
+                        return
+                    }
+                    const isFirst = getAndSetFirstChunk(false)
+                    const timestamp = Date.now()
+                    outputQueue.push({
+                        timestamp,
+                        isStdout: true,
+                        content: chunk,
+                        isFirst,
+                    })
+                    processQueue()
                 },
-                onStderr: (chunk: string) => {
-                    ExecuteBash.handleChunk(firstStderrChunk ? '```console\n' + chunk : chunk, stderrBuffer, writer)
-                    firstStderrChunk = false
+                onStderr: async (chunk: string) => {
+                    if (cancellationToken?.isCancellationRequested) {
+                        this.logging.debug('Bash command execution cancelled during stderr processing')
+                        return
+                    }
+                    const isFirst = getAndSetFirstChunk(false)
+                    const timestamp = Date.now()
+                    outputQueue.push({
+                        timestamp,
+                        isStdout: false,
+                        content: chunk,
+                        isFirst,
+                    })
+                    processQueue()
                 },
             }
 
-            const childProcess = new processUtils.ChildProcess(
-                this.logger,
-                'bash',
-                ['-c', params.command],
-                childProcessOptions
-            )
+            this.childProcess = new ChildProcess(this.logging, 'bash', ['-c', params.command], childProcessOptions)
+
+            // Set up cancellation listener
+            if (cancellationToken) {
+                cancellationToken.onCancellationRequested(() => {
+                    this.logging.debug('Cancellation requested, killing child process')
+                    this.childProcess?.stop()
+                })
+            }
 
             try {
-                const result = await childProcess.run()
+                const result = await this.childProcess.run()
+
+                // Check if cancelled after execution
+                if (cancellationToken?.isCancellationRequested) {
+                    this.logging.debug('Bash command execution cancelled after completion')
+                    reject(new Error('Command execution cancelled'))
+                    return
+                }
+
                 const exitStatus = result.exitCode ?? 0
                 const stdout = stdoutBuffer.join('\n')
                 const stderr = stderrBuffer.join('\n')
+                const success = exitStatus === 0 && !stderr
                 const [stdoutTrunc, stdoutSuffix] = ExecuteBash.truncateSafelyWithSuffix(
                     stdout,
                     maxBashToolResponseSize / 3
@@ -269,11 +370,17 @@ export class ExecuteBash {
                     output: {
                         kind: 'json',
                         content: outputJson,
+                        success,
                     },
                 })
             } catch (err: any) {
-                this.logger.error(`Failed to execute bash command '${params.command}': ${err.message}`)
-                reject(new Error(`Failed to execute command: ${err.message}`))
+                // Check if this was due to cancellation
+                if (cancellationToken?.isCancellationRequested) {
+                    reject(new Error('Command execution cancelled'))
+                } else {
+                    this.logging.error(`Failed to execute bash command '${params.command}': ${err.message}`)
+                    reject(new Error(`Failed to execute command: ${err.message}`))
+                }
             } finally {
                 await writer?.close()
                 writer?.releaseLock()
@@ -326,11 +433,11 @@ export class ExecuteBash {
         return output
     }
 
-    public queueDescription(command: string): string {
-        const description = ''
-        description.concat(`I will run the following shell command:\n`)
-        description.concat('```bash\n' + command + '\n```')
-        return description
+    public async queueDescription(command: string, updates: WritableStream) {
+        const writer = updates.getWriter()
+        await writer.write('```shell\n' + command + '\n```')
+        await writer.close()
+        writer.releaseLock()
     }
 
     public getSpec() {
@@ -340,6 +447,11 @@ export class ExecuteBash {
             inputSchema: {
                 type: 'object',
                 properties: {
+                    explanation: {
+                        type: 'string',
+                        description:
+                            'One sentence explanation as to why this tool is being used, and how it contributes to the goal.',
+                    },
                     command: {
                         type: 'string',
                         description: 'Bash command to execute',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -5,7 +5,6 @@ import { split } from 'shlex'
 import { Logging } from '@aws/language-server-runtimes/server-interface'
 import { processUtils, workspaceUtils } from '@aws/lsp-core'
 import { CancellationToken } from 'vscode-languageserver'
-import { getUserHomeDir, sanitize } from '@aws/lsp-core/out/util/path'
 import { ChildProcess, ChildProcessOptions } from '@aws/lsp-core/out/util/processUtils'
 // eslint-disable-next-line import/no-nodejs-modules
 import { isAbsolute, join } from 'path' // Safe to import on web since this is part of path-browserify
@@ -233,6 +232,7 @@ export class ExecuteBash {
         return arg.startsWith('/') || arg.startsWith('./') || arg.startsWith('../')
     }
 
+    // TODO: generalize cancellation logic for tools.
     public async invoke(
         params: ExecuteBashParams,
         updates?: WritableStream,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -29,8 +29,8 @@ export const FsToolsServer: Server = ({ workspace, logging, agent }) => {
     return () => {}
 }
 
-export const BashToolsServer: Server = ({ logging, agent }) => {
-    const bashTool = new ExecuteBash(logging)
+export const BashToolsServer: Server = ({ logging, workspace, agent }) => {
+    const bashTool = new ExecuteBash({ logging, workspace })
     agent.addTool(bashTool.getSpec(), (input: ExecuteBashParams) => bashTool.invoke(input))
     return () => {}
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -1,11 +1,9 @@
+interface Output<Kind, Content> {
+    kind: Kind
+    content: Content
+    success?: boolean
+}
+
 export interface InvokeOutput {
-    output:
-        | {
-              kind: 'text'
-              content: string
-          }
-        | {
-              kind: 'json'
-              content: object
-          }
+    output: Output<'text', string> | Output<'json', object>
 }


### PR DESCRIPTION
## Problem
There have been recent changes to the VSC implementation that are not reflected here. 

## Solution
Sync up to most recent changes: https://github.com/aws/aws-toolkit-vscode/blob/741c2c481bcf0dca2d9554e32dc91d8514b1b1d1/packages/core/src/codewhispererChat/tools/executeBash.ts#L132

## Notes
There are two items marked for future work:
- expose a function to check if workspace contains a file (in runtimes). 
- generalize a proper way to handle tool cancellation. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
