### PR TITLE
fix(amazonq): hide stop generating button in hybrid chat

### DIFF
--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -54,6 +54,7 @@ export class TabFactory {
                   ? (chatMessages as ChatItem[])
                   : [],
             ...(disclaimerCardActive ? { promptInputStickyCard: disclaimerCard } : {}),
+            cancelButtonWhenLoading: false,
         }
         return tabData
     }


### PR DESCRIPTION
## Problem
when a chat adapter is passed into createMynahUi onStopChatResponse is defined causing "stop generating" to show on the regular chat panel

## Solution
set cancelButtonWhenLoading to false in the tab factory which always disables "stop generating"

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
