### PR TITLE
Agentic chat

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/src/agent-standalone.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/src/agent-standalone.ts
@@ -8,6 +8,7 @@ import {
     QNetTransformServerTokenProxy,
 } from '@aws/lsp-codewhisperer'
 import { IdentityServer } from '@aws/lsp-identity'
+import { FsToolsServer } from '@aws/lsp-codewhisperer/out/language-server/agenticChat/tools/toolServer'
 
 const MAJOR = 0
 const MINOR = 1
@@ -23,6 +24,7 @@ const props: RuntimeProps = {
         QNetTransformServerTokenProxy,
         QAgenticChatServerProxy,
         IdentityServer.create,
+        FsToolsServer,
     ],
     name: 'AWS CodeWhisperer',
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -429,7 +429,7 @@ describe('AgenticChatController', () => {
             assert.deepStrictEqual(
                 secondCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
                     ?.toolResults[0].content[0].json,
-                { result: mockToolResult }
+                mockToolResult
             )
 
             // Verify that the history was updated correctly

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -154,6 +154,13 @@ describe('AgenticChatController', () => {
             rm: sinon.stub().resolves(),
         }
 
+        // Add agent with runTool method to testFeatures
+        testFeatures.agent = {
+            runTool: sinon.stub().resolves({}),
+            getTools: sinon.stub().returns([]),
+            addTool: sinon.stub().resolves(),
+        }
+
         // @ts-ignore
         const cachedInitializeParams: InitializeParams = {
             initializationOptions: {
@@ -302,6 +309,326 @@ describe('AgenticChatController', () => {
             const chatResult = await chatResultPromise
 
             sinon.assert.callCount(testFeatures.lsp.sendProgress, 0)
+            assert.deepStrictEqual(chatResult, expectedCompleteChatResult)
+        })
+
+        it('handles tool use responses and makes multiple requests', async () => {
+            // First response includes a tool use request
+            const mockToolUseId = 'mock-tool-use-id'
+            const mockToolName = 'mock-tool-name'
+            const mockToolInput = JSON.stringify({ param1: 'value1' })
+            const mockToolResult = { result: 'tool execution result' }
+
+            const mockToolUseResponseList: ChatResponseStream[] = [
+                {
+                    messageMetadataEvent: {
+                        conversationId: mockConversationId,
+                    },
+                },
+                {
+                    assistantResponseEvent: {
+                        content: 'I need to use a tool. ',
+                    },
+                },
+                {
+                    toolUseEvent: {
+                        toolUseId: mockToolUseId,
+                        name: mockToolName,
+                        input: mockToolInput,
+                        stop: true,
+                    },
+                },
+            ]
+
+            // Second response after tool execution
+            const mockFinalResponseList: ChatResponseStream[] = [
+                {
+                    messageMetadataEvent: {
+                        conversationId: mockConversationId,
+                    },
+                },
+                {
+                    assistantResponseEvent: {
+                        content: 'Hello ',
+                    },
+                },
+                {
+                    assistantResponseEvent: {
+                        content: 'World',
+                    },
+                },
+                {
+                    assistantResponseEvent: {
+                        content: '!',
+                    },
+                },
+            ]
+
+            // Reset the stub and set up to return different responses on consecutive calls
+            generateAssistantResponseStub.restore()
+            generateAssistantResponseStub = sinon.stub(CodeWhispererStreaming.prototype, 'generateAssistantResponse')
+
+            generateAssistantResponseStub.onFirstCall().returns(
+                Promise.resolve({
+                    $metadata: {
+                        requestId: mockMessageId,
+                    },
+                    generateAssistantResponseResponse: createIterableResponse(mockToolUseResponseList),
+                })
+            )
+
+            generateAssistantResponseStub.onSecondCall().returns(
+                Promise.resolve({
+                    $metadata: {
+                        requestId: mockMessageId,
+                    },
+                    generateAssistantResponseResponse: createIterableResponse(mockFinalResponseList),
+                })
+            )
+
+            // Reset the runTool stub
+            const runToolStub = testFeatures.agent.runTool as sinon.SinonStub
+            runToolStub.reset()
+            runToolStub.resolves(mockToolResult)
+
+            // Make the request
+            const chatResultPromise = chatController.onChatPrompt(
+                { tabId: mockTabId, prompt: { prompt: 'Hello with tool' } },
+                mockCancellationToken
+            )
+
+            const chatResult = await chatResultPromise
+
+            // Verify that generateAssistantResponse was called twice
+            sinon.assert.calledTwice(generateAssistantResponseStub)
+
+            // Verify that the tool was executed
+            sinon.assert.calledOnce(runToolStub)
+            sinon.assert.calledWith(runToolStub, mockToolName, JSON.parse(mockToolInput))
+
+            // Verify that the second request included the tool results in the userInputMessageContext
+            const secondCallArgs = generateAssistantResponseStub.secondCall.args[0]
+            assert.ok(
+                secondCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.toolResults
+            )
+            assert.strictEqual(
+                secondCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.toolResults
+                    .length,
+                1
+            )
+            assert.strictEqual(
+                secondCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
+                    ?.toolResults[0].toolUseId,
+                mockToolUseId
+            )
+            assert.strictEqual(
+                secondCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
+                    ?.toolResults[0].status,
+                'success'
+            )
+            assert.deepStrictEqual(
+                secondCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
+                    ?.toolResults[0].content[0].json,
+                { result: mockToolResult }
+            )
+
+            // Verify that the history was updated correctly
+            assert.ok(secondCallArgs.conversationState?.history)
+            assert.strictEqual(secondCallArgs.conversationState?.history.length, 2)
+            assert.ok(secondCallArgs.conversationState?.history[0].userInputMessage)
+            assert.ok(secondCallArgs.conversationState?.history[1].assistantResponseMessage)
+
+            // Verify the final result
+            assert.deepStrictEqual(chatResult, expectedCompleteChatResult)
+        })
+
+        it('handles multiple iterations of tool uses with proper history updates', async () => {
+            // First response includes a tool use request
+            const mockToolUseId1 = 'mock-tool-use-id-1'
+            const mockToolName1 = 'mock-tool-name-1'
+            const mockToolInput1 = JSON.stringify({ param1: 'value1' })
+            const mockToolResult1 = { result: 'tool execution result 1' }
+
+            // Second tool use in a subsequent response
+            const mockToolUseId2 = 'mock-tool-use-id-2'
+            const mockToolName2 = 'mock-tool-name-2'
+            const mockToolInput2 = JSON.stringify({ param2: 'value2' })
+            const mockToolResult2 = { result: 'tool execution result 2' }
+
+            // First response with first tool use
+            const mockFirstToolUseResponseList: ChatResponseStream[] = [
+                {
+                    messageMetadataEvent: {
+                        conversationId: mockConversationId,
+                    },
+                },
+                {
+                    assistantResponseEvent: {
+                        content: 'I need to use tool 1. ',
+                    },
+                },
+                {
+                    toolUseEvent: {
+                        toolUseId: mockToolUseId1,
+                        name: mockToolName1,
+                        input: mockToolInput1,
+                        stop: true,
+                    },
+                },
+            ]
+
+            // Second response with second tool use
+            const mockSecondToolUseResponseList: ChatResponseStream[] = [
+                {
+                    messageMetadataEvent: {
+                        conversationId: mockConversationId,
+                    },
+                },
+                {
+                    assistantResponseEvent: {
+                        content: 'Now I need to use tool 2. ',
+                    },
+                },
+                {
+                    toolUseEvent: {
+                        toolUseId: mockToolUseId2,
+                        name: mockToolName2,
+                        input: mockToolInput2,
+                        stop: true,
+                    },
+                },
+            ]
+
+            // Final response with complete answer
+            const mockFinalResponseList: ChatResponseStream[] = [
+                {
+                    messageMetadataEvent: {
+                        conversationId: mockConversationId,
+                    },
+                },
+                {
+                    assistantResponseEvent: {
+                        content: 'Hello ',
+                    },
+                },
+                {
+                    assistantResponseEvent: {
+                        content: 'World',
+                    },
+                },
+                {
+                    assistantResponseEvent: {
+                        content: '!',
+                    },
+                },
+            ]
+
+            // Reset the stub and set up to return different responses on consecutive calls
+            generateAssistantResponseStub.restore()
+            generateAssistantResponseStub = sinon.stub(CodeWhispererStreaming.prototype, 'generateAssistantResponse')
+
+            generateAssistantResponseStub.onFirstCall().returns(
+                Promise.resolve({
+                    $metadata: {
+                        requestId: mockMessageId,
+                    },
+                    generateAssistantResponseResponse: createIterableResponse(mockFirstToolUseResponseList),
+                })
+            )
+
+            generateAssistantResponseStub.onSecondCall().returns(
+                Promise.resolve({
+                    $metadata: {
+                        requestId: mockMessageId,
+                    },
+                    generateAssistantResponseResponse: createIterableResponse(mockSecondToolUseResponseList),
+                })
+            )
+
+            generateAssistantResponseStub.onThirdCall().returns(
+                Promise.resolve({
+                    $metadata: {
+                        requestId: mockMessageId,
+                    },
+                    generateAssistantResponseResponse: createIterableResponse(mockFinalResponseList),
+                })
+            )
+
+            // Reset the runTool stub
+            const runToolStub = testFeatures.agent.runTool as sinon.SinonStub
+            runToolStub.reset()
+            runToolStub.withArgs(mockToolName1, JSON.parse(mockToolInput1)).resolves(mockToolResult1)
+            runToolStub.withArgs(mockToolName2, JSON.parse(mockToolInput2)).resolves(mockToolResult2)
+
+            // Make the request
+            const chatResultPromise = chatController.onChatPrompt(
+                { tabId: mockTabId, prompt: { prompt: 'Hello with multiple tools' } },
+                mockCancellationToken
+            )
+
+            const chatResult = await chatResultPromise
+
+            // Verify that generateAssistantResponse was called three times
+            sinon.assert.calledThrice(generateAssistantResponseStub)
+
+            // Verify that the tools were executed
+            sinon.assert.calledTwice(runToolStub)
+            sinon.assert.calledWith(runToolStub, mockToolName1, JSON.parse(mockToolInput1))
+            sinon.assert.calledWith(runToolStub, mockToolName2, JSON.parse(mockToolInput2))
+
+            // Verify that the second request included the first tool results
+            const secondCallArgs = generateAssistantResponseStub.secondCall.args[0]
+            assert.ok(
+                secondCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.toolResults
+            )
+            assert.strictEqual(
+                secondCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.toolResults
+                    .length,
+                1
+            )
+            assert.strictEqual(
+                secondCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
+                    ?.toolResults[0].toolUseId,
+                mockToolUseId1
+            )
+
+            // Verify that the history was updated correctly after first tool use
+            assert.ok(secondCallArgs.conversationState?.history)
+            assert.strictEqual(secondCallArgs.conversationState?.history.length, 2)
+            assert.ok(secondCallArgs.conversationState?.history[0].userInputMessage)
+            assert.ok(secondCallArgs.conversationState?.history[1].assistantResponseMessage)
+            assert.strictEqual(
+                secondCallArgs.conversationState?.history[1].assistantResponseMessage?.content,
+                'I need to use tool 1. '
+            )
+
+            // Verify that the third request included the second tool results
+            const thirdCallArgs = generateAssistantResponseStub.thirdCall.args[0]
+            assert.ok(
+                thirdCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.toolResults
+            )
+            assert.strictEqual(
+                thirdCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.toolResults
+                    .length,
+                1
+            )
+            assert.strictEqual(
+                thirdCallArgs.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
+                    ?.toolResults[0].toolUseId,
+                mockToolUseId2
+            )
+
+            // Verify that the history was updated correctly after second tool use
+            assert.ok(thirdCallArgs.conversationState?.history)
+            assert.strictEqual(thirdCallArgs.conversationState?.history.length, 4)
+            assert.ok(thirdCallArgs.conversationState?.history[2].userInputMessage)
+            assert.ok(thirdCallArgs.conversationState?.history[3].assistantResponseMessage)
+            assert.strictEqual(
+                thirdCallArgs.conversationState?.history[3].assistantResponseMessage?.content,
+                'Now I need to use tool 2. '
+            )
+
+            // Verify the final result
             assert.deepStrictEqual(chatResult, expectedCompleteChatResult)
         })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -9,6 +9,7 @@ import {
     GenerateAssistantResponseCommandOutput,
     SendMessageCommandInput,
     SendMessageCommandOutput,
+    ToolUse,
 } from '@amzn/codewhisperer-streaming'
 import { chatRequestType } from '@aws/language-server-runtimes/protocol'
 import {
@@ -61,7 +62,11 @@ import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/A
 import { AmazonQWorkspaceConfig } from '../../shared/amazonQServiceManager/configurationUtils'
 import { TabBarController } from './tabBarController'
 import { ChatDatabase } from './tools/chatDb/chatDb'
-import { AgenticChatEventParser } from './agenticChatEventParser'
+import {
+    AgenticChatEventParser,
+    ChatResultWithMetadata as AgenticChatResultWithMetadata,
+} from './agenticChatEventParser'
+import { ChatSessionService } from '../chat/chatSessionService'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -93,25 +98,6 @@ export class AgenticChatController implements ChatHandlers {
         this.#amazonQServiceManager = amazonQServiceManager
         this.#chatHistoryDb = new ChatDatabase(features)
         this.#tabBarController = new TabBarController(features, this.#chatHistoryDb)
-
-        features.agent.addTool(
-            {
-                name: 'count_input',
-                description: 'Count the length of the prompt',
-                inputSchema: {
-                    type: 'object',
-                    properties: {
-                        prompt: {
-                            type: 'string',
-                        },
-                    },
-                    required: ['prompt'],
-                },
-            },
-            async input => {
-                return input.prompt?.length
-            }
-        )
     }
 
     dispose() {
@@ -129,6 +115,7 @@ export class AgenticChatController implements ChatHandlers {
     }
 
     async onChatPrompt(params: ChatParams, token: CancellationToken): Promise<ChatResult | ResponseError<ChatResult>> {
+        // Phase 1: Initial Setup - This happens only once
         const maybeDefaultResponse = getDefaultChatResponse(params.prompt.prompt)
 
         if (maybeDefaultResponse) {
@@ -155,141 +142,355 @@ export class AgenticChatController implements ChatHandlers {
             session.abortRequest()
         })
 
-        let response: GenerateAssistantResponseCommandOutput
-        let requestInput: GenerateAssistantResponseCommandInput
-
         const conversationIdentifier = session?.conversationId ?? 'New conversation'
+
         try {
-            this.#log('Request for conversation id:', conversationIdentifier)
-            const profileArn = AmazonQTokenServiceManager.getInstance(this.#features).getActiveProfileArn()
-            requestInput = this.#triggerContext.getChatParamsFromTrigger(
+            // Get the initial request input
+            const initialRequestInput = await this.#prepareRequestInput(params, session, triggerContext)
+
+            // Start the agent loop
+            const finalResult = await this.#runAgentLoop(
+                initialRequestInput,
+                session,
+                metric,
+                params.partialResultToken,
+                conversationIdentifier,
+                token
+            )
+
+            // Phase 5: Result Handling - This happens only once
+            return await this.#handleFinalResult(
+                finalResult,
+                session,
                 params,
+                metric,
                 triggerContext,
-                ChatTriggerType.MANUAL,
-                this.#customizationArn,
-                profileArn,
-                this.#features.agent.getTools({ format: 'bedrock' })
+                isNewConversation
             )
-
-            if (!session.localHistoryHydrated && requestInput.conversationState) {
-                requestInput.conversationState.history = this.#chatHistoryDb.getMessages(params.tabId, 10)
-                session.localHistoryHydrated = true
-            }
-
-            metric.recordStart()
-            response = await session.generateAssistantResponse(requestInput)
-            this.#log('Response for conversation id:', conversationIdentifier, JSON.stringify(response.$metadata))
         } catch (err) {
-            if (isAwsError(err) || (isObject(err) && 'statusCode' in err && typeof err.statusCode === 'number')) {
-                metric.setDimension('cwsprChatRepsonseCode', err.statusCode ?? 400)
-                this.#telemetryController.emitMessageResponseError(params.tabId, metric.metric)
-            }
+            return this.#handleRequestError(err, params.tabId, metric)
+        }
+    }
 
-            if (err instanceof AmazonQServicePendingSigninError) {
-                this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
+    /**
+     * Prepares the initial request input for the chat prompt
+     */
+    async #prepareRequestInput(
+        params: ChatParams,
+        session: ChatSessionService,
+        triggerContext: TriggerContext
+    ): Promise<GenerateAssistantResponseCommandInput> {
+        this.#log('Preparing request input')
+        const profileArn = AmazonQTokenServiceManager.getInstance(this.#features).getActiveProfileArn()
+        const requestInput = this.#triggerContext.getChatParamsFromTrigger(
+            params,
+            triggerContext,
+            ChatTriggerType.MANUAL,
+            this.#customizationArn,
+            profileArn,
+            this.#features.agent.getTools({ format: 'bedrock' })
+        )
 
-                return createAuthFollowUpResult('full-auth')
-            }
-
-            if (err instanceof AmazonQServicePendingProfileError) {
-                this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
-
-                const followUpResult = createAuthFollowUpResult('use-supported-auth')
-                // Access first element in array
-                if (followUpResult.followUp?.options) {
-                    followUpResult.followUp.options[0].pillText = 'Select Q Developer Profile'
-                }
-
-                return followUpResult
-            }
-
-            const authFollowType = getAuthFollowUpType(err)
-
-            if (authFollowType) {
-                this.#log(`Q auth error: ${getErrorMessage(err)}`)
-
-                return createAuthFollowUpResult(authFollowType)
-            }
-
-            this.#log(`Q api request error ${err instanceof Error ? err.message : 'unknown'}`)
-            return new ResponseError<ChatResult>(
-                LSPErrorCodes.RequestFailed,
-                err instanceof Error ? err.message : 'Unknown request error'
-            )
+        if (!session.localHistoryHydrated && requestInput.conversationState) {
+            requestInput.conversationState.history = this.#chatHistoryDb.getMessages(params.tabId, 10)
+            session.localHistoryHydrated = true
         }
 
-        try {
+        return requestInput
+    }
+
+    /**
+     * Runs the agent loop, making requests and processing tool uses until completion
+     */
+    async #runAgentLoop(
+        initialRequestInput: GenerateAssistantResponseCommandInput,
+        session: ChatSessionService,
+        metric: Metric<CombinedConversationEvent>,
+        partialResultToken?: string | number,
+        conversationIdentifier?: string,
+        token?: CancellationToken
+    ): Promise<Result<AgenticChatResultWithMetadata, string>> {
+        let currentRequestInput = { ...initialRequestInput }
+        let finalResult: Result<AgenticChatResultWithMetadata, string> | null = null
+        let iterationCount = 0
+        const maxIterations = 3 // Safety limit to prevent infinite loops
+
+        metric.recordStart()
+
+        while (iterationCount < maxIterations) {
+            iterationCount++
+            this.#log(`Agent loop iteration ${iterationCount} for conversation id:`, conversationIdentifier || '')
+
+            // Check for cancellation
+            if (token?.isCancellationRequested) {
+                this.#log('Request cancelled during agent loop')
+                break
+            }
+
+            // Phase 3: Request Execution
+            this.#log(`Request Input: ${JSON.stringify(currentRequestInput)}`)
+            const response = await session.generateAssistantResponse(currentRequestInput)
+            this.#log(`Response received for iteration ${iterationCount}:`, JSON.stringify(response.$metadata))
+
+            // Phase 4: Response Processing
             const result = await this.#processGenerateAssistantResponseResponse(
                 response,
                 metric.mergeWith({
                     cwsprChatResponseCode: response.$metadata.httpStatusCode,
                     cwsprChatMessageId: response.$metadata.requestId,
                 }),
-                params.partialResultToken
+                partialResultToken
             )
 
-            session.conversationId = result.data?.conversationId
-            this.#log('Session conversation id:', session.conversationId || '')
-
-            if (session.conversationId) {
-                this.#telemetryController.setConversationId(params.tabId, session.conversationId)
-
-                if (isNewConversation) {
-                    this.#telemetryController.updateTriggerInfo(params.tabId, {
-                        startTrigger: {
-                            hasUserSnippet: metric.metric.cwsprChatHasCodeSnippet ?? false,
-                            triggerType: triggerContext.triggerType,
-                        },
-                    })
-
-                    this.#telemetryController.emitStartConversationMetric(params.tabId, metric.metric)
-                }
+            // Store the conversation ID from the first response
+            if (iterationCount === 1 && result.data?.conversationId) {
+                session.conversationId = result.data.conversationId
             }
 
-            metric.setDimension('codewhispererCustomizationArn', requestInput.conversationState?.customizationArn)
-            await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric)
+            // Check if we have any tool uses that need to be processed
+            const pendingToolUses = this.#getPendingToolUses(result.data?.toolUses || {})
 
-            this.#telemetryController.updateTriggerInfo(params.tabId, {
-                lastMessageTrigger: {
-                    ...triggerContext,
-                    messageId: response.$metadata.requestId,
-                    followUpActions: new Set(
-                        result.data?.chatResult.followUp?.options
-                            ?.map(option => option.prompt ?? '')
-                            .filter(prompt => prompt.length > 0)
-                    ),
+            if (pendingToolUses.length === 0) {
+                // No more tool uses, we're done
+                finalResult = result
+                break
+            }
+
+            const currentMessage = currentRequestInput.conversationState?.currentMessage
+
+            // Process tool uses and update the request input for the next iteration
+            const toolResults = await this.#processToolUses(pendingToolUses)
+            currentRequestInput = this.#updateRequestInputWithToolResults(currentRequestInput, toolResults)
+
+            if (!currentRequestInput.conversationState!.history) {
+                currentRequestInput.conversationState!.history = []
+            }
+
+            currentRequestInput.conversationState!.history.push({
+                userInputMessage: {
+                    content: currentMessage?.userInputMessage?.content,
+                    origin: currentMessage?.userInputMessage?.origin,
+                    userIntent: currentMessage?.userInputMessage?.userIntent,
+                    userInputMessageContext: currentMessage?.userInputMessage?.userInputMessageContext,
                 },
             })
-            // Save question/answer interaction to chat history
-            if (params.prompt.prompt && session.conversationId && result.data?.chatResult.body) {
-                this.#chatHistoryDb.addMessage(params.tabId, 'cwc', session.conversationId, {
-                    body: params.prompt.prompt,
-                    type: 'prompt' as any,
+
+            currentRequestInput.conversationState!.history.push({
+                assistantResponseMessage: {
+                    content: result.data?.chatResult.body,
+                    toolUses: Object.keys(result.data?.toolUses!).map(k => ({
+                        input:
+                            typeof result.data!.toolUses[k].input === 'string'
+                                ? JSON.parse(result.data!.toolUses[k].input)
+                                : result.data!.toolUses[k].input,
+                        name: result.data!.toolUses[k].name,
+                        toolUseId: result.data!.toolUses[k].toolUseId,
+                    })),
+                },
+            })
+        }
+
+        if (iterationCount >= maxIterations) {
+            this.#log('Agent loop reached maximum iterations limit')
+        }
+
+        return (
+            finalResult || {
+                success: false,
+                error: 'Agent loop failed to produce a final result',
+                data: { chatResult: {}, toolUses: {} },
+            }
+        )
+    }
+
+    /**
+     * Extracts tool uses that need to be processed
+     */
+    #getPendingToolUses(toolUses: Record<string, ToolUse & { stop: boolean }>): Array<ToolUse & { stop: boolean }> {
+        return Object.values(toolUses).filter(toolUse => toolUse.stop)
+    }
+
+    /**
+     * Processes tool uses by running the tools and collecting results
+     */
+    async #processToolUses(toolUses: Array<ToolUse & { stop: boolean }>): Promise<
+        Array<{
+            toolUseId: string
+            name: string
+            result: any
+        }>
+    > {
+        const results = []
+
+        for (const toolUse of toolUses) {
+            if (!toolUse.name || !toolUse.toolUseId) continue
+
+            try {
+                const input = typeof toolUse.input === 'string' ? JSON.parse(toolUse.input) : toolUse.input
+                this.#log(`Running tool ${toolUse.name} with input:`, JSON.stringify(input))
+
+                const result = await this.#features.agent.runTool(toolUse.name, input)
+                results.push({
+                    toolUseId: toolUse.toolUseId,
+                    name: toolUse.name,
+                    result,
                 })
 
-                this.#chatHistoryDb.addMessage(params.tabId, 'cwc', session.conversationId, {
-                    body: result.data.chatResult.body,
-                    type: 'answer' as any,
-                    codeReference: result.data.chatResult.codeReference,
-                    relatedContent:
-                        result.data.chatResult.relatedContent?.content &&
-                        result.data.chatResult.relatedContent.content.length > 0
-                            ? result.data?.chatResult.relatedContent
-                            : undefined,
+                this.#log(`Tool ${toolUse.name} completed with result:`, JSON.stringify(result))
+            } catch (err) {
+                this.#log(`Error running tool ${toolUse.name}:`, err instanceof Error ? err.message : 'unknown error')
+                results.push({
+                    toolUseId: toolUse.toolUseId,
+                    name: toolUse.name,
+                    result: { error: err instanceof Error ? err.message : 'Unknown error' },
                 })
             }
+        }
 
-            return result.success
-                ? result.data.chatResult
-                : new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, result.error)
-        } catch (err) {
-            this.#log('Error encountered during response streaming:', err instanceof Error ? err.message : 'unknown')
+        return results
+    }
 
-            return new ResponseError<ChatResult>(
-                LSPErrorCodes.RequestFailed,
-                err instanceof Error ? err.message : 'Unknown error occured during response stream'
+    /**
+     * Updates the request input with tool results for the next iteration
+     */
+    #updateRequestInputWithToolResults(
+        requestInput: GenerateAssistantResponseCommandInput,
+        toolResults: Array<{ toolUseId: string; name: string; result: any }>
+    ): GenerateAssistantResponseCommandInput {
+        // Create a deep copy of the request input
+        const updatedRequestInput = JSON.parse(JSON.stringify(requestInput)) as GenerateAssistantResponseCommandInput
+
+        // Add tool results to the request
+        updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.userInputMessageContext!.toolResults =
+            []
+        updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.content = ''
+
+        for (const toolResult of toolResults) {
+            updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.userInputMessageContext!.toolResults.push(
+                {
+                    toolUseId: toolResult.toolUseId,
+                    status: 'success',
+                    content: [
+                        {
+                            json: { result: toolResult.result },
+                        },
+                    ],
+                }
             )
         }
+
+        return updatedRequestInput
+    }
+
+    /**
+     * Handles the final result after the agent loop completes
+     */
+    async #handleFinalResult(
+        result: Result<AgenticChatResultWithMetadata, string>,
+        session: ChatSessionService,
+        params: ChatParams,
+        metric: Metric<CombinedConversationEvent>,
+        triggerContext: TriggerContext,
+        isNewConversation: boolean
+    ): Promise<ChatResult | ResponseError<ChatResult>> {
+        if (!result.success) {
+            return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, result.error)
+        }
+
+        const conversationId = session.conversationId
+        this.#log('Final session conversation id:', conversationId || '')
+
+        if (conversationId) {
+            this.#telemetryController.setConversationId(params.tabId, conversationId)
+
+            if (isNewConversation) {
+                this.#telemetryController.updateTriggerInfo(params.tabId, {
+                    startTrigger: {
+                        hasUserSnippet: metric.metric.cwsprChatHasCodeSnippet ?? false,
+                        triggerType: triggerContext.triggerType,
+                    },
+                })
+
+                this.#telemetryController.emitStartConversationMetric(params.tabId, metric.metric)
+            }
+        }
+
+        metric.setDimension('codewhispererCustomizationArn', this.#customizationArn)
+        await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric)
+
+        this.#telemetryController.updateTriggerInfo(params.tabId, {
+            lastMessageTrigger: {
+                ...triggerContext,
+                messageId: result.data?.chatResult.messageId,
+                followUpActions: new Set(
+                    result.data?.chatResult.followUp?.options
+                        ?.map(option => option.prompt ?? '')
+                        .filter(prompt => prompt.length > 0)
+                ),
+            },
+        })
+
+        // Save question/answer interaction to chat history
+        if (params.prompt.prompt && conversationId && result.data?.chatResult.body) {
+            this.#chatHistoryDb.addMessage(params.tabId, 'cwc', conversationId, {
+                body: params.prompt.prompt,
+                type: 'prompt' as any,
+            })
+
+            this.#chatHistoryDb.addMessage(params.tabId, 'cwc', conversationId, {
+                body: result.data.chatResult.body,
+                type: 'answer' as any,
+                codeReference: result.data.chatResult.codeReference,
+                relatedContent:
+                    result.data.chatResult.relatedContent?.content &&
+                    result.data.chatResult.relatedContent.content.length > 0
+                        ? result.data?.chatResult.relatedContent
+                        : undefined,
+            })
+        }
+
+        return result.data.chatResult
+    }
+
+    /**
+     * Handles errors that occur during the request
+     */
+    #handleRequestError(
+        err: any,
+        tabId: string,
+        metric: Metric<CombinedConversationEvent>
+    ): ChatResult | ResponseError<ChatResult> {
+        if (isAwsError(err) || (isObject(err) && 'statusCode' in err && typeof err.statusCode === 'number')) {
+            metric.setDimension('cwsprChatRepsonseCode', err.statusCode ?? 400)
+            this.#telemetryController.emitMessageResponseError(tabId, metric.metric)
+        }
+
+        if (err instanceof AmazonQServicePendingSigninError) {
+            this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
+            return createAuthFollowUpResult('full-auth')
+        }
+
+        if (err instanceof AmazonQServicePendingProfileError) {
+            this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
+            const followUpResult = createAuthFollowUpResult('use-supported-auth')
+            // Access first element in array
+            if (followUpResult.followUp?.options) {
+                followUpResult.followUp.options[0].pillText = 'Select Q Developer Profile'
+            }
+            return followUpResult
+        }
+
+        const authFollowType = getAuthFollowUpType(err)
+        if (authFollowType) {
+            this.#log(`Q auth error: ${getErrorMessage(err)}`)
+            return createAuthFollowUpResult(authFollowType)
+        }
+
+        this.#log(`Q api request error ${err instanceof Error ? JSON.stringify(err) : 'unknown'}`)
+        return new ResponseError<ChatResult>(
+            LSPErrorCodes.RequestFailed,
+            err instanceof Error ? err.message : 'Unknown request error'
+        )
     }
 
     async onInlineChatPrompt(
@@ -327,7 +528,7 @@ export class AgenticChatController implements ChatHandlers {
                 this.#log(`Q Inline Chat SSO Connection error: ${getErrorMessage(err)}`)
                 return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message)
             }
-            this.#log(`Q api request error ${err instanceof Error ? err.message : 'unknown'}`)
+            this.#log(`Q api request error ${err instanceof Error ? JSON.stringify(err) : 'unknown'}`)
             return new ResponseError<ChatResult>(
                 LSPErrorCodes.RequestFailed,
                 err instanceof Error ? err.message : 'Unknown request error'
@@ -587,7 +788,7 @@ export class AgenticChatController implements ChatHandlers {
         response: GenerateAssistantResponseCommandOutput,
         metric: Metric<AddMessageEvent>,
         partialResultToken?: string | number
-    ): Promise<Result<ChatResultWithMetadata, string>> {
+    ): Promise<Result<AgenticChatResultWithMetadata, string>> {
         const requestId = response.$metadata.requestId!
         const chatEventParser = new AgenticChatEventParser(requestId, metric)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -9,6 +9,7 @@ import {
     GenerateAssistantResponseCommandOutput,
     SendMessageCommandInput,
     SendMessageCommandOutput,
+    ToolResult,
     ToolResultContentBlock,
     ToolUse,
 } from '@amzn/codewhisperer-streaming'
@@ -311,14 +312,8 @@ export class AgenticChatController implements ChatHandlers {
     /**
      * Processes tool uses by running the tools and collecting results
      */
-    async #processToolUses(toolUses: Array<ToolUse & { stop: boolean }>): Promise<
-        Array<{
-            toolUseId: string
-            name: string
-            result: any
-        }>
-    > {
-        const results = []
+    async #processToolUses(toolUses: Array<ToolUse & { stop: boolean }>): Promise<ToolResult[]> {
+        const results: ToolResult[] = []
 
         for (const toolUse of toolUses) {
             if (!toolUse.name || !toolUse.toolUseId) continue
@@ -327,10 +322,20 @@ export class AgenticChatController implements ChatHandlers {
                 this.#debug(`Running tool ${toolUse.name} with input:`, JSON.stringify(toolUse.input))
 
                 const result = await this.#features.agent.runTool(toolUse.name, toolUse.input)
+                let toolResultContent: ToolResultContentBlock
+
+                if (typeof result === 'string') {
+                    toolResultContent = { text: result }
+                } else if (Array.isArray(result)) {
+                    toolResultContent = { json: { items: result } }
+                } else if (typeof result === 'object') {
+                    toolResultContent = { json: result }
+                } else toolResultContent = { text: JSON.stringify(result) }
+
                 results.push({
                     toolUseId: toolUse.toolUseId,
-                    name: toolUse.name,
-                    result,
+                    status: 'success',
+                    content: [toolResultContent],
                 })
 
                 this.#debug(`Tool ${toolUse.name} completed with result:`, JSON.stringify(result))
@@ -338,8 +343,8 @@ export class AgenticChatController implements ChatHandlers {
                 this.#log(`Error running tool ${toolUse.name}:`, err instanceof Error ? err.message : 'unknown error')
                 results.push({
                     toolUseId: toolUse.toolUseId,
-                    name: toolUse.name,
-                    result: { error: err instanceof Error ? err.message : 'Unknown error' },
+                    status: 'error',
+                    content: [{ json: { error: err instanceof Error ? err.message : 'Unknown error' } }],
                 })
             }
         }
@@ -352,7 +357,7 @@ export class AgenticChatController implements ChatHandlers {
      */
     #updateRequestInputWithToolResults(
         requestInput: GenerateAssistantResponseCommandInput,
-        toolResults: Array<{ toolUseId: string; name: string; result: any }>
+        toolResults: ToolResult[]
     ): GenerateAssistantResponseCommandInput {
         // Create a deep copy of the request input
         const updatedRequestInput = JSON.parse(JSON.stringify(requestInput)) as GenerateAssistantResponseCommandInput
@@ -363,22 +368,10 @@ export class AgenticChatController implements ChatHandlers {
         updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.content = ''
 
         for (const toolResult of toolResults) {
-            let toolResultContent: ToolResultContentBlock
-
-            if (typeof toolResult.result === 'string') {
-                toolResultContent = { text: toolResult.result }
-            } else if (Array.isArray(toolResult.result)) {
-                toolResultContent = { json: { items: toolResult.result } }
-            } else if (typeof toolResult.result === 'object') {
-                toolResultContent = { json: toolResult.result }
-            } else toolResultContent = { text: JSON.stringify(toolResult.result) }
-
-            this.#debug(`ToolResult: ${JSON.stringify(toolResultContent)}`)
+            this.#debug(`ToolResult: ${JSON.stringify(toolResult)}`)
             updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.userInputMessageContext!.toolResults.push(
                 {
-                    toolUseId: toolResult.toolUseId,
-                    status: 'success',
-                    content: [toolResultContent],
+                    ...toolResult,
                 }
             )
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -9,6 +9,7 @@ import {
     GenerateAssistantResponseCommandOutput,
     SendMessageCommandInput,
     SendMessageCommandOutput,
+    ToolResultContentBlock,
     ToolUse,
 } from '@amzn/codewhisperer-streaming'
 import { chatRequestType } from '@aws/language-server-runtimes/protocol'
@@ -213,7 +214,7 @@ export class AgenticChatController implements ChatHandlers {
         let currentRequestInput = { ...initialRequestInput }
         let finalResult: Result<AgenticChatResultWithMetadata, string> | null = null
         let iterationCount = 0
-        const maxIterations = 3 // Safety limit to prevent infinite loops
+        const maxIterations = 10 // Safety limit to prevent infinite loops
 
         metric.recordStart()
 
@@ -279,12 +280,9 @@ export class AgenticChatController implements ChatHandlers {
                 assistantResponseMessage: {
                     content: result.data?.chatResult.body,
                     toolUses: Object.keys(result.data?.toolUses!).map(k => ({
-                        input:
-                            typeof result.data!.toolUses[k].input === 'string'
-                                ? JSON.parse(result.data!.toolUses[k].input)
-                                : result.data!.toolUses[k].input,
-                        name: result.data!.toolUses[k].name,
                         toolUseId: result.data!.toolUses[k].toolUseId,
+                        name: result.data!.toolUses[k].name,
+                        input: result.data!.toolUses[k].input,
                     })),
                 },
             })
@@ -326,10 +324,9 @@ export class AgenticChatController implements ChatHandlers {
             if (!toolUse.name || !toolUse.toolUseId) continue
 
             try {
-                const input = typeof toolUse.input === 'string' ? JSON.parse(toolUse.input) : toolUse.input
-                this.#log(`Running tool ${toolUse.name} with input:`, JSON.stringify(input))
+                this.#log(`Running tool ${toolUse.name} with input:`, JSON.stringify(toolUse.input))
 
-                const result = await this.#features.agent.runTool(toolUse.name, input)
+                const result = await this.#features.agent.runTool(toolUse.name, toolUse.input)
                 results.push({
                     toolUseId: toolUse.toolUseId,
                     name: toolUse.name,
@@ -366,15 +363,22 @@ export class AgenticChatController implements ChatHandlers {
         updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.content = ''
 
         for (const toolResult of toolResults) {
+            let toolResultContent: ToolResultContentBlock
+
+            if (typeof toolResult.result === 'string') {
+                toolResultContent = { text: toolResult.result }
+            } else if (Array.isArray(toolResult.result)) {
+                toolResultContent = { json: { items: toolResult.result } }
+            } else if (typeof toolResult.result === 'object') {
+                toolResultContent = { json: toolResult.result }
+            } else toolResultContent = { text: JSON.stringify(toolResult.result) }
+
+            this.#log(`ToolResult: ${JSON.stringify(toolResultContent)}`)
             updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.userInputMessageContext!.toolResults.push(
                 {
                     toolUseId: toolResult.toolUseId,
                     status: 'success',
-                    content: [
-                        {
-                            json: { result: toolResult.result },
-                        },
-                    ],
+                    content: [toolResultContent],
                 }
             )
         }
@@ -487,6 +491,8 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         this.#log(`Q api request error ${err instanceof Error ? JSON.stringify(err) : 'unknown'}`)
+        this.#log(`Q api request error stack ${err instanceof Error ? JSON.stringify(err.stack) : 'unknown'}`)
+        this.#log(`Q api request error cause ${err instanceof Error ? JSON.stringify(err.cause) : 'unknown'}`)
         return new ResponseError<ChatResult>(
             LSPErrorCodes.RequestFailed,
             err instanceof Error ? err.message : 'Unknown request error'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -181,7 +181,7 @@ export class AgenticChatController implements ChatHandlers {
         session: ChatSessionService,
         triggerContext: TriggerContext
     ): Promise<GenerateAssistantResponseCommandInput> {
-        this.#log('Preparing request input')
+        this.#debug('Preparing request input')
         const profileArn = AmazonQTokenServiceManager.getInstance(this.#features).getActiveProfileArn()
         const requestInput = this.#triggerContext.getChatParamsFromTrigger(
             params,
@@ -220,18 +220,18 @@ export class AgenticChatController implements ChatHandlers {
 
         while (iterationCount < maxIterations) {
             iterationCount++
-            this.#log(`Agent loop iteration ${iterationCount} for conversation id:`, conversationIdentifier || '')
+            this.#debug(`Agent loop iteration ${iterationCount} for conversation id:`, conversationIdentifier || '')
 
             // Check for cancellation
             if (token?.isCancellationRequested) {
-                this.#log('Request cancelled during agent loop')
+                this.#debug('Request cancelled during agent loop')
                 break
             }
 
             // Phase 3: Request Execution
-            this.#log(`Request Input: ${JSON.stringify(currentRequestInput)}`)
+            this.#debug(`Request Input: ${JSON.stringify(currentRequestInput)}`)
             const response = await session.generateAssistantResponse(currentRequestInput)
-            this.#log(`Response received for iteration ${iterationCount}:`, JSON.stringify(response.$metadata))
+            this.#debug(`Response received for iteration ${iterationCount}:`, JSON.stringify(response.$metadata))
 
             // Phase 4: Response Processing
             const result = await this.#processGenerateAssistantResponseResponse(
@@ -324,7 +324,7 @@ export class AgenticChatController implements ChatHandlers {
             if (!toolUse.name || !toolUse.toolUseId) continue
 
             try {
-                this.#log(`Running tool ${toolUse.name} with input:`, JSON.stringify(toolUse.input))
+                this.#debug(`Running tool ${toolUse.name} with input:`, JSON.stringify(toolUse.input))
 
                 const result = await this.#features.agent.runTool(toolUse.name, toolUse.input)
                 results.push({
@@ -333,7 +333,7 @@ export class AgenticChatController implements ChatHandlers {
                     result,
                 })
 
-                this.#log(`Tool ${toolUse.name} completed with result:`, JSON.stringify(result))
+                this.#debug(`Tool ${toolUse.name} completed with result:`, JSON.stringify(result))
             } catch (err) {
                 this.#log(`Error running tool ${toolUse.name}:`, err instanceof Error ? err.message : 'unknown error')
                 results.push({
@@ -373,7 +373,7 @@ export class AgenticChatController implements ChatHandlers {
                 toolResultContent = { json: toolResult.result }
             } else toolResultContent = { text: JSON.stringify(toolResult.result) }
 
-            this.#log(`ToolResult: ${JSON.stringify(toolResultContent)}`)
+            this.#debug(`ToolResult: ${JSON.stringify(toolResultContent)}`)
             updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.userInputMessageContext!.toolResults.push(
                 {
                     toolUseId: toolResult.toolUseId,
@@ -402,7 +402,7 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         const conversationId = session.conversationId
-        this.#log('Final session conversation id:', conversationId || '')
+        this.#debug('Final session conversation id:', conversationId || '')
 
         if (conversationId) {
             this.#telemetryController.setConversationId(params.tabId, conversationId)
@@ -491,8 +491,8 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         this.#log(`Q api request error ${err instanceof Error ? JSON.stringify(err) : 'unknown'}`)
-        this.#log(`Q api request error stack ${err instanceof Error ? JSON.stringify(err.stack) : 'unknown'}`)
-        this.#log(`Q api request error cause ${err instanceof Error ? JSON.stringify(err.cause) : 'unknown'}`)
+        this.#debug(`Q api request error stack ${err instanceof Error ? JSON.stringify(err.stack) : 'unknown'}`)
+        this.#debug(`Q api request error cause ${err instanceof Error ? JSON.stringify(err.cause) : 'unknown'}`)
         return new ResponseError<ChatResult>(
             LSPErrorCodes.RequestFailed,
             err instanceof Error ? err.message : 'Unknown request error'
@@ -862,5 +862,9 @@ export class AgenticChatController implements ChatHandlers {
 
     #log(...messages: string[]) {
         this.#features.logging.log(messages.join(' '))
+    }
+
+    #debug(...messages: string[]) {
+        this.#features.logging.debug(messages.join(' '))
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -128,7 +128,15 @@ export class AgenticChatEventParser implements ChatResult {
                 }
 
                 if (toolUseEvent.stop) {
-                    console.log(`ToolUseEvent: ${toolUseId} ${name} ${this.toolUses[toolUseId]?.input}`)
+                    const parsedInput =
+                        typeof this.toolUses[toolUseId].input === 'string'
+                            ? JSON.parse(this.toolUses[toolUseId].input === '' ? '{}' : this.toolUses[toolUseId].input)
+                            : this.toolUses[toolUseId].input
+                    this.toolUses[toolUseId] = {
+                        ...this.toolUses[toolUseId],
+                        input: parsedInput,
+                    }
+                    console.log(`ToolUseEvent: ${toolUseId} ${name} ${this.toolUses[toolUseId].input}`)
                 }
             }
         } else if (followupPromptEvent?.followupPrompt) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -18,7 +18,7 @@ import { TabBarController } from './tabBarController'
 export const QAgenticChatServer =
     // prettier-ignore
     (): Server => features => {
-        const { chat, credentialsProvider, telemetry, logging, lsp, runtime } = features
+        const { chat, credentialsProvider, telemetry, logging, lsp, runtime, agent } = features
 
         let amazonQServiceManager: AmazonQTokenServiceManager
         let chatController: AgenticChatController
@@ -104,6 +104,22 @@ export const QAgenticChatServer =
         chat.onEndChat((...params) => {
             logging.log('Received end chat request')
             return chatController.onEndChat(...params)
+        })
+
+        agent.addTool({
+            name: 'count_input',
+            description: 'Count the length of the prompt',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    prompt: {
+                        type: 'string',
+                    },
+                },
+                required: ['prompt'],
+            },
+        } as const, async input => {
+            return input.prompt?.length
         })
 
         chat.onChatPrompt((...params) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
@@ -118,7 +118,8 @@ export class FsRead {
                 type: 'object',
                 properties: {
                     path: {
-                        description: 'Absolute path to a file, e.g. `/repo/file.py`.',
+                        description:
+                            'Path to a file, e.g. `/path/to/repo/file.py`. If you want to access a path relative to the current workspace, use relative paths e.g. `./src/file.py`.',
                         type: 'string',
                     },
                     readRange: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -290,7 +290,8 @@ export class FsWrite {
                         type: 'string',
                     },
                     path: {
-                        description: 'Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.',
+                        description:
+                            'Path to a file, e.g. `/path/to/repo/file.py`. If you want to access a path relative to the current workspace, use relative paths e.g. `./src/file.py`.',
                         type: 'string',
                     },
                 },

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -14,14 +14,14 @@ export const FsToolsServer: Server = ({ workspace, logging, agent }) => {
         // TODO: fill in logic for handling invalid tool invocations
         // TODO: implement chat streaming via queueDescription.
         await fsReadTool.validate(input)
-        await fsReadTool.invoke(input)
+        return await fsReadTool.invoke(input)
     })
 
     agent.addTool(fsWriteTool.getSpec(), async (input: FsWriteParams) => {
         // TODO: fill in logic for handling invalid tool invocations
         // TODO: implement chat streaming via queueDescription.
         await fsWriteTool.validate(input)
-        await fsWriteTool.invoke(input)
+        return await fsWriteTool.invoke(input)
     })
 
     agent.addTool(listDirectoryTool.getSpec(), (input: ListDirectoryParams) => listDirectoryTool.invoke(input))


### PR DESCRIPTION
## Problem
Tool Results need to be passed back into the model for the next request.

## Solution
Add user and assistant responses to the history, and add tool results to the current message.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
