### PR TITLE
chore: ensure runtime versions are synced across package.json

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -13,7 +13,7 @@
         "test": "node scripts/test-runner.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.67",
+        "@aws/language-server-runtimes": "^0.2.69",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.67"
+        "@aws/language-server-runtimes": "^0.2.69"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.22",
-        "@aws/language-server-runtimes-types": "^0.1.19",
+        "@aws/language-server-runtimes-types": "^0.1.21",
         "@aws/mynah-ui": "file:./lib/aws-mynah-ui-4.31.0-beta.6.tgz"
     },
     "bundleDependencies": [


### PR DESCRIPTION
## Problem
This previous PR missed a few files https://github.com/aws/language-servers/pull/1031. 
Search and replace betrayed me somehow. 

the newest appears to be resolved either way since we use `^`, but this keeps all `package.json` in sync and also solves outdated types in the chat client.

## Solution
- resync them. 
- update chat-client types dep. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
