### PR TITLE
fix: update fsWrite spec specify absolute path only

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -307,8 +307,7 @@ export class FsWrite {
                         type: 'string',
                     },
                     path: {
-                        description:
-                            'Path to a file, e.g. `/path/to/repo/file.py`. If you want to access a path relative to the current workspace, use relative paths e.g. `./src/file.py`.',
+                        description: 'Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.',
                         type: 'string',
                     },
                 },


### PR DESCRIPTION
## Problem
FsWrite will try to write files in the workspace via `./filename`, but this is not supported in the tool. 
This also leads to files being written to home directory by default, but we want workspace by default. 
 
## Solution
- update the spec such to make the instructions to the model clear. 
- This is in-line with VSC-side implementation. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
