### PR TITLE
feat: improve symlink handling

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
@@ -68,10 +68,10 @@ interface QInlineSuggestionsConfig {
 }
 
 interface LocalIndexConfig {
-    ignoreFilePatterns?: string[]
+    ignoreFilePatterns?: string[] // patterns must follow .gitignore convention
     maxFileSizeMB?: number
     maxIndexSizeMB?: number
-    indexCacheDirPath?: string
+    indexCacheDirPath?: string // defaults to homedir/.aws/amazonq/cache
 }
 
 interface QProjectContextConfig {

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
@@ -122,8 +122,8 @@ export async function getAmazonQRelatedWorkspaceConfigs(
                     enableLocalIndexing: newQConfig.projectContext?.enableLocalIndexing === true,
                     localIndexing: {
                         ignoreFilePatterns: newQConfig.projectContext?.localIndexing?.ignoreFilePatterns ?? [],
-                        maxFileSizeMB: newQConfig.projectContext?.localIndexing?.maxFileSizeMb ?? 10,
-                        maxIndexSizeMB: newQConfig.projectContext?.localIndexing?.maxIndexSizeMb ?? 2048,
+                        maxFileSizeMB: newQConfig.projectContext?.localIndexing?.maxFileSizeMB ?? 10,
+                        maxIndexSizeMB: newQConfig.projectContext?.localIndexing?.maxIndexSizeMB ?? 2048,
                         indexCacheDirPath: newQConfig.projectContext?.localIndexing?.indexCacheDirPath ?? undefined,
                     },
                 },

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -113,7 +113,7 @@ export class LocalProjectContextController {
                 LocalProjectContextController.instance = this
 
                 const contextItems = await this.getContextCommandItems()
-                await this.contextCommandsProvider?.processContextCommandUpdate(contextItems)
+                await this.contextCommandsProvider.processContextCommandUpdate(contextItems)
                 void this.maybeUpdateCodeSymbols()
             } else {
                 this.log.warn(`Vector library could not be imported from: ${libraryPath}`)
@@ -128,7 +128,7 @@ export class LocalProjectContextController {
             await this._vecLib?.clear?.()
             this._vecLib = undefined
         }
-        this.contextCommandsProvider?.dispose()
+        this.contextCommandsProvider.dispose()
     }
 
     public async updateIndex(filePaths: string[], operation: UpdateMode): Promise<void> {
@@ -273,7 +273,7 @@ export class LocalProjectContextController {
         const needUpdate = await LocalProjectContextController.getInstance().shouldUpdateContextCommandSymbolsOnce()
         if (needUpdate) {
             const items = await this.getContextCommandItems()
-            await this.contextCommandsProvider?.processContextCommandUpdate(items)
+            await this.contextCommandsProvider.processContextCommandUpdate(items)
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -128,7 +128,7 @@ export class LocalProjectContextController {
             await this._vecLib?.clear?.()
             this._vecLib = undefined
         }
-        this.contextCommandsProvider.dispose()
+        this.contextCommandsProvider?.dispose()
     }
 
     public async updateIndex(filePaths: string[], operation: UpdateMode): Promise<void> {
@@ -295,7 +295,7 @@ export class LocalProjectContextController {
         return true
     }
 
-    public async processWorkspaceFolders(
+    private async processWorkspaceFolders(
         workspaceFolders?: WorkspaceFolder[] | null,
         ignoreFilePatterns?: string[],
         respectUserGitIgnores?: boolean,


### PR DESCRIPTION
## Problem
When `resolvePaths` in `withSymlinks({ resolvePaths })` is set to true, `fdir` uses the absolute path to the symlinked directory. However, ignore, unless `allowRelativePaths` is toggled on, [throws on paths outside the base workspace folder directory](https://www.npmjs.com/package/ignore#:~:text=options.allowRelativePaths%3F%3A%20boolean%20since%205.2.0), so path's beginning with `..` will throw.

## Solution
Exclude directories that are outside the current workspace folder. If `includeSymlinks` is set to true, then use the relative path for the directory (i.e. with prefix `absolute/path/to/symlink/in/workspace/**`), which would arguably provide better context to Q.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
