### PR TITLE
fix: fallback to fs if document context fails to sync

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
@@ -5,6 +5,7 @@
 
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import assert = require('assert')
+import * as fs from 'fs/promises'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import sinon = require('sinon')
 import { AgenticChatTriggerContext } from './agenticChatTriggerContext'
@@ -12,6 +13,7 @@ import { DocumentContext, DocumentContextExtractor } from '../../chat/contexts/d
 import { ChatTriggerType, CursorState } from '@amzn/codewhisperer-streaming'
 import { URI } from 'vscode-uri'
 import { InitializeParams } from '@aws/language-server-runtimes/protocol'
+import { TestFolder } from '@aws/lsp-core/out/test/testFolder'
 
 describe('AgenticChatTriggerContext', () => {
     let testFeatures: TestFeatures
@@ -58,8 +60,16 @@ describe('AgenticChatTriggerContext', () => {
     })
 
     it('returns null if text document is not found', async () => {
+        testFeatures.workspace = {
+            ...testFeatures.workspace,
+            fs: {
+                ...testFeatures.workspace.fs,
+                readFile: (_path, _options?) => {
+                    throw new Error('File not found')
+                },
+            },
+        }
         const triggerContext = new AgenticChatTriggerContext(testFeatures)
-
         const documentContext = await triggerContext.extractDocumentContext({
             cursorState: [
                 {
@@ -127,5 +137,60 @@ describe('AgenticChatTriggerContext', () => {
                 ?.workspaceFolders,
             mockWorkspaceFolders.map(f => URI.parse(f.uri).fsPath)
         )
+    })
+    describe('getTextDocument', function () {
+        let tempFolder: TestFolder
+
+        before(async () => {
+            tempFolder = await TestFolder.create()
+        })
+
+        afterEach(async () => {
+            await tempFolder.clear()
+        })
+
+        after(async () => {
+            await tempFolder.delete()
+        })
+
+        it('returns text document if it is synced', async function () {
+            const mockDocument = {
+                uri: 'file://this/is/my/file.py',
+                languageId: 'python',
+                version: 0,
+            } as TextDocument
+            testFeatures.workspace.getTextDocument.resolves(mockDocument)
+
+            const result = await new AgenticChatTriggerContext(testFeatures).getTextDocument(mockDocument.uri)
+            assert.deepStrictEqual(result, mockDocument)
+        })
+
+        it('falls back to file system if it is not synced', async function () {
+            const pythonContent = 'print("hello")'
+            const pythonFilePath = await tempFolder.write('pythonFile.py', pythonContent)
+            const uri = URI.file(pythonFilePath).toString()
+            testFeatures.workspace.getTextDocument.resolves(undefined)
+            testFeatures.workspace = {
+                ...testFeatures.workspace,
+                fs: {
+                    ...testFeatures.workspace.fs,
+                    readFile: path => fs.readFile(path, { encoding: 'utf-8' }),
+                },
+            }
+            const result = await new AgenticChatTriggerContext(testFeatures).getTextDocument(uri)
+
+            assert.ok(result)
+            assert.strictEqual(result.uri, uri)
+            assert.strictEqual(result.getText(), pythonContent)
+        })
+
+        it('returns undefined if both sync and fs fails', async function () {
+            const uri = 'file://not/a/real/path'
+            testFeatures.workspace.getTextDocument.resolves(undefined)
+
+            const result = await new AgenticChatTriggerContext(testFeatures).getTextDocument(uri)
+
+            assert.deepStrictEqual(result, undefined)
+        })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
@@ -60,15 +60,6 @@ describe('AgenticChatTriggerContext', () => {
     })
 
     it('returns null if text document is not found', async () => {
-        testFeatures.workspace = {
-            ...testFeatures.workspace,
-            fs: {
-                ...testFeatures.workspace.fs,
-                readFile: (_path, _options?) => {
-                    throw new Error('File not found')
-                },
-            },
-        }
         const triggerContext = new AgenticChatTriggerContext(testFeatures)
         const documentContext = await triggerContext.extractDocumentContext({
             cursorState: [


### PR DESCRIPTION
## Problem
If the document can't be found in the active documents, then it fails to populate it in the request to the server. This results in confusing behavior where some files may fail to fetch here: https://github.com/aws/language-servers/blob/main/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts#L84. 

## Solution
- add a fallback mechanism such that if we can't find the document through the LSP, we use the underlying file system to read the file instead. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
