### PR TITLE
fix: temporary fix for error where undefined is being passed to path.…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -13,7 +13,7 @@ import { URI } from 'vscode-uri'
 
 const fs = require('fs').promises
 const path = require('path')
-const LIBRARY_DIR = path.join(dirname(require.main!.filename), 'indexing')
+const LIBRARY_DIR = path.join('//TODO FIXME', 'indexing')
 
 export class LocalProjectContextController {
     private static instance: LocalProjectContextController | undefined


### PR DESCRIPTION
## Problem

Trying to run the built artifacts gives the following error:
```
Uncaught Exception: The "path" argument must be of type string. Received undefined
node:internal/validators:162
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at dirname (node:path:1275:5)
...
  code: 'ERR_INVALID_ARG_TYPE'
}
```

This is happening due to changes introduced in: https://github.com/aws/language-servers/pull/949

This line in particular is the root cause: `path.join(dirname(require.main!.filename), 'indexing')` 

`require.main` returns undefined so the `!` assertion is a naive assertion here. And when path.join tries to join `undefined` with `indexing` it fails because `path.join` doesn't accept `undefined`


## Solution
As a temporary fix, I have removed the problematic line and replaced it with a hardcoded value. I will let @breedloj know about this and discuss details 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
