### PR TITLE
TEAM REVIEW : TESTING NEEDED : Make RemoveDuplicateNugetPackage failure a non-blocker for transformation

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -61,17 +61,21 @@ export class ArtifactManager {
     }
 
     async removeDuplicateNugetPackagesFolder(request: StartTransformRequest) {
-        const packagesFolder = path.join(
-            this.workspacePath,
-            artifactFolderName,
-            sourceCodeFolderName,
-            packagesFolderName
-        )
-        if (fs.existsSync(packagesFolder)) {
-            fs.rmSync(packagesFolder, { recursive: true, force: true })
-            this.logging.log(
-                `Removed packages folder ${packagesFolder} from source code directory to be uploaded because it is a duplicate of references folder from artifacts`
+        try {
+            const packagesFolder = path.join(
+                this.workspacePath,
+                artifactFolderName,
+                sourceCodeFolderName,
+                packagesFolderName
             )
+            if (fs.existsSync(packagesFolder)) {
+                fs.rmSync(packagesFolder, { recursive: true, force: true })
+                this.logging.log(
+                    `Removed packages folder ${packagesFolder} from source code directory to be uploaded because it is a duplicate of references folder from artifacts`
+                )
+            }
+        } catch (error) {
+            this.logging.log('Failed to remove duplicate nugget package folder: ' + error)
         }
     }
 


### PR DESCRIPTION
## Problem
When an error is thrown from RemoveDuplicateNugetPackage it causes the entire transformation to fail

## Solution
Adding a try catch anf just logging the error since RemoveDuplicateNugetPackage is not a necessary step for transformation.

