### PR TITLE
feat: enable hot reloading on server file changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -112,7 +112,8 @@
                 "ENABLE_CHAT": "true",
                 "ENABLE_CUSTOMIZATIONS": "true",
                 "ENABLE_AMAZON_Q_PROFILES": "true",
-                "ENABLE_AWS_Q_SECTION": "true"
+                "ENABLE_AWS_Q_SECTION": "true",
+                "ENABLE_HOT_RELOAD": "true"
                 // "HTTPS_PROXY": "http://127.0.0.1:8888",
                 // "AWS_CA_BUNDLE": "/path/to/cert.pem"
             }

--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -9,6 +9,7 @@ import * as path from 'path'
 import { ExtensionContext, workspace, env, version } from 'vscode'
 
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node'
+import { watchServerModule } from './serverWatcher'
 import { registerChat } from './chatActivation'
 import {
     configureCredentialsCapabilities,
@@ -177,6 +178,14 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
 
     // Create the language client and start the client.
     const client = new LanguageClient('awsDocuments', 'AWS Documents Language Server', serverOptions, clientOptions)
+
+    // Set up file watcher to restart the language server when the server module changes
+    // Only enable if ENABLE_HOT_RELOAD is set to "true"
+    const enableHotReload = process.env.ENABLE_HOT_RELOAD === 'true'
+    if (enableHotReload) {
+        console.log('Hot reload enabled for server module:', serverModule)
+        watchServerModule(serverModule, client, extensionContext)
+    }
 
     if (enableIamProvider) {
         await registerIamCredentialsProviderSupport(client, extensionContext, enableEncryptionInit)

--- a/client/vscode/src/serverWatcher.ts
+++ b/client/vscode/src/serverWatcher.ts
@@ -1,0 +1,102 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { ExtensionContext, Disposable } from 'vscode'
+import { LanguageClient, State } from 'vscode-languageclient/node'
+
+/**
+ * Watches the server module file for changes and restarts the language server when changes are detected.
+ * @param serverModule Path to the server module file
+ * @param client The language client instance to restart
+ * @param context Extension context
+ * @returns Disposable for the file watcher
+ */
+export function watchServerModule(serverModule: string, client: LanguageClient, context: ExtensionContext): Disposable {
+    // Ensure the server module path exists
+    if (!fs.existsSync(serverModule)) {
+        console.warn(`Server module path does not exist: ${serverModule}`)
+        return new Disposable(() => {})
+    }
+
+    console.log(`Setting up watcher for server module: ${serverModule}`)
+
+    // Get the directory and filename of the server module
+    const serverDir = path.dirname(serverModule)
+
+    // Use Node.js fs.watch API directly
+    let fsWatcher: fs.FSWatcher | undefined
+    let debounceTimer: NodeJS.Timeout | undefined
+    let isRestarting = false
+
+    try {
+        // Watch the directory containing the server module
+        fsWatcher = fs.watch(serverDir, (eventType, filename) => {
+            // Only react to changes to our specific file
+            if (filename && path.join(serverDir, filename) === serverModule) {
+                console.log(`Server module ${eventType} detected: ${filename}`)
+
+                // Debounce the restart to avoid multiple restarts for a single change
+                if (debounceTimer) {
+                    clearTimeout(debounceTimer)
+                }
+
+                debounceTimer = setTimeout(async () => {
+                    if (isRestarting) {
+                        return
+                    }
+
+                    isRestarting = true
+
+                    try {
+                        console.log('Restarting language server...')
+
+                        // Log the client state before restart
+                        console.log('Client state before restart:', client.state)
+                        console.log(
+                            'Client initializeResult before restart:',
+                            client.initializeResult ? 'exists' : 'undefined'
+                        )
+
+                        // Use the built-in restart method which should preserve handlers
+                        await client.restart()
+
+                        // Log the client state after restart
+                        console.log('Client state after restart:', client.state)
+                        console.log(
+                            'Client initializeResult after restart:',
+                            client.initializeResult ? 'exists' : 'undefined'
+                        )
+
+                        console.log('Language server restarted successfully')
+
+                        // Note: Bearer token restoration is handled in credentialsActivation.ts
+                        // through the onDidChangeState event handler
+                    } catch (error) {
+                        console.error('Failed to restart language server:', error)
+                    } finally {
+                        isRestarting = false
+                    }
+                }, 500) // 500ms debounce
+            }
+        })
+
+        console.log(`Native file watcher set up for directory: ${serverDir}`)
+    } catch (error) {
+        console.error(`Failed to set up file watcher: ${error}`)
+    }
+
+    // Create a disposable to clean up the watcher
+    return new Disposable(() => {
+        if (fsWatcher) {
+            fsWatcher.close()
+        }
+
+        if (debounceTimer) {
+            clearTimeout(debounceTimer)
+        }
+    })
+}


### PR DESCRIPTION
## Problem
Whenever you iterate on the chat server it's quite a long cycle to close vscode, recompile, relaunch the dev vscode, and re-authentice.

## Solution
By specifying `ENABLE_HOT_RELOAD` in the `launch.json` config, the language server restarts whenever the server module is changed. After it starts, the bearer token is re-submitted. Only works without encryption for now.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
