### PR TITLE
fix: wrong path for file click uri

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1001,7 +1001,7 @@ export class AgenticChatController implements ChatHandlers {
                     absolutePath = path.join(getUserPromptsDirectory(), params.filePath)
                 }
             }
-            await this.#features.lsp.window.showDocument({ uri: absolutePath })
+            await this.#features.lsp.window.showDocument({ uri: params.filePath })
         }
     }
 


### PR DESCRIPTION
## Problem

File click did not work for list/read because the workspaceRoot was getting appended twice in the path.

## Solution

Use the path parameter directly 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
