### PR TITLE
feat: add @workspace context in agentic chat

### DIFF
--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -93,7 +93,7 @@ describe('MynahUI', () => {
             handleChatPrompt(mynahUi, tabId, prompt, messager)
 
             assert.notCalled(onQuickActionSpy)
-            assert.calledWith(onChatPromptSpy, { prompt, tabId })
+            assert.calledWith(onChatPromptSpy, { prompt, tabId, context: undefined })
             assert.calledWith(addChatItemSpy, tabId, { type: ChatItemType.PROMPT, body: prompt.escapedPrompt })
             assert.calledWith(updateStoreSpy, tabId, { loadingChat: true, promptInputDisabledState: true })
             assert.calledWith(addChatItemSpy, tabId, { type: ChatItemType.ANSWER_STREAM })

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -108,7 +108,8 @@ export const handleChatPrompt = (
         }
     } else {
         // Send chat prompt to server
-        messager.onChatPrompt({ prompt, tabId }, triggerType)
+        const context = prompt.context?.map(c => (typeof c === 'string' ? { command: c } : c))
+        messager.onChatPrompt({ prompt, tabId, context }, triggerType)
     }
     // Add user prompt to UI
     mynahUi.addChatItem(tabId, {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -1059,6 +1059,8 @@ describe('AgenticChatController', () => {
                             text: undefined,
                         },
                         workspaceFolders: [],
+                        relevantDocuments: undefined,
+                        useRelevantDocuments: false,
                     }
                 )
             })
@@ -1305,6 +1307,8 @@ describe('AgenticChatController', () => {
                             text: undefined,
                         },
                         workspaceFolders: [],
+                        relevantDocuments: undefined,
+                        useRelevantDocuments: false,
                     }
                 )
             })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -269,7 +269,7 @@ export class AgenticChatController implements ChatHandlers {
     ): Promise<GenerateAssistantResponseCommandInput> {
         this.#debug('Preparing request input')
         const profileArn = AmazonQTokenServiceManager.getInstance(this.#features).getActiveProfileArn()
-        const requestInput = this.#triggerContext.getChatParamsFromTrigger(
+        const requestInput = await this.#triggerContext.getChatParamsFromTrigger(
             params,
             triggerContext,
             ChatTriggerType.MANUAL,
@@ -684,7 +684,7 @@ export class AgenticChatController implements ChatHandlers {
         let requestInput: SendMessageCommandInput
 
         try {
-            requestInput = this.#triggerContext.getChatParamsFromTrigger(
+            requestInput = await this.#triggerContext.getChatParamsFromTrigger(
                 params,
                 triggerContext,
                 ChatTriggerType.INLINE_CHAT,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -122,6 +122,8 @@ export class AgenticChatTriggerContext {
                                       tools,
                                       additionalContext: additionalContent,
                                       editorState: {
+                                          relevantDocuments: relevantDocuments,
+                                          useRelevantDocuments: useRelevantDocuments,
                                           ...defaultEditorState,
                                       },
                                   },

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -7,8 +7,6 @@ import { TriggerType } from '@aws/chat-client-ui-types'
 import {
     ChatTriggerType,
     UserIntent,
-    Tool,
-    ToolResult,
     AdditionalContentEntry,
     GenerateAssistantResponseCommandInput,
     ChatMessage,
@@ -18,7 +16,6 @@ import {
     ChatParams,
     CursorState,
     InlineChatParams,
-    QuickActionCommand,
     FileList,
     TextDocument,
 } from '@aws/language-server-runtimes/server-interface'
@@ -26,6 +23,9 @@ import { Features } from '../../types'
 import { DocumentContext, DocumentContextExtractor } from '../../chat/contexts/documentContext'
 import { workspaceUtils } from '@aws/lsp-core'
 import { URI } from 'vscode-uri'
+import { LocalProjectContextController } from '../../../shared/localProjectContextController'
+import * as path from 'path'
+import { RelevantTextDocument } from '@amzn/codewhisperer-streaming'
 
 export interface TriggerContext extends Partial<DocumentContext> {
     userIntent?: UserIntent
@@ -37,16 +37,28 @@ export type LineInfo = { startLine: number; endLine: number }
 
 export type AdditionalContentEntryAddition = AdditionalContentEntry & { type: string; relativePath: string } & LineInfo
 
+export type RelevantTextDocumentAddition = RelevantTextDocument & LineInfo
+
+// limit for each chunk of @workspace
+export const workspaceChunkMaxSize = 40_960
+
+export interface DocumentReference {
+    readonly relativeFilePath: string
+    readonly lineRanges: Array<{ first: number; second: number }>
+}
+
 export class AgenticChatTriggerContext {
     private static readonly DEFAULT_CURSOR_STATE: CursorState = { position: { line: 0, character: 0 } }
 
     #workspace: Features['workspace']
     #lsp: Features['lsp']
+    #logging: Features['logging']
     #documentContextExtractor: DocumentContextExtractor
 
     constructor({ workspace, lsp, logging }: Pick<Features, 'workspace' | 'lsp' | 'logging'> & Partial<Features>) {
         this.#workspace = workspace
         this.#lsp = lsp
+        this.#logging = logging
         this.#documentContextExtractor = new DocumentContextExtractor({ logger: logging, workspace })
     }
 
@@ -59,7 +71,7 @@ export class AgenticChatTriggerContext {
         }
     }
 
-    getChatParamsFromTrigger(
+    async getChatParamsFromTrigger(
         params: ChatParams | InlineChatParams,
         triggerContext: TriggerContext,
         chatTriggerType: ChatTriggerType,
@@ -68,15 +80,27 @@ export class AgenticChatTriggerContext {
         history: ChatMessage[] = [],
         tools: BedrockTools = [],
         additionalContent?: AdditionalContentEntryAddition[]
-    ): GenerateAssistantResponseCommandInput {
+    ): Promise<GenerateAssistantResponseCommandInput> {
         const { prompt } = params
         const defaultEditorState = { workspaceFolders: workspaceUtils.getWorkspaceFolderPaths(this.#lsp) }
+
+        const useRelevantDocuments = 'context' in params ? params.context?.some(c => c.command === '@workspace') : false
+
+        let promptContent = prompt.escapedPrompt ?? prompt.prompt
+        if (useRelevantDocuments) {
+            promptContent = promptContent?.replace(/^@workspace\/?/, '')
+        }
+
+        const relevantDocuments = useRelevantDocuments
+            ? await this.#getRelevantDocuments(promptContent ?? '')
+            : undefined
+
         const data: GenerateAssistantResponseCommandInput = {
             conversationState: {
                 chatTriggerType: chatTriggerType,
                 currentMessage: {
                     userInputMessage: {
-                        content: prompt.escapedPrompt ?? prompt.prompt,
+                        content: promptContent,
                         userInputMessageContext:
                             triggerContext.cursorState && triggerContext.relativeFilePath
                                 ? {
@@ -87,6 +111,8 @@ export class AgenticChatTriggerContext {
                                               programmingLanguage: triggerContext.programmingLanguage,
                                               relativeFilePath: triggerContext.relativeFilePath,
                                           },
+                                          relevantDocuments: relevantDocuments,
+                                          useRelevantDocuments: useRelevantDocuments,
                                           ...defaultEditorState,
                                       },
                                       tools,
@@ -169,5 +195,63 @@ export class AgenticChatTriggerContext {
         }
 
         return undefined
+    }
+
+    async #getRelevantDocuments(prompt: string): Promise<RelevantTextDocumentAddition[]> {
+        const localProjectContextController = await LocalProjectContextController.getInstance()
+        if (!localProjectContextController.isEnabled) {
+            // TODO: Prompt user to enable indexing
+            return []
+        }
+
+        let relevantTextDocuments = await this.#queryRelevantDocuments(prompt, localProjectContextController)
+        relevantTextDocuments = relevantTextDocuments.filter(doc => doc.text && doc.text.length > 0)
+        for (const relevantDocument of relevantTextDocuments) {
+            if (relevantDocument.text && relevantDocument.text.length > workspaceChunkMaxSize) {
+                relevantDocument.text = relevantDocument.text.substring(0, workspaceChunkMaxSize)
+                this.#logging.debug(`Truncating @workspace chunk: ${relevantDocument.relativeFilePath} `)
+            }
+        }
+
+        return relevantTextDocuments
+    }
+
+    async #queryRelevantDocuments(
+        prompt: string,
+        localProjectContextController: LocalProjectContextController
+    ): Promise<RelevantTextDocumentAddition[]> {
+        try {
+            const chunks = await localProjectContextController.queryVectorIndex({ query: prompt })
+            const relevantTextDocuments: RelevantTextDocumentAddition[] = []
+            if (!chunks) {
+                return relevantTextDocuments
+            }
+
+            for (const chunk of chunks) {
+                const text = chunk.context ?? chunk.content
+                const baseDocument = {
+                    text,
+                    relativeFilePath: chunk.relativePath ?? path.basename(chunk.filePath),
+                    startLine: chunk.startLine ?? -1,
+                    endLine: chunk.endLine ?? -1,
+                }
+
+                if (chunk.programmingLanguage && chunk.programmingLanguage !== 'unknown') {
+                    relevantTextDocuments.push({
+                        ...baseDocument,
+                        programmingLanguage: {
+                            languageName: chunk.programmingLanguage,
+                        },
+                    })
+                } else {
+                    relevantTextDocuments.push(baseDocument)
+                }
+            }
+
+            return relevantTextDocuments
+        } catch (e) {
+            this.#logging.error(`Error querying query vector index to get relevant documents: ${e}`)
+            return []
+        }
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
@@ -107,12 +107,12 @@ describe('AgenticChatTriggerContext', () => {
 
     it('includes workspace folders as part of editor state in chat params', async () => {
         const triggerContext = new AgenticChatTriggerContext(testFeatures)
-        const chatParams = triggerContext.getChatParamsFromTrigger(
+        const chatParams = await triggerContext.getChatParamsFromTrigger(
             { tabId: 'tab', prompt: {} },
             {},
             ChatTriggerType.MANUAL
         )
-        const chatParamsWithMore = triggerContext.getChatParamsFromTrigger(
+        const chatParamsWithMore = await triggerContext.getChatParamsFromTrigger(
             { tabId: 'tab', prompt: {} },
             { cursorState: {} as CursorState, relativeFilePath: '' },
             ChatTriggerType.MANUAL

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -71,6 +71,10 @@ export class LocalProjectContextController {
         this.log = logging
     }
 
+    get isEnabled(): boolean {
+        return this._vecLib !== undefined && this._vecLib !== null
+    }
+
     public static async getInstance(): Promise<LocalProjectContextController> {
         try {
             await waitUntil(async () => this.instance, {


### PR DESCRIPTION
## Problem

`@workspace` is not supported in agentic chat context commands now.

## Solution

The support for `@workspace` was added. It relies on local workspace indexing working.

TODO in followup PRs: prompt customer to enable indexing if it's disabled.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
