### PR TITLE
fix: add history to request on each chat prompt

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -265,14 +265,10 @@ export class AgenticChatController implements ChatHandlers {
             ChatTriggerType.MANUAL,
             this.#customizationArn,
             profileArn,
+            this.#chatHistoryDb.getMessages(params.tabId, 10),
             this.#features.agent.getTools({ format: 'bedrock' }),
             additionalContext
         )
-
-        if (!session.localHistoryHydrated && requestInput.conversationState) {
-            requestInput.conversationState.history = this.#chatHistoryDb.getMessages(params.tabId, 10)
-            session.localHistoryHydrated = true
-        }
 
         return requestInput
     }
@@ -320,11 +316,6 @@ export class AgenticChatController implements ChatHandlers {
                 chatResultStream,
                 documentReference
             )
-
-            // Store the conversation ID from the first response
-            if (iterationCount === 1 && result.data?.conversationId) {
-                session.conversationId = result.data.conversationId
-            }
 
             // Check if we have any tool uses that need to be processed
             const pendingToolUses = this.#getPendingToolUses(result.data?.toolUses || {})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -11,6 +11,7 @@ import {
     ToolResult,
     AdditionalContentEntry,
     GenerateAssistantResponseCommandInput,
+    ChatMessage,
 } from '@amzn/codewhisperer-streaming'
 import {
     BedrockTools,
@@ -62,6 +63,7 @@ export class AgenticChatTriggerContext {
         chatTriggerType: ChatTriggerType,
         customizationArn?: string,
         profileArn?: string,
+        history: ChatMessage[] = [],
         tools: BedrockTools = [],
         additionalContent?: AdditionalContentEntryAddition[]
     ): GenerateAssistantResponseCommandInput {
@@ -100,6 +102,7 @@ export class AgenticChatTriggerContext {
                     },
                 },
                 customizationArn,
+                history,
             },
             profileArn,
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -14,7 +14,6 @@ import {
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
-    public localHistoryHydrated: boolean = false
     #abortController?: AbortController
     #conversationId?: string
     #amazonQServiceManager?: AmazonQBaseServiceManager


### PR DESCRIPTION
## Problem
Chat history was not included on every request unless the history was just rehydrated before the first prompt.

## Solution
Add the chat history from the chat database on the initial request for each prompt.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
