### PR TITLE
fix: history not persisted for agentic chat via IdC signin

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -192,13 +192,18 @@ export class AgenticChatController implements ChatHandlers {
 
         const triggerContext = await this.#getTriggerContext(params, metric)
         const isNewConversation = !session.conversationId
+        if (isNewConversation) {
+            // agentic chat does not support conversationId in API response,
+            // so we set it to random UUID per session, as other chat functionality
+            // depends on it
+            session.conversationId = uuid()
+        }
 
         token.onCancellationRequested(() => {
             this.#log('cancellation requested')
             session.abortRequest()
         })
 
-        const conversationIdentifier = session?.conversationId ?? 'New conversation'
         const chatResultStream = this.#getChatResultStream(params.partialResultToken)
         try {
             const additionalContext = await this.#additionalContextProvider.getAdditionalContext(
@@ -223,7 +228,7 @@ export class AgenticChatController implements ChatHandlers {
                 session,
                 metric,
                 chatResultStream,
-                conversationIdentifier,
+                session.conversationId,
                 token,
                 triggerContext.documentReference
             )


### PR DESCRIPTION
## Problem

Currently, history is not persisted if I use agentic chat and sign in via IdC, but work if I sign in via BuilderId.
Apparently, Q API does not return `conversationId` anymore in response (reason to be clarified).

## Solution

Given a lot of chat functionality, including history, depends on `conversationId` present, we set it to random UUID. We set it for agentic chat only, base chat based on `SendMessage` continues working as before.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
