### PR TITLE
fix: do not include references in request history

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -368,7 +368,7 @@ describe('AgenticChatController', () => {
             )
 
             // Verify that history was requested from the db
-            sinon.assert.calledWith(getMessagesStub, mockTabId, 10)
+            sinon.assert.calledWith(getMessagesStub, mockTabId)
 
             assert.ok(generateAssistantResponseStub.calledOnce)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -345,7 +345,7 @@ export class AgenticChatController implements ChatHandlers {
             this.#customizationArn,
             chatResultStream,
             profileArn,
-            this.#chatHistoryDb.getMessages(params.tabId, 10),
+            this.#chatHistoryDb.getMessages(params.tabId),
             this.#getTools(session),
             additionalContext
         )

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
@@ -52,9 +52,6 @@ describe('ChatDb Utilities', () => {
                 assistantResponseMessage: {
                     messageId: 'msg-1',
                     content: 'Response',
-                    references: [
-                        { url: 'test.js', recommendationContentSpan: { start: 10, end: 15 }, information: '' },
-                    ],
                     toolUses: [],
                 },
             })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
@@ -79,7 +79,6 @@ export function messageToStreamingMessage(msg: Message): StreamingMessage {
               assistantResponseMessage: {
                   messageId: msg.messageId,
                   content: msg.body,
-                  references: msg.codeReference || [],
                   toolUses: msg.toolUses || [],
               },
           }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -155,7 +155,7 @@ export class FsWrite {
                 and otherwise create a new file\n * The `append` command will add content to the end of an existing file, \
                 automatically adding a newline if the file does not end with one. \
                 The file must exist.\n Notes for using the `strReplace` command:\n * \
-                IMPORTANT: For the `fsWrite` tool, only use the `strReplace` command for simple, isolated single-line replacements. \
+                IMPORTANT: Only use the `strReplace` command for simple, isolated single-line replacements. \
                 If you are editing multiple lines, always prefer the `create` command and replace the entire file content instead.\n * \
                 The `oldStr` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!\n * \
                 If the `oldStr` parameter is not unique in the file, the replacement will not be performed. \


### PR DESCRIPTION
## Related commit in agentic chat branch
https://github.com/aws/aws-toolkit-vscode/commit/6f0dc14877457d9ce0a174a9a8b567a6265ea6f1

## Problem
- We currently include codeReferences as part of the history field in
the request which can sometimes cause validation issues
- We are currently only retrieving the last 10 messages in the history. This will break the history validation

## Solution

 - Do not include references in request history
 - Retrieve entire history then call fixHistory when sending request

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
