### PR TITLE
fix: parsing AmazonQWorkspaceConfiguration

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
@@ -122,8 +122,8 @@ export async function getAmazonQRelatedWorkspaceConfigs(
                     enableLocalIndexing: newQConfig.projectContext?.enableLocalIndexing === true,
                     localIndexing: {
                         ignoreFilePatterns: newQConfig.projectContext?.localIndexing?.ignoreFilePatterns ?? [],
-                        maxFileSizeMB: newQConfig.projectContext?.localIndexing?.maxFileSizeMb ?? 10,
-                        maxIndexSizeMB: newQConfig.projectContext?.localIndexing?.maxIndexSizeMb ?? 2048,
+                        maxFileSizeMB: newQConfig.projectContext?.localIndexing?.maxFileSizeMB ?? 10,
+                        maxIndexSizeMB: newQConfig.projectContext?.localIndexing?.maxIndexSizeMB ?? 2048,
                         indexCacheDirPath: newQConfig.projectContext?.localIndexing?.indexCacheDirPath ?? undefined,
                     },
                 },


### PR DESCRIPTION
## Problem
When parsing the AmazonQWorkspaceConfiguration object, two parameters are using the old parameter names.

## Solution
Refactored to use correct parameter names.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
