### PR TITLE
fix: remove examples from welcome message

### DIFF
--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -48,10 +48,6 @@ export class TabFactory {
                         Ask me to explain, debug, or optimize your code. 
                         You can enter \`/\` to see a list of quick actions.`,
                       },
-                      {
-                          type: ChatItemType.ANSWER,
-                          followUp: this.getWelcomeBlock(),
-                      },
                   ]
                 : chatMessages
                   ? (chatMessages as ChatItem[])
@@ -82,23 +78,6 @@ export class TabFactory {
 
         tabData.tabBarButtons = this.getTabBarButtons()
         return tabData
-    }
-
-    private getWelcomeBlock() {
-        return {
-            text: 'Try Examples:',
-            options: [
-                {
-                    pillText: 'Explain selected code',
-                    prompt: 'Explain selected code',
-                    type: 'init-prompt',
-                },
-                {
-                    pillText: 'How can Amazon Q help me?',
-                    type: 'help',
-                },
-            ],
-        }
     }
 
     private getTabBarButtons(): TabBarMainAction[] | undefined {


### PR DESCRIPTION
## Problem
- remove examples from welcome message
## Solution
before:
<img width="584" alt="image" src="https://github.com/user-attachments/assets/e68088e8-94b9-4f35-ba95-d823340d3db4" />

after change:
![image](https://github.com/user-attachments/assets/152338dc-eac9-4ba8-9d31-57a436f6d626)



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
