### PR TITLE
feat: initial fsWrite chat message

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -461,7 +461,24 @@ export const createMynahUi = (
 
         if (isPartialResult) {
             // type for MynahUI differs from ChatResult types so we ignore it
-            mynahUi.updateLastChatAnswer(tabId, { ...chatResultWithoutType, header: header, buttons: buttons })
+            mynahUi.updateLastChatAnswer(tabId, {
+                ...chatResultWithoutType,
+                header: header,
+                buttons: buttons,
+                // TODO: this won't be needed once we have multiple message support
+                ...(type === 'tool'
+                    ? {
+                          header: {
+                              ...header,
+                              // TODO: this is specific to fsWrite tool, modify for other tools as needed
+                              fileList: { ...header?.fileList, fileTreeTitle: '', hideFileCount: true },
+                              buttons: header?.buttons?.map(button => ({ ...button, status: 'clear' })),
+                          },
+                          fullWidth: true,
+                          padding: false,
+                      }
+                    : {}),
+            })
             return
         }
 


### PR DESCRIPTION
## Problem

Initial FsWrite tool message implementation

![image](https://github.com/user-attachments/assets/c0bcff98-5f9e-49b1-8a62-075a39850c37)


## Solution
- Send header params from controller
- Update mynahUi to handle tool specific messages. Things like fullWidth and padding do not belong in the flare library, so we need custom logic to add them in the UI.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
