### PR TITLE
fix: loop gets stuck if response body is undefined

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -26,7 +26,7 @@ export class AgenticChatEventParser implements ChatResult {
 
     error?: string
     messageId?: string
-    body?: string
+    body: string = ''
     canBeVoted?: boolean
     relatedContent?: { title?: string; content: SourceLink[] }
     followUp?: { text?: string; options?: ChatItemAction[] }
@@ -117,7 +117,7 @@ export class AgenticChatEventParser implements ChatResult {
                 this.contextList = contextList
             }
             this.#totalEvents.assistantResponseEvent += 1
-            this.body = (this.body ?? '') + assistantResponseEvent.content
+            this.body = this.body + assistantResponseEvent.content
         } else if (toolUseEvent) {
             this.#totalEvents.toolUserEvent += 1
 


### PR DESCRIPTION
## Problem

Validation exception when history contains assistant response message with content value of `undefined`

## Solution

Always initialize `body` to an empty string

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
