### PR TITLE
fix: don't crash if local indexing controller does not start in 60 se…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -736,9 +736,14 @@ export class AgenticChatController implements ChatHandlers {
 
     async onReady() {
         await this.#tabBarController.loadChats()
-        const contextItems = await (await LocalProjectContextController.getInstance()).getContextCommandItems()
-        await this.#contextCommandsProvider.processContextCommandUpdate(contextItems)
-        void this.#contextCommandsProvider.maybeUpdateCodeSymbols()
+        try {
+            const localProjectContextController = await LocalProjectContextController.getInstance()
+            const contextItems = await localProjectContextController.getContextCommandItems()
+            await this.#contextCommandsProvider.processContextCommandUpdate(contextItems)
+            void this.#contextCommandsProvider.maybeUpdateCodeSymbols()
+        } catch (error) {
+            this.#log('Error initializing context commands: ' + error)
+        }
     }
 
     onSendFeedback({ tabId, feedbackPayload }: FeedbackParams) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
@@ -81,9 +81,13 @@ export class AdditionalContextProvider {
             return []
         }
 
-        const prompts = await (
-            await LocalProjectContextController.getInstance()
-        ).getContextCommandPrompt(additionalContextCommands)
+        let prompts: AdditionalContextPrompt[] = []
+        try {
+            const localProjectContextController = await LocalProjectContextController.getInstance()
+            prompts = await localProjectContextController.getContextCommandPrompt(additionalContextCommands)
+        } catch (error) {
+            // do nothing
+        }
 
         const contextEntry: AdditionalContentEntryAddition[] = []
         for (const prompt of prompts.slice(0, 20)) {


### PR DESCRIPTION
…conds

## Problem
If the local indexing server does not fully initialize in 60 seconds (or, I suspect, is disabled in general) the `LocalProjectContextController.getInstance()` Promise fails. This was not handled, leading to a language server crash.

## Solution
Assume there are no local context items if the local indexing server is still / not starting.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
