### PR TITLE
feat(agentic chat): add permission check for all tools and add UI permission cards

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -96,8 +96,8 @@ import { getNewPromptFilePath, getUserPromptsDirectory, promptFileExtension } fr
 import { ContextCommandsProvider } from './context/contextCommandsProvider'
 import { LocalProjectContextController } from '../../shared/localProjectContextController'
 import { CancellationError, workspaceUtils } from '@aws/lsp-core'
-import { FsReadParams } from './tools/fsRead'
-import { ListDirectoryParams } from './tools/listDirectory'
+import { FsRead, FsReadParams } from './tools/fsRead'
+import { ListDirectory, ListDirectoryParams } from './tools/listDirectory'
 import { FsWrite, FsWriteParams, getDiffChanges } from './tools/fsWrite'
 import { ExecuteBash, ExecuteBashOutput, ExecuteBashParams } from './tools/executeBash'
 import { ExplanatoryParams, InvokeOutput, ToolApprovalException } from './tools/toolShared'
@@ -151,7 +151,11 @@ export class AgenticChatController implements ChatHandlers {
 
     async onButtonClick(params: ButtonClickParams): Promise<ButtonClickResult> {
         this.#log(`onButtonClick event with params: ${JSON.stringify(params)}`)
-        if (params.buttonId === 'run-shell-command' || params.buttonId === 'reject-shell-command') {
+        if (
+            params.buttonId === 'run-shell-command' ||
+            params.buttonId === 'reject-shell-command' ||
+            params.buttonId === 'allow-tools'
+        ) {
             const session = this.#chatSessionManagementService.getSession(params.tabId)
             if (!session.data) {
                 return { success: false, failureReason: `could not find chat session for tab: ${params.tabId} ` }
@@ -488,29 +492,26 @@ export class AgenticChatController implements ChatHandlers {
                 switch (toolUse.name) {
                     case 'fsRead':
                     case 'listDirectory':
-                        const initialReadOrListResult = this.#processReadOrList(toolUse, chatResultStream)
-                        if (initialReadOrListResult) {
-                            await chatResultStream.writeResultBlock(initialReadOrListResult)
-                        }
-                        break
                     case 'fsWrite':
-                        const input = toolUse.input as unknown as FsWriteParams
-                        const document = await this.#triggerContext.getTextDocument(input.path)
-                        this.#triggerContext
-                            .getToolUseLookup()
-                            .set(toolUse.toolUseId, { ...toolUse, oldContent: document?.getText() })
-                        break
-                    case 'executeBash':
-                        const bashTool = new ExecuteBash(this.#features)
-                        const { requiresAcceptance, warning } = await bashTool.requiresAcceptance(
-                            toolUse.input as unknown as ExecuteBashParams
-                        )
+                    case 'executeBash': {
+                        const toolMap = {
+                            fsRead: { Tool: FsRead },
+                            listDirectory: { Tool: ListDirectory },
+                            fsWrite: { Tool: FsWrite },
+                            executeBash: { Tool: ExecuteBash },
+                        }
+
+                        const { Tool } = toolMap[toolUse.name as keyof typeof toolMap]
+                        const tool = new Tool(this.#features)
+                        const { requiresAcceptance, warning } = await tool.requiresAcceptance(toolUse.input as any)
+
                         if (requiresAcceptance) {
                             needsConfirmation = true
-                            const confirmationResult = this.#processExecuteBashConfirmation(toolUse, warning)
+                            const confirmationResult = this.#processToolConfirmation(toolUse, warning, toolUse.name)
                             await chatResultStream.writeResultBlock(confirmationResult)
                         }
                         break
+                    }
                     default:
                         await chatResultStream.writeResultBlock({
                             type: 'tool',
@@ -528,6 +529,19 @@ export class AgenticChatController implements ChatHandlers {
                     if (toolUse.name === 'executeBash') {
                         await chatResultStream.writeResultBlock(this.#getUpdateBashConfirmResult(toolUse, true))
                     }
+                }
+
+                if (['fsRead', 'listDirectory'].includes(toolUse.name)) {
+                    const initialListDirResult = this.#processReadOrList(toolUse, chatResultStream)
+                    if (initialListDirResult) {
+                        await chatResultStream.writeResultBlock(initialListDirResult)
+                    }
+                } else if (toolUse.name === 'fsWrite') {
+                    const input = toolUse.input as unknown as FsWriteParams
+                    const document = await this.#triggerContext.getTextDocument(input.path)
+                    this.#triggerContext
+                        .getToolUseLookup()
+                        .set(toolUse.toolUseId, { ...toolUse, oldContent: document?.getText() })
                 }
 
                 const result = await this.#features.agent.runTool(toolUse.name, toolUse.input, token)
@@ -622,31 +636,76 @@ export class AgenticChatController implements ChatHandlers {
         }
     }
 
-    #processExecuteBashConfirmation(toolUse: ToolUse, warning?: string): ChatResult {
-        const buttons: Button[] = [
-            {
-                id: 'reject-shell-command',
-                text: 'Reject',
-                icon: 'cancel',
-            },
-            {
-                id: 'run-shell-command',
-                text: 'Run',
-                icon: 'play',
-            },
-        ]
-        const header = {
-            body: 'shell',
-            buttons,
+    #processToolConfirmation(toolUse: ToolUse, warning?: string, toolType?: string): ChatResult {
+        let buttons: Button[] = []
+        let header: { body: string; buttons: Button[] }
+        let body: string
+
+        switch (toolType || toolUse.name) {
+            case 'executeBash':
+                buttons = [
+                    {
+                        id: 'reject-shell-command',
+                        text: 'Reject',
+                        icon: 'cancel',
+                    },
+                    {
+                        id: 'run-shell-command',
+                        text: 'Run',
+                        icon: 'play',
+                    },
+                ]
+                header = {
+                    body: 'shell',
+                    buttons,
+                }
+                const commandString = (toolUse.input as unknown as ExecuteBashParams).command
+                body = '```shell\n' + commandString + '\n```'
+                break
+
+            case 'fsWrite':
+                buttons = [
+                    {
+                        id: 'allow-tools', // Reusing the same ID for simplicity, could be changed to 'allow-write-tools'
+                        text: 'Allow',
+                        icon: 'ok',
+                        status: 'clear',
+                    },
+                ]
+                header = {
+                    body: '#### ⚠️ Allow file modification outside of your workspace',
+                    buttons,
+                }
+                const writeFilePath = (toolUse.input as unknown as FsWriteParams).path
+                body = `I need permission to modify files in your workspace.\n\`${writeFilePath}\``
+                break
+
+            case 'fsRead':
+            case 'listDirectory':
+            default:
+                buttons = [
+                    {
+                        id: 'allow-tools',
+                        text: 'Allow',
+                        icon: 'ok',
+                        status: 'clear',
+                    },
+                ]
+                header = {
+                    body: '#### ⚠️ Allow read-only tools outside your workspace',
+                    buttons,
+                }
+                // ⚠️ Warning: This accesses files outside the workspace
+                const readFilePath = (toolUse.input as unknown as FsReadParams | ListDirectoryParams).path
+                body = `I need permission to read files and list directories outside the workspace.\n\`${readFilePath}\``
+                break
         }
 
-        const commandString = (toolUse.input as unknown as ExecuteBashParams).command
-        const body = '```shell\n' + commandString + '\n```'
         return {
             type: 'tool',
             messageId: toolUse.toolUseId,
             header,
-            body: warning ? warning + body : body,
+            body: warning ? warning + (toolType === 'executeBash' ? '' : '\n\n') + body : body,
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -528,7 +528,7 @@ export class AgenticChatController implements ChatHandlers {
                         const { requiresAcceptance, warning } = await tool.requiresAcceptance(toolUse.input as any)
 
                         if (requiresAcceptance) {
-                            const confirmationResult = this.#processExecuteBashConfirmation(toolUse, warning)
+                            const confirmationResult = this.#processToolConfirmation(toolUse, warning)
                             const buttonBlockId = await chatResultStream.writeResultBlock(confirmationResult)
                             await this.waitForToolApproval(toolUse, chatResultStream, buttonBlockId, session)
                         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -1,7 +1,8 @@
-import { ExplanatoryParams, InvokeOutput } from './toolShared'
+import { CommandValidation, ExplanatoryParams, InvokeOutput } from './toolShared'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
 import { Change, diffLines } from 'diff'
+import { URI } from 'vscode-uri'
 
 // Port of https://github.com/aws/aws-toolkit-vscode/blob/16aa8768834f41ae512522473a6a962bb96abe51/packages/core/src/codewhispererChat/tools/fsWrite.ts#L42
 
@@ -121,6 +122,10 @@ export class FsWrite {
         await updateWriter.write(' ')
         await updateWriter.close()
         updateWriter.releaseLock()
+    }
+
+    public async requiresAcceptance(params: FsWriteParams): Promise<CommandValidation> {
+        return { requiresAcceptance: !(await this.workspace.getTextDocument(URI.file(params.path).toString())) }
     }
 
     private async handleCreate(params: CreateParams, sanitizedPath: string): Promise<void> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -52,8 +52,8 @@ export class ListDirectory {
         await closeWriter(writer)
     }
 
-    public async requiresAcceptance(path: string): Promise<CommandValidation> {
-        return { requiresAcceptance: !workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), path) }
+    public async requiresAcceptance(params: ListDirectoryParams): Promise<CommandValidation> {
+        return { requiresAcceptance: !workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), params.path) }
     }
 
     public async invoke(params: ListDirectoryParams, token?: CancellationToken): Promise<InvokeOutput> {


### PR DESCRIPTION
## Problem
User permissions check for reading files/list directory outside of workspace is not setup.

## Solution
- add permission check for fsRead and listDirectory tools
- Adds permission cards for allowing access
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
