### PR TITLE
feat: added support for injecting additional context commands

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -22,7 +22,7 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.1.24",
+        "@aws/chat-client-ui-types": "^0.1.27",
         "@aws/language-server-runtimes-types": "^0.1.22",
         "@aws/mynah-ui": "file:./lib/aws-mynah-ui-4.31.0-beta.6.tgz"
     },

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -83,7 +83,7 @@ import { Messager, OutboundChatApi } from './messager'
 import { InboundChatApi, createMynahUi } from './mynahUi'
 import { TabFactory } from './tabs/tabFactory'
 import { ChatClientAdapter } from '../contracts/chatClientAdapter'
-import { toMynahIcon } from './utils'
+import { toMynahContextCommand, toMynahIcon } from './utils'
 
 const DEFAULT_TAB_DATA = {
     tabTitle: 'Chat',
@@ -195,21 +195,19 @@ export const createChat = (
                 }
 
                 const allExistingTabs: MynahUITabStoreModel = mynahUi.getAllTabs()
+                const highlightCommands = featureConfig.get('highlightCommands')
 
                 for (const tabId in allExistingTabs) {
                     mynahUi.updateStore(tabId, {
                         ...tabFactory.getDefaultTabData(),
-                        contextCommands: [
-                            {
-                                groupName: 'Additional Context Commands',
-                                commands: [
-                                    {
-                                        description: featureConfig.get('highlightCommands')?.variation ?? '',
-                                        command: featureConfig.get('highlightCommands')?.value.stringValue ?? '',
-                                    },
-                                ],
-                            },
-                        ],
+                        contextCommands: highlightCommands
+                            ? [
+                                  {
+                                      groupName: 'Additional Commands',
+                                      commands: [toMynahContextCommand(highlightCommands)],
+                                  },
+                              ]
+                            : [],
                     })
                 }
                 break

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -113,7 +113,7 @@ export const createChat = (
         try {
             return new Map<string, FeatureContext>(JSON.parse(featureConfigSerialized || '{}'))
         } catch (error) {
-            console.error('Error parsing feature config:', error)
+            console.error('Error parsing feature config:', featureConfigSerialized, error)
         }
         return new Map()
     }

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -196,21 +196,18 @@ export const createChat = (
 
                 const allExistingTabs: MynahUITabStoreModel = mynahUi.getAllTabs()
 
-                const additionalContextCommands: any[] = []
-                featureConfig.forEach((featureContext: FeatureContext, _feature: string) => {
-                    additionalContextCommands.push({
-                        command: featureContext.value.stringValue ?? '',
-                        description: featureContext.variation,
-                    })
-                })
-
                 for (const tabId in allExistingTabs) {
                     mynahUi.updateStore(tabId, {
                         ...tabFactory.getDefaultTabData(),
                         contextCommands: [
                             {
                                 groupName: 'Additional Context Commands',
-                                commands: additionalContextCommands,
+                                commands: [
+                                    {
+                                        description: featureConfig.get('highlightCommands')?.variation ?? '',
+                                        command: featureConfig.get('highlightCommands')?.value.stringValue ?? '',
+                                    },
+                                ],
                             },
                         ],
                     })

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -6,6 +6,7 @@ import {
     AuthFollowUpClickedParams,
     CopyCodeToClipboardParams,
     ErrorParams,
+    FeatureContext,
     GenericCommandParams,
     InsertToCursorPositionParams,
     SendToPromptParams,
@@ -74,6 +75,18 @@ export const handlePromptInputChange = (mynahUi: MynahUI, tabId: string, options
         mynahUi.addChatItem(tabId, pairProgrammingModeOn)
     } else {
         mynahUi.addChatItem(tabId, pairProgrammingModeOff)
+    }
+}
+
+export const getAdditionalCommands = (highlightedCommands: FeatureContext) => {
+    return {
+        groupName: 'Additional Commands',
+        commands: [
+            {
+                command: highlightedCommands.value.stringValue ?? '',
+                description: highlightedCommands.variation,
+            },
+        ],
     }
 }
 
@@ -201,11 +214,11 @@ export const createMynahUi = (
         },
         onTabAdd: (tabId: string) => {
             const defaultTabBarData = tabFactory.getDefaultTabData()
-            const contextCommands = [...(contextCommandGroups || []), ...(featureConfig?.get('contextCommands') || [])]
+            const highlightedCommands: FeatureContext = featureConfig?.get('highlightCommands')
             const defaultTabConfig: Partial<MynahUIDataModel> = {
                 quickActionCommands: defaultTabBarData.quickActionCommands,
                 tabBarButtons: defaultTabBarData.tabBarButtons,
-                contextCommands: contextCommands,
+                contextCommands: [...(contextCommandGroups || []), getAdditionalCommands(highlightedCommands)],
                 ...(disclaimerCardActive ? { promptInputStickyCard: disclaimerCard } : {}),
             }
             mynahUi.updateStore(tabId, defaultTabConfig)
@@ -694,7 +707,8 @@ ${params.message}`,
             commands: toContextCommands(group.commands),
         }))
 
-        const contextCommands = [...contextCommandGroups, ...(featureConfig?.get('contextCommands') || [])]
+        console.log('Context commands feature ', featureConfig?.get('highlightCommands'))
+        const contextCommands = [...(contextCommandGroups || []), ...(featureConfig?.get('highlightCommands') || [])]
 
         Object.keys(mynahUi.getAllTabs()).forEach(tabId => {
             mynahUi.updateStore(tabId, {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -134,7 +134,8 @@ export const createMynahUi = (
     tabFactory: TabFactory,
     disclaimerAcknowledged: boolean,
     pairProgrammingCardAcknowledged: boolean,
-    customChatClientAdapter?: ChatClientAdapter
+    customChatClientAdapter?: ChatClientAdapter,
+    featureConfig?: Map<string, any>
 ): [MynahUI, InboundChatApi] => {
     const initialTabId = TabFactory.generateUniqueId()
     let disclaimerCardActive = !disclaimerAcknowledged
@@ -200,10 +201,11 @@ export const createMynahUi = (
         },
         onTabAdd: (tabId: string) => {
             const defaultTabBarData = tabFactory.getDefaultTabData()
+            const contextCommands = [...(contextCommandGroups || []), ...(featureConfig?.get('contextCommands') || [])]
             const defaultTabConfig: Partial<MynahUIDataModel> = {
                 quickActionCommands: defaultTabBarData.quickActionCommands,
                 tabBarButtons: defaultTabBarData.tabBarButtons,
-                contextCommands: contextCommandGroups,
+                contextCommands: contextCommands,
                 ...(disclaimerCardActive ? { promptInputStickyCard: disclaimerCard } : {}),
             }
             mynahUi.updateStore(tabId, defaultTabConfig)
@@ -692,9 +694,11 @@ ${params.message}`,
             commands: toContextCommands(group.commands),
         }))
 
+        const contextCommands = [...contextCommandGroups, ...(featureConfig?.get('contextCommands') || [])]
+
         Object.keys(mynahUi.getAllTabs()).forEach(tabId => {
             mynahUi.updateStore(tabId, {
-                contextCommands: contextCommandGroups,
+                contextCommands: contextCommands,
             })
         })
     }

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -6,7 +6,6 @@ import {
     AuthFollowUpClickedParams,
     CopyCodeToClipboardParams,
     ErrorParams,
-    FeatureContext,
     GenericCommandParams,
     InsertToCursorPositionParams,
     SendToPromptParams,

--- a/chat-client/src/client/utils.ts
+++ b/chat-client/src/client/utils.ts
@@ -1,3 +1,4 @@
+import { FeatureContext } from '@aws/chat-client-ui-types'
 import { Button, ChatMessage } from '@aws/language-server-runtimes-types'
 import { ChatItemButton, ChatItemContent, MynahIcons, TreeNodeDetails } from '@aws/mynah-ui'
 
@@ -19,4 +20,15 @@ export function toDetailsWithoutIcon(
     return Object.fromEntries(
         Object.entries(details || {}).map(([filePath, fileDetails]) => [filePath, { ...fileDetails, icon: null }])
     )
+}
+
+export function toMynahContextCommand(feature?: FeatureContext): any {
+    if (!feature) {
+        return {}
+    }
+
+    return {
+        command: feature.value.stringValue,
+        description: feature.variation,
+    }
 }

--- a/chat-client/src/client/utils.ts
+++ b/chat-client/src/client/utils.ts
@@ -1,5 +1,5 @@
 import { FeatureContext } from '@aws/chat-client-ui-types'
-import { Button, ChatMessage } from '@aws/language-server-runtimes-types'
+import { Button, ChatMessage, QuickActionCommand } from '@aws/language-server-runtimes-types'
 import { ChatItemButton, ChatItemContent, MynahIcons, TreeNodeDetails } from '@aws/mynah-ui'
 
 export function toMynahIcon(icon: string | undefined): MynahIcons | undefined {
@@ -22,8 +22,8 @@ export function toDetailsWithoutIcon(
     )
 }
 
-export function toMynahContextCommand(feature?: FeatureContext): any {
-    if (!feature) {
+export function toMynahContextCommand(feature?: FeatureContext): QuickActionCommand | Record<string, never> {
+    if (!feature || !feature.value.stringValue) {
         return {}
     }
 

--- a/chat-client/src/client/utils.ts
+++ b/chat-client/src/client/utils.ts
@@ -1,5 +1,5 @@
 import { FeatureContext } from '@aws/chat-client-ui-types'
-import { Button, ChatMessage, QuickActionCommand } from '@aws/language-server-runtimes-types'
+import { Button, ChatMessage } from '@aws/language-server-runtimes-types'
 import { ChatItemButton, ChatItemContent, MynahIcons, TreeNodeDetails } from '@aws/mynah-ui'
 
 export function toMynahIcon(icon: string | undefined): MynahIcons | undefined {
@@ -22,7 +22,7 @@ export function toDetailsWithoutIcon(
     )
 }
 
-export function toMynahContextCommand(feature?: FeatureContext): QuickActionCommand | Record<string, never> {
+export function toMynahContextCommand(feature?: FeatureContext): any {
     if (!feature || !feature.value.stringValue) {
         return {}
     }

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -345,7 +345,7 @@
     "devDependencies": {
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
-        "@aws/chat-client-ui-types": "^0.1.16",
+        "@aws/chat-client-ui-types": "^0.1.27",
         "@aws/language-server-runtimes": "^0.2.71",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -404,7 +404,11 @@ function generateJS(webView: Webview, extensionUri: Uri): string {
     <script type="text/javascript" src="${entrypoint.toString()}" defer onload="init()"></script>
     <script type="text/javascript">
         const init = () => {
-            amazonQChat.createChat(acquireVsCodeApi(), {disclaimerAcknowledged: false});
+            amazonQChat.createChat(acquireVsCodeApi(), 
+                {disclaimerAcknowledged: false}, 
+                undefined,
+                undefined,
+            );
         }
     </script>
     `

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -401,7 +401,7 @@ function generateJS(webView: Webview, extensionUri: Uri): string {
 
     const entrypoint = webView.asWebviewUri(chatUri)
     const chatFeatures: Map<string, FeatureContext> = new Map()
-    chatFeatures.set('contextCommands', {
+    chatFeatures.set('highlightCommands', {
         variation: 'Context commands for chat',
         value: {
             stringValue: '@sage',

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -1,5 +1,6 @@
 import {
     isValidAuthFollowUpType,
+    FeatureContext,
     INSERT_TO_CURSOR_POSITION,
     AUTH_FOLLOW_UP_CLICKED,
     CHAT_OPTIONS,
@@ -399,6 +400,14 @@ function generateJS(webView: Webview, extensionUri: Uri): string {
     const chatUri = Uri.joinPath(assetsPath, 'build', 'amazonq-ui.js')
 
     const entrypoint = webView.asWebviewUri(chatUri)
+    const chatFeatures: Map<string, FeatureContext> = new Map()
+    chatFeatures.set('contextCommands', {
+        variation: 'Context commands for chat',
+        value: {
+            stringValue: '@sage',
+        },
+    })
+    const stringifiedContextCommands = JSON.stringify(Array.from(chatFeatures.entries()))
 
     return `
     <script type="text/javascript" src="${entrypoint.toString()}" defer onload="init()"></script>
@@ -407,7 +416,7 @@ function generateJS(webView: Webview, extensionUri: Uri): string {
             amazonQChat.createChat(acquireVsCodeApi(), 
                 {disclaimerAcknowledged: false}, 
                 undefined,
-                undefined,
+                JSON.stringify(${stringifiedContextCommands})
             );
         }
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,7 +246,7 @@
             ],
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.1.24",
+                "@aws/chat-client-ui-types": "^0.1.27",
                 "@aws/language-server-runtimes-types": "^0.1.22",
                 "@aws/mynah-ui": "file:./lib/aws-mynah-ui-4.31.0-beta.6.tgz"
             },
@@ -269,7 +269,7 @@
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
-                "@aws/chat-client-ui-types": "^0.1.16",
+                "@aws/chat-client-ui-types": "^0.1.27",
                 "@aws/language-server-runtimes": "^0.2.71",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
@@ -3268,10 +3268,12 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.24",
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.27.tgz",
+            "integrity": "sha512-FHCpKJuBfVk1OxITuXarw/xte2mvzQ3j1plNcwidmoJqv28TFr3xUSCLMhhCDzT5ysMGmVd4+ukJ8e5fcqjWfg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.20"
+                "@aws/language-server-runtimes-types": "^0.1.22"
             }
         },
         "node_modules/@aws/hello-world-lsp": {
@@ -22860,7 +22862,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.4.tgz",
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
-                "@aws/chat-client-ui-types": "^0.1.16",
+                "@aws/chat-client-ui-types": "^0.1.27",
                 "@aws/language-server-runtimes": "^0.2.71",
                 "@aws/lsp-core": "^0.0.3",
                 "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -31,7 +31,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.4.tgz",
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
-        "@aws/chat-client-ui-types": "^0.1.16",
+        "@aws/chat-client-ui-types": "^0.1.27",
         "@aws/language-server-runtimes": "^0.2.71",
         "@aws/lsp-core": "^0.0.3",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -334,6 +334,12 @@ export class AgenticChatController implements ChatHandlers {
 
             // Phase 3: Request Execution
             this.#debug(`Request Input: ${JSON.stringify(currentRequestInput)}`)
+
+            // Remove ** from the input because markdown adds content that interferes with context commands
+            if (currentRequestInput.conversationState?.currentMessage?.userInputMessage?.content) {
+                currentRequestInput.conversationState.currentMessage.userInputMessage.content =
+                    currentRequestInput.conversationState.currentMessage.userInputMessage.content.replace(/\*\*/g, '')
+            }
             const response = await session.generateAssistantResponse(currentRequestInput)
             this.#debug(`Response received for iteration ${iterationCount}:`, JSON.stringify(response.$metadata))
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -335,11 +335,6 @@ export class AgenticChatController implements ChatHandlers {
             // Phase 3: Request Execution
             this.#debug(`Request Input: ${JSON.stringify(currentRequestInput)}`)
 
-            // Remove ** from the input because markdown adds content that interferes with context commands
-            if (currentRequestInput.conversationState?.currentMessage?.userInputMessage?.content) {
-                currentRequestInput.conversationState.currentMessage.userInputMessage.content =
-                    currentRequestInput.conversationState.currentMessage.userInputMessage.content.replace(/\*\*/g, '')
-            }
             const response = await session.generateAssistantResponse(currentRequestInput)
             this.#debug(`Response received for iteration ${iterationCount}:`, JSON.stringify(response.$metadata))
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -90,6 +90,13 @@ export class AgenticChatTriggerContext {
         const useRelevantDocuments = 'context' in params ? params.context?.some(c => c.command === '@workspace') : false
 
         let promptContent = prompt.escapedPrompt ?? prompt.prompt
+
+        // When the user adds @sage context, ** gets prepended and appended to the prompt because of markdown.
+        // This intereferes with routing logic thus we need to remove it
+        if (promptContent && promptContent.includes('@sage')) {
+            promptContent = promptContent.replace(/\*\*@sage\*\*/g, '@sage')
+        }
+
         if (useRelevantDocuments) {
             promptContent = promptContent?.replace(/^@workspace\/?/, '')
         }


### PR DESCRIPTION
## Problem
Currently we don't have a way to support additional context commands from the client side.

## Solution
Adding support for this

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
