### PR TITLE
fix: update fsWrite toolSpec

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -155,6 +155,8 @@ export class FsWrite {
                 and otherwise create a new file\n * The `append` command will add content to the end of an existing file, \
                 automatically adding a newline if the file does not end with one. \
                 The file must exist.\n Notes for using the `strReplace` command:\n * \
+                IMPORTANT: For the `fsWrite` tool, only use the `strReplace` command for simple, isolated single-line replacements. \
+                If you are editing multiple lines, always prefer the `create` command and replace the entire file content instead.\n * \
                 The `oldStr` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!\n * \
                 If the `oldStr` parameter is not unique in the file, the replacement will not be performed. \
                 Make sure to include enough context in `oldStr` to make it unique\n * \


### PR DESCRIPTION
## Problem
- `fsWrite` tool tends to favor doing line-by-line replaces which causes
an increase in latency.

## Solution

- Updated the tool spec to add an important guideline around the fsWrite
tool usage - restricting strReplace command to only simple single-line
replacements, while recommending the create command for multi-line
edits.:
 
`* IMPORTANT: For the `fsWrite` tool, only use the `strReplace` command
for simple, isolated single-line replacements. If you are editing
multiple lines, always prefer the `create` command and replace the
entire file content instead.`

## Testing

#### Latency test results
|     | Build with strReplace | Build without strReplace |
| -------- | ------- |  ------- |
| renaming a single function |  16s  |  17s |
| translate comments (multi-line replace +19 -20) |  98s  | 20s |

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
