### PR TITLE
fix(chat-client): disable click event for empty history list item

### DIFF
--- a/chat-client/src/client/features/history.ts
+++ b/chat-client/src/client/features/history.ts
@@ -65,6 +65,11 @@ export class ChatHistoryList {
         if (!item.id) {
             throw new Error('Conversation id is not defined')
         }
+
+        if (item.id === 'empty') {
+            return
+        }
+
         this.messager.onConversationClick(item.id)
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.test.ts
@@ -7,7 +7,7 @@ import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import sinon from 'ts-sinon'
 import * as assert from 'assert'
 import { TabBarController } from './tabBarController'
-import { ChatDatabase } from './tools/chatDb/chatDb'
+import { ChatDatabase, EMPTY_CONVERSATION_LIST_ID } from './tools/chatDb/chatDb'
 import { Tab } from './tools/chatDb/util'
 import { ConversationItemGroup, OpenTabParams, OpenTabResult } from '@aws/language-server-runtimes-types'
 import { InitializeParams } from '@aws/language-server-runtimes/protocol'
@@ -243,6 +243,23 @@ describe('TabBarController', () => {
 
             sinon.assert.calledWith(chatHistoryDb.deleteHistory as sinon.SinonStub, historyId)
             assert.strictEqual(result.success, true)
+        })
+
+        it('should not perform actions when item with `empty` historyId is clicked', async () => {
+            const historyId = EMPTY_CONVERSATION_LIST_ID
+            const openTabId = 'tab1'
+            ;(chatHistoryDb.getOpenTabId as sinon.SinonStub).withArgs(historyId).returns(openTabId)
+
+            const openTabStub = sinon.stub<[OpenTabParams], Promise<OpenTabResult>>()
+            testFeatures.chat.openTab = openTabStub
+
+            const result = await tabBarController.onConversationClick({ id: historyId })
+
+            sinon.assert.notCalled(openTabStub)
+            assert.deepStrictEqual(result, {
+                id: EMPTY_CONVERSATION_LIST_ID,
+                success: true,
+            })
         })
     })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChatDatabase } from './tools/chatDb/chatDb'
+import { ChatDatabase, EMPTY_CONVERSATION_LIST_ID } from './tools/chatDb/chatDb'
 import { Conversation, messageToChatMessage, Tab } from './tools/chatDb/util'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import {
@@ -58,7 +58,9 @@ export class TabBarController {
                 const items =
                     group.items?.map(item => ({
                         ...item,
-                        ...(item.id !== 'empty' ? { actions: this.getConversationActions(item.id) } : {}),
+                        ...(item.id !== EMPTY_CONVERSATION_LIST_ID
+                            ? { actions: this.getConversationActions(item.id) }
+                            : {}),
                     })) || []
 
                 return {
@@ -127,6 +129,11 @@ export class TabBarController {
      */
     async onConversationClick(params: ConversationClickParams): Promise<ConversationClickResult> {
         const historyID = params.id
+
+        if (historyID === EMPTY_CONVERSATION_LIST_ID) {
+            this.#features.logging.debug('Empty conversation history list item clicked')
+            return { ...params, success: true }
+        }
 
         // Handle user click on conversation in history
         if (!params.action) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -20,6 +20,8 @@ import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { ConversationItemGroup } from '@aws/language-server-runtimes/protocol'
 import { getUserHomeDir } from '@aws/lsp-core/out/util/path'
 
+export const EMPTY_CONVERSATION_LIST_ID = 'empty'
+
 /**
  * A singleton database class that manages chat history persistence using LokiJS.
  * This class handles storage and retrieval of chat conversations, messages, and tab states
@@ -212,7 +214,7 @@ export class ChatDatabase {
         }
         if (searchResults.length === 0) {
             this.#features.logging.log(`No matches found`)
-            searchResults = [{ items: [{ id: 'empty', description: 'No matches found' }] }]
+            searchResults = [{ items: [{ id: EMPTY_CONVERSATION_LIST_ID, description: 'No matches found' }] }]
         }
         return searchResults
     }
@@ -253,7 +255,7 @@ export class ChatDatabase {
             let groupedTabs = groupTabsByDate(tabs)
             this.#features.logging.log(`Found ${tabs.length} conversations from history`)
             if (groupedTabs.length === 0) {
-                return [{ items: [{ id: 'empty', description: 'No chat history found' }] }]
+                return [{ items: [{ id: EMPTY_CONVERSATION_LIST_ID, description: 'No chat history found' }] }]
             } else {
                 return groupedTabs
             }


### PR DESCRIPTION
## Problem
Click on empty history list item open chat window and sends `conversationClicked` event to language server.

## Solution
* Do not invoke click event on empty history item in chat client
* Do not handle click event on "empty" history item in language server

<img width="412" alt="Screenshot 2025-04-16 at 13 25 21" src="https://github.com/user-attachments/assets/0c5dca5c-c594-47e6-9f5f-ab6c9cb39ec1" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
