### PR TITLE
fix: added/deleted lines is incorrect

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.test.ts
@@ -1,4 +1,4 @@
-import { AppendParams, CreateParams, FsWrite, InsertParams, StrReplaceParams } from './fsWrite'
+import { AppendParams, CreateParams, FsWrite, getDiffChanges, InsertParams, StrReplaceParams } from './fsWrite'
 import { testFolder } from '@aws/lsp-core'
 import * as path from 'path'
 import * as assert from 'assert'
@@ -392,113 +392,120 @@ describe('FsWrite Tool', function () {
             await assert.rejects(() => fsWrite.invoke(params), /no such file or directory/)
         })
     })
+})
 
-    describe('getDiffChanges', function () {
-        it('handles create case', async function () {
-            const testContent = 'newFileText'
-            const fsWrite = new FsWrite(features)
+describe('getDiffChanges', function () {
+    let tempFolder: testFolder.TestFolder
+    before(async function () {
+        tempFolder = await testFolder.TestFolder.create()
+    })
 
-            const filepath = path.join(tempFolder.path, 'testFile.txt')
+    it('handles create case', async function () {
+        const testContent = 'newFileText'
 
-            const result = await fsWrite.getDiffChanges({ command: 'create', path: filepath, fileText: testContent })
-            assert.deepStrictEqual(result, [
-                {
-                    added: true,
-                    count: 1,
-                    removed: false,
-                    value: testContent,
-                },
-            ])
-        })
+        const filepath = path.join(tempFolder.path, 'testFile.txt')
 
-        it('handles replace case', async function () {
-            const fsWrite = new FsWrite(features)
-            const content = 'replace this old word'
-            const filepath = await tempFolder.write('testFile.txt', content)
+        const result = getDiffChanges({ command: 'create', path: filepath, fileText: testContent }, '')
+        assert.deepStrictEqual(result, [
+            {
+                added: true,
+                count: 1,
+                removed: false,
+                value: testContent,
+            },
+        ])
+    })
 
-            const result = await fsWrite.getDiffChanges({
+    it('handles replace case', async function () {
+        const content = 'replace this old word'
+        const filepath = await tempFolder.write('testFile.txt', content)
+
+        const result = getDiffChanges(
+            {
                 command: 'strReplace',
                 path: filepath,
                 oldStr: 'old',
                 newStr: 'new',
-            })
-            assert.deepStrictEqual(result, [
-                {
-                    added: false,
-                    count: 1,
-                    removed: true,
-                    value: content,
-                },
-                {
-                    added: true,
-                    count: 1,
-                    removed: false,
-                    value: content.replace('old', 'new'),
-                },
-            ])
-        })
+            },
+            content
+        )
+        assert.deepStrictEqual(result, [
+            {
+                added: false,
+                count: 1,
+                removed: true,
+                value: content,
+            },
+            {
+                added: true,
+                count: 1,
+                removed: false,
+                value: content.replace('old', 'new'),
+            },
+        ])
+    })
 
-        it('handles insert case', async function () {
-            const fsWrite = new FsWrite(features)
-            const content = 'line1 \n line2 \n line3'
-            const filepath = await tempFolder.write('testFile.txt', content)
+    it('handles insert case', async function () {
+        const content = 'line1 \n line2 \n line3'
+        const filepath = await tempFolder.write('testFile.txt', content)
 
-            const result = await fsWrite.getDiffChanges({
+        const result = getDiffChanges(
+            {
                 command: 'insert',
                 path: filepath,
                 insertLine: 2,
                 newStr: 'new text',
-            })
+            },
+            content
+        )
 
-            assert.deepStrictEqual(result, [
-                {
-                    added: false,
-                    count: 2,
-                    removed: false,
-                    value: 'line1 \n line2 \n',
-                },
-                {
-                    added: true,
-                    count: 1,
-                    removed: false,
-                    value: 'new text\n',
-                },
-                {
-                    added: false,
-                    count: 1,
-                    removed: false,
-                    value: ' line3',
-                },
-            ])
-        })
+        assert.deepStrictEqual(result, [
+            {
+                added: false,
+                count: 2,
+                removed: false,
+                value: 'line1 \n line2 \n',
+            },
+            {
+                added: true,
+                count: 1,
+                removed: false,
+                value: 'new text\n',
+            },
+            {
+                added: false,
+                count: 1,
+                removed: false,
+                value: ' line3',
+            },
+        ])
+    })
 
-        it('handles append case', async function () {
-            const fsWrite = new FsWrite(features)
-            const content = 'line1 \n line2'
-            const filepath = await tempFolder.write('testFile.txt', content)
+    it('handles append case', async function () {
+        const content = 'line1 \n line2'
+        const filepath = await tempFolder.write('testFile.txt', content)
 
-            const result = await fsWrite.getDiffChanges({ command: 'append', path: filepath, newStr: 'line3' })
+        const result = getDiffChanges({ command: 'append', path: filepath, newStr: 'line3' }, content)
 
-            assert.deepStrictEqual(result, [
-                {
-                    added: false,
-                    count: 1,
-                    removed: false,
-                    value: 'line1 \n',
-                },
-                {
-                    added: false,
-                    count: 1,
-                    removed: true,
-                    value: ' line2',
-                },
-                {
-                    added: true,
-                    count: 2,
-                    removed: false,
-                    value: ' line2\nline3',
-                },
-            ])
-        })
+        assert.deepStrictEqual(result, [
+            {
+                added: false,
+                count: 1,
+                removed: false,
+                value: 'line1 \n',
+            },
+            {
+                added: false,
+                count: 1,
+                removed: true,
+                value: ' line2',
+            },
+            {
+                added: true,
+                count: 2,
+                removed: false,
+                value: ' line2\nline3',
+            },
+        ])
     })
 })


### PR DESCRIPTION
## Problem
FsWrite card always shows +0 -0 for diff changes. This is happening because we aren't comparing with the old content before the tool executed.

## Solution
- Refactor fsWrite to move out all the logic relating to getting the contents before/after the change
- Ensure we are always comparing with the old content (we are now storing this in a tool lookup map)
- Fixed an issue where openDiff did not work for nested file paths because relative file path was not used
![image](https://github.com/user-attachments/assets/28f677a7-26bb-48e7-82c0-9dcbfdb60a89)



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
