### PR TITLE
feat: add explanation text as directive

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -514,7 +514,12 @@ export const createMynahUi = (
             chatResult.additionalMessages.forEach(am => {
                 const chatItem: ChatItem = {
                     messageId: am.messageId,
-                    type: am.type === 'tool' ? ChatItemType.ANSWER : ChatItemType.ANSWER_STREAM,
+                    type:
+                        am.type === 'tool'
+                            ? ChatItemType.ANSWER
+                            : am.type === 'directive'
+                              ? ChatItemType.DIRECTIVE
+                              : ChatItemType.ANSWER_STREAM,
                     ...prepareChatItemFromMessage(am),
                 }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -100,7 +100,7 @@ import { FsReadParams } from './tools/fsRead'
 import { ListDirectoryParams } from './tools/listDirectory'
 import { FsWrite, FsWriteParams, getDiffChanges } from './tools/fsWrite'
 import { ExecuteBash, ExecuteBashOutput, ExecuteBashParams } from './tools/executeBash'
-import { InvokeOutput } from './tools/toolShared'
+import { ExplanatoryParams, InvokeOutput } from './tools/toolShared'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -447,6 +447,14 @@ export class AgenticChatController implements ChatHandlers {
             let needsConfirmation
 
             try {
+                const { explanation } = toolUse.input as unknown as ExplanatoryParams
+                if (explanation) {
+                    await chatResultStream.writeResultBlock({
+                        type: 'directive',
+                        messageId: toolUse.toolUseId + '_explanation',
+                        body: explanation,
+                    })
+                }
                 switch (toolUse.name) {
                     case 'fsRead':
                     case 'listDirectory':

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -1,6 +1,6 @@
 // Port from VSC https://github.com/aws/aws-toolkit-vscode/blob/741c2c481bcf0dca2d9554e32dc91d8514b1b1d1/packages/core/src/codewhispererChat/tools/executeBash.ts#L134
 
-import { CommandValidation, InvokeOutput } from './toolShared'
+import { CommandValidation, ExplanatoryParams, InvokeOutput } from './toolShared'
 import { split } from 'shlex'
 import { Logging } from '@aws/language-server-runtimes/server-interface'
 import { processUtils, workspaceUtils } from '@aws/lsp-core'
@@ -108,10 +108,9 @@ export const lineCount: number = 1024
 export const destructiveCommandWarningMessage = '⚠️ WARNING: Destructive command detected:\n\n'
 export const mutateCommandWarningMessage = 'Mutation command:\n\n'
 
-export interface ExecuteBashParams {
+export interface ExecuteBashParams extends ExplanatoryParams {
     command: string
     cwd?: string
-    explanation?: string
 }
 
 interface TimestampedChunk {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -1,13 +1,12 @@
-import { InvokeOutput } from './toolShared'
+import { ExplanatoryParams, InvokeOutput } from './toolShared'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
 import { Change, diffLines } from 'diff'
 
 // Port of https://github.com/aws/aws-toolkit-vscode/blob/16aa8768834f41ae512522473a6a962bb96abe51/packages/core/src/codewhispererChat/tools/fsWrite.ts#L42
 
-interface BaseParams {
+interface BaseParams extends ExplanatoryParams {
     path: string
-    explanation?: string
 }
 
 export interface CreateParams extends BaseParams {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -27,3 +27,7 @@ export interface CommandValidation {
     requiresAcceptance: boolean
     warning?: string
 }
+
+export interface ExplanatoryParams {
+    explanation?: string
+}


### PR DESCRIPTION
## Problem
Explanation from tools are not rendered in the chat

## Solution
Render explanation as directive chat from tools
<img width="465" alt="Screenshot 2025-04-22 at 18 39 33" src="https://github.com/user-attachments/assets/20cbab08-c2d3-463e-bc2d-05fcfd95cc2d" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
