### PR TITLE
fix: export for answer-stream card item

### DIFF
--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -22,7 +22,7 @@ import {
     SEND_TO_PROMPT_TELEMETRY_EVENT,
     TAB_ADD_TELEMETRY_EVENT,
 } from '../contracts/telemetry'
-import { MynahUI } from '@aws/mynah-ui'
+import { ChatItemType, MynahUI } from '@aws/mynah-ui'
 import { TabFactory } from './tabs/tabFactory'
 import { ChatClientAdapter } from '../contracts/chatClientAdapter'
 
@@ -218,7 +218,9 @@ describe('Chat', () => {
         window.dispatchEvent(chatEvent)
 
         assert.calledOnceWithExactly(endMessageStreamStub, tabId, '')
-        assert.calledOnceWithMatch(updateLastChatAnswerStub, tabId, { body })
+        assert.calledTwice(updateLastChatAnswerStub)
+        assert.calledWithMatch(updateLastChatAnswerStub, tabId, { body: '' })
+        assert.calledWithMatch(updateLastChatAnswerStub, tabId, { body, type: ChatItemType.ANSWER })
         assert.calledOnceWithExactly(updateStoreStub, tabId, {
             loadingChat: false,
             promptInputDisabledState: false,

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -495,11 +495,11 @@ export const createMynahUi = (
               }
             : {}
 
-        // TODO: fix this on MynahUI side.
+        // TODO: ensure all card item types are supported for export on MynahUI side.
         // Chat export does not work with 'ANSWER_STREAM' cards, so at the end of the streaming
         // we convert 'ANSWER_STREAM' to 'ANSWER' card.
         // First, we unset all the properties and then insert all the data as card item type 'ANSWER'.
-        // This approach works, because 'addChatResponse' reveives aggregated/joined data send in every next progress update.
+        // It works, because 'addChatResponse' receives aggregated/joined data send in every next progress update.
         mynahUi.updateLastChatAnswer(tabId, {
             header: undefined,
             body: '',

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -495,16 +495,34 @@ export const createMynahUi = (
               }
             : {}
 
+        // TODO: fix this on MynahUI side.
+        // Chat export does not work with 'ANSWER_STREAM' cards, so at the end of the streaming
+        // we convert 'ANSWER_STREAM' to 'ANSWER' card.
+        // First, we unset all the properties and then insert all the data as card item type 'ANSWER'.
+        // This approach works, because 'addChatResponse' reveives aggregated/joined data send in every next progress update.
         mynahUi.updateLastChatAnswer(tabId, {
-            header: header,
-            body: chatResult.body,
-            messageId: chatResult.messageId,
-            followUp: followUps,
-            relatedContent: chatResult.relatedContent,
-            canBeVoted: chatResult.canBeVoted,
+            header: undefined,
+            body: '',
+            followUp: undefined,
+            relatedContent: undefined,
+            canBeVoted: undefined,
+            codeReference: undefined,
+            fileList: undefined,
         })
 
         mynahUi.endMessageStream(tabId, chatResult.messageId ?? '')
+
+        mynahUi.updateLastChatAnswer(tabId, {
+            type: ChatItemType.ANSWER,
+            header: header,
+            body: chatResult.body,
+            followUp: followUps,
+            relatedContent: chatResult.relatedContent,
+            canBeVoted: chatResult.canBeVoted,
+            codeReference: chatResult.codeReference,
+            fileList: chatResult.fileList,
+            // messageId excluded
+        })
 
         mynahUi.updateStore(tabId, {
             loadingChat: false,


### PR DESCRIPTION
## Problem

We had export for tabs open from history working fine, but it turns out export is not supported with card items with `type: ChatItemType.ANSWER_STREAM`. Flare, unlike vscode, uses MynahUI streaming card items. So, export is not working if you try to export active tabs (not open from history, but with content streamed from server).

## Solution

Convert card items with `type: ChatItemType.ANSWER_STREAM` to card items with `type: ChatItemType.ANSWER` at the end of streaming response.


https://github.com/user-attachments/assets/36e1431b-e7f2-4d5c-8041-9476d87a1216




Next steps:
Work with @Jurredr  and @dogusata to ensure export support for all types of card items.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
