### PR TITLE
fix(amazonq): avoid double rendering on confirmation.

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -460,7 +460,7 @@ export class AgenticChatController implements ChatHandlers {
         return Object.values(toolUses).filter(toolUse => toolUse.stop)
     }
     /**
-     * Creates a promise that does not resolve until the user accepts or reject the tool usage.
+     * Creates a promise that does not resolve until the user accepts or rejects the tool usage.
      * @param toolUseId
      * @param toolUseName
      * @param resultStream

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.test.ts
@@ -3,6 +3,7 @@ import { ChatResult } from '@aws/language-server-runtimes/protocol'
 import { AgenticChatResultStream } from './agenticChatResultStream'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 
+// TODO: renable this test suite and update the following tests.
 xdescribe('agenticChatResponse', function () {
     let output: (ChatResult | string)[] = []
     const logging = new TestFeatures().logging
@@ -68,5 +69,18 @@ xdescribe('agenticChatResponse', function () {
         await writer.close()
 
         assert.ok(chatResultStream.getResultStreamWriter())
+    })
+
+    it('allows blocks to overwritten on id', async function () {
+        const first = await chatResultStream.writeResultBlock({ body: 'first' })
+        const second = await chatResultStream.writeResultBlock({ body: 'second' })
+        await chatResultStream.writeResultBlock({ body: 'third' })
+
+        await chatResultStream.overwriteResultBlock({ body: 'fourth' }, first)
+        await chatResultStream.overwriteResultBlock({ body: 'fifth' }, second)
+
+        assert.deepStrictEqual(chatResultStream.getResult(), {
+            body: `fourth${AgenticChatResultStream.resultDelimiter}fifth${AgenticChatResultStream.resultDelimiter}third`,
+        })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -1,7 +1,7 @@
 import { ChatResult, FileDetails, ChatMessage } from '@aws/language-server-runtimes/protocol'
 import { randomUUID } from 'crypto'
 
-export interface ResultStreamWriter {
+interface ResultStreamWriter {
     write(chunk: ChatResult, final?: boolean): Promise<void>
     close(): Promise<void>
 }
@@ -97,12 +97,22 @@ export class AgenticChatResultStream {
             }, result)
     }
 
+    /**
+     * Add a block to the message block store and send it to the client.
+     * @param result the blockId associated with the block such that it can be overwritten later
+     * @returns
+     */
     async writeResultBlock(result: ChatMessage): Promise<number> {
         this.#state.chatResultBlocks.push(result)
         await this.#sendProgress(this.getResult(result.messageId))
         return this.#state.chatResultBlocks.length - 1
     }
 
+    /**
+     * Overwrites a specific blockId and re-sends the resulting blocks to the client.
+     * @param result
+     * @param blockId
+     */
     async overwriteResultBlock(result: ChatMessage, blockId: number) {
         this.#state.chatResultBlocks[blockId] = result
         await this.#sendProgress(this.getResult(result.messageId))

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -1,7 +1,7 @@
 import { ChatResult, FileDetails, ChatMessage } from '@aws/language-server-runtimes/protocol'
 import { randomUUID } from 'crypto'
 
-interface ResultStreamWriter {
+export interface ResultStreamWriter {
     write(chunk: ChatResult, final?: boolean): Promise<void>
     close(): Promise<void>
 }
@@ -97,8 +97,14 @@ export class AgenticChatResultStream {
             }, result)
     }
 
-    async writeResultBlock(result: ChatMessage) {
+    async writeResultBlock(result: ChatMessage): Promise<number> {
         this.#state.chatResultBlocks.push(result)
+        await this.#sendProgress(this.getResult(result.messageId))
+        return this.#state.chatResultBlocks.length - 1
+    }
+
+    async overwriteResultBlock(result: ChatMessage, blockId: number) {
+        this.#state.chatResultBlocks[blockId] = result
         await this.#sendProgress(this.getResult(result.messageId))
     }
 


### PR DESCRIPTION
## Problem
See the attached demo:


https://github.com/user-attachments/assets/ae59d434-941b-4633-99c6-3164c362ffee



## Solution
- The core of the problem is that rather than writing the new block after the tool confirmation, we should update the previous. However, I want to be careful how I allow overwriting of previous blocks.
- However, I want to be careful how I allow overwriting of previous blocks. Therefore, the `writeBlock` function returns a `blockId` (really an index), that allows us to modify it later.  relevant: https://github.com/aws/language-servers/pull/984#discussion_r2049707634
- I imagine this will be very useful for undoing previous tasks and updating their resulting blocks. 

## Notes
- I went to add a test suite and it was disabled so marked re-enabling and fixing the tests there as a follow-up. 
 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
