### PR TITLE
fix: avoid webpack path resolution interfering with vecLib import

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -131,7 +131,7 @@ export class LocalProjectContextController {
             )
 
             const libraryPath = path.join(LIBRARY_DIR, 'dist', 'extension.js')
-            const vecLib = vectorLib ?? (await import(libraryPath))
+            const vecLib = vectorLib ?? (await eval(`import("${libraryPath}")`))
             if (vecLib) {
                 this._vecLib = await vecLib.start(LIBRARY_DIR, this.clientName, this.indexCacheDirPath)
                 void this.buildIndex()


### PR DESCRIPTION
## Problem
Webpack is trying to handle the dynamic import for the vector libary using its own module resolution system. This causes the library to fail at runtime.
## Solution
Import the library using eval, which webpack will ignore and leave the path resolution unchanged.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
