### PR TITLE
feat: enable inline project context in suggestion requests

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
@@ -45,6 +45,7 @@ import {
 import { CodeDiffTracker } from './codeDiffTracker'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { initBaseTestServiceManager, TestAmazonQServiceManager } from '../../shared/amazonQServiceManager/testUtils'
+import { LocalProjectContextController } from '../../shared/localProjectContextController'
 
 const updateConfiguration = async (
     features: TestFeatures,
@@ -545,6 +546,10 @@ describe('CodeWhisperer Server', () => {
                         responseContext: EXPECTED_RESPONSE_CONTEXT,
                     })
                 )
+
+                sandbox.stub(LocalProjectContextController, 'getInstance').returns({
+                    queryInlineProjectContext: sandbox.stub().resolves([]),
+                } as unknown as LocalProjectContextController)
 
                 // Initialize the features, but don't start server yet
                 TestAmazonQServiceManager.resetInstance()

--- a/server/aws-lsp-codewhisperer/src/shared/models/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/models/constants.ts
@@ -10,10 +10,17 @@ export enum UserGroup {
 
 export const supplemetalContextFetchingTimeoutMsg = 'Amazon Q supplemental context fetching timeout'
 
+export const supplementalContextMaxTotalLength = 20480
+
+export const supplementalContextTimeoutInMs = 100
+
 export const crossFileContextConfig = {
     numberOfChunkToFetch: 60,
     topK: 3,
     numberOfLinesEachChunk: 10,
+    maximumTotalLength: 20480,
+    maxLengthEachChunk: 10240,
+    maxContextCount: 5,
 }
 
 export const utgConfig = {

--- a/server/aws-lsp-codewhisperer/src/shared/models/model.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/models/model.ts
@@ -5,7 +5,9 @@ export type UtgStrategy = 'ByName' | 'ByContent'
 
 export type CrossFileStrategy = 'OpenTabs_BM25'
 
-export type SupplementalContextStrategy = CrossFileStrategy | UtgStrategy | 'Empty'
+export type ProjectContextStrategy = 'codemap'
+
+export type SupplementalContextStrategy = CrossFileStrategy | ProjectContextStrategy | UtgStrategy | 'Empty'
 
 export interface CodeWhispererSupplementalContext {
     isUtg: boolean

--- a/server/aws-lsp-codewhisperer/src/shared/supplementalContextUtil/crossFileContextUtil.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/supplementalContextUtil/crossFileContextUtil.test.ts
@@ -11,6 +11,7 @@ import { CancellationToken } from '@aws/language-server-runtimes/server-interfac
 import { SAMPLE_FILE_OF_60_LINES_IN_JAVA, shuffleList } from '../testUtils'
 import { supportedLanguageToDialects } from './crossFileContextUtil'
 import { crossFileContextConfig } from '../models/constants'
+import { LocalProjectContextController } from '../localProjectContextController'
 
 describe('crossFileContextUtil', function () {
     const fakeCancellationToken: CancellationToken = {
@@ -244,6 +245,91 @@ describe('crossFileContextUtil', function () {
 
             const chunks = crossFile.splitFileToChunks(document, crossFileContextConfig.numberOfLinesEachChunk)
             assert.strictEqual(chunks.length, 6)
+        })
+    })
+    describe('codemapContext', () => {
+        let sandbox: sinon.SinonSandbox
+        beforeEach(() => {
+            sandbox = sinon.createSandbox()
+        })
+        afterEach(() => {
+            sandbox.restore()
+        })
+
+        it('should return Empty strategy when no contexts are found', async () => {
+            const document = TextDocument.create(
+                'file:///testfile.java',
+                'java',
+                1,
+                'line_1\nline_2\nline_3\nline_4\nline_5\nline_6\nline_7'
+            )
+            sandbox.stub(LocalProjectContextController, 'getInstance').returns({
+                queryInlineProjectContext: sandbox.stub().resolves([]),
+            } as unknown as LocalProjectContextController)
+
+            const result = await crossFile.codemapContext(
+                document,
+                { line: 0, character: 0 },
+                features.workspace,
+                fakeCancellationToken
+            )
+            assert.deepStrictEqual(result, {
+                supplementalContextItems: [],
+                strategy: 'Empty',
+            })
+        })
+        it('should return codemap strategy when project context exists', async () => {
+            const document = TextDocument.create(
+                'file:///testfile.java',
+                'java',
+                1,
+                'line_1\nline_2\nline_3\nline_4\nline_5\nline_6\nline_7'
+            )
+
+            sandbox.stub(LocalProjectContextController, 'getInstance').returns({
+                queryInlineProjectContext: sandbox
+                    .stub()
+                    .resolves([{ content: 'someOtherContet', filePath: '/path/', score: 29.879 }]),
+            } as unknown as LocalProjectContextController)
+
+            const result = await crossFile.codemapContext(
+                document,
+                { line: 0, character: 0 },
+                features.workspace,
+                fakeCancellationToken
+            )
+            assert.deepStrictEqual(result, {
+                supplementalContextItems: [{ content: 'someOtherContet', filePath: '/path/', score: 29.879 }],
+                strategy: 'codemap',
+            })
+        })
+        it('should return OpenTabs_BM25 strategy when only open tabs context exists', async () => {
+            const document = TextDocument.create(
+                'file:///testfile.java',
+                'java',
+                1,
+                'line_1\nline_2\nline_3\nline_4\nline_5\nline_6\nline_7'
+            )
+            // Open files for openTabsContext to find
+            features.openDocument(TextDocument.create('file:///OpenFile.java', 'java', 1, 'sample-content'))
+            // Return [] for fetchProjectContext
+            sandbox.stub(LocalProjectContextController, 'getInstance').returns({
+                queryInlineProjectContext: sandbox.stub().resolves([]),
+            } as unknown as LocalProjectContextController)
+
+            const result = await crossFile.codemapContext(
+                document,
+                { line: 0, character: 0 },
+                features.workspace,
+                fakeCancellationToken
+            )
+            assert.deepStrictEqual(result, {
+                supplementalContextItems: [
+                    { content: 'sample-content', filePath: '/OpenFile.java', score: 0 },
+                    { content: 'sample-content', filePath: '/OpenFile.java', score: 0 },
+                ],
+                strategy: 'OpenTabs_BM25',
+            })
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/shared/supplementalContextUtil/crossFileContextUtil.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/supplementalContextUtil/crossFileContextUtil.ts
@@ -5,10 +5,18 @@
 import * as path from 'path'
 import * as nodeUrl from 'url'
 import { BM25Document, BM25Okapi } from './rankBm25'
-import { crossFileContextConfig } from '../models/constants'
+import {
+    crossFileContextConfig,
+    supplementalContextMaxTotalLength,
+    supplementalContextTimeoutInMs,
+} from '../models/constants'
 import { isTestFile } from './codeParsingUtil'
 import { fileSystemUtils } from '@aws/lsp-core'
-import { CodeWhispererSupplementalContext, CodeWhispererSupplementalContextItem } from '../models/model'
+import {
+    CodeWhispererSupplementalContext,
+    CodeWhispererSupplementalContextItem,
+    SupplementalContextStrategy,
+} from '../models/model'
 import {
     CancellationToken,
     Position,
@@ -17,6 +25,10 @@ import {
     Range,
 } from '@aws/language-server-runtimes/server-interface'
 import { CancellationError } from './supplementalContextUtil'
+import { LocalProjectContextController } from '../../shared/localProjectContextController'
+import { QueryInlineProjectContextRequestV2 } from 'local-indexing'
+import { URI } from 'vscode-uri'
+import { waitUntil } from '@aws/lsp-core/out/util/timeoutUtils'
 
 type CrossFileSupportedLanguage =
     | 'java'
@@ -55,17 +67,106 @@ export async function fetchSupplementalContextForSrc(
     workspace: Workspace,
     cancellationToken: CancellationToken
 ): Promise<Pick<CodeWhispererSupplementalContext, 'supplementalContextItems' | 'strategy'> | undefined> {
-    const shouldProceed = shouldFetchCrossFileContext(document.languageId)
+    const supplementalContextConfig = getSupplementalContextConfig(document.languageId)
 
-    if (!shouldProceed) {
-        return shouldProceed === undefined
-            ? undefined
-            : {
-                  supplementalContextItems: [],
-                  strategy: 'Empty',
-              }
+    if (supplementalContextConfig === undefined) {
+        return supplementalContextConfig
     }
 
+    if (supplementalContextConfig === 'OpenTabs_BM25') {
+        const opentabsContextPromise = waitUntil(
+            async function () {
+                return await fetchOpenTabsContext(document, position, workspace, cancellationToken)
+            },
+            { timeout: supplementalContextTimeoutInMs, interval: 5, truthy: false }
+        )
+        const supContext = (await opentabsContextPromise) ?? []
+        return {
+            supplementalContextItems: supContext,
+            strategy: supContext.length === 0 ? 'Empty' : 'OpenTabs_BM25',
+        }
+    }
+
+    if (supplementalContextConfig === 'codemap') {
+        return await codemapContext(document, position, workspace, cancellationToken)
+    }
+}
+
+export async function codemapContext(
+    document: TextDocument,
+    position: Position,
+    workspace: Workspace,
+    cancellationToken: CancellationToken
+): Promise<Pick<CodeWhispererSupplementalContext, 'supplementalContextItems' | 'strategy'> | undefined> {
+    let strategy: SupplementalContextStrategy = 'Empty'
+
+    const openTabsContextPromise = waitUntil(
+        async function () {
+            return await fetchOpenTabsContext(document, position, workspace, cancellationToken)
+        },
+        { timeout: supplementalContextTimeoutInMs, interval: 5, truthy: false }
+    )
+
+    const projectContextPromise = waitUntil(
+        async function () {
+            return await fetchProjectContext(document, position, 'codemap')
+        },
+        { timeout: supplementalContextTimeoutInMs, interval: 5, truthy: false }
+    )
+
+    const supContext: CodeWhispererSupplementalContextItem[] = []
+    const [openTabsContext, projectContext] = await Promise.all([openTabsContextPromise, projectContextPromise])
+
+    function addToResult(items: CodeWhispererSupplementalContextItem[]) {
+        for (const item of items) {
+            const curLen = supContext.reduce((acc, i) => acc + i.content.length, 0)
+            if (curLen + item.content.length < supplementalContextMaxTotalLength) {
+                supContext.push(item)
+            }
+        }
+    }
+
+    if (projectContext && projectContext.length > 0) {
+        addToResult(projectContext)
+        strategy = 'codemap'
+    }
+
+    if (openTabsContext && openTabsContext.length > 0) {
+        addToResult(openTabsContext)
+        if (strategy === 'Empty') {
+            strategy = 'OpenTabs_BM25'
+        }
+    }
+
+    return {
+        supplementalContextItems: supContext ?? [],
+        strategy,
+    }
+}
+
+export async function fetchProjectContext(
+    document: TextDocument,
+    position: Position,
+    target: 'default' | 'codemap' | 'bm25'
+): Promise<CodeWhispererSupplementalContextItem[]> {
+    const inputChunk: Chunk = getInputChunk(document, position, crossFileContextConfig.numberOfLinesEachChunk)
+    const fsPath = URI.parse(document.uri).fsPath
+    const inlineProjectContextRequest: QueryInlineProjectContextRequestV2 = {
+        query: inputChunk.content,
+        filePath: fsPath,
+        target,
+    }
+
+    const controller = LocalProjectContextController.getInstance()
+    return controller.queryInlineProjectContext(inlineProjectContextRequest)
+}
+
+export async function fetchOpenTabsContext(
+    document: TextDocument,
+    position: Position,
+    workspace: Workspace,
+    cancellationToken: CancellationToken
+): Promise<CodeWhispererSupplementalContextItem[]> {
     const codeChunksCalculated = crossFileContextConfig.numberOfChunkToFetch
 
     // Step 1: Get relevant cross files to refer
@@ -98,8 +199,14 @@ export async function fetchSupplementalContextForSrc(
 
     // Step 4: Transform best chunks to supplemental contexts
     const supplementalContexts: CodeWhispererSupplementalContextItem[] = []
+    let totalLength = 0
     for (const chunk of bestChunks) {
         throwIfCancelled(cancellationToken)
+        totalLength += chunk.nextContent.length
+
+        if (totalLength > crossFileContextConfig.maximumTotalLength) {
+            break
+        }
 
         supplementalContexts.push({
             filePath: chunk.fileName,
@@ -109,10 +216,7 @@ export async function fetchSupplementalContextForSrc(
     }
 
     // DO NOT send code chunk with empty content
-    return {
-        supplementalContextItems: supplementalContexts.filter(item => item.content.trim().length !== 0),
-        strategy: 'OpenTabs_BM25',
-    }
+    return supplementalContexts.filter(item => item.content.trim().length !== 0)
 }
 
 function findBestKChunkMatches(chunkInput: Chunk, chunkReferences: Chunk[], k: number): Chunk[] {
@@ -157,12 +261,11 @@ function getInputChunk(document: TextDocument, cursorPosition: Position, chunkSi
  * @returns specifically returning undefined if the langueage is not supported,
  * otherwise true/false depending on if the language is fully supported or not belonging to the user group
  */
-function shouldFetchCrossFileContext(languageId: TextDocument['languageId'], _userGroup?: any): boolean | undefined {
-    if (!isCrossFileSupported(languageId)) {
-        return undefined
-    }
-
-    return true
+function getSupplementalContextConfig(
+    languageId: TextDocument['languageId'],
+    _userGroup?: any
+): SupplementalContextStrategy | undefined {
+    return isCrossFileSupported(languageId) ? 'codemap' : undefined
 }
 
 /**

--- a/server/aws-lsp-codewhisperer/src/shared/supplementalContextUtil/supplementalContextUtil.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/supplementalContextUtil/supplementalContextUtil.ts
@@ -11,6 +11,8 @@ import {
     TextDocument,
     Workspace,
 } from '@aws/language-server-runtimes/server-interface'
+import { crossFileContextConfig } from '../models/constants'
+import * as os from 'os'
 
 export class CancellationError extends Error {}
 
@@ -45,10 +47,12 @@ export async function fetchSupplementalContext(
         }
 
         if (supplementalContextValue) {
-            return {
+            const resBeforeTruncation = {
                 isUtg: isUtg,
                 isProcessTimeout: false,
-                supplementalContextItems: supplementalContextValue.supplementalContextItems,
+                supplementalContextItems: supplementalContextValue.supplementalContextItems.filter(
+                    item => item.content.trim().length !== 0
+                ),
                 contentsLength: supplementalContextValue.supplementalContextItems.reduce(
                     (acc, curr) => acc + curr.content.length,
                     0
@@ -56,6 +60,8 @@ export async function fetchSupplementalContext(
                 latency: performance.now() - timesBeforeFetching,
                 strategy: supplementalContextValue.strategy,
             }
+
+            return truncateSupplementalContext(resBeforeTruncation)
         } else {
             return undefined
         }
@@ -73,5 +79,68 @@ export async function fetchSupplementalContext(
             logging.log(`Fail to fetch supplemental context for target file ${document.uri}: ${err}`)
             return undefined
         }
+    }
+}
+
+/**
+ * Requirement
+ * - Maximum 5 supplemental context.
+ * - Each chunk can't exceed 10240 characters
+ * - Sum of all chunks can't exceed 20480 characters
+ */
+export function truncateSupplementalContext(
+    context: CodeWhispererSupplementalContext
+): CodeWhispererSupplementalContext {
+    let c = context.supplementalContextItems.map(item => {
+        if (item.content.length > crossFileContextConfig.maxLengthEachChunk) {
+            return {
+                ...item,
+                content: truncateLineByLine(item.content, crossFileContextConfig.maxLengthEachChunk),
+            }
+        } else {
+            return item
+        }
+    })
+
+    if (c.length > crossFileContextConfig.maxContextCount) {
+        c = c.slice(0, crossFileContextConfig.maxContextCount)
+    }
+
+    let curTotalLength = c.reduce((acc, cur) => {
+        return acc + cur.content.length
+    }, 0)
+    while (curTotalLength >= 20480 && c.length - 1 >= 0) {
+        const last = c[c.length - 1]
+        c = c.slice(0, -1)
+        curTotalLength -= last.content.length
+    }
+
+    return {
+        ...context,
+        supplementalContextItems: c,
+        contentsLength: curTotalLength,
+    }
+}
+
+export function truncateLineByLine(input: string, l: number): string {
+    const maxLength = l > 0 ? l : -1 * l
+    if (input.length === 0) {
+        return ''
+    }
+
+    const shouldAddNewLineBack = input.endsWith(os.EOL)
+    let lines = input.trim().split(os.EOL)
+    let curLen = input.length
+    while (curLen > maxLength && lines.length - 1 >= 0) {
+        const last = lines[lines.length - 1]
+        lines = lines.slice(0, -1)
+        curLen -= last.length + 1
+    }
+
+    const r = lines.join(os.EOL)
+    if (shouldAddNewLineBack) {
+        return r + os.EOL
+    } else {
+        return r
     }
 }


### PR DESCRIPTION
## Problem
Supplemental Context included in suggestions requests currently does not include inline project context
## Solution
Port over vscode toolkit implementation to include project context in supplemental context sent in suggestions request. Leverages vector library and local project context addition to the language server component.
 
_**Note:**_ This code is reliant on PR #982 re-enabling the localProjectContextController's ability to find the vector library.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
