### PR TITLE
chore: update language-server-runtimes to 0.2.72

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -13,7 +13,7 @@
         "test": "node scripts/test-runner.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -346,7 +346,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.16",
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -78,7 +78,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -111,7 +111,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -119,7 +119,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -139,7 +139,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -181,7 +181,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -201,7 +201,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -270,7 +270,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.16",
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -3283,10 +3283,9 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.71",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.71.tgz",
-            "integrity": "sha512-/RcPlk/UhH8UKBNHwZ0qXC4A3xo7siYkipJsuG24feqjdpur3IrfBQFS/KRRraGl05wkHxU9UAoCWxTyQYMKvw==",
-            "license": "Apache-2.0",
+            "version": "0.2.72",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.72.tgz",
+            "integrity": "sha512-rJY6NL/X9iMLihj4B1TTez0hYgFg3GQqAUYshs+Iqls4RyAOPBXZgWd6haJwItc8VRi2G1kQj5f83YZ9hzjjIg==",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.9.3",
                 "@aws-crypto/sha256-js": "^5.2.0",
@@ -22790,7 +22789,7 @@
             "version": "0.1.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-core": "^0.0.3"
             },
             "devDependencies": {
@@ -22862,7 +22861,7 @@
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.16",
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-core": "^0.0.3",
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
@@ -23029,7 +23028,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-core": "^0.0.3",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -23130,7 +23129,7 @@
             "version": "0.1.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-core": "^0.0.3",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -23144,7 +23143,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-core": "0.0.3",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -23184,7 +23183,7 @@
             "version": "0.0.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -23217,7 +23216,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "@aws/lsp-core": "^0.0.3",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -23231,7 +23230,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -23242,7 +23241,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.71",
+                "@aws/language-server-runtimes": "^0.2.72",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-core": "^0.0.3"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.16",
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-core": "^0.0.3",
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-core": "^0.0.3",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-core": "^0.0.3",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-core": "0.0.3",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "@aws/lsp-core": "^0.0.3",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.71",
+        "@aws/language-server-runtimes": "^0.2.72",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem
update the language-server-runtimes to 0.2.72 which includes the optional cancellation token for tools

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
