### PR TITLE
feat: send chat update on undo

### DIFF
--- a/chat-client/src/client/utils.ts
+++ b/chat-client/src/client/utils.ts
@@ -11,7 +11,12 @@ export function toMynahButtons(buttons: Button[] | undefined): ChatItemButton[] 
 }
 
 export function toMynahHeader(header: ChatMessage['header']): ChatItemContent['header'] {
-    return { ...header, icon: toMynahIcon(header?.icon), buttons: toMynahButtons(header?.buttons) }
+    return {
+        ...header,
+        icon: toMynahIcon(header?.icon),
+        buttons: toMynahButtons(header?.buttons),
+        status: { ...header?.status, icon: toMynahIcon(header?.status?.icon) },
+    }
 }
 
 export function toDetailsWithoutIcon(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -20,6 +20,7 @@ import {
     FileList,
     TextDocument,
     OPEN_WORKSPACE_INDEX_SETTINGS_BUTTON_ID,
+    ChatResult,
 } from '@aws/language-server-runtimes/server-interface'
 import { Features } from '../../types'
 import { DocumentContext, DocumentContextExtractor } from '../../chat/contexts/documentContext'
@@ -58,7 +59,7 @@ export class AgenticChatTriggerContext {
     #lsp: Features['lsp']
     #logging: Features['logging']
     #documentContextExtractor: DocumentContextExtractor
-    #toolUseLookup: Map<string, ToolUse & { oldContent?: string }>
+    #toolUseLookup: Map<string, ToolUse & { oldContent?: string; chatResult?: ChatResult }>
 
     constructor({ workspace, lsp, logging }: Pick<Features, 'workspace' | 'lsp' | 'logging'> & Partial<Features>) {
         this.#workspace = workspace


### PR DESCRIPTION
## Problem

Card should be updated after undo is clicked

## Solution

Implement the chat update mechanism on button click

Refer to https://github.com/aws/aws-toolkit-vscode/blob/feature/agentic-chat/packages/core/src/amazonq/webview/ui/apps/cwChatConnector.ts#L394-L404 for previous implementation.

<img width="675" alt="image" src="https://github.com/user-attachments/assets/c9c03705-2967-476a-8312-89cbfd9c711e" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
