### PR TITLE
chore: bump runtimes to 0.2.69

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -346,7 +346,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.16",
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -139,7 +139,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -201,7 +201,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -270,7 +270,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.16",
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -3293,14 +3293,15 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.67",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.67.tgz",
-            "integrity": "sha512-1FmnJ1w27uwnC3L907aaMfDLA3ttOr2wpXgqjAlnXxgUy50Kxq4mpI8832OMDXJNAuZLR1+QQTo6fgSMgh+vEQ==",
+            "version": "0.2.69",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.69.tgz",
+            "integrity": "sha512-NzUYP9+1zrPoaVrPNXKAmEFrl1n9TvQ6rJpsbJzJAKhwRdMH4hljkGwqxhBmwocYhRYZxGEdTg0LshLpjVIH+g==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.9.3",
                 "@aws-crypto/sha256-js": "^5.2.0",
                 "@aws-sdk/client-cognito-identity": "^3.758.0",
-                "@aws/language-server-runtimes-types": "^0.1.19",
+                "@aws/language-server-runtimes-types": "^0.1.21",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/resources": "^1.30.1",
                 "@opentelemetry/sdk-metrics": "^1.30.1",
@@ -3326,9 +3327,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.19",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.19.tgz",
-            "integrity": "sha512-c81J3G3N6JP5A6g70xTpK/XPS1YWwviQBn307Rk3S5fSiALT8INeHM+IPDg9AuONU6w378RJjzQy3+PE0gJvsw==",
+            "version": "0.1.21",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.21.tgz",
+            "integrity": "sha512-03C3dz4MvMyKg4UAgHMNNw675OQJkDq+7TPXUPaiasqPF946ywTDD9xoNPaVOQI+YTtC7Re4vhPRfBzyad3MOg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -22810,7 +22811,7 @@
             "version": "0.1.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "@aws/lsp-core": "^0.0.3"
             },
             "devDependencies": {
@@ -22882,7 +22883,7 @@
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.16",
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "@aws/lsp-core": "^0.0.3",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
@@ -23054,7 +23055,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "@aws/lsp-core": "^0.0.3",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -23157,7 +23158,7 @@
             "version": "0.1.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "@aws/lsp-core": "^0.0.3",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -23171,7 +23172,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "@aws/lsp-core": "0.0.3",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -23213,7 +23214,7 @@
             "version": "0.0.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -23246,7 +23247,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "@aws/lsp-core": "^0.0.3",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -23260,7 +23261,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -23271,7 +23272,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.67",
+                "@aws/language-server-runtimes": "^0.2.69",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-core": "^0.0.3"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.16",
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-core": "^0.0.3",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -16,6 +16,8 @@ import {
     ToolUse,
 } from '@amzn/codewhisperer-streaming'
 import {
+    ButtonClickParams,
+    ButtonClickResult,
     chatRequestType,
     FileDetails,
     InlineChatResultParams,
@@ -140,6 +142,13 @@ export class AgenticChatController implements ChatHandlers {
             this.#features.chat,
             this.#features.workspace
         )
+    }
+
+    async onButtonClick(params: ButtonClickParams): Promise<ButtonClickResult> {
+        return {
+            success: false,
+            failureReason: 'not implemented',
+        }
     }
 
     async onCreatePrompt(params: CreatePromptParams): Promise<void> {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -11,6 +11,8 @@ import {
     InlineChatResultParams,
     NotificationHandler,
     PromptInputOptionChangeParams,
+    ButtonClickParams,
+    ButtonClickResult,
 } from '@aws/language-server-runtimes/protocol'
 import {
     CancellationToken,
@@ -93,6 +95,13 @@ export class ChatController implements ChatHandlers {
     dispose() {
         this.#chatSessionManagementService.dispose()
         this.#telemetryController.dispose()
+    }
+
+    async onButtonClick(params: ButtonClickParams): Promise<ButtonClickResult> {
+        return {
+            success: false,
+            failureReason: 'not implemented',
+        }
     }
 
     async onChatPrompt(params: ChatParams, token: CancellationToken): Promise<ChatResult | ResponseError<ChatResult>> {

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-core": "^0.0.3",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-core": "^0.0.3",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-core": "0.0.3",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-core": "^0.0.3",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem
internal pipeline always uses latest runtimes which not compatible with current version. 

## Solution
- update runtimes and implement stubs for new `onButtonClick` method. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
