### PR TITLE
fix: handle indexing library import when require.main is undefined

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -49,7 +49,7 @@ export class LocalProjectContextController {
             const vecLib = vectorLib ?? (await import(libraryPath))
             if (vecLib) {
                 const root = this.findCommonWorkspaceRoot(this.workspaceFolders)
-                this._vecLib = await vecLib.start(libraryPath, this.clientName, root)
+                this._vecLib = await vecLib.start(LIBRARY_DIR, this.clientName, root)
                 await this.buildIndex()
                 LocalProjectContextController.instance = this
             } else {

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -49,7 +49,7 @@ export class LocalProjectContextController {
             const vecLib = vectorLib ?? (await import(libraryPath))
             if (vecLib) {
                 const root = this.findCommonWorkspaceRoot(this.workspaceFolders)
-                this._vecLib = await vecLib.start(LIBRARY_DIR, this.clientName, root)
+                this._vecLib = await vecLib.start(libraryPath, this.clientName, root)
                 await this.buildIndex()
                 LocalProjectContextController.instance = this
             } else {

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -45,12 +45,15 @@ export class LocalProjectContextController {
 
     public async init(vectorLib?: any): Promise<void> {
         try {
-            const vecLib = vectorLib ?? (await import(path.join(LIBRARY_DIR, 'dist', 'extension.js')))
+            const libraryPath = path.join(LIBRARY_DIR, 'dist', 'extension.js')
+            const vecLib = vectorLib ?? (await import(libraryPath))
             if (vecLib) {
                 const root = this.findCommonWorkspaceRoot(this.workspaceFolders)
                 this._vecLib = await vecLib.start(LIBRARY_DIR, this.clientName, root)
                 await this.buildIndex()
                 LocalProjectContextController.instance = this
+            } else {
+                this.log.warn(`Vector library could not be imported from: ${libraryPath}`)
             }
         } catch (error) {
             this.log.error('Vector library failed to initialize:' + error)


### PR DESCRIPTION
## Problem
`require.main` may be undefined in cases such as the Webpack build process. This previously would have resulted in an exception.

## Solution
Handling for case where `require.main` is undefined, with fallback attempt being made to resolve off `__dirname` to discover the import. Ultimately if the library cannot be found indexing will not be available but will not break other LSP functionality.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
