### PR TITLE
fix: strengthen undefined checks for require.main in LocalProjectCont…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -23,7 +23,7 @@ import * as ignore from 'ignore'
 import { fdir } from 'fdir'
 
 const LIBRARY_DIR = (() => {
-    if (require.main) {
+    if (require.main?.filename) {
         return path.join(dirname(require.main.filename), 'indexing')
     }
     return path.join(__dirname, 'indexing')


### PR DESCRIPTION
…extController

## Problem
Related items:
https://github.com/aws/language-servers/pull/980 
https://github.com/aws/language-servers/pull/982

After 982, the path error is happening again so this should fix the errors



## Solution
Make sure that `require.main.filename` is not `undefined` before passing it as a parameter to `path.join` 

## Testing

I have tested and verified this solution. I created a custom webpack config that allows me to create a single `js` bundle inside `app/aws-lsp-codewhisperer-runtimes` and I verified that if I create a bundle from the code and run it with `node bundle.js --stdio`, I get the path error and if I do the same after the changes the problem is gone 

## Next steps

We will follow up on this to make sure that we catch broken builds as early as possible 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
