### PR TITLE
fix(amazonq): init localContextController don't wait for indexing finish

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.test.ts
@@ -1,5 +1,5 @@
 import { LocalProjectContextController } from './localProjectContextController'
-import { SinonStub, stub, assert as sinonAssert, match, restore } from 'sinon'
+import { SinonStub, stub, assert as sinonAssert, match, restore, spy } from 'sinon'
 import * as assert from 'assert'
 import * as fs from 'fs'
 import { Dirent } from 'fs'
@@ -75,12 +75,13 @@ describe('LocalProjectContextController', () => {
 
     describe('init', () => {
         it('should initialize vector library successfully', async () => {
+            const buildIndexSpy = spy(controller, 'buildIndex')
             await controller.init({ vectorLib: vectorLibMock })
 
             sinonAssert.notCalled(logging.error)
             sinonAssert.called(vectorLibMock.start)
             const vecLib = await vectorLibMock.start()
-            sinonAssert.called(vecLib.buildIndex)
+            sinonAssert.called(buildIndexSpy)
         })
 
         it('should handle initialization errors', async () => {
@@ -89,6 +90,15 @@ describe('LocalProjectContextController', () => {
             await controller.init({ vectorLib: vectorLibMock })
 
             sinonAssert.called(logging.error)
+        })
+    })
+
+    describe('buildIndex', () => {
+        it('should build Index with vectorLib', async () => {
+            await controller.init({ vectorLib: vectorLibMock })
+            const vecLib = await vectorLibMock.start()
+            await controller.buildIndex()
+            sinonAssert.called(vecLib.buildIndex)
         })
     })
 

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -111,7 +111,7 @@ export class LocalProjectContextController {
             const vecLib = vectorLib ?? (await import(libraryPath))
             if (vecLib) {
                 this._vecLib = await vecLib.start(LIBRARY_DIR, this.clientName, this.indexCacheDirPath)
-                await this.buildIndex()
+                void this.buildIndex()
                 LocalProjectContextController.instance = this
             } else {
                 this.log.warn(`Vector library could not be imported from: ${libraryPath}`)
@@ -140,7 +140,8 @@ export class LocalProjectContextController {
         }
     }
 
-    private async buildIndex(): Promise<void> {
+    // public for test
+    async buildIndex(): Promise<void> {
         try {
             if (this._vecLib) {
                 const sourceFiles = await this.processWorkspaceFolders(


### PR DESCRIPTION
## Problem
We don't need to wait until indexing finish to init the instance of projectContext controller
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
