### PR TITLE
feat(chat): add permission check for fsRead and listDirectory tools

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -171,6 +171,8 @@ describe('AgenticChatController', () => {
             runTool: sinon.stub().resolves({}),
             getTools: sinon.stub().returns([]),
             addTool: sinon.stub().resolves(),
+            requiresAcceptance: sinon.stub().resolves(),
+            queueDescription: sinon.stub().resolves(),
         }
 
         additionalContextProviderStub = sinon.stub(AdditionalContextProvider.prototype, 'getAdditionalContext')

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
@@ -122,4 +122,29 @@ describe('ExecuteBash Tool', () => {
             'A command without any path-like token should not require acceptance'
         )
     })
+
+    it('returns formatted command in code block', async () => {
+        const execBash = new ExecuteBash(features)
+        const params = { command: 'ls -la', cwd: '/some/path' }
+        const description = await execBash.queueDescription(params)
+        assert.strictEqual(description, '```shell\nls -la\n```', 'Should return command in shell code block')
+    })
+
+    it('preserves complex commands in description', async () => {
+        const execBash = new ExecuteBash(features)
+        const params = { command: 'find . -name "*.js" | xargs grep "TODO"', cwd: '/some/path' }
+        const description = await execBash.queueDescription(params)
+        assert.strictEqual(
+            description,
+            '```shell\nfind . -name "*.js" | xargs grep "TODO"\n```',
+            'Should preserve complex command syntax in description'
+        )
+    })
+
+    it('returns empty string when requiresAcceptance is false', async () => {
+        const execBash = new ExecuteBash(features)
+        const params = { command: 'echo hello', cwd: '/some/path' }
+        const description = await execBash.queueDescription(params, false)
+        assert.strictEqual(description, '', 'Should return empty string when requiresAcceptance is false')
+    })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -432,11 +432,11 @@ export class ExecuteBash {
         return output
     }
 
-    public async queueDescription(command: string, updates: WritableStream) {
-        const writer = updates.getWriter()
-        await writer.write('```shell\n' + command + '\n```')
-        await writer.close()
-        writer.releaseLock()
+    public async queueDescription(params: ExecuteBashParams, requiresAcceptance?: boolean): Promise<string> {
+        if (requiresAcceptance === false) {
+            return ''
+        }
+        return '```shell\n' + params.command + '\n```'
     }
 
     public getSpec() {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.test.ts
@@ -94,17 +94,22 @@ describe('FsRead Tool', () => {
         verifyResult(result, { content: '', truncated: false })
     })
 
-    it('updates the stream', async () => {
+    it('returns description string when requiresAcceptance is true', async () => {
         const fsRead = new FsRead(features)
-        const chunks = []
-        const stream = new WritableStream({
-            write: c => {
-                chunks.push(c)
-            },
-        })
-        await fsRead.queueDescription({ path: 'this/is/my/path' }, stream, true)
-        assert.ok(chunks.length > 0)
-        assert.ok(!stream.locked)
+        const description = await fsRead.queueDescription({ path: 'this/is/my/path' }, true)
+        assert.strictEqual(description, 'Reading file: [this/is/my/path] all lines')
+    })
+
+    it('returns description string with line range', async () => {
+        const fsRead = new FsRead(features)
+        const description = await fsRead.queueDescription({ path: 'this/is/my/path', readRange: [5, 10] })
+        assert.strictEqual(description, 'Reading file: [this/is/my/path] from line 5 to 10')
+    })
+
+    it('returns empty string when requiresAcceptance is false', async () => {
+        const fsRead = new FsRead(features)
+        const description = await fsRead.queueDescription({ path: 'this/is/my/path' }, false)
+        assert.strictEqual(description, '')
     })
 
     it('should require acceptance if fsPath is outside the workspace', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.test.ts
@@ -44,18 +44,61 @@ describe('FsWrite Tool', function () {
         await tempFolder.delete()
     })
 
-    it('writes a empty space to updates stream', async function () {
-        const fsRead = new FsWrite(features)
-        const chunks: string[] = []
-        const stream = new WritableStream({
-            write: c => {
-                chunks.push(c)
-            },
-        })
-        await fsRead.queueDescription(stream)
-        assert.strictEqual(chunks.length, 1)
-        assert.ok(chunks[0], ' ')
-        assert.ok(!stream.locked)
+    it('returns description for create command', async function () {
+        const fsWrite = new FsWrite(features)
+        const params = {
+            command: 'create' as const,
+            path: '/path/to/file.txt',
+            fileText: 'content',
+        }
+        const description = await fsWrite.queueDescription(params)
+        assert.strictEqual(description, 'Creating file: /path/to/file.txt')
+    })
+
+    it('returns description for strReplace command', async function () {
+        const fsWrite = new FsWrite(features)
+        const params = {
+            command: 'strReplace' as const,
+            path: '/path/to/file.txt',
+            oldStr: 'old',
+            newStr: 'new',
+        }
+        const description = await fsWrite.queueDescription(params)
+        assert.strictEqual(description, 'Replacing text in file: /path/to/file.txt')
+    })
+
+    it('returns description for insert command', async function () {
+        const fsWrite = new FsWrite(features)
+        const params = {
+            command: 'insert' as const,
+            path: '/path/to/file.txt',
+            insertLine: 5,
+            newStr: 'new line',
+        }
+        const description = await fsWrite.queueDescription(params)
+        assert.strictEqual(description, 'Inserting text at line 5 in file: /path/to/file.txt')
+    })
+
+    it('returns description for append command', async function () {
+        const fsWrite = new FsWrite(features)
+        const params = {
+            command: 'append' as const,
+            path: '/path/to/file.txt',
+            newStr: 'appended text',
+        }
+        const description = await fsWrite.queueDescription(params)
+        assert.strictEqual(description, 'Appending text to file: /path/to/file.txt')
+    })
+
+    it('returns empty string when requiresAcceptance is false', async function () {
+        const fsWrite = new FsWrite(features)
+        const params = {
+            command: 'create' as const,
+            path: '/path/to/file.txt',
+            fileText: 'content',
+        }
+        const description = await fsWrite.queueDescription(params, false)
+        assert.strictEqual(description, '')
     })
 
     describe('handleCreate', function () {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -115,12 +115,28 @@ export class FsWrite {
         }
     }
 
-    public async queueDescription(updates: WritableStream): Promise<void> {
-        const updateWriter = updates.getWriter()
-        // Write an empty string because FsWrite should only show a chat message with header
-        await updateWriter.write(' ')
-        await updateWriter.close()
-        updateWriter.releaseLock()
+    public async queueDescription(params: FsWriteParams, requiresAcceptance?: boolean): Promise<string> {
+        if (requiresAcceptance === false) {
+            return ''
+        }
+
+        let description = ''
+        switch (params.command) {
+            case 'create':
+                description = `Creating file: ${params.path}`
+                break
+            case 'strReplace':
+                description = `Replacing text in file: ${params.path}`
+                break
+            case 'insert':
+                description = `Inserting text at line ${params.insertLine} in file: ${params.path}`
+                break
+            case 'append':
+                description = `Appending text to file: ${params.path}`
+                break
+        }
+
+        return description
     }
 
     private async handleCreate(params: CreateParams, sanitizedPath: string): Promise<void> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
@@ -112,6 +112,36 @@ describe('ListDirectory Tool', () => {
         await assert.rejects(listDirectory.invoke({ path: missingPath, maxDepth: 0 }))
     })
 
+    it('returns description for recursive listing', async () => {
+        const listDirectory = new ListDirectory(testFeatures)
+        const description = await listDirectory.queueDescription({ path: '/some/path' })
+        assert.strictEqual(description, 'Listing directory recursively: /some/path')
+    })
+
+    it('returns description for non-recursive listing', async () => {
+        const listDirectory = new ListDirectory(testFeatures)
+        const description = await listDirectory.queueDescription({ path: '/some/path', maxDepth: 0 })
+        assert.strictEqual(description, 'Listing directory: /some/path')
+    })
+
+    it('returns description with depth limit', async () => {
+        const listDirectory = new ListDirectory(testFeatures)
+        const description = await listDirectory.queueDescription({ path: '/some/path', maxDepth: 2 })
+        assert.strictEqual(description, 'Listing directory: /some/path limited to 2 subfolder levels')
+    })
+
+    it('returns description with singular level text for maxDepth=1', async () => {
+        const listDirectory = new ListDirectory(testFeatures)
+        const description = await listDirectory.queueDescription({ path: '/some/path', maxDepth: 1 })
+        assert.strictEqual(description, 'Listing directory: /some/path limited to 1 subfolder level')
+    })
+
+    it('returns empty string when requiresAcceptance is false', async () => {
+        const listDirectory = new ListDirectory(testFeatures)
+        const description = await listDirectory.queueDescription({ path: '/some/path' }, false)
+        assert.strictEqual(description, '')
+    })
+
     it('expands ~ path', async () => {
         const listDirectory = new ListDirectory(testFeatures)
         const result = await listDirectory.invoke({ path: '~', maxDepth: 0 })


### PR DESCRIPTION
## Problem
User permissions check for reading files/list directory outside of workspace is not setup.

## Solution
- add permission check for fsRead and listDirectory tools

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
