### PR TITLE
fix: never leave body undefined in history, even if that assistant re…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.test.ts
@@ -29,7 +29,7 @@ describe('AgenticChatEventParser', () => {
                 data: {
                     chatResult: {
                         messageId: mockMessageId,
-                        body: undefined,
+                        body: '',
                         canBeVoted: true,
                         codeReference: undefined,
                         followUp: undefined,
@@ -61,7 +61,7 @@ describe('AgenticChatEventParser', () => {
                 data: {
                     chatResult: {
                         messageId: mockMessageId,
-                        body: undefined,
+                        body: '',
                         canBeVoted: true,
                         codeReference: undefined,
                         followUp: undefined,
@@ -155,6 +155,22 @@ describe('AgenticChatEventParser', () => {
                 toolUses: {},
             },
         })
+    })
+
+    it('ensures body is an empty string instead of undefined when adding to history', () => {
+        const chatEventParser = new AgenticChatEventParser(mockMessageId, new Metric<AddMessageEvent>())
+
+        // Only add messageMetadataEvent but no assistantResponseEvent
+        chatEventParser.processPartialEvent({
+            messageMetadataEvent: {
+                conversationId: 'id-2345',
+            },
+        })
+
+        // Get the result - body should be an empty string, not undefined
+        const result = chatEventParser.getResult()
+
+        assert.strictEqual(result.data?.chatResult.body, '')
     })
 
     it('getResult returns the accumulated result', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -188,7 +188,7 @@ export class AgenticChatEventParser implements ChatResult {
     public getResult(): Result<ChatResultWithMetadata, string> {
         const chatResult: ChatResult = {
             messageId: this.messageId,
-            body: this.body,
+            body: this.body || '',
             canBeVoted: this.canBeVoted ?? true,
             relatedContent: this.relatedContent,
             followUp: this.followUp,


### PR DESCRIPTION
…sponse did not have content

## Problem
An assistant response can result in only tool uses, or might fail before the response is captured. In those cases we don't want to break the history on subsequent requests.

## Solution
History body is never null, but insert an empty string if there is no body tracked.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
