### PR TITLE
fix: add workspace folders as context for agentic-chat

### DIFF
--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -1,7 +1,6 @@
 import * as path from 'path'
 import { URI } from 'vscode-uri'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
-import { URI } from 'vscode-uri'
 
 type ElementType<T> = T extends (infer U)[] ? U : never
 type Dirent = ElementType<Awaited<ReturnType<Features['workspace']['fs']['readdir']>>>
@@ -88,8 +87,8 @@ export function getEntryPath(entry: Dirent) {
 // TODO: port this to runtimes?
 export function getWorkspaceFolders(lsp: Features['lsp']): string[] {
     return lsp.getClientInitializeParams()?.workspaceFolders?.map(({ uri }) => URI.parse(uri).fsPath) ?? []
+}
 
 export async function inWorkspace(workspace: Features['workspace'], filepath: string) {
     return (await workspace.getTextDocument(URI.file(filepath).toString())) !== undefined
-
 }

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { URI } from 'vscode-uri'
 
 type ElementType<T> = T extends (infer U)[] ? U : never
 type Dirent = ElementType<Awaited<ReturnType<Features['workspace']['fs']['readdir']>>>
@@ -78,4 +79,9 @@ export function formatListing(entry: Dirent): string {
 
 export function getEntryPath(entry: Dirent) {
     return path.join(entry.parentPath, entry.name)
+}
+
+// TODO: port this to runtimes?
+export function getWorkspaceFolders(lsp: Features['lsp']): string[] {
+    return lsp.getClientInitializeParams()?.workspaceFolders?.map(({ uri }) => URI.parse(uri).fsPath) ?? []
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -918,7 +918,7 @@ describe('AgenticChatController', () => {
                 extractDocumentContextStub.restore()
             })
 
-            it('leaves editor state as undefined if cursorState is not passed', async () => {
+            it('leaves cursorState as undefined if cursorState is not passed', async () => {
                 const documentContextObject = {
                     programmingLanguage: 'typescript',
                     cursorState: undefined,
@@ -941,12 +941,12 @@ describe('AgenticChatController', () => {
 
                 assert.strictEqual(
                     calledRequestInput.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
-                        ?.editorState,
+                        ?.editorState?.cursorState,
                     undefined
                 )
             })
 
-            it('leaves editor state as undefined if relative file path is undefined', async () => {
+            it('leaves document as undefined if relative file path is undefined', async () => {
                 const documentContextObject = {
                     programmingLanguage: 'typescript',
                     cursorState: [],
@@ -968,7 +968,7 @@ describe('AgenticChatController', () => {
 
                 assert.strictEqual(
                     calledRequestInput.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
-                        ?.editorState,
+                        ?.editorState?.document,
                     undefined
                 )
             })
@@ -1004,6 +1004,7 @@ describe('AgenticChatController', () => {
                             relativeFilePath: 'file:///test.ts',
                             text: undefined,
                         },
+                        workspaceFolders: [],
                     }
                 )
             })
@@ -1169,7 +1170,7 @@ describe('AgenticChatController', () => {
                 extractDocumentContextStub.restore()
             })
 
-            it('leaves editor state as undefined if cursorState is not passed', async () => {
+            it('leaves cursorState as undefined if cursorState is not passed', async () => {
                 const documentContextObject = {
                     programmingLanguage: 'typescript',
                     cursorState: undefined,
@@ -1190,12 +1191,12 @@ describe('AgenticChatController', () => {
 
                 assert.strictEqual(
                     calledRequestInput.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
-                        ?.editorState,
+                        ?.editorState?.cursorState,
                     undefined
                 )
             })
 
-            it('leaves editor state as undefined if relative file path is undefined', async () => {
+            it('leaves document as undefined if relative file path is undefined', async () => {
                 const documentContextObject = {
                     programmingLanguage: 'typescript',
                     cursorState: [],
@@ -1215,7 +1216,7 @@ describe('AgenticChatController', () => {
 
                 assert.strictEqual(
                     calledRequestInput.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
-                        ?.editorState,
+                        ?.editorState?.document,
                     undefined
                 )
             })
@@ -1249,6 +1250,7 @@ describe('AgenticChatController', () => {
                             relativeFilePath: 'file:///test.ts',
                             text: undefined,
                         },
+                        workspaceFolders: [],
                     }
                 )
             })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -116,7 +116,7 @@ export class AgenticChatController implements ChatHandlers {
     ) {
         this.#features = features
         this.#chatSessionManagementService = chatSessionManagementService
-        this.#triggerContext = new AgenticChatTriggerContext(features.workspace, features.logging)
+        this.#triggerContext = new AgenticChatTriggerContext(features)
         this.#telemetryController = new ChatTelemetryController(features, telemetryService)
         this.#telemetryService = telemetryService
         this.#amazonQServiceManager = amazonQServiceManager

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
@@ -33,7 +33,7 @@ describe('AgenticChatTriggerContext', () => {
     })
 
     it('returns null if text document is not defined in params', async () => {
-        const triggerContext = new AgenticChatTriggerContext(testFeatures.workspace, testFeatures.logging)
+        const triggerContext = new AgenticChatTriggerContext(testFeatures)
 
         const documentContext = await triggerContext.extractDocumentContext({
             cursorState: [
@@ -51,7 +51,7 @@ describe('AgenticChatTriggerContext', () => {
     })
 
     it('returns null if text document is not found', async () => {
-        const triggerContext = new AgenticChatTriggerContext(testFeatures.workspace, testFeatures.logging)
+        const triggerContext = new AgenticChatTriggerContext(testFeatures)
 
         const documentContext = await triggerContext.extractDocumentContext({
             cursorState: [
@@ -71,7 +71,7 @@ describe('AgenticChatTriggerContext', () => {
     })
 
     it('passes default cursor state if no cursor is found', async () => {
-        const triggerContext = new AgenticChatTriggerContext(testFeatures.workspace, testFeatures.logging)
+        const triggerContext = new AgenticChatTriggerContext(testFeatures)
 
         const documentContext = await triggerContext.extractDocumentContext({
             cursorState: [],
@@ -84,7 +84,7 @@ describe('AgenticChatTriggerContext', () => {
     })
 
     it('includes cursor state from the parameters and text document if found', async () => {
-        const triggerContext = new AgenticChatTriggerContext(testFeatures.workspace, testFeatures.logging)
+        const triggerContext = new AgenticChatTriggerContext(testFeatures)
 
         testFeatures.openDocument(mockTSDocument)
         const documentContext = await triggerContext.extractDocumentContext({

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
@@ -17,6 +17,7 @@ describe('AgenticChatTriggerContext', () => {
     let testFeatures: TestFeatures
 
     const filePath = 'file://test.ts'
+    const mockWorkspaceFolders = [{ uri: URI.file('/path/to/my/workspace/').toString(), name: 'myWorkspace' }]
     const mockTSDocument = TextDocument.create(filePath, 'typescript', 1, '')
     const mockDocumentContext: DocumentContext = {
         text: '',
@@ -29,7 +30,7 @@ describe('AgenticChatTriggerContext', () => {
     beforeEach(() => {
         testFeatures = new TestFeatures()
         testFeatures.lsp.getClientInitializeParams.returns({
-            workspaceFolders: [{ uri: URI.file('/path/to/my/workspace/').toString(), name: 'myWorkspace' }],
+            workspaceFolders: mockWorkspaceFolders,
         } as InitializeParams)
         sinon.stub(DocumentContextExtractor.prototype, 'extractDocumentContext').resolves(mockDocumentContext)
     })
@@ -119,12 +120,12 @@ describe('AgenticChatTriggerContext', () => {
         assert.deepStrictEqual(
             chatParams.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
                 ?.workspaceFolders,
-            ['/path/to/my/workspace/']
+            mockWorkspaceFolders.map(f => URI.parse(f.uri).fsPath)
         )
         assert.deepStrictEqual(
             chatParamsWithMore.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
                 ?.workspaceFolders,
-            ['/path/to/my/workspace/']
+            mockWorkspaceFolders.map(f => URI.parse(f.uri).fsPath)
         )
     })
 })


### PR DESCRIPTION
## Problem
Moved from https://github.com/aws/language-servers/pull/987. 

Q doesn't know what the workspace folder path is. When I ask it "what is the path to my workspace" it tries to use a few tools, then fails, then tries to find from the root directory, which takes a very long time and basically forces the user to delete the tab. 

This works on the VSC implementation. This is affecting how tools are used.
## Solution
- Ensure it is passed as context similar to how agentic-chat feature branch does it

## Verification and Testing
- added a unit test
- can be verified end-to-end with the following prompt:
<img width="405" alt="image" src="https://github.com/user-attachments/assets/656de2cf-743e-421b-9a77-6111829a7f66" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
