### PR TITLE
feat: support for project context in Q Chat

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
@@ -70,17 +70,21 @@ export class QChatTriggerContext {
                                               programmingLanguage: triggerContext.programmingLanguage,
                                               relativeFilePath: triggerContext.relativeFilePath,
                                           },
-                                          relevantDocuments: triggerContext.relevantDocuments,
-                                          useRelevantDocuments: triggerContext.useRelevantDocuments,
+                                          ...(triggerContext.useRelevantDocuments && {
+                                              useRelevantDocuments: triggerContext.useRelevantDocuments,
+                                              relevantDocuments: triggerContext.relevantDocuments,
+                                          }),
                                       },
                                       tools,
                                   }
                                 : {
                                       tools,
-                                      editorState: {
-                                          relevantDocuments: triggerContext.relevantDocuments,
-                                          useRelevantDocuments: triggerContext.useRelevantDocuments,
-                                      },
+                                      ...(triggerContext.useRelevantDocuments && {
+                                          editorState: {
+                                              useRelevantDocuments: triggerContext.useRelevantDocuments,
+                                              relevantDocuments: triggerContext.relevantDocuments,
+                                          },
+                                      }),
                                   },
                         userIntent: triggerContext.userIntent,
                         origin: 'IDE',

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
@@ -1,13 +1,17 @@
 import { TriggerType } from '@aws/chat-client-ui-types'
-import { ChatTriggerType, UserIntent, Tool, ToolResult } from '@amzn/codewhisperer-streaming'
+import { ChatTriggerType, UserIntent, Tool, ToolResult, RelevantTextDocument } from '@amzn/codewhisperer-streaming'
 import { BedrockTools, ChatParams, CursorState, InlineChatParams } from '@aws/language-server-runtimes/server-interface'
 import { Features } from '../../types'
 import { DocumentContext, DocumentContextExtractor } from './documentContext'
 import { SendMessageCommandInput } from '../../../shared/streamingClientService'
+import { LocalProjectContextController } from '../../../shared/localProjectContextController'
+import { convertChunksToRelevantTextDocuments } from '../tools/relevantTextDocuments'
 
 export interface TriggerContext extends Partial<DocumentContext> {
     userIntent?: UserIntent
     triggerType?: TriggerType
+    useRelevantDocuments?: boolean
+    relevantDocuments?: RelevantTextDocument[]
 }
 
 export class QChatTriggerContext {
@@ -15,18 +19,28 @@ export class QChatTriggerContext {
 
     #workspace: Features['workspace']
     #documentContextExtractor: DocumentContextExtractor
+    #logger: Features['logging']
 
     constructor(workspace: Features['workspace'], logger: Features['logging']) {
         this.#workspace = workspace
         this.#documentContextExtractor = new DocumentContextExtractor({ logger, workspace })
+        this.#logger = logger
     }
 
     async getNewTriggerContext(params: ChatParams | InlineChatParams): Promise<TriggerContext> {
         const documentContext: DocumentContext | undefined = await this.extractDocumentContext(params)
 
+        const useRelevantDocuments =
+            'context' in params
+                ? params.context?.some(context => typeof context !== 'string' && context.command === '@workspace')
+                : false
+        const relevantDocuments = useRelevantDocuments ? await this.extractProjectContext(params.prompt.prompt) : []
+
         return {
             ...documentContext,
             userIntent: this.#guessIntentFromPrompt(params.prompt.prompt),
+            useRelevantDocuments,
+            relevantDocuments,
         }
     }
 
@@ -56,11 +70,17 @@ export class QChatTriggerContext {
                                               programmingLanguage: triggerContext.programmingLanguage,
                                               relativeFilePath: triggerContext.relativeFilePath,
                                           },
+                                          relevantDocuments: triggerContext.relevantDocuments,
+                                          useRelevantDocuments: triggerContext.useRelevantDocuments,
                                       },
                                       tools,
                                   }
                                 : {
                                       tools,
+                                      editorState: {
+                                          relevantDocuments: triggerContext.relevantDocuments,
+                                          useRelevantDocuments: triggerContext.useRelevantDocuments,
+                                      },
                                   },
                         userIntent: triggerContext.userIntent,
                         origin: 'IDE',
@@ -91,6 +111,19 @@ export class QChatTriggerContext {
                   cursorState?.[0] ?? QChatTriggerContext.DEFAULT_CURSOR_STATE
               )
             : undefined
+    }
+
+    async extractProjectContext(query?: string): Promise<RelevantTextDocument[]> {
+        if (query) {
+            try {
+                const contextController = await LocalProjectContextController.getInstance()
+                const resp = await contextController.queryVectorIndex({ query })
+                return convertChunksToRelevantTextDocuments(resp)
+            } catch (e) {
+                this.#logger.error(`Failed to extract project context for chat trigger: ${e}`)
+            }
+        }
+        return []
     }
 
     #guessIntentFromPrompt(prompt?: string): UserIntent | undefined {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.test.ts
@@ -3,7 +3,7 @@ import { Chunk } from 'local-indexing'
 import { RelevantTextDocument } from '@amzn/codewhisperer-streaming'
 import * as assert from 'assert'
 
-describe('convertChunksToRelevantTextDocuments', () => {
+describe('relevantTextDocuments', () => {
     it('converts empty array to empty array', () => {
         const result = convertChunksToRelevantTextDocuments([])
         assert.deepStrictEqual(result, [])

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.test.ts
@@ -1,13 +1,15 @@
 import { convertChunksToRelevantTextDocuments } from './relevantTextDocuments'
 import { Chunk } from 'local-indexing'
 import { RelevantTextDocument } from '@amzn/codewhisperer-streaming'
+import * as assert from 'assert'
 
 describe('convertChunksToRelevantTextDocuments', () => {
-    test('converts empty array to empty array', () => {
-        expect(convertChunksToRelevantTextDocuments([])).toEqual([])
+    it('converts empty array to empty array', () => {
+        const result = convertChunksToRelevantTextDocuments([])
+        assert.deepStrictEqual(result, [])
     })
 
-    test('combines chunks from same file and sorts by startLine', () => {
+    it('combines chunks from same file and sorts by startLine', () => {
         const chunks: Chunk[] = [
             {
                 id: '1',
@@ -39,10 +41,11 @@ describe('convertChunksToRelevantTextDocuments', () => {
             },
         ]
 
-        expect(convertChunksToRelevantTextDocuments(chunks)).toEqual(expected)
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.deepStrictEqual(result, expected)
     })
 
-    test('handles chunks without startLine', () => {
+    it('handles chunks without startLine', () => {
         const chunks: Chunk[] = [
             {
                 id: '1',
@@ -72,10 +75,11 @@ describe('convertChunksToRelevantTextDocuments', () => {
             },
         ]
 
-        expect(convertChunksToRelevantTextDocuments(chunks)).toEqual(expected)
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.deepStrictEqual(result, expected)
     })
 
-    test('handles unknown programming language', () => {
+    it('handles unknown programming language', () => {
         const chunks: Chunk[] = [
             {
                 id: '1',
@@ -95,10 +99,11 @@ describe('convertChunksToRelevantTextDocuments', () => {
             },
         ]
 
-        expect(convertChunksToRelevantTextDocuments(chunks)).toEqual(expected)
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.deepStrictEqual(result, expected)
     })
 
-    test('filters out empty content', () => {
+    it('filters out empty content', () => {
         const chunks: Chunk[] = [
             {
                 id: '1',
@@ -128,10 +133,11 @@ describe('convertChunksToRelevantTextDocuments', () => {
             },
         ]
 
-        expect(convertChunksToRelevantTextDocuments(chunks)).toEqual(expected)
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.deepStrictEqual(result, expected)
     })
 
-    test('truncates relative file path if too long', () => {
+    it('truncates relative file path if too long', () => {
         const longPath = 'a'.repeat(5000)
         const chunks: Chunk[] = [
             {
@@ -146,10 +152,11 @@ describe('convertChunksToRelevantTextDocuments', () => {
         ]
 
         const result = convertChunksToRelevantTextDocuments(chunks)
-        expect(result[0].relativeFilePath?.length).toBe(4000)
+        // Assuming the function truncates the relative path to 4000 characters.
+        assert.strictEqual(result[0].relativeFilePath?.length, 4000)
     })
 
-    test('handles multiple files', () => {
+    it('handles multiple files', () => {
         const chunks: Chunk[] = [
             {
                 id: '1',
@@ -184,6 +191,7 @@ describe('convertChunksToRelevantTextDocuments', () => {
             },
         ]
 
-        expect(convertChunksToRelevantTextDocuments(chunks)).toEqual(expected)
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.deepStrictEqual(result, expected)
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.test.ts
@@ -1,0 +1,189 @@
+import { convertChunksToRelevantTextDocuments } from './relevantTextDocuments'
+import { Chunk } from 'local-indexing'
+import { RelevantTextDocument } from '@amzn/codewhisperer-streaming'
+
+describe('convertChunksToRelevantTextDocuments', () => {
+    test('converts empty array to empty array', () => {
+        expect(convertChunksToRelevantTextDocuments([])).toEqual([])
+    })
+
+    test('combines chunks from same file and sorts by startLine', () => {
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: 'second chunk',
+                startLine: 2,
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+            {
+                id: '2',
+                index: 1,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: 'first chunk',
+                startLine: 1,
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+        ]
+
+        const expected: RelevantTextDocument[] = [
+            {
+                relativeFilePath: 'src/test.ts',
+                programmingLanguage: { languageName: 'typescript' },
+                text: 'first chunk\nsecond chunk',
+            },
+        ]
+
+        expect(convertChunksToRelevantTextDocuments(chunks)).toEqual(expected)
+    })
+
+    test('handles chunks without startLine', () => {
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: 'chunk1',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+            {
+                id: '2',
+                index: 1,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: 'chunk2',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+        ]
+
+        const expected: RelevantTextDocument[] = [
+            {
+                relativeFilePath: 'src/test.ts',
+                programmingLanguage: { languageName: 'typescript' },
+                text: 'chunk1\nchunk2',
+            },
+        ]
+
+        expect(convertChunksToRelevantTextDocuments(chunks)).toEqual(expected)
+    })
+
+    test('handles unknown programming language', () => {
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test.txt',
+                relativePath: 'src/test.txt',
+                content: 'content',
+                programmingLanguage: 'unknown',
+                vec: [],
+            },
+        ]
+
+        const expected: RelevantTextDocument[] = [
+            {
+                relativeFilePath: 'src/test.txt',
+                text: 'content',
+            },
+        ]
+
+        expect(convertChunksToRelevantTextDocuments(chunks)).toEqual(expected)
+    })
+
+    test('filters out empty content', () => {
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: '',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+            {
+                id: '2',
+                index: 1,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: 'valid content',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+        ]
+
+        const expected: RelevantTextDocument[] = [
+            {
+                relativeFilePath: 'src/test.ts',
+                programmingLanguage: { languageName: 'typescript' },
+                text: 'valid content',
+            },
+        ]
+
+        expect(convertChunksToRelevantTextDocuments(chunks)).toEqual(expected)
+    })
+
+    test('truncates relative file path if too long', () => {
+        const longPath = 'a'.repeat(5000)
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test.ts',
+                relativePath: longPath,
+                content: 'content',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        expect(result[0].relativeFilePath?.length).toBe(4000)
+    })
+
+    test('handles multiple files', () => {
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test1.ts',
+                relativePath: 'src/test1.ts',
+                content: 'content1',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+            {
+                id: '2',
+                index: 1,
+                filePath: 'test2.ts',
+                relativePath: 'src/test2.ts',
+                content: 'content2',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+        ]
+
+        const expected: RelevantTextDocument[] = [
+            {
+                relativeFilePath: 'src/test1.ts',
+                programmingLanguage: { languageName: 'typescript' },
+                text: 'content1',
+            },
+            {
+                relativeFilePath: 'src/test2.ts',
+                programmingLanguage: { languageName: 'typescript' },
+                text: 'content2',
+            },
+        ]
+
+        expect(convertChunksToRelevantTextDocuments(chunks)).toEqual(expected)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.ts
@@ -1,0 +1,53 @@
+import { RelevantTextDocument } from '@amzn/codewhisperer-streaming'
+import { Chunk } from 'local-indexing'
+
+export function convertChunksToRelevantTextDocuments(chunks: Chunk[]): RelevantTextDocument[] {
+    const filePathSizeLimit = 4_000
+
+    const groupedChunks = chunks.reduce(
+        (acc, chunk) => {
+            const key = chunk.filePath
+            if (!acc[key]) {
+                acc[key] = []
+            }
+            acc[key].push(chunk)
+            return acc
+        },
+        {} as Record<string, Chunk[]>
+    )
+
+    return Object.entries(groupedChunks).map(([filePath, fileChunks]) => {
+        fileChunks.sort((a, b) => {
+            if (a.startLine !== undefined && b.startLine !== undefined) {
+                return a.startLine - b.startLine
+            }
+            return 0
+        })
+
+        const firstChunk = fileChunks[0]
+
+        let programmingLanguage
+        if (firstChunk.programmingLanguage && firstChunk.programmingLanguage !== 'unknown') {
+            programmingLanguage = {
+                languageName: firstChunk.programmingLanguage,
+            }
+        }
+
+        const combinedContent = fileChunks
+            .map(chunk => chunk.content)
+            .filter(content => content !== undefined && content !== '')
+            .join('\n')
+
+        const relevantTextDocument: RelevantTextDocument = {
+            relativeFilePath: firstChunk.relativePath
+                ? firstChunk.relativePath.substring(0, filePathSizeLimit)
+                : undefined,
+            programmingLanguage,
+            text: combinedContent || undefined,
+        }
+
+        return Object.fromEntries(
+            Object.entries(relevantTextDocument).filter(([_, value]) => value !== undefined)
+        ) as RelevantTextDocument
+    })
+}


### PR DESCRIPTION
## Problem
Local project context is available in Flare but not currently wired up to Q chat.

## Solution
Added support for enriching Q chat requests with local project context. Context is added when chat requests contain the `@workspace` context command and are available whether files are open in the editor or not.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
