### PR TITLE
fix(amazonq): fix context transparency doesn't show for file & file c…

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/src/agent-standalone.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/src/agent-standalone.ts
@@ -5,6 +5,7 @@ import {
     CodeWhispererServerTokenProxy,
     QAgenticChatServerTokenProxy,
     QConfigurationServerTokenProxy,
+    QLocalProjectContextServerTokenProxy,
     QNetTransformServerTokenProxy,
 } from '@aws/lsp-codewhisperer'
 import { IdentityServer } from '@aws/lsp-identity'
@@ -26,6 +27,7 @@ const props: RuntimeProps = {
         IdentityServer.create,
         FsToolsServer,
         BashToolsServer,
+        QLocalProjectContextServerTokenProxy,
         // LspToolsServer,
     ],
     name: 'AWS CodeWhisperer',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -3,6 +3,7 @@
  * Will be deleted or merged.
  */
 
+import * as path from 'path'
 import {
     ChatTriggerType,
     GenerateAssistantResponseCommandInput,
@@ -82,9 +83,10 @@ import {
     TriggerContext,
 } from './context/agenticChatTriggerContext'
 import { AdditionalContextProvider } from './context/addtionalContextProvider'
-import { getNewPromptFilePath } from './context/contextUtils'
+import { getNewPromptFilePath, getUserPromptsDirectory, promptFileExtension } from './context/contextUtils'
 import { ContextCommandsProvider } from './context/contextCommandsProvider'
 import { LocalProjectContextController } from '../../shared/localProjectContextController'
+import { workspaceUtils } from '@aws/lsp-core'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -125,7 +127,7 @@ export class AgenticChatController implements ChatHandlers {
         this.#amazonQServiceManager = amazonQServiceManager
         this.#chatHistoryDb = new ChatDatabase(features)
         this.#tabBarController = new TabBarController(features, this.#chatHistoryDb)
-        this.#additionalContextProvider = new AdditionalContextProvider(features.workspace)
+        this.#additionalContextProvider = new AdditionalContextProvider(features.workspace, features.lsp)
         this.#contextCommandsProvider = new ContextCommandsProvider(
             this.#features.logging,
             this.#features.chat,
@@ -721,7 +723,16 @@ export class AgenticChatController implements ChatHandlers {
 
     async onFileClicked(params: FileClickParams) {
         // TODO: also pass in selection and handle on client side
-        await this.#features.lsp.window.showDocument({ uri: params.filePath })
+        const workspaceRoot = workspaceUtils.getWorkspaceFolderPaths(this.#features.lsp)[0]
+        let absolutePath = path.join(workspaceRoot, params.filePath)
+        // handle prompt file outside of workspace
+        if (params.filePath.endsWith(promptFileExtension)) {
+            const existsInWorkspace = await this.#features.workspace.fs.exists(absolutePath)
+            if (!existsInWorkspace) {
+                absolutePath = path.join(getUserPromptsDirectory(), params.filePath)
+            }
+        }
+        await this.#features.lsp.window.showDocument({ uri: absolutePath })
     }
 
     onFollowUpClicked() {}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
@@ -23,7 +23,7 @@ describe('AdditionalContextProvider', () => {
         testFeatures.workspace.fs.exists = fsExistsStub
         testFeatures.workspace.fs.readdir = fsReadDirStub
         getContextCommandPromptStub = sinon.stub()
-        provider = new AdditionalContextProvider(testFeatures.workspace)
+        provider = new AdditionalContextProvider(testFeatures.workspace, testFeatures.lsp)
         localProjectContextControllerInstanceStub = sinon.stub(LocalProjectContextController, 'getInstance').resolves({
             getContextCommandPrompt: getContextCommandPromptStub,
         } as unknown as LocalProjectContextController)


### PR DESCRIPTION
…lick

## Problem
- fileClick pass in absolute path and handle prompt file outside of workspace
- fix an issue when no file open the context transparency list in chat response doesn't show because the workspace is not in triggerContext, we should utilize the workspaceUtil to get the current workspace
- fix typing for context command

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
