### PR TITLE
feat(amazonq): initial UI for execute bash chat message

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -498,8 +498,8 @@ export const createMynahUi = (
                     buttons: toMynahButtons(am.buttons),
 
                     // file diffs in the header need space
-                    fullWidth: am.type === 'tool' && am.header?.fileList ? true : undefined,
-                    padding: am.type === 'tool' && am.header?.fileList ? false : undefined,
+                    fullWidth: am.type === 'tool' ? true : undefined,
+                    padding: am.type === 'tool' ? false : undefined,
                 }
                 const message = chatItems.find(ci => ci.messageId === am.messageId)
                 if (!message) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -16,6 +16,7 @@ import {
     ToolUse,
 } from '@amzn/codewhisperer-streaming'
 import {
+    Button,
     ButtonClickParams,
     ButtonClickResult,
     ChatMessage,
@@ -98,6 +99,8 @@ import { workspaceUtils } from '@aws/lsp-core'
 import { FsReadParams } from './tools/fsRead'
 import { ListDirectoryParams } from './tools/listDirectory'
 import { FsWrite, FsWriteParams } from './tools/fsWrite'
+import { ExecuteBash, ExecuteBashOutput, ExecuteBashParams } from './tools/executeBash'
+import { InvokeOutput } from './tools/toolShared'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -147,9 +150,24 @@ export class AgenticChatController implements ChatHandlers {
     }
 
     async onButtonClick(params: ButtonClickParams): Promise<ButtonClickResult> {
-        return {
-            success: false,
-            failureReason: 'not implemented',
+        if (params.buttonId === 'run-shell-command' || params.buttonId === 'reject-shell-command') {
+            const session = this.#chatSessionManagementService.getSession(params.tabId)
+            if (!session.data) {
+                return { success: false, failureReason: `could not find chat session for tab: ${params.tabId} ` }
+            }
+            const handler = session.data.getDeferredToolExecution(params.messageId)
+            if (!handler?.reject || !handler.resolve) {
+                return {
+                    success: false,
+                    failureReason: `could not find deferred tool execution for message: ${params.messageId} `,
+                }
+            }
+            params.buttonId === 'reject-shell-command' ? handler.reject() : handler.resolve()
+            return {
+                success: true,
+            }
+        } else {
+            return { success: false, failureReason: 'not implemented' }
         }
     }
 
@@ -349,7 +367,7 @@ export class AgenticChatController implements ChatHandlers {
             const currentMessage = currentRequestInput.conversationState?.currentMessage
 
             // Process tool uses and update the request input for the next iteration
-            const toolResults = await this.#processToolUses(pendingToolUses, chatResultStream)
+            const toolResults = await this.#processToolUses(pendingToolUses, chatResultStream, session)
             currentRequestInput = this.#updateRequestInputWithToolResults(currentRequestInput, toolResults)
 
             if (!currentRequestInput.conversationState!.history) {
@@ -402,26 +420,49 @@ export class AgenticChatController implements ChatHandlers {
      */
     async #processToolUses(
         toolUses: Array<ToolUse & { stop: boolean }>,
-        chatResultStream: AgenticChatResultStream
+        chatResultStream: AgenticChatResultStream,
+        session: ChatSessionService
     ): Promise<ToolResult[]> {
         const results: ToolResult[] = []
 
         for (const toolUse of toolUses) {
             if (!toolUse.name || !toolUse.toolUseId) continue
-
+            let needsConfirmation
             try {
                 if (toolUse.name === 'fsRead' || toolUse.name === 'listDirectory') {
                     const initialReadOrListResult = this.#processReadOrList(toolUse, chatResultStream)
                     if (initialReadOrListResult) {
                         await chatResultStream.writeResultBlock(initialReadOrListResult)
                     }
-                } else if (toolUse.name === 'fsWrite' || toolUse.name === 'executeBash') {
+                } else if (toolUse.name === 'executeBash') {
+                    const bashTool = new ExecuteBash(this.#features)
+                    const { requiresAcceptance, warning } = await bashTool.requiresAcceptance(
+                        toolUse.input as unknown as ExecuteBashParams
+                    )
+                    if (requiresAcceptance) {
+                        needsConfirmation = true
+                        const confirmationResult = this.#processExecuteBashConfirmation(toolUse, warning)
+                        await chatResultStream.writeResultBlock(confirmationResult)
+                    }
+                } else if (toolUse.name === 'fsWrite') {
                     // todo: pending tool use cards?
                 } else {
                     await chatResultStream.writeResultBlock({
                         body: `${executeToolMessage(toolUse)}`,
                         messageId: toolUse.toolUseId,
                     })
+                }
+
+                if (needsConfirmation) {
+                    const deferred = this.#createDeferred()
+                    session.setDeferredToolExecution(toolUse.toolUseId, deferred.resolve, deferred.reject)
+
+                    // the below line was commented out for now because
+                    // the partial result block from above is not streamed to chat window yet at this point
+                    // so the buttons are not in the window for the promise to be rejected/resolved
+                    // this can to be brought back once intermediate messages are shown
+
+                    // await deferred.promise
                 }
 
                 const result = await this.#features.agent.runTool(toolUse.name, toolUse.input)
@@ -450,6 +491,9 @@ export class AgenticChatController implements ChatHandlers {
                         const chatResult = await this.#getFsWriteChatResult(toolUse)
                         await chatResultStream.writeResultBlock(chatResult)
                         break
+                    case 'executeBash':
+                        const bashToolResult = this.#getBashExecutionChatResult(toolUse, result)
+                        await chatResultStream.writeResultBlock(bashToolResult)
                     default:
                         await chatResultStream.writeResultBlock({ body: toolResultMessage(toolUse, result) })
                         break
@@ -469,6 +513,45 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         return results
+    }
+
+    #getBashExecutionChatResult(toolUse: ToolUse, result: InvokeOutput): ChatResult {
+        const outputString = result.output.success
+            ? (result.output.content as ExecuteBashOutput).stdout
+            : (result.output.content as ExecuteBashOutput).stderr
+        return {
+            type: 'tool',
+            messageId: toolUse.toolUseId,
+            body: outputString,
+        }
+    }
+
+    #processExecuteBashConfirmation(toolUse: ToolUse, warning?: string): ChatResult {
+        const buttons: Button[] = [
+            {
+                id: 'reject-shell-command',
+                text: 'Reject',
+                icon: 'cancel',
+            },
+            {
+                id: 'run-shell-command',
+                text: 'Run',
+                icon: 'play',
+            },
+        ]
+        const header = {
+            body: 'shell',
+            buttons,
+        }
+
+        const commandString = (toolUse.input as unknown as ExecuteBashParams).command
+        const body = '```shell\n' + commandString + '\n```'
+        return {
+            type: 'tool',
+            messageId: toolUse.toolUseId,
+            header,
+            body: warning ? warning + body : body,
+        }
     }
 
     async #getFsWriteChatResult(toolUse: ToolUse): Promise<ChatMessage> {
@@ -1088,6 +1171,16 @@ export class AgenticChatController implements ChatHandlers {
             return tools.filter(tool => !['fsWrite', 'executeBash'].includes(tool.toolSpecification?.name || ''))
         }
         return tools
+    }
+
+    #createDeferred() {
+        let resolve
+        let reject
+        const promise = new Promise((res, rej) => {
+            resolve = res
+            reject = rej
+        })
+        return { promise, resolve, reject }
     }
 
     #log(...messages: string[]) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -121,6 +121,12 @@ interface TimestampedChunk {
     isFirst: boolean
 }
 
+export interface ExecuteBashOutput {
+    exitStatus: string
+    stdout: string
+    stderr: string
+}
+
 export class ExecuteBash {
     private childProcess?: ChildProcess
     private readonly logging: Features['logging']
@@ -356,7 +362,7 @@ export class ExecuteBash {
                     maxBashToolResponseSize / 3
                 )
 
-                const outputJson = {
+                const outputJson: ExecuteBashOutput = {
                     exitStatus: exitStatus.toString(),
                     stdout: stdoutTrunc + (stdoutSuffix ? ' ... truncated' : ''),
                     stderr: stderrTrunc + (stderrSuffix ? ' ... truncated' : ''),

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -12,12 +12,18 @@ import {
 } from '../../shared/streamingClientService'
 
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
+
+type DeferredHandler = {
+    resolve: () => void
+    reject: () => void
+}
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
     public pairProgrammingMode: boolean = true
     #abortController?: AbortController
     #conversationId?: string
     #amazonQServiceManager?: AmazonQBaseServiceManager
+    #deferredToolExecution: Record<string, DeferredHandler> = {}
 
     public get conversationId(): string | undefined {
         return this.#conversationId
@@ -25,6 +31,13 @@ export class ChatSessionService {
 
     public set conversationId(value: string | undefined) {
         this.#conversationId = value
+    }
+
+    public getDeferredToolExecution(messageId: string): DeferredHandler | undefined {
+        return this.#deferredToolExecution[messageId]
+    }
+    public setDeferredToolExecution(messageId: string, resolve: any, reject: any) {
+        this.#deferredToolExecution[messageId] = { resolve, reject }
     }
 
     constructor(amazonQServiceManager?: AmazonQBaseServiceManager) {


### PR DESCRIPTION
## Problem
- currently execute bash output json to chat message
## Solution
- have UI message for asking user confirmation and handle reject/ accept onButtonClick
- write stderr/stdout to chat message
<img width="531" alt="Screenshot 2025-04-21 at 10 42 25 PM" src="https://github.com/user-attachments/assets/4742d730-815e-4ff3-aeaf-0dfee5b7c655" />


remaining work:

- currently commented out blocking on user confirmation ([this line](https://github.com/aws/language-servers/pull/1041/files#diff-0da876fbe798d89b1ae25052ceca6949c8b334ed02f207f1f5c45b3d5dbeebf0R465)) because intermediate messages are somehow not streamed to the chat window (the confirmation buttons are not there yet)
- testing to verify once we block on user confirmation the buttons are functioning as expected
- polish UI to match the mock

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
