### PR TITLE
feat(amazonq): add pair programming toggle

### DIFF
--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -58,6 +58,8 @@ import {
     OPEN_TAB_REQUEST_METHOD,
     OpenTabParams,
     OpenTabResult,
+    PROMPT_INPUT_OPTION_CHANGE_METHOD,
+    PromptInputOptionChangeParams,
     QUICK_ACTION_REQUEST_METHOD,
     QuickActionParams,
     READY_NOTIFICATION_METHOD,
@@ -296,6 +298,9 @@ export const createChat = (
                     },
                 })
             }
+        },
+        promptInputOptionChange: (params: PromptInputOptionChangeParams) => {
+            sendMessageToClient({ command: PROMPT_INPUT_OPTION_CHANGE_METHOD, params })
         },
     }
 

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -34,6 +34,7 @@ import {
     LinkClickParams,
     ListConversationsParams,
     OpenTabResult,
+    PromptInputOptionChangeParams,
     QuickActionParams,
     SourceLinkClickParams,
     TabAddParams,
@@ -87,6 +88,7 @@ export interface OutboundChatApi {
     conversationClick(params: ConversationClickParams): void
     tabBarAction(params: TabBarActionParams): void
     onGetSerializedChat(requestId: string, result: GetSerializedChatResult | ErrorResult): void
+    promptInputOptionChange(params: PromptInputOptionChangeParams): void
 }
 
 export class Messager {
@@ -208,5 +210,9 @@ export class Messager {
 
     onGetSerializedChat = (requestId: string, result: GetSerializedChatResult | ErrorResult): void => {
         this.chatApi.onGetSerializedChat(requestId, result)
+    }
+
+    onPromptInputOptionChange = (params: PromptInputOptionChangeParams): void => {
+        this.chatApi.promptInputOptionChange(params)
     }
 }

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -53,6 +53,7 @@ describe('MynahUI', () => {
             conversationClick: sinon.stub(),
             tabBarAction: sinon.stub(),
             onGetSerializedChat: sinon.stub(),
+            promptInputOptionChange: sinon.stub(),
         }
 
         messager = new Messager(outboundChatApi)

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -45,6 +45,7 @@ import { ChatClientAdapter, ChatEventHandler } from '../contracts/chatClientAdap
 import { withAdapter } from './withAdapter'
 import { toMynahIcon } from './utils'
 import { ChatHistory, ChatHistoryList } from './features/history'
+import { pairProgrammingModeOff, pairProgrammingModeOn } from './texts/pairProgramming'
 
 export interface InboundChatApi {
     addChatResponse(params: ChatResult, tabId: string, isPartialResult: boolean): void
@@ -66,6 +67,15 @@ const ContextPrompt = {
     SubmitButtonId: 'submit-create-prompt',
     PromptNameFieldId: 'prompt-name',
 } as const
+
+export const handlePromptInputChange = (mynahUi: MynahUI, tabId: string, optionsValues: Record<string, string>) => {
+    const promptTypeValue = optionsValues['pair-programmer-mode']
+    if (promptTypeValue === 'true') {
+        mynahUi.addChatItem(tabId, pairProgrammingModeOn)
+    } else {
+        mynahUi.addChatItem(tabId, pairProgrammingModeOff)
+    }
+}
 
 export const handleChatPrompt = (
     mynahUi: MynahUI,
@@ -353,6 +363,10 @@ export const createMynahUi = (
             }
 
             throw new Error(`Unhandled tab bar button id: ${buttonId}`)
+        },
+        onPromptInputOptionChange: (tabId, optionsValues) => {
+            handlePromptInputChange(mynahUi, tabId, optionsValues)
+            messager.onPromptInputOptionChange({ tabId, optionsValues })
         },
     }
 

--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -9,6 +9,7 @@ import {
 import { disclaimerCard } from '../texts/disclaimer'
 import { ChatMessage } from '@aws/language-server-runtimes-types'
 import { ChatHistory } from '../features/history'
+import { pairProgrammingPromptInput } from '../texts/pairProgramming'
 
 export type DefaultTabData = MynahUIDataModel
 
@@ -55,6 +56,7 @@ export class TabFactory {
                   : [],
             ...(disclaimerCardActive ? { promptInputStickyCard: disclaimerCard } : {}),
             cancelButtonWhenLoading: false,
+            promptInputOptions: [pairProgrammingPromptInput],
         }
         return tabData
     }

--- a/chat-client/src/client/texts/pairProgramming.ts
+++ b/chat-client/src/client/texts/pairProgramming.ts
@@ -1,0 +1,20 @@
+import { ChatItem, ChatItemFormItem, ChatItemType } from '@aws/mynah-ui'
+
+export const pairProgrammingPromptInput: ChatItemFormItem = {
+    type: 'switch',
+    id: 'pair-programmer-mode',
+    tooltip: 'Turn off for read only responses',
+    alternateTooltip: 'Turn on to allow Q to run commands and generate code diffs',
+    value: 'true',
+    icon: 'code-block',
+}
+
+export const pairProgrammingModeOn: ChatItem = {
+    type: ChatItemType.DIRECTIVE,
+    body: 'You are using **pair programming**: Q can now list files, preview code diffs and allow you to run shell commands.',
+}
+
+export const pairProgrammingModeOff: ChatItem = {
+    type: ChatItemType.DIRECTIVE,
+    body: 'You turned off **pair programming**. Q will not include code diffs or run commands in the chat.',
+}

--- a/chat-client/src/client/withAdapter.ts
+++ b/chat-client/src/client/withAdapter.ts
@@ -56,6 +56,7 @@ export const withAdapter = (
         onShowMoreWebResultsClick: addDefaultRouting('onShowMoreWebResultsClick'),
         onChatPromptProgressActionButtonClicked: addDefaultRouting('onChatPromptProgressActionButtonClicked'),
         onTabbedContentTabChange: addDefaultRouting('onTabbedContentTabChange'),
+        onPromptInputOptionChange: addDefaultRouting('onPromptInputOptionChange'),
 
         /**
          * Handler with special routing logic

--- a/chat-client/src/contracts/chatClientAdapter.ts
+++ b/chat-client/src/contracts/chatClientAdapter.ts
@@ -35,6 +35,7 @@ export interface ChatEventHandler
         | 'onFocusStateChanged'
         | 'onResetStore'
         | 'onReady'
+        | 'onPromptInputOptionChange'
     > {}
 
 /**

--- a/chat-client/src/contracts/serverContracts.ts
+++ b/chat-client/src/contracts/serverContracts.ts
@@ -33,6 +33,7 @@ import {
     TAB_BAR_ACTION_REQUEST_METHOD,
     TabBarActionParams,
     GetSerializedChatResult,
+    PROMPT_INPUT_OPTION_CHANGE_METHOD,
 } from '@aws/language-server-runtimes-types'
 
 export const TELEMETRY = 'telemetry/event'
@@ -57,6 +58,7 @@ export type ServerMessageCommand =
     | typeof CONVERSATION_CLICK_REQUEST_METHOD
     | typeof TAB_BAR_ACTION_REQUEST_METHOD
     | typeof GET_SERIALIZED_CHAT_REQUEST_METHOD
+    | typeof PROMPT_INPUT_OPTION_CHANGE_METHOD
 
 export interface ServerMessage {
     command: ServerMessageCommand

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -153,6 +153,10 @@ export const QAgenticChatServer =
             return chatController.onTabBarAction(params)
         })
 
+        chat.onPromptInputOptionChange(params => {
+            return chatController.onPromptInputOptionChange(params)
+        })
+
         logging.log('Q Chat server has been initialized')
 
         return () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -567,6 +567,8 @@ export class ChatController implements ChatHandlers {
         return chatEventParser.getResult()
     }
 
+    onPromptInputOptionChange() {}
+
     updateConfiguration = (newConfig: AmazonQWorkspaceConfig) => {
         this.#customizationArn = newConfig.customizationArn
         this.#log(`Chat configuration updated customizationArn to ${this.#customizationArn}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -15,6 +15,7 @@ export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
     public localHistoryHydrated: boolean = false
+    public pairProgrammingMode: boolean = true
     #abortController?: AbortController
     #conversationId?: string
     #amazonQServiceManager?: AmazonQBaseServiceManager


### PR DESCRIPTION
## Problem
Missing pair programming toggle

## Solution
Add pair programming toggle on the bottom left of chat

Depends on https://github.com/aws/language-server-runtimes/pull/449

<img width="497" alt="Screenshot 2025-04-19 at 8 30 04 PM" src="https://github.com/user-attachments/assets/68d55f78-3452-4f55-b62e-1f9fd15f9dfa" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
