### PR TITLE
chore: resync listDir tool with VSC

### DIFF
--- a/core/aws-lsp-core/src/util/workspaceUtils.test.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.test.ts
@@ -85,9 +85,10 @@ describe('workspaceUtils', function () {
             await fs.symlink(tempFolder.path, linkPath, 'dir')
 
             const results = (await readDirectoryRecursively(testFeatures, tempFolder.path, undefined)).sort()
-            assert.deepStrictEqual(results, [`[DIR] ${subdir.path}`, `[FILE] ${file}`, `[LINK] ${linkPath}`])
+            assert.deepStrictEqual(results, [`[D] ${subdir.path}`, `[F] ${file}`, `[L] ${linkPath}`])
         })
 
+        // This test doesn't work on windows since it modifies file permissions
         if (process.platform !== 'win32') {
             it('respects the failOnError flag', async function () {
                 const subdir1 = await tempFolder.nest('subdir1')

--- a/core/aws-lsp-core/src/util/workspaceUtils.test.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.test.ts
@@ -118,5 +118,53 @@ describe('workspaceUtils', function () {
                 })
             )
         })
+
+        it('ignores patterns in the exclude pattern', async function () {
+            const subdir1 = await tempFolder.nest('subdir1')
+            const file1 = await subdir1.write('file1', 'this is content')
+            const subdir2 = await tempFolder.nest('subdir2')
+            await subdir2.write('file2-bad', 'this is other content')
+
+            const subdir11 = await subdir1.nest('subdir11')
+            const file3 = await subdir11.write('file3', 'this is also content')
+            const subdir12 = await subdir1.nest('subdir12')
+            await subdir12.write('file4-bad', 'this is even more content')
+            const file5 = await subdir12.write('file5', 'and this is it')
+
+            const result = (
+                await readDirectoryRecursively(testFeatures, tempFolder.path, {
+                    customFormatCallback: getEntryPath,
+                    excludePatterns: [/.*-bad/],
+                })
+            ).sort()
+            assert.deepStrictEqual(
+                result,
+                [subdir1.path, file1, subdir11.path, file3, subdir12.path, file5, subdir2.path].sort()
+            )
+        })
+
+        it('ignores files in the exclude pattern', async function () {
+            const subdir1 = await tempFolder.nest('subdir1')
+            const file1 = await subdir1.write('file1', 'this is content')
+            const subdir2 = await tempFolder.nest('subdir2')
+            await subdir2.write('file2-bad', 'this is other content')
+
+            const subdir11 = await subdir1.nest('subdir11')
+            const file3 = await subdir11.write('file3', 'this is also content')
+            const subdir12 = await subdir1.nest('subdir12')
+            await subdir12.write('file4-bad', 'this is even more content')
+            const file5 = await subdir12.write('file5', 'and this is it')
+
+            const result = (
+                await readDirectoryRecursively(testFeatures, tempFolder.path, {
+                    customFormatCallback: getEntryPath,
+                    excludePatterns: ['-bad'],
+                })
+            ).sort()
+            assert.deepStrictEqual(
+                result,
+                [subdir1.path, file1, subdir11.path, file3, subdir12.path, file5, subdir2.path].sort()
+            )
+        })
     })
 })

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -48,7 +48,6 @@ export async function readDirectoryRecursively(
             features.logging.warn(errMsg)
             continue
         }
-        // TODO: add tests here
         for (const entry of entries) {
             const childPath = getEntryPath(entry)
             if (options?.excludePatterns?.some(pattern => new RegExp(pattern).test(childPath))) {
@@ -65,18 +64,18 @@ export async function readDirectoryRecursively(
 }
 
 /**
- * Returns a prefix for a directory ('[DIR]'), symlink ('[LINK]'), or file ('[FILE]').
+ * Returns a prefix for a directory ('[D]'), symlink ('[L]'), or file ('[F]').
  */
 export function formatListing(entry: Dirent): string {
     let typeChar: string
     if (entry.isDirectory()) {
-        typeChar = '[DIR]'
+        typeChar = '[D]'
     } else if (entry.isSymbolicLink()) {
-        typeChar = '[LINK]'
+        typeChar = '[L]'
     } else if (entry.isFile()) {
-        typeChar = '[FILE]'
+        typeChar = '[F]'
     } else {
-        typeChar = '[UNKNOWN]'
+        typeChar = '[?]'
     }
     return `${typeChar} ${path.join(entry.parentPath, entry.name)}`
 }

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -1,4 +1,5 @@
 import * as path from 'path'
+import { URI } from 'vscode-uri'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 
 type ElementType<T> = T extends (infer U)[] ? U : never
@@ -86,6 +87,5 @@ export function getEntryPath(entry: Dirent) {
 
 // TODO: port this to runtimes?
 export async function inWorkspace(workspace: Features['workspace'], filepath: string) {
-    const r = await workspace.getTextDocument(filepath)
-    return r !== undefined
+    return (await workspace.getTextDocument(URI.file(filepath).toString())) !== undefined
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -1,6 +1,6 @@
 // Port from VSC https://github.com/aws/aws-toolkit-vscode/blob/093d5bcbce777c88cf18c76b52738610263d1fc0/packages/core/src/codewhispererChat/tools/executeBash.ts#L134
 
-import { InvokeOutput } from './toolShared'
+import { CommandValidation, InvokeOutput } from './toolShared'
 import { split } from 'shlex'
 import { Logging } from '@aws/language-server-runtimes/server-interface'
 import { processUtils } from '@aws/lsp-core'
@@ -120,11 +120,6 @@ export const highRiskCommandWarningMessage = '⚠️ WARNING: High risk command 
 export interface ExecuteBashParams {
     command: string
     cwd?: string
-}
-
-export interface CommandValidation {
-    requiresAcceptance: boolean
-    warning?: string
 }
 
 export class ExecuteBash {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
@@ -1,5 +1,5 @@
 import { sanitize } from '@aws/lsp-core/out/util/path'
-import { InvokeOutput } from './toolShared'
+import { InvokeOutput, validatePath } from './toolShared'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 
 // Port of https://github.com/aws/aws-toolkit-vscode/blob/8e00eefa33f4eee99eed162582c32c270e9e798e/packages/core/src/codewhispererChat/tools/fsRead.ts#L17
@@ -19,17 +19,7 @@ export class FsRead {
     }
 
     public async validate(params: FsReadParams): Promise<void> {
-        this.logging.debug(`Validating path: ${params.path}`)
-        if (!params.path || params.path.trim().length === 0) {
-            throw new Error('Path cannot be empty.')
-        }
-
-        const fileExists = await this.workspace.fs.exists(params.path)
-        if (!fileExists) {
-            throw new Error(`Path: "${params.path}" does not exist or cannot be accessed.`)
-        }
-
-        this.logging.debug(`Validation succeeded for path: ${params.path}`)
+        await validatePath(params.path, this.workspace.fs.exists)
     }
 
     public async queueDescription(params: FsReadParams, updates: WritableStream) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
@@ -87,8 +87,8 @@ describe('ListDirectory Tool', () => {
     })
 
     it('lists directory contents with ignored pattern', async () => {
-        await tempFolder.nest('node_modules')
-        await tempFolder.write('fileC.md', '# fileC')
+        const nestedFolder = await tempFolder.nest('node_modules')
+        await nestedFolder.write('fileC.md', '# fileC')
 
         const listDirectory = new ListDirectory(testFeatures)
         await listDirectory.validate({ path: tempFolder.path })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
@@ -56,9 +56,9 @@ describe('ListDirectory Tool', () => {
 
         assert.strictEqual(result.output.kind, 'text')
         const lines = result.output.content.split('\n')
-        const hasFileA = lines.some((line: string | string[]) => line.includes('[FILE] ') && line.includes('fileA.txt'))
+        const hasFileA = lines.some((line: string | string[]) => line.includes('[F] ') && line.includes('fileA.txt'))
         const hasSubfolder = lines.some(
-            (line: string | string[]) => line.includes('[DIR] ') && line.includes('subfolder')
+            (line: string | string[]) => line.includes('[D] ') && line.includes('subfolder')
         )
 
         assert.ok(hasFileA, 'Should list fileA.txt in the directory output')
@@ -75,11 +75,11 @@ describe('ListDirectory Tool', () => {
 
         assert.strictEqual(result.output.kind, 'text')
         const lines = result.output.content.split('\n')
-        const hasFileA = lines.some((line: string | string[]) => line.includes('[FILE] ') && line.includes('fileA.txt'))
+        const hasFileA = lines.some((line: string | string[]) => line.includes('[F] ') && line.includes('fileA.txt'))
         const hasSubfolder = lines.some(
-            (line: string | string[]) => line.includes('[DIR] ') && line.includes('subfolder')
+            (line: string | string[]) => line.includes('[D] ') && line.includes('subfolder')
         )
-        const hasFileB = lines.some((line: string | string[]) => line.includes('[FILE] ') && line.includes('fileB.md'))
+        const hasFileB = lines.some((line: string | string[]) => line.includes('[F] ') && line.includes('fileB.md'))
 
         assert.ok(hasFileA, 'Should list fileA.txt in the directory output')
         assert.ok(hasSubfolder, 'Should list the subfolder in the directory output')
@@ -97,9 +97,9 @@ describe('ListDirectory Tool', () => {
         assert.strictEqual(result.output.kind, 'text')
         const lines = result.output.content.split('\n')
         const hasNodeModules = lines.some(
-            (line: string | string[]) => line.includes('[DIR] ') && line.includes('node_modules')
+            (line: string | string[]) => line.includes('[D] ') && line.includes('node_modules')
         )
-        const hasFileC = lines.some((line: string | string[]) => line.includes('[FILE] ') && line.includes('fileC.md'))
+        const hasFileC = lines.some((line: string | string[]) => line.includes('[F] ') && line.includes('fileC.md'))
 
         assert.ok(!hasNodeModules, 'Should not list node_modules in the directory output')
         assert.ok(!hasFileC, 'Should not list fileC.md under node_modules in the directory output')

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -1,8 +1,9 @@
 // VSC Port from https://github.com/aws/aws-toolkit-vscode/blob/dfee9f7a400e677e91a75e9c20d9515a52a6fad4/packages/core/src/codewhispererChat/tools/listDirectory.ts#L18
-import { InvokeOutput } from './toolShared'
+import { CommandValidation, InvokeOutput, validatePath } from './toolShared'
 import { workspaceUtils } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
+import { DEFAULT_EXCLUDE_PATTERNS } from '../../chat/constants'
 
 export interface ListDirectoryParams {
     path: string
@@ -18,8 +19,24 @@ export class ListDirectory {
         this.workspace = features.workspace
     }
 
-    public async queueDescription(params: ListDirectoryParams, updates: WritableStream) {
+    public async validate(params: ListDirectoryParams): Promise<void> {
+        if (params.maxDepth !== undefined && params.maxDepth < 0) {
+            throw new Error('MaxDepth cannot be negative.')
+        }
+        await validatePath(params.path, this.workspace.fs.exists)
+    }
+
+    public async queueDescription(params: ListDirectoryParams, updates: WritableStream, requiresAcceptance: boolean) {
         const writer = updates.getWriter()
+        const closeWriter = async (w: WritableStreamDefaultWriter) => {
+            await w.close()
+            w.releaseLock()
+        }
+        if (!requiresAcceptance) {
+            await writer.write('')
+            await closeWriter(writer)
+            return
+        }
         if (params.maxDepth === undefined) {
             await writer.write(`Listing directory recursively: ${params.path}`)
         } else if (params.maxDepth === 0) {
@@ -28,7 +45,11 @@ export class ListDirectory {
             const level = params.maxDepth > 1 ? 'levels' : 'level'
             await writer.write(`Listing directory: ${params.path} limited to ${params.maxDepth} subfolder ${level}`)
         }
-        await writer.close()
+        await closeWriter(writer)
+    }
+
+    public async requiresAcceptance(path: string): Promise<CommandValidation> {
+        return { requiresAcceptance: !(await workspaceUtils.inWorkspace(this.workspace, path)) }
     }
 
     public async invoke(params: ListDirectoryParams): Promise<InvokeOutput> {
@@ -37,7 +58,7 @@ export class ListDirectory {
             const listing = await workspaceUtils.readDirectoryRecursively(
                 { workspace: this.workspace, logging: this.logging },
                 path,
-                { maxDepth: params.maxDepth }
+                { maxDepth: params.maxDepth, excludePatterns: DEFAULT_EXCLUDE_PATTERNS }
             )
             return this.createOutput(listing.join('\n'))
         } catch (error: any) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -80,7 +80,7 @@ export class ListDirectory {
         return {
             name: 'listDirectory',
             description:
-                'List the contents of a directory and its subdirectories.\n * Use this tool for discovery, before using more targeted tools like fsRead.\n *Useful to try to understand the file structure before diving deeper into specific files.\n *Can be used to explore the codebase.\n *Results clearly distinguish between files, directories or symlinks with [FILE], [DIR] and [LINK] prefixes.',
+                'List the contents of a directory and its subdirectories, it will filter out build outputs such as `build/`, `out/` and `dist` and dependency directory such as `node_modules/`.\n * Use this tool for discovery, before using more targeted tools like fsRead.\n *Useful to try to understand the file structure before diving deeper into specific files.\n *Can be used to explore the codebase.\n *Results clearly distinguish between files, directories or symlinks with [F], [D] and [L] prefixes.',
             inputSchema: {
                 type: 'object',
                 properties: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -1,4 +1,4 @@
-// VSC Port from https://github.com/aws/aws-toolkit-vscode/blob/dfee9f7a400e677e91a75e9c20d9515a52a6fad4/packages/core/src/codewhispererChat/tools/listDirectory.ts#L18
+// VSC Port from https://github.com/aws/aws-toolkit-vscode/blob/741c2c481bcf0dca2d9554e32dc91d8514b1b1d1/packages/core/src/codewhispererChat/tools/listDirectory.ts#L19
 import { CommandValidation, InvokeOutput, validatePath } from './toolShared'
 import { workspaceUtils } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -1,4 +1,4 @@
-// VSC Port from https://github.com/aws/aws-toolkit-vscode/blob/741c2c481bcf0dca2d9554e32dc91d8514b1b1d1/packages/core/src/codewhispererChat/tools/listDirectory.ts#L19
+// Port from VSChttps://github.com/aws/aws-toolkit-vscode/blob/0eea1d8ca6e25243609a07dc2a2c31886b224baa/packages/core/src/codewhispererChat/tools/listDirectory.ts#L19
 import { CommandValidation, InvokeOutput, validatePath } from './toolShared'
 import { workspaceUtils } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -1,4 +1,4 @@
-// Port from VSChttps://github.com/aws/aws-toolkit-vscode/blob/0eea1d8ca6e25243609a07dc2a2c31886b224baa/packages/core/src/codewhispererChat/tools/listDirectory.ts#L19
+// Port from VSC: https://github.com/aws/aws-toolkit-vscode/blob/0eea1d8ca6e25243609a07dc2a2c31886b224baa/packages/core/src/codewhispererChat/tools/listDirectory.ts#L19
 import { CommandValidation, InvokeOutput, validatePath } from './toolShared'
 import { workspaceUtils } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -9,3 +9,18 @@ export interface InvokeOutput {
               content: object
           }
 }
+
+export interface CommandValidation {
+    requiresAcceptance: boolean
+    warning?: string
+}
+
+export async function validatePath(path: string, exists: (p: string) => Promise<boolean>) {
+    if (!path || path.trim().length === 0) {
+        throw new Error('Path cannot be empty.')
+    }
+    const pathExists = await exists(path)
+    if (!pathExists) {
+        throw new Error(`Path "${path}" does not exist or cannot be accessed.`)
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/constants.ts
@@ -28,3 +28,14 @@ export const HELP_MESSAGE = `I'm Amazon Q, a generative AI assistant. Learn more
 \n\n*For additional help, visit the [Amazon Q User Guide](${userGuideURL}).*`
 
 export const DEFAULT_HELP_FOLLOW_UP_PROMPT = 'How can Amazon Q help me?'
+
+export const DEFAULT_EXCLUDE_PATTERNS = [
+    // Dependency directories
+    'node_modules',
+    // Build outputs
+    'dist',
+    'build',
+    'out',
+    // OS specific files
+    '.DS_Store',
+]


### PR DESCRIPTION
## Problem
There have been recent changes to the VSC implementation that are not reflected here. 

## Solution
- Sync up to most recent changes: https://github.com/aws/aws-toolkit-vscode/blob/741c2c481bcf0dca2d9554e32dc91d8514b1b1d1/packages/core/src/codewhispererChat/tools/listDirectory.ts#L19
- In VSC, they re-implement a regex type checker. Instead of doing that I simplified the code to use regex directly. See [here](https://github.com/aws/aws-toolkit-vscode/blob/0eea1d8ca6e25243609a07dc2a2c31886b224baa/packages/core/src/codewhispererChat/tools/listDirectory.ts#L19) for the VSC implementation. 
- Centralize path validation object, rather than having two identical implementations. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
