### PR TITLE
feat: update confirm header after button click WIP

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -652,8 +652,8 @@ export const createMynahUi = (
             buttons: toMynahButtons(message.buttons),
 
             // file diffs in the header need space
-            fullWidth: message.type === 'tool' && message.header?.fileList ? true : undefined,
-            padding: message.type === 'tool' && message.header?.fileList ? false : undefined,
+            fullWidth: message.type === 'tool' ? true : undefined,
+            padding: message.type === 'tool' ? false : undefined,
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -85,6 +85,7 @@ export class AgenticChatResultStream {
                                         : (acc.contextList?.rootFolderTitle ?? ''),
                                 },
                             }),
+                            header: c.header ? { ...c.header } : { ...am.header },
                         })),
                     }
                 } else {


### PR DESCRIPTION
## Problem
- fix issue that json output is still shown due to missed `break` in prev rebase
- update the header buttons for user confirmation 
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
