### PR TITLE
fix: isInWorkspace should work on closed files. 

### DIFF
--- a/core/aws-lsp-core/src/util/workspaceUtils.test.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.test.ts
@@ -3,12 +3,49 @@ import * as fs from 'fs/promises'
 import * as assert from 'assert'
 import * as path from 'path'
 import { TestFolder } from '../test/testFolder'
-import { readDirectoryRecursively, getEntryPath } from './workspaceUtils'
+import { readDirectoryRecursively, getEntryPath, isParentFolder, isInWorkspace } from './workspaceUtils'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 
 describe('workspaceUtils', function () {
     beforeEach(function () {
         mockfs.restore()
+    })
+
+    describe('isParentFolder', function () {
+        it('handles different cases', function () {
+            assert.ok(isParentFolder('/foo', '/foo/bar'), 'simple case')
+            assert.ok(isParentFolder('/foo', '/foo/bar/'), 'trailing slash in child')
+            assert.ok(isParentFolder('/foo', '/foo/bar.txt'), 'files')
+            assert.ok(isParentFolder('/foo', '/foo/bar/baz'), 'neseted directory')
+            assert.ok(!isParentFolder('/foo', '/foo'), 'duplicates')
+            assert.ok(!isParentFolder('/foo', '/foobar'), 'prefixing')
+            assert.ok(!isParentFolder('/foo/bar', '/foo'), 'reverse')
+            assert.ok(isParentFolder('/foo/', '/foo/bar/baz/'), 'trailing slash in both')
+        })
+    })
+
+    describe('inWorkspace', function () {
+        it('finds the file within the workspace', function () {
+            const workspaceFolders = ['foo']
+
+            const positiveFilePath = '/foo/bar/baz.txt'
+            const negativeFilePath = '/notfoo/bar/baz.txt'
+
+            assert.ok(isInWorkspace(workspaceFolders, positiveFilePath), 'file is within the workspace')
+            assert.ok(!isInWorkspace(workspaceFolders, negativeFilePath), 'file is not within the workspace')
+        })
+
+        it('handles multi-root workspaces', function () {
+            const workspaceFolders = ['/foo', '/bar']
+
+            const positiveFilePath = '/foo/bar/baz.txt'
+            const secondPositiveFilePath = '/bar/bax.txt'
+            const negativeFilePath = '/notfoo/bar/baz.txt'
+
+            assert.ok(isInWorkspace(workspaceFolders, positiveFilePath), 'file is within the workspace')
+            assert.ok(isInWorkspace(workspaceFolders, secondPositiveFilePath), 'file is within the workspace')
+            assert.ok(!isInWorkspace(workspaceFolders, negativeFilePath), 'file is not within the workspace')
+        })
     })
 
     describe('readDirectoryRecursively', function () {

--- a/core/aws-lsp-core/src/util/workspaceUtils.test.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.test.ts
@@ -24,7 +24,7 @@ describe('workspaceUtils', function () {
         })
     })
 
-    describe('inWorkspace', function () {
+    describe('isInWorkspace', function () {
         it('finds the file within the workspace', function () {
             const workspaceFolders = ['/foo']
 
@@ -45,6 +45,12 @@ describe('workspaceUtils', function () {
             assert.ok(isInWorkspace(workspaceFolders, positiveFilePath), 'file is within the workspace')
             assert.ok(isInWorkspace(workspaceFolders, secondPositiveFilePath), 'file is within the workspace')
             assert.ok(!isInWorkspace(workspaceFolders, negativeFilePath), 'file is not within the workspace')
+        })
+
+        it('handles the case where its the workspace itself', function () {
+            const workspaceFolders = ['/foo']
+
+            assert.ok(isInWorkspace(workspaceFolders, '/foo'), 'workspace is inside itself')
         })
     })
 

--- a/core/aws-lsp-core/src/util/workspaceUtils.test.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.test.ts
@@ -26,7 +26,7 @@ describe('workspaceUtils', function () {
 
     describe('inWorkspace', function () {
         it('finds the file within the workspace', function () {
-            const workspaceFolders = ['foo']
+            const workspaceFolders = ['/foo']
 
             const positiveFilePath = '/foo/bar/baz.txt'
             const negativeFilePath = '/notfoo/bar/baz.txt'

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -98,5 +98,5 @@ export function isParentFolder(parentPath: string, childPath: string): boolean {
 }
 
 export function isInWorkspace(workspaceFolderPaths: string[], filepath: string) {
-    return workspaceFolderPaths.some(wsFolder => isParentFolder(wsFolder, filepath))
+    return workspaceFolderPaths.some(wsFolder => isParentFolder(wsFolder, filepath) || wsFolder === filepath)
 }

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -85,10 +85,18 @@ export function getEntryPath(entry: Dirent) {
 }
 
 // TODO: port this to runtimes?
-export function getWorkspaceFolders(lsp: Features['lsp']): string[] {
+export function getWorkspaceFolderPaths(lsp: Features['lsp']): string[] {
     return lsp.getClientInitializeParams()?.workspaceFolders?.map(({ uri }) => URI.parse(uri).fsPath) ?? []
 }
 
-export async function inWorkspace(workspace: Features['workspace'], filepath: string) {
-    return (await workspace.getTextDocument(URI.file(filepath).toString())) !== undefined
+export function isParentFolder(parentPath: string, childPath: string): boolean {
+    const normalizedParentPath = path.normalize(parentPath)
+    const normalizedChildPath = path.normalize(childPath)
+
+    const relative = path.relative(normalizedParentPath, normalizedChildPath)
+    return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative)
+}
+
+export function isInWorkspace(workspaceFolderPaths: string[], filepath: string) {
+    return workspaceFolderPaths.some(wsFolder => isParentFolder(wsFolder, filepath))
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -66,7 +66,7 @@ export class AgenticChatTriggerContext {
         additionalContent?: AdditionalContentEntryAddition[]
     ): GenerateAssistantResponseCommandInput {
         const { prompt } = params
-        const defaultEditorState = { workspaceFolders: workspaceUtils.getWorkspaceFolders(this.#lsp) }
+        const defaultEditorState = { workspaceFolders: workspaceUtils.getWorkspaceFolderPaths(this.#lsp) }
         const data: GenerateAssistantResponseCommandInput = {
             conversationState: {
                 chatTriggerType: chatTriggerType,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
@@ -22,12 +22,12 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('pass validation for a safe command (read-only)', async () => {
-        const execBash = new ExecuteBash(features)
+        const execBash = new ExecuteBash(features, [])
         await execBash.validate('ls')
     })
 
     it('fail validation if the command is empty', async () => {
-        const execBash = new ExecuteBash(features)
+        const execBash = new ExecuteBash(features, [])
         await assert.rejects(
             execBash.validate('   '),
             /Bash command cannot be empty/i,
@@ -36,19 +36,19 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('set requiresAcceptance=true if the command has dangerous patterns', async () => {
-        const execBash = new ExecuteBash(features)
+        const execBash = new ExecuteBash(features, [])
         const validation = await execBash.requiresAcceptance({ command: 'ls && rm -rf /' })
         assert.equal(validation.requiresAcceptance, true, 'Should require acceptance for dangerous pattern')
     })
 
     it('set requiresAcceptance=false if it is a read-only command', async () => {
-        const execBash = new ExecuteBash(features)
+        const execBash = new ExecuteBash(features, [])
         const validation = await execBash.requiresAcceptance({ command: 'cat file.txt' })
         assert.equal(validation.requiresAcceptance, false, 'Read-only command should not require acceptance')
     })
 
     it('whichCommand cannot find the first arg', async () => {
-        const execBash = new ExecuteBash(features)
+        const execBash = new ExecuteBash(features, [])
         await assert.rejects(
             execBash.validate('noSuchCmd'),
             /not found on PATH/i,
@@ -57,7 +57,7 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('validate and invokes the command', async () => {
-        const execBash = new ExecuteBash(features)
+        const execBash = new ExecuteBash(features, [])
 
         const writable = new WritableStream()
         const result = await execBash.invoke({ command: 'ls' }, writable)
@@ -67,13 +67,16 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('requires acceptance if the command references an absolute file path outside the workspace', async () => {
-        const execBash = new ExecuteBash({
-            ...features,
-            workspace: {
-                ...features.workspace,
-                getTextDocument: async s => undefined,
+        const execBash = new ExecuteBash(
+            {
+                ...features,
+                workspace: {
+                    ...features.workspace,
+                    getTextDocument: async s => undefined,
+                },
             },
-        })
+            []
+        )
         const result = await execBash.requiresAcceptance({
             command: 'cat /not/in/workspace/file.txt',
             cwd: '/workspace/folder',
@@ -88,26 +91,32 @@ describe('ExecuteBash Tool', () => {
 
     it('does NOT require acceptance if the command references a relative file path inside the workspace', async () => {
         // Command references a relative path that resolves within the workspace
-        const execBash = new ExecuteBash({
-            ...features,
-            workspace: {
-                ...features.workspace,
-                getTextDocument: async s => ({}) as TextDocument,
+        const execBash = new ExecuteBash(
+            {
+                ...features,
+                workspace: {
+                    ...features.workspace,
+                    getTextDocument: async s => ({}) as TextDocument,
+                },
             },
-        })
+            []
+        )
         const result = await execBash.requiresAcceptance({ command: 'cat ./file.txt', cwd: '/workspace/folder' })
 
         assert.equal(result.requiresAcceptance, false, 'Relative path inside workspace should not require acceptance')
     })
 
     it('does NOT require acceptance if there is no path-like token in the command', async () => {
-        const execBash = new ExecuteBash({
-            ...features,
-            workspace: {
-                ...features.workspace,
-                getTextDocument: async s => ({}) as TextDocument,
+        const execBash = new ExecuteBash(
+            {
+                ...features,
+                workspace: {
+                    ...features.workspace,
+                    getTextDocument: async s => ({}) as TextDocument,
+                },
             },
-        })
+            []
+        )
         const result = await execBash.requiresAcceptance({ command: 'echo hello world', cwd: '/workspace/folder' })
 
         assert.equal(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
@@ -22,12 +22,12 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('pass validation for a safe command (read-only)', async () => {
-        const execBash = new ExecuteBash(features, [])
+        const execBash = new ExecuteBash(features)
         await execBash.validate('ls')
     })
 
     it('fail validation if the command is empty', async () => {
-        const execBash = new ExecuteBash(features, [])
+        const execBash = new ExecuteBash(features)
         await assert.rejects(
             execBash.validate('   '),
             /Bash command cannot be empty/i,
@@ -36,19 +36,19 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('set requiresAcceptance=true if the command has dangerous patterns', async () => {
-        const execBash = new ExecuteBash(features, [])
+        const execBash = new ExecuteBash(features)
         const validation = await execBash.requiresAcceptance({ command: 'ls && rm -rf /' })
         assert.equal(validation.requiresAcceptance, true, 'Should require acceptance for dangerous pattern')
     })
 
     it('set requiresAcceptance=false if it is a read-only command', async () => {
-        const execBash = new ExecuteBash(features, [])
+        const execBash = new ExecuteBash(features)
         const validation = await execBash.requiresAcceptance({ command: 'cat file.txt' })
         assert.equal(validation.requiresAcceptance, false, 'Read-only command should not require acceptance')
     })
 
     it('whichCommand cannot find the first arg', async () => {
-        const execBash = new ExecuteBash(features, [])
+        const execBash = new ExecuteBash(features)
         await assert.rejects(
             execBash.validate('noSuchCmd'),
             /not found on PATH/i,
@@ -57,7 +57,7 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('validate and invokes the command', async () => {
-        const execBash = new ExecuteBash(features, [])
+        const execBash = new ExecuteBash(features)
 
         const writable = new WritableStream()
         const result = await execBash.invoke({ command: 'ls' }, writable)
@@ -67,16 +67,13 @@ describe('ExecuteBash Tool', () => {
     })
 
     it('requires acceptance if the command references an absolute file path outside the workspace', async () => {
-        const execBash = new ExecuteBash(
-            {
-                ...features,
-                workspace: {
-                    ...features.workspace,
-                    getTextDocument: async s => undefined,
-                },
+        const execBash = new ExecuteBash({
+            ...features,
+            workspace: {
+                ...features.workspace,
+                getTextDocument: async s => undefined,
             },
-            []
-        )
+        })
         const result = await execBash.requiresAcceptance({
             command: 'cat /not/in/workspace/file.txt',
             cwd: '/workspace/folder',
@@ -91,32 +88,26 @@ describe('ExecuteBash Tool', () => {
 
     it('does NOT require acceptance if the command references a relative file path inside the workspace', async () => {
         // Command references a relative path that resolves within the workspace
-        const execBash = new ExecuteBash(
-            {
-                ...features,
-                workspace: {
-                    ...features.workspace,
-                    getTextDocument: async s => ({}) as TextDocument,
-                },
+        const execBash = new ExecuteBash({
+            ...features,
+            workspace: {
+                ...features.workspace,
+                getTextDocument: async s => ({}) as TextDocument,
             },
-            []
-        )
+        })
         const result = await execBash.requiresAcceptance({ command: 'cat ./file.txt', cwd: '/workspace/folder' })
 
         assert.equal(result.requiresAcceptance, false, 'Relative path inside workspace should not require acceptance')
     })
 
     it('does NOT require acceptance if there is no path-like token in the command', async () => {
-        const execBash = new ExecuteBash(
-            {
-                ...features,
-                workspace: {
-                    ...features.workspace,
-                    getTextDocument: async s => ({}) as TextDocument,
-                },
+        const execBash = new ExecuteBash({
+            ...features,
+            workspace: {
+                ...features.workspace,
+                getTextDocument: async s => ({}) as TextDocument,
             },
-            []
-        )
+        })
         const result = await execBash.requiresAcceptance({ command: 'echo hello world', cwd: '/workspace/folder' })
 
         assert.equal(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
@@ -5,12 +5,18 @@ import { ExecuteBash } from './executeBash'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import { TextDocument } from 'vscode-languageserver-textdocument'
+import { URI } from 'vscode-uri'
+import { InitializeParams } from '@aws/language-server-runtimes/protocol'
 
 describe('ExecuteBash Tool', () => {
-    let features: Features
+    let features: TestFeatures
+    const workspaceFolder = '/workspace/folder'
 
     before(function () {
         features = new TestFeatures()
+        features.lsp.getClientInitializeParams.returns({
+            workspaceFolders: [{ uri: URI.file(workspaceFolder).toString(), name: 'test' }],
+        } as InitializeParams)
     })
 
     beforeEach(() => {
@@ -76,7 +82,7 @@ describe('ExecuteBash Tool', () => {
         })
         const result = await execBash.requiresAcceptance({
             command: 'cat /not/in/workspace/file.txt',
-            cwd: '/workspace/folder',
+            cwd: workspaceFolder,
         })
 
         assert.equal(
@@ -95,7 +101,7 @@ describe('ExecuteBash Tool', () => {
                 getTextDocument: async s => ({}) as TextDocument,
             },
         })
-        const result = await execBash.requiresAcceptance({ command: 'cat ./file.txt', cwd: '/workspace/folder' })
+        const result = await execBash.requiresAcceptance({ command: 'cat ./file.txt', cwd: workspaceFolder })
 
         assert.equal(result.requiresAcceptance, false, 'Relative path inside workspace should not require acceptance')
     })
@@ -108,7 +114,7 @@ describe('ExecuteBash Tool', () => {
                 getTextDocument: async s => ({}) as TextDocument,
             },
         })
-        const result = await execBash.requiresAcceptance({ command: 'echo hello world', cwd: '/workspace/folder' })
+        const result = await execBash.requiresAcceptance({ command: 'echo hello world', cwd: workspaceFolder })
 
         assert.equal(
             result.requiresAcceptance,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -122,10 +122,11 @@ interface TimestampedChunk {
 
 export class ExecuteBash {
     private childProcess?: ChildProcess
-    private readonly workspace: Features['workspace']
     private readonly logging: Features['logging']
-    constructor(features: Pick<Features, 'logging' | 'workspace'> & Partial<Features>) {
-        this.workspace = features.workspace
+    constructor(
+        features: Pick<Features, 'logging' | 'workspace'> & Partial<Features>,
+        private readonly workspaceFolderPaths: string[]
+    ) {
         this.logging = features.logging
     }
 
@@ -195,7 +196,7 @@ export class ExecuteBash {
                     if (this.looksLikePath(arg)) {
                         // If not absolute, resolve using workingDirectory if available.
                         const fullPath = !isAbsolute(arg) && params.cwd ? join(params.cwd, arg) : arg
-                        const isInWorkspace = await workspaceUtils.inWorkspace(this.workspace, fullPath)
+                        const isInWorkspace = await workspaceUtils.isInWorkspace(this.workspaceFolderPaths, fullPath)
                         if (!isInWorkspace) {
                             return { requiresAcceptance: true, warning: destructiveCommandWarningMessage }
                         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -196,10 +196,7 @@ export class ExecuteBash {
                     if (this.looksLikePath(arg)) {
                         // If not absolute, resolve using workingDirectory if available.
                         const fullPath = !isAbsolute(arg) && params.cwd ? join(params.cwd, arg) : arg
-                        const isInWorkspace = await workspaceUtils.isInWorkspace(
-                            getWorkspaceFolderPaths(this.lsp),
-                            fullPath
-                        )
+                        const isInWorkspace = workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), fullPath)
                         if (!isInWorkspace) {
                             return { requiresAcceptance: true, warning: destructiveCommandWarningMessage }
                         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
@@ -30,7 +30,7 @@ describe('ListDirectory Tool', () => {
     })
 
     it('invalidates empty path', async () => {
-        const listDirectory = new ListDirectory(testFeatures, [])
+        const listDirectory = new ListDirectory(testFeatures)
         await assert.rejects(
             listDirectory.validate({ path: '', maxDepth: 0 }),
             /Path cannot be empty/i,
@@ -39,7 +39,7 @@ describe('ListDirectory Tool', () => {
     })
 
     it('invalidates negative maxDepth', async () => {
-        const listDirectory = new ListDirectory(testFeatures, [])
+        const listDirectory = new ListDirectory(testFeatures)
         await assert.rejects(
             listDirectory.validate({ path: '~', maxDepth: -1 }),
             /MaxDepth cannot be negative/i,
@@ -51,7 +51,7 @@ describe('ListDirectory Tool', () => {
         await tempFolder.nest('subfolder')
         await tempFolder.write('fileA.txt', 'fileA content')
 
-        const listDirectory = new ListDirectory(testFeatures, [])
+        const listDirectory = new ListDirectory(testFeatures)
         const result = await listDirectory.invoke({ path: tempFolder.path, maxDepth: 0 })
 
         assert.strictEqual(result.output.kind, 'text')
@@ -70,7 +70,7 @@ describe('ListDirectory Tool', () => {
         await tempFolder.write('fileA.txt', 'fileA content')
         await tempFolder.write(path.join('subfolder', 'fileB.md'), '# fileB')
 
-        const listDirectory = new ListDirectory(testFeatures, [])
+        const listDirectory = new ListDirectory(testFeatures)
         const result = await listDirectory.invoke({ path: tempFolder.path })
 
         assert.strictEqual(result.output.kind, 'text')
@@ -90,7 +90,7 @@ describe('ListDirectory Tool', () => {
         const nestedFolder = await tempFolder.nest('node_modules')
         await nestedFolder.write('fileC.md', '# fileC')
 
-        const listDirectory = new ListDirectory(testFeatures, [])
+        const listDirectory = new ListDirectory(testFeatures)
         await listDirectory.validate({ path: tempFolder.path })
         const result = await listDirectory.invoke({ path: tempFolder.path })
 
@@ -107,13 +107,13 @@ describe('ListDirectory Tool', () => {
 
     it('throws error if path does not exist', async () => {
         const missingPath = path.join(tempFolder.path, 'no_such_file.txt')
-        const listDirectory = new ListDirectory(testFeatures, [])
+        const listDirectory = new ListDirectory(testFeatures)
 
         await assert.rejects(listDirectory.invoke({ path: missingPath, maxDepth: 0 }))
     })
 
     it('expands ~ path', async () => {
-        const listDirectory = new ListDirectory(testFeatures, [])
+        const listDirectory = new ListDirectory(testFeatures)
         const result = await listDirectory.invoke({ path: '~', maxDepth: 0 })
 
         assert.strictEqual(result.output.kind, 'text')

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
@@ -30,7 +30,7 @@ describe('ListDirectory Tool', () => {
     })
 
     it('invalidates empty path', async () => {
-        const listDirectory = new ListDirectory(testFeatures)
+        const listDirectory = new ListDirectory(testFeatures, [])
         await assert.rejects(
             listDirectory.validate({ path: '', maxDepth: 0 }),
             /Path cannot be empty/i,
@@ -39,7 +39,7 @@ describe('ListDirectory Tool', () => {
     })
 
     it('invalidates negative maxDepth', async () => {
-        const listDirectory = new ListDirectory(testFeatures)
+        const listDirectory = new ListDirectory(testFeatures, [])
         await assert.rejects(
             listDirectory.validate({ path: '~', maxDepth: -1 }),
             /MaxDepth cannot be negative/i,
@@ -51,7 +51,7 @@ describe('ListDirectory Tool', () => {
         await tempFolder.nest('subfolder')
         await tempFolder.write('fileA.txt', 'fileA content')
 
-        const listDirectory = new ListDirectory(testFeatures)
+        const listDirectory = new ListDirectory(testFeatures, [])
         const result = await listDirectory.invoke({ path: tempFolder.path, maxDepth: 0 })
 
         assert.strictEqual(result.output.kind, 'text')
@@ -70,7 +70,7 @@ describe('ListDirectory Tool', () => {
         await tempFolder.write('fileA.txt', 'fileA content')
         await tempFolder.write(path.join('subfolder', 'fileB.md'), '# fileB')
 
-        const listDirectory = new ListDirectory(testFeatures)
+        const listDirectory = new ListDirectory(testFeatures, [])
         const result = await listDirectory.invoke({ path: tempFolder.path })
 
         assert.strictEqual(result.output.kind, 'text')
@@ -90,7 +90,7 @@ describe('ListDirectory Tool', () => {
         const nestedFolder = await tempFolder.nest('node_modules')
         await nestedFolder.write('fileC.md', '# fileC')
 
-        const listDirectory = new ListDirectory(testFeatures)
+        const listDirectory = new ListDirectory(testFeatures, [])
         await listDirectory.validate({ path: tempFolder.path })
         const result = await listDirectory.invoke({ path: tempFolder.path })
 
@@ -107,13 +107,13 @@ describe('ListDirectory Tool', () => {
 
     it('throws error if path does not exist', async () => {
         const missingPath = path.join(tempFolder.path, 'no_such_file.txt')
-        const listDirectory = new ListDirectory(testFeatures)
+        const listDirectory = new ListDirectory(testFeatures, [])
 
         await assert.rejects(listDirectory.invoke({ path: missingPath, maxDepth: 0 }))
     })
 
     it('expands ~ path', async () => {
-        const listDirectory = new ListDirectory(testFeatures)
+        const listDirectory = new ListDirectory(testFeatures, [])
         const result = await listDirectory.invoke({ path: '~', maxDepth: 0 })
 
         assert.strictEqual(result.output.kind, 'text')

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -14,7 +14,10 @@ export class ListDirectory {
     private readonly logging: Features['logging']
     private readonly workspace: Features['workspace']
 
-    constructor(features: Pick<Features, 'logging' | 'workspace'>) {
+    constructor(
+        features: Pick<Features, 'logging' | 'workspace'>,
+        private readonly workspacePaths: string[]
+    ) {
         this.logging = features.logging
         this.workspace = features.workspace
     }
@@ -49,7 +52,7 @@ export class ListDirectory {
     }
 
     public async requiresAcceptance(path: string): Promise<CommandValidation> {
-        return { requiresAcceptance: !(await workspaceUtils.inWorkspace(this.workspace, path)) }
+        return { requiresAcceptance: !workspaceUtils.isInWorkspace(this.workspacePaths, path) }
     }
 
     public async invoke(params: ListDirectoryParams): Promise<InvokeOutput> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -4,6 +4,7 @@ import { workspaceUtils } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
 import { DEFAULT_EXCLUDE_PATTERNS } from '../../chat/constants'
+import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
 
 export interface ListDirectoryParams {
     path: string
@@ -13,13 +14,12 @@ export interface ListDirectoryParams {
 export class ListDirectory {
     private readonly logging: Features['logging']
     private readonly workspace: Features['workspace']
+    private readonly lsp: Features['lsp']
 
-    constructor(
-        features: Pick<Features, 'logging' | 'workspace'>,
-        private readonly workspacePaths: string[]
-    ) {
+    constructor(features: Pick<Features, 'logging' | 'workspace' | 'lsp'>) {
         this.logging = features.logging
         this.workspace = features.workspace
+        this.lsp = features.lsp
     }
 
     public async validate(params: ListDirectoryParams): Promise<void> {
@@ -52,7 +52,7 @@ export class ListDirectory {
     }
 
     public async requiresAcceptance(path: string): Promise<CommandValidation> {
-        return { requiresAcceptance: !workspaceUtils.isInWorkspace(this.workspacePaths, path) }
+        return { requiresAcceptance: !workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), path) }
     }
 
     public async invoke(params: ListDirectoryParams): Promise<InvokeOutput> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -3,12 +3,13 @@ import { FsRead, FsReadParams } from './fsRead'
 import { FsWrite, FsWriteParams } from './fsWrite'
 import { ListDirectory, ListDirectoryParams } from './listDirectory'
 import { ExecuteBash, ExecuteBashParams } from './executeBash'
+import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
 
-export const FsToolsServer: Server = ({ workspace, logging, agent }) => {
+export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     const fsReadTool = new FsRead({ workspace, logging })
     const fsWriteTool = new FsWrite({ workspace, logging })
 
-    const listDirectoryTool = new ListDirectory({ workspace, logging })
+    const listDirectoryTool = new ListDirectory({ workspace, logging }, getWorkspaceFolderPaths(lsp))
 
     agent.addTool(fsReadTool.getSpec(), async (input: FsReadParams) => {
         // TODO: fill in logic for handling invalid tool invocations
@@ -30,7 +31,7 @@ export const FsToolsServer: Server = ({ workspace, logging, agent }) => {
 }
 
 export const BashToolsServer: Server = ({ logging, workspace, agent }) => {
-    const bashTool = new ExecuteBash({ logging, workspace })
+    const bashTool = new ExecuteBash({ logging, workspace }, [])
     agent.addTool(bashTool.getSpec(), (input: ExecuteBashParams) => bashTool.invoke(input))
     return () => {}
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -3,7 +3,6 @@ import { FsRead, FsReadParams } from './fsRead'
 import { FsWrite, FsWriteParams } from './fsWrite'
 import { ListDirectory, ListDirectoryParams } from './listDirectory'
 import { ExecuteBash, ExecuteBashParams } from './executeBash'
-import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
 import { LspGetDocuments, LspGetDocumentsParams } from './lspGetDocuments'
 import { LspReadDocumentContents, LspReadDocumentContentsParams } from './lspReadDocumentContents'
 import { LspApplyWorkspaceEdit, LspApplyWorkspaceEditParams } from './lspApplyWorkspaceEdit'
@@ -12,7 +11,7 @@ export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     const fsReadTool = new FsRead({ workspace, logging })
     const fsWriteTool = new FsWrite({ workspace, logging })
 
-    const listDirectoryTool = new ListDirectory({ workspace, logging }, getWorkspaceFolderPaths(lsp))
+    const listDirectoryTool = new ListDirectory({ workspace, logging, lsp })
 
     agent.addTool(fsReadTool.getSpec(), async (input: FsReadParams) => {
         // TODO: fill in logic for handling invalid tool invocations
@@ -33,8 +32,8 @@ export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     return () => {}
 }
 
-export const BashToolsServer: Server = ({ logging, workspace, agent }) => {
-    const bashTool = new ExecuteBash({ logging, workspace }, getWorkspaceFolderPaths(lsp))
+export const BashToolsServer: Server = ({ logging, workspace, agent, lsp }) => {
+    const bashTool = new ExecuteBash({ logging, workspace, lsp })
     agent.addTool(bashTool.getSpec(), (input: ExecuteBashParams) => bashTool.invoke(input))
     return () => {}
 }


### PR DESCRIPTION
## Problem
Follow up: https://github.com/aws/language-servers/pull/969#discussion_r2051179501. 

This utility function didn't do exactly what its expected to do. See the discussion linked above for more information. 

## Solution
- use the initializeParams to determine if a file is part of the workspace. 
- inject the lsp into the tools so that we can fetch these workspace folders. 

## Question:
~~Do the initializeParams update when the info changes? Ex. if I open a new workspace, are these updated? In my testing, the answer appears to be yes, because the language server reloads, but would like to confirm this somehow.~~
answered below, thanks @jpinkney-aws. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
