### PR TITLE
feat(chat-client): support profile banner changes

### DIFF
--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -18,6 +18,7 @@ import { createChat } from './chat'
 import sinon = require('sinon')
 import { TELEMETRY } from '../contracts/serverContracts'
 import {
+    ENTER_FOCUS,
     ERROR_MESSAGE_TELEMETRY_EVENT,
     SEND_TO_PROMPT_TELEMETRY_EVENT,
     TAB_ADD_TELEMETRY_EVENT,
@@ -65,18 +66,33 @@ describe('Chat', () => {
         global.ResizeObserver = undefined
     })
 
-    it('publishes ready event and initial tab add event, when initialized', () => {
-        assert.callCount(clientApi.postMessage, 4)
+    it('publishes ready event when initialized', () => {
+        assert.calledWithExactly(clientApi.postMessage.firstCall, { command: READY_NOTIFICATION_METHOD })
+    })
 
-        assert.calledWithExactly(clientApi.postMessage.firstCall, {
+    it('creates initial tab when chat options are provided', () => {
+        const bannerText = 'This is a test banner message'
+        const eventParams = {
+            command: CHAT_OPTIONS,
+            params: {
+                chatNotifications: {
+                    bannerText: bannerText,
+                },
+            },
+        }
+        const sendToPromptEvent = createInboundEvent(eventParams)
+        window.dispatchEvent(sendToPromptEvent)
+
+        assert.calledWithExactly(clientApi.postMessage.firstCall, { command: READY_NOTIFICATION_METHOD })
+
+        assert.calledWithExactly(clientApi.postMessage.secondCall, {
             command: TELEMETRY,
-            params: { name: 'enterFocus' },
+            params: { name: ENTER_FOCUS },
         })
-        assert.calledWithExactly(clientApi.postMessage.secondCall, { command: READY_NOTIFICATION_METHOD })
 
         assert.calledWithExactly(clientApi.postMessage.thirdCall, {
             command: TAB_ADD_NOTIFICATION_METHOD,
-            params: { tabId: initialTabId },
+            params: { tabId: sinon.match.string },
         })
 
         assert.calledWithExactly(clientApi.postMessage.lastCall, {
@@ -84,7 +100,7 @@ describe('Chat', () => {
             params: {
                 triggerType: 'click',
                 name: TAB_ADD_TELEMETRY_EVENT,
-                tabId: initialTabId,
+                tabId: sinon.match.string,
             },
         })
     })
@@ -313,9 +329,9 @@ describe('Chat', () => {
             assert.called(TabFactory.prototype.enableHistory)
             // @ts-ignore
             assert.called(TabFactory.prototype.enableExport)
-        })
+        }).timeout(20000)
 
-        it('does not enable history and export features support if flags are falsy', () => {
+        it('does not enable history and export features support if flags are falsy', async () => {
             const chatOptionsRequest = createInboundEvent({
                 command: CHAT_OPTIONS,
                 params: {
@@ -329,7 +345,7 @@ describe('Chat', () => {
             assert.notCalled(TabFactory.prototype.enableHistory)
             // @ts-ignore
             assert.notCalled(TabFactory.prototype.enableExport)
-        })
+        }).timeout(20000)
     })
 
     describe('onGetSerializedChat', () => {

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -35,11 +35,13 @@ import {
 } from '@aws/chat-client-ui-types'
 import {
     BUTTON_CLICK_REQUEST_METHOD,
+    CHAT_OPTIONS_UPDATE_NOTIFICATION_METHOD,
     CHAT_REQUEST_METHOD,
     CHAT_UPDATE_NOTIFICATION_METHOD,
     CONTEXT_COMMAND_NOTIFICATION_METHOD,
     CONVERSATION_CLICK_REQUEST_METHOD,
     CREATE_PROMPT_NOTIFICATION_METHOD,
+    ChatOptionsUpdateParams,
     ChatParams,
     ChatUpdateParams,
     ContextCommandParams,
@@ -181,8 +183,16 @@ export const createChat = (
             case GET_SERIALIZED_CHAT_REQUEST_METHOD:
                 mynahApi.getSerializedChat(message.requestId, message.params as GetSerializedChatParams)
                 break
+            case CHAT_OPTIONS_UPDATE_NOTIFICATION_METHOD:
+                tabFactory.setInfoMessages((message.params as ChatOptionsUpdateParams).chatNotifications)
+                break
             case CHAT_OPTIONS: {
                 const params = (message as ChatOptionsMessage).params
+
+                if (params?.chatNotifications) {
+                    tabFactory.setInfoMessages((message.params as ChatOptionsUpdateParams).chatNotifications)
+                }
+
                 if (params?.quickActions?.quickActionsCommandGroups) {
                     const quickActionCommandGroups = params.quickActions.quickActionsCommandGroups.map(group => ({
                         ...group,
@@ -201,6 +211,9 @@ export const createChat = (
                 if (params?.export) {
                     tabFactory.enableExport()
                 }
+
+                const initialTabId = mynahApi.createTabId()
+                if (initialTabId) mynahUi.selectTab(initialTabId)
 
                 const allExistingTabs: MynahUITabStoreModel = mynahUi.getAllTabs()
                 const highlightCommand = featureConfig.get('highlightCommand')

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -17,6 +17,7 @@ describe('MynahUI', () => {
 
     let getSelectedTabIdStub: sinon.SinonStub
     let createTabStub: sinon.SinonStub
+    let getChatItemsStub: sinon.SinonStub
     let getAllTabsStub: sinon.SinonStub
     let updateStoreSpy: sinon.SinonSpy
     let addChatItemSpy: sinon.SinonSpy
@@ -68,6 +69,8 @@ describe('MynahUI', () => {
         const tabFactory = new TabFactory({})
         createTabStub = sinon.stub(tabFactory, 'createTab')
         createTabStub.returns({})
+        getChatItemsStub = sinon.stub(tabFactory, 'getChatItems')
+        getChatItemsStub.returns([])
         const mynahUiResult = createMynahUi(messager, tabFactory, true, true)
         mynahUi = mynahUiResult[0]
         inboundChatApi = mynahUiResult[1]
@@ -142,10 +145,12 @@ describe('MynahUI', () => {
     describe('openTab', () => {
         it('should create a new tab with welcome messages if tabId not passed and previous messages not passed', () => {
             createTabStub.resetHistory()
+            getChatItemsStub.resetHistory()
 
             inboundChatApi.openTab(requestId, {})
 
-            sinon.assert.calledOnceWithExactly(createTabStub, true, false, false, undefined)
+            sinon.assert.calledOnceWithExactly(createTabStub, false)
+            sinon.assert.calledOnceWithExactly(getChatItemsStub, true, false, undefined)
             sinon.assert.notCalled(selectTabSpy)
             sinon.assert.calledOnce(onOpenTabSpy)
         })
@@ -165,6 +170,7 @@ describe('MynahUI', () => {
             ]
 
             createTabStub.resetHistory()
+            getChatItemsStub.resetHistory()
 
             inboundChatApi.openTab(requestId, {
                 newTabOptions: {
@@ -174,19 +180,21 @@ describe('MynahUI', () => {
                 },
             })
 
-            sinon.assert.calledOnceWithExactly(createTabStub, false, false, false, mockMessages)
+            sinon.assert.calledOnceWithExactly(createTabStub, false)
+            sinon.assert.calledOnceWithExactly(getChatItemsStub, false, false, mockMessages)
             sinon.assert.notCalled(selectTabSpy)
             sinon.assert.calledOnce(onOpenTabSpy)
         })
 
         it('should call onOpenTab if a new tab if tabId not passed and tab not created', () => {
             createTabStub.resetHistory()
+            getChatItemsStub.resetHistory()
             updateStoreSpy.restore()
             sinon.stub(mynahUi, 'updateStore').returns(undefined)
 
             inboundChatApi.openTab(requestId, {})
 
-            sinon.assert.calledOnceWithExactly(createTabStub, true, false, false, undefined)
+            sinon.assert.calledOnceWithExactly(createTabStub, false)
             sinon.assert.notCalled(selectTabSpy)
             sinon.assert.calledOnceWithMatch(onOpenTabSpy, requestId, { type: 'InvalidRequest' })
         })
@@ -229,7 +237,7 @@ describe('MynahUI', () => {
             getSelectedTabIdStub.returns(undefined)
             inboundChatApi.sendGenericCommand({ genericCommand, selection, tabId, triggerType })
 
-            sinon.assert.calledOnceWithExactly(createTabStub, false, false, false, undefined)
+            sinon.assert.calledOnceWithExactly(createTabStub, false)
             sinon.assert.calledThrice(updateStoreSpy)
         })
 
@@ -245,7 +253,7 @@ describe('MynahUI', () => {
             getSelectedTabIdStub.returns(tabId)
             inboundChatApi.sendGenericCommand({ genericCommand, selection, tabId, triggerType })
 
-            sinon.assert.calledOnceWithExactly(createTabStub, false, false, false, undefined)
+            sinon.assert.calledOnceWithExactly(createTabStub, false)
             sinon.assert.calledThrice(updateStoreSpy)
         })
 

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -67,6 +67,7 @@ export interface InboundChatApi {
     listConversations(params: ListConversationsResult): void
     conversationClicked(params: ConversationClickResult): void
     getSerializedChat(requestId: string, params: GetSerializedChatParams): void
+    createTabId(openTab?: boolean): string | undefined
 }
 
 type ContextCommandGroups = MynahUIDataModel['contextCommands']
@@ -82,6 +83,8 @@ const getTabPairProgrammingMode = (mynahUi: MynahUI, tabId: string) => {
     const promptInputOptions = mynahUi.getTabData(tabId)?.getStore()?.promptInputOptions ?? []
     return promptInputOptions.find(item => item.id === 'pair-programmer-mode')?.value === 'true'
 }
+
+const openTabKey = 'openTab'
 
 export const handlePromptInputChange = (mynahUi: MynahUI, tabId: string, optionsValues: Record<string, string>) => {
     const promptTypeValue = optionsValues['pair-programmer-mode']
@@ -170,7 +173,6 @@ export const createMynahUi = (
     customChatClientAdapter?: ChatClientAdapter,
     featureConfig?: Map<string, any>
 ): [MynahUI, InboundChatApi] => {
-    const initialTabId = TabFactory.generateUniqueId()
     let disclaimerCardActive = !disclaimerAcknowledged
     let programmingModeCardActive = !pairProgrammingCardAcknowledged
     let contextCommandGroups: ContextCommandGroups | undefined
@@ -227,7 +229,6 @@ export const createMynahUi = (
         },
         onReady: () => {
             messager.onUiReady()
-            messager.onTabAdd(initialTabId)
         },
         onFileClick: (tabId, filePath, deleted, messageId, eventId, fileDetails) => {
             messager.onFileClick({ tabId, filePath, messageId, fullPath: fileDetails?.data?.['fullPath'] })
@@ -249,6 +250,16 @@ export const createMynahUi = (
                         : []),
                 ],
                 ...(disclaimerCardActive ? { promptInputStickyCard: disclaimerCard } : {}),
+            }
+
+            const tabStore = mynahUi.getTabData(tabId).getStore()
+
+            // Tabs can be opened through different methods, including server-initiated 'openTab' requests.
+            // The 'openTab' request is specifically used for loading historical chat sessions with pre-existing messages.
+            // We check if tabMetadata.openTabKey exists - if it does and is set to true, we skip showing welcome messages
+            // since this indicates we're loading a previous chat session rather than starting a new one.
+            if (!tabStore?.tabMetadata || !tabStore.tabMetadata.openTabKey) {
+                defaultTabConfig.chatItems = tabFactory.getChatItems(true, programmingModeCardActive, [])
             }
             mynahUi.updateStore(tabId, defaultTabConfig)
             messager.onTabAdd(tabId)
@@ -446,7 +457,7 @@ export const createMynahUi = (
                 // Update the tab defaults to hide the programmer mode card for new tabs
                 mynahUi.updateTabDefaults({
                     store: {
-                        chatItems: tabFactory.createTab(true, disclaimerCardActive, false).chatItems,
+                        chatItems: tabFactory.getChatItems(true, false),
                     },
                 })
             }
@@ -464,14 +475,9 @@ export const createMynahUi = (
     }
 
     const mynahUiProps: MynahUIProps = {
-        tabs: {
-            [initialTabId]: {
-                isSelected: true,
-                store: tabFactory.createTab(true, disclaimerCardActive, programmingModeCardActive),
-            },
-        },
+        tabs: {},
         defaults: {
-            store: tabFactory.createTab(true, false, programmingModeCardActive),
+            store: tabFactory.createTab(false),
         },
         config: {
             maxTabs: 10,
@@ -495,11 +501,14 @@ export const createMynahUi = (
         return tabId ? mynahUi.getAllTabs()[tabId]?.store : undefined
     }
 
-    const createTabId = (needWelcomeMessages: boolean = false, chatMessages?: ChatMessage[]) => {
-        const tabId = mynahUi.updateStore(
-            '',
-            tabFactory.createTab(needWelcomeMessages, disclaimerCardActive, programmingModeCardActive, chatMessages)
-        )
+    // The 'openTab' parameter indicates whether this tab creation is initiated by 'openTab' server request
+    // to restore a previous chat session (true) or if it's a new client-side tab creation (false/undefined).
+    // This distinction helps maintain consistent tab behavior between fresh conversations and restored sessions.
+    const createTabId = (openTab?: boolean) => {
+        const tabId = mynahUi.updateStore('', {
+            ...tabFactory.createTab(disclaimerCardActive),
+            tabMetadata: { openTabKey: openTab ? true : false },
+        })
         if (tabId === undefined) {
             mynahUi.notify({
                 content: uiComponentsTexts.noMoreTabsTooltip,
@@ -789,8 +798,11 @@ ${params.message}`,
             messager.onOpenTab(requestId, { tabId: params.tabId })
         } else {
             const messages = params.newTabOptions?.data?.messages
-            const tabId = createTabId(messages ? false : true, messages)
+            const tabId = createTabId(true)
             if (tabId) {
+                mynahUi.updateStore(tabId, {
+                    chatItems: tabFactory.getChatItems(messages ? false : true, programmingModeCardActive, messages),
+                })
                 messager.onOpenTab(requestId, { tabId })
             } else {
                 messager.onOpenTab(requestId, {
@@ -902,6 +914,7 @@ ${params.message}`,
         listConversations: listConversations,
         conversationClicked: conversationClicked,
         getSerializedChat: getSerializedChat,
+        createTabId: createTabId,
     }
 
     return [mynahUi, api]

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -29,6 +29,7 @@ import {
     ShowSaveFileDialogRequestType,
     ShowSaveFileDialogParams,
     tabBarActionRequestType,
+    chatOptionsUpdateType,
     buttonClickRequestType,
     chatUpdateNotificationType,
 } from '@aws/language-server-runtimes/protocol'
@@ -192,6 +193,13 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri, 
                             break
                     }
                 }, undefined)
+
+                languageClient.onNotification(chatOptionsUpdateType, params => {
+                    webviewView.webview.postMessage({
+                        command: chatOptionsUpdateType.method,
+                        params: params,
+                    })
+                })
 
                 languageClient.onNotification(contextCommandsNotificationType, params => {
                     webviewView.webview.postMessage({


### PR DESCRIPTION
## Problem
Regional dev profile support for chat client.

## Solution
<img width="495" alt="image" src="https://github.com/user-attachments/assets/a468eeb2-4384-470a-8c8a-22dfb48a1159" />

<img width="486" alt="image" src="https://github.com/user-attachments/assets/2f020c5d-23da-47f1-aa13-49851a83e973" />



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
