### PR TITLE
fix(chat-client): do not route onTabBarButtonClick to custom handler

### DIFF
--- a/chat-client/src/client/withAdapter.test.ts
+++ b/chat-client/src/client/withAdapter.test.ts
@@ -327,11 +327,6 @@ describe('withAdapter', () => {
             handlerName: 'onTabbedContentTabChange',
             args: ['__TAB_ID__', 'message-1', 'content-tab-1', 'event-1'],
         })
-
-        testEventHandler({
-            handlerName: 'onTabBarButtonClick',
-            args: ['__TAB_ID__', 'message-1', 'button-1', 'event-1'],
-        })
     })
 
     describe('Special Routing Logic', () => {
@@ -580,6 +575,17 @@ describe('withAdapter', () => {
                 sinon.assert.notCalled(customOnFormLinkClickHandler as sinon.SinonStub)
                 sinon.assert.calledOnceWithExactly(onFormLinkClickStub, 'https://example.com', mouseEvent, 'event-1')
             })
+        })
+
+        it('should call route onTabBarButtonClick only to default handler', () => {
+            mynahUiPropsWithAdapter.onTabBarButtonClick?.('tab-1', 'button-1')
+
+            sinon.assert.notCalled(customEventHandlers.onTabBarButtonClick as sinon.SinonStub)
+            sinon.assert.calledOnceWithMatch(
+                defaultEventHandlers.onTabBarButtonClick as sinon.SinonStub,
+                'tab-1',
+                'button-1'
+            )
         })
 
         it('should call both custom and original onReady handlers', () => {

--- a/chat-client/src/client/withAdapter.ts
+++ b/chat-client/src/client/withAdapter.ts
@@ -56,7 +56,6 @@ export const withAdapter = (
         onShowMoreWebResultsClick: addDefaultRouting('onShowMoreWebResultsClick'),
         onChatPromptProgressActionButtonClicked: addDefaultRouting('onChatPromptProgressActionButtonClicked'),
         onTabbedContentTabChange: addDefaultRouting('onTabbedContentTabChange'),
-        onTabBarButtonClick: addDefaultRouting('onTabBarButtonClick'),
 
         /**
          * Handler with special routing logic
@@ -127,6 +126,11 @@ export const withAdapter = (
             }
 
             defaultEventHandler.onFormLinkClick?.(link, mouseEvent, eventId)
+        },
+
+        onTabBarButtonClick(tabId, buttonId) {
+            // Always route tab bar actions to original handler
+            defaultEventHandler.onTabBarButtonClick?.(tabId, buttonId)
         },
 
         onReady() {


### PR DESCRIPTION
## Problem
Tab bar actions for chat History and Export do not work in tabs handled with injected hybrid controller.

## Solution
Do not route tab bar events to injected controller, handle all in Chat Client itself. There's no use case to route them outside

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
