### PR TITLE
fix: highlight command mistype

### DIFF
--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -202,16 +202,16 @@ export const createChat = (
                 }
 
                 const allExistingTabs: MynahUITabStoreModel = mynahUi.getAllTabs()
-                const highlightCommands = featureConfig.get('highlightCommands')
+                const highlightCommand = featureConfig.get('highlightCommand')
 
                 for (const tabId in allExistingTabs) {
                     mynahUi.updateStore(tabId, {
                         ...tabFactory.getDefaultTabData(),
-                        contextCommands: highlightCommands
+                        contextCommands: highlightCommand
                             ? [
                                   {
                                       groupName: 'Additional Commands',
-                                      commands: [toMynahContextCommand(highlightCommands)],
+                                      commands: [toMynahContextCommand(highlightCommand)],
                                   },
                               ]
                             : [],

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -210,11 +210,11 @@ export const createMynahUi = (
                 tabBarButtons: defaultTabBarData.tabBarButtons,
                 contextCommands: [
                     ...(contextCommandGroups || []),
-                    ...(featureConfig?.get('highlightCommands')
+                    ...(featureConfig?.get('highlightCommand')
                         ? [
                               {
                                   groupName: 'Additional commands',
-                                  commands: [toMynahContextCommand(featureConfig.get('highlightCommands'))],
+                                  commands: [toMynahContextCommand(featureConfig.get('highlightCommand'))],
                               },
                           ]
                         : []),
@@ -748,11 +748,11 @@ ${params.message}`,
             mynahUi.updateStore(tabId, {
                 contextCommands: [
                     ...(contextCommandGroups || []),
-                    ...(featureConfig?.get('highlightCommands')
+                    ...(featureConfig?.get('highlightCommand')
                         ? [
                               {
                                   groupName: 'Additional commands',
-                                  commands: [toMynahContextCommand(featureConfig.get('highlightCommands'))],
+                                  commands: [toMynahContextCommand(featureConfig.get('highlightCommand'))],
                               },
                           ]
                         : []),

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -401,7 +401,7 @@ function generateJS(webView: Webview, extensionUri: Uri): string {
 
     const entrypoint = webView.asWebviewUri(chatUri)
     const chatFeatures: Map<string, FeatureContext> = new Map()
-    chatFeatures.set('highlightCommands', {
+    chatFeatures.set('highlightCommand', {
         variation: 'Context commands for chat',
         value: {
             stringValue: '@sage',


### PR DESCRIPTION
## Problem
flare is using "highlightCommands" and vscode is using "highlightCommand". We can either fix it in flare or we can convert what the frontend receives from the backend in vscode to use highlightCommands

## Solution
"highlightCommands" -> "highlightCommand" in flare

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
