### PR TITLE
feat: add cancellation handling to tools

### DIFF
--- a/core/aws-lsp-core/src/util/awsError.ts
+++ b/core/aws-lsp-core/src/util/awsError.ts
@@ -22,3 +22,20 @@ export class AwsError extends Error {
             : new AwsError(error?.message ?? 'Unknown error', awsErrorCode, { cause: error })
     }
 }
+
+const expiredMessage = 'token expired'
+const cancelledMessage = 'token cancelled'
+type CancellationAgent = 'user' | 'timeout'
+export class CancellationError extends Error {
+    public constructor(public readonly agent: CancellationAgent) {
+        super(agent === 'user' ? cancelledMessage : expiredMessage)
+    }
+
+    public static isUserCancelled(err: any): err is CancellationError & { agent: 'user' } {
+        return err instanceof CancellationError && err.agent === 'user'
+    }
+
+    public static isExpired(err: any): err is CancellationError & { agent: 'timeout' } {
+        return err instanceof CancellationError && err.agent === 'timeout'
+    }
+}

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -35,7 +35,7 @@ export async function readDirectoryRecursively(
 
     while (queue.length > 0) {
         if (token?.isCancellationRequested) {
-            features.logging.info('cancelled listing directory')
+            features.logging.info('cancelled readDirectoryRecursively')
             throw new CancellationError('user')
         }
 

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -1,6 +1,8 @@
 import * as path from 'path'
 import { URI } from 'vscode-uri'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { CancellationToken } from '@aws/language-server-runtimes/server-interface'
+import { CancellationError } from './awsError'
 
 type ElementType<T> = T extends (infer U)[] ? U : never
 type Dirent = ElementType<Awaited<ReturnType<Features['workspace']['fs']['readdir']>>>
@@ -14,7 +16,8 @@ export async function readDirectoryRecursively(
         excludePatterns?: (string | RegExp)[]
         customFormatCallback?: (entry: Dirent) => string
         failOnError?: boolean
-    }
+    },
+    token?: CancellationToken
 ): Promise<string[]> {
     const dirExists = await features.workspace.fs.exists(folderPath)
     if (!dirExists) {
@@ -31,6 +34,11 @@ export async function readDirectoryRecursively(
     const formatter = options?.customFormatCallback ?? formatListing
 
     while (queue.length > 0) {
+        if (token?.isCancellationRequested) {
+            features.logging.info('cancelled listing directory')
+            throw new CancellationError('user')
+        }
+
         const { filepath, depth } = queue.shift()!
         if (options?.maxDepth !== undefined && depth > options?.maxDepth) {
             features.logging.info(`Skipping directory: ${filepath} (depth ${depth} > max ${options.maxDepth})`)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -1,4 +1,4 @@
-import { Server } from '@aws/language-server-runtimes/server-interface'
+import { CancellationToken, Server } from '@aws/language-server-runtimes/server-interface'
 import { FsRead, FsReadParams } from './fsRead'
 import { FsWrite, FsWriteParams } from './fsWrite'
 import { ListDirectory, ListDirectoryParams } from './listDirectory'
@@ -27,14 +27,18 @@ export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
         return await fsWriteTool.invoke(input)
     })
 
-    agent.addTool(listDirectoryTool.getSpec(), (input: ListDirectoryParams) => listDirectoryTool.invoke(input))
+    agent.addTool(listDirectoryTool.getSpec(), (input: ListDirectoryParams, token?: CancellationToken) =>
+        listDirectoryTool.invoke(input, token)
+    )
 
     return () => {}
 }
 
 export const BashToolsServer: Server = ({ logging, workspace, agent, lsp }) => {
     const bashTool = new ExecuteBash({ logging, workspace, lsp })
-    agent.addTool(bashTool.getSpec(), (input: ExecuteBashParams) => bashTool.invoke(input))
+    agent.addTool(bashTool.getSpec(), (input: ExecuteBashParams, token?: CancellationToken) =>
+        bashTool.invoke(input, undefined, token)
+    )
     return () => {}
 }
 


### PR DESCRIPTION
## Problem
tools can't be canceled

## Solution
- plumb the cancellation token through to the tools
- tools can optionally handle the cancellation token if it makes sense. e.g. execute bash/list directories makes sense, write file and read file doesn't
- when a token is cancelled, it bubbles up the main agentic loop, sending an answer back to the chat-client and unlocking the UI 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
