### PR TITLE
fix(chat-client): missing break in getSerializedChat request handling

### DIFF
--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -153,6 +153,7 @@ export const createChat = (
                 break
             case GET_SERIALIZED_CHAT_REQUEST_METHOD:
                 mynahApi.getSerializedChat(message.requestId, message.params as GetSerializedChatParams)
+                break
             case CHAT_OPTIONS: {
                 const params = (message as ChatOptionsMessage).params
                 if (params?.quickActions?.quickActionsCommandGroups) {


### PR DESCRIPTION
## Problem
Missed `break` in switch-case statement

## Solution
Added missing break

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
