### PR TITLE
fix: avoid unnecessary vector library re-initialization on config update

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
@@ -12,6 +12,8 @@ export const LocalProjectContextServer = (): Server => features => {
     let amazonQServiceManager: AmazonQTokenServiceManager
     let telemetryService: TelemetryService
 
+    let projectContextEnabled: boolean = false
+
     lsp.addInitializer((params: InitializeParams) => {
         amazonQServiceManager = AmazonQTokenServiceManager.getInstance(features)
         telemetryService = new TelemetryService(amazonQServiceManager, credentialsProvider, telemetry, logging)
@@ -117,10 +119,14 @@ export const LocalProjectContextServer = (): Server => features => {
     const updateConfigurationHandler = async (updatedConfig: AmazonQWorkspaceConfig) => {
         logging.log('Updating configuration of local context server')
         try {
-            logging.log(`Setting project context enabled to ${updatedConfig.projectContext?.enableLocalIndexing}`)
-            updatedConfig.projectContext?.enableLocalIndexing
-                ? await localProjectContextController.init()
-                : await localProjectContextController.dispose()
+            const newSetting = updatedConfig.projectContext?.enableLocalIndexing
+            if (projectContextEnabled !== newSetting) {
+                projectContextEnabled = newSetting
+                logging.log(`Setting project context enabled to ${newSetting}`)
+                updatedConfig.projectContext?.enableLocalIndexing
+                    ? await localProjectContextController.init()
+                    : await localProjectContextController.dispose()
+            }
         } catch (error) {
             logging.error(`Error handling configuration change: ${error}`)
         }


### PR DESCRIPTION
## Problem
Vector library can be unnecessarily re-initialized on configuration changes even if the enablement setting does not change.

## Solution
Cache the current value and only enable/disable the library on an appropriate change.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
