### PR TITLE
refactor(amazonq): adding error handling for security scan and inline suggestions.

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -22,13 +22,23 @@ import { truncateOverlapWithRightContext } from './mergeRightUtils'
 import { CodeWhispererSession, SessionManager } from './session/sessionManager'
 import { CodePercentageTracker } from './codePercentage'
 import { CodeWhispererPerceivedLatencyEvent, CodeWhispererServiceInvocationEvent } from '../../shared/telemetry/types'
-import { getCompletionType, getEndPositionForAcceptedSuggestion, isAwsError, safeGet } from '../../shared/utils'
+import {
+    getCompletionType,
+    getEndPositionForAcceptedSuggestion,
+    getErrorMessage,
+    isAwsError,
+    safeGet,
+} from '../../shared/utils'
 import { makeUserContextObject } from '../../shared/telemetryUtils'
 import { fetchSupplementalContext } from '../../shared/supplementalContextUtil/supplementalContextUtil'
 import { textUtils } from '@aws/lsp-core'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { AcceptedSuggestionEntry, CodeDiffTracker } from './codeDiffTracker'
-import { AmazonQError, AmazonQServiceInitializationError } from '../../shared/amazonQServiceManager/errors'
+import {
+    AmazonQError,
+    AmazonQServiceAuthenticationExpiredError,
+    AmazonQServiceInitializationError,
+} from '../../shared/amazonQServiceManager/errors'
 import {
     AmazonQBaseServiceManager,
     QServiceManagerFeatures,
@@ -36,6 +46,7 @@ import {
 import { initBaseTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 import { AmazonQWorkspaceConfig } from '../../shared/amazonQServiceManager/configurationUtils'
 import { initBaseIAMServiceManager } from '../../shared/amazonQServiceManager/AmazonQIAMServiceManager'
+import { getAuthFollowUpType } from '../chat/utils'
 
 const EMPTY_RESULT = { sessionId: '', items: [] }
 export const CONTEXT_CHARACTERS_LIMIT = 10240
@@ -480,6 +491,10 @@ export const CodewhispererServerFactory =
                                 throw error
                             }
 
+                            const authFollowType = getAuthFollowUpType(error)
+                            if (authFollowType == 're-auth') {
+                                throw new AmazonQServiceAuthenticationExpiredError(getErrorMessage(error))
+                            }
                             return EMPTY_RESULT
                         })
                 })

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
@@ -63,3 +63,10 @@ export class AmazonQServiceNoProfileSupportError extends AmazonQError {
         this.name = 'AmazonQServiceNoProfileSupportError'
     }
 }
+
+export class AmazonQServiceAuthenticationExpiredError extends AmazonQError {
+    constructor(message: string = 'Current authentication token is expired.') {
+        super(message, 'E_AMAZON_Q_AUTHENTICATION_EXPIRED')
+        this.name = 'AmazonQServiceAuthenticationExpiredError'
+    }
+}


### PR DESCRIPTION
## Problem
With the chat functionality, Flare LSP has logic to intercept and detect when auth errors are thrown by the Q API for eg. when token has expired, it parses the error to determine it and crafts the auth follow up type that sends a response to the toolkit which indicates to the CHAT UI to show the Re-authenticate button.
We want to see if a similar error parsing can be supported with inline suggestions and security scans.

## Solution
Updated the error handling in security scan and inline suggestions. So, when the token expires we will throw a custom AmazonQServiceAuthenticationExpiredError and handle it appropriately on the client side.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
