### PR TITLE
chore: disable profiles and encryption for Q language server by default

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -84,12 +84,12 @@
             "env": {
                 "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-codewhisperer-runtimes/out/token-standalone.js",
                 "ENABLE_INLINE_COMPLETION": "true",
-                "ENABLE_ENCRYPTION": "true",
+                "ENABLE_ENCRYPTION": "false",
                 "ENABLE_TOKEN_PROVIDER": "true",
                 "ENABLE_CUSTOM_COMMANDS": "true",
                 "ENABLE_CHAT": "true",
                 "ENABLE_CUSTOMIZATIONS": "true",
-                "ENABLE_AMAZON_Q_PROFILES": "true",
+                "ENABLE_AMAZON_Q_PROFILES": "false",
                 "ENABLE_AWS_Q_SECTION": "true"
                 // "HTTPS_PROXY": "http://127.0.0.1:8888",
                 // "AWS_CA_BUNDLE": "/path/to/cert.pem"
@@ -106,12 +106,12 @@
             "env": {
                 "LSP_SERVER": "${workspaceFolder}/app/aws-lsp-codewhisperer-runtimes/out/agent-standalone.js",
                 "ENABLE_INLINE_COMPLETION": "true",
-                "ENABLE_ENCRYPTION": "true",
+                "ENABLE_ENCRYPTION": "false",
                 "ENABLE_TOKEN_PROVIDER": "true",
                 "ENABLE_CUSTOM_COMMANDS": "true",
                 "ENABLE_CHAT": "true",
                 "ENABLE_CUSTOMIZATIONS": "true",
-                "ENABLE_AMAZON_Q_PROFILES": "true",
+                "ENABLE_AMAZON_Q_PROFILES": "false",
                 "ENABLE_AWS_Q_SECTION": "true"
                 // "HTTPS_PROXY": "http://127.0.0.1:8888",
                 // "AWS_CA_BUNDLE": "/path/to/cert.pem"
@@ -225,7 +225,7 @@
     "compounds": [
         {
             "name": "Launch as VSCode Extension + Debugging",
-            "configurations": ["CodeWhisperer Server Token", "Attach to AWS Documents Language Server"]
+            "configurations": ["CodeWhisperer Agentic Server Token", "Attach to AWS Documents Language Server"]
         }
     ]
 }


### PR DESCRIPTION
## Problem
Enabling Q profiles and communication encryption by default slows down development cycle.

## Solution
disable profiles and encryption when launching Q language server for testing

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
