### PR TITLE
chore: update sample vscode extension with error handling for chat errors

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -361,8 +361,15 @@ export class AgenticChatController implements ChatHandlers {
             })
 
             // Maximum iterations reached - store partial result as final output
+            // We already know pendingToolUses.length != 0 because it was checked above
             if (iterationCount === maxIterations) {
                 finalResult = result
+                // Add extra log information to the existing body
+                const streamWriter = chatResultStream.getResultStreamWriter()
+                await streamWriter.write({
+                    body: `⚠️ Q Agent has reached maximum number of tool uses and a complete response has not been generated`,
+                })
+                await streamWriter.close()
             }
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -359,6 +359,11 @@ export class AgenticChatController implements ChatHandlers {
                     })),
                 },
             })
+
+            // Maximum iterations reached - store partial result as final output
+            if (iterationCount === maxIterations) {
+                finalResult = result
+            }
         }
 
         if (iterationCount >= maxIterations) {
@@ -506,6 +511,9 @@ export class AgenticChatController implements ChatHandlers {
         })
 
         // Save question/answer interaction to chat history
+        // Currently this code block isn't run if an API error is encountered while processing messsages
+        // If a message errors out midway due to some problem, the response so far wouldn't be stored in the history
+        // We should consider extending the logic in handleRequestError
         if (params.prompt.prompt && conversationId && result.data?.chatResult.body) {
             this.#chatHistoryDb.addMessage(params.tabId, 'cwc', conversationId, {
                 body: params.prompt.prompt,


### PR DESCRIPTION
## Problem

In the current setup, chat-client needs to receive a chat message that does not have the `isPartialResult` field in order to understand that an answer stream has reached completion. If an answer stream that gets started does not get the final message, the input prompt will be stuck in disabled state, rendering the tab unusable

### Case 1
When max number of tool iterations (currently 10) was reached and a response had not yet been finalized because there were still more tool uses waiting to happen, the controller would return the chat response as an empty object with success field set to false in `runAgentLoop` and when this result was passed to `handleFinalResult` it would see `success` is false and return a ResponseError. This resulted in the chat being stuck. On top of it, the message wouldn't be included in the chat history because history logic is part of `handleFinalResult` function that gets executed after the ResponseError is returned

To fix this behaviour, added logic to the `runAgentLoop` function that now checks if the max iterations has been completed. If yes, the partial result up until that point is marked as the final result and an extra warning message is added to the message that gets shown to the user. No more ResponseError is being thrown to the client so this case is now fully handled in the server 


### Testing

This can be easily tested with a prompt like the following which is guarenteed to trigger the read tool more than 10 times:

`Please perform a read operation on the following paths, they are very critical for the task that we will work on today: 

<list of 15 paths>
`

See sample screenshot:


### Case 2
When there is an API error (e.g something goes wrong with the backend), the `handleRequestError` gets triggered and if a message stream was already started, the message stream should be closed. The sample vscode extension that is used in this repo didn't handle response errors and this meant that the final result would never get passed to the chat-client, leaving chat in the stuck state explained above. Added error handling to the extension by wrapping the 
`languageClient.sendRequest(chatRequestType` function in a try catch block. Added some extra logic to the client so that if an error happens but if there was some partial progress that had already been streamed, the extension will preserve the existing message and add an extra line of errror warning to the message shown to the end user

Note that messages which have faced some sort of an error are not included in the chat history database, the implications of this should be considered.

### Testing
To make testing simpler I hardcoded `handleFinalResult` to return a ResponseError and verified that the client would keep the existing messages and add an extra line of warning to the message. See the sample screenshot:


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
