### PR TITLE
fix(agenticChat): Only show the file name in chat

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -685,7 +685,7 @@ export class AgenticChatController implements ChatHandlers {
                     details: {
                         [fileName]: {
                             changes,
-                            description: input.path, // Show full path in description when hovering
+                            description: input.path,
                         },
                     },
                 },
@@ -1052,9 +1052,10 @@ export class AgenticChatController implements ChatHandlers {
         const toolUseId = params.messageId
         const toolUse = toolUseId ? this.#triggerContext.getToolUseLookup().get(toolUseId) : undefined
         if (toolUse?.name === 'fsWrite') {
+            const input = toolUse.input as unknown as FsWriteParams
             // TODO: since the tool already executed, we need to reverse the old/new content for the diff
             this.#features.lsp.workspace.openFileDiff({
-                originalFileUri: absolutePath,
+                originalFileUri: input.path,
                 isDeleted: false,
                 fileContent: toolUse.oldContent,
             })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -663,9 +663,8 @@ export class AgenticChatController implements ChatHandlers {
         const input = toolUse.input as unknown as FsWriteParams
         const oldContent = this.#triggerContext.getToolUseLookup().get(toolUse.toolUseId!)?.oldContent ?? ''
         const diffChanges = getDiffChanges(input, oldContent)
-        // TODO: support multi folder workspaces
-        const workspaceRoot = workspaceUtils.getWorkspaceFolderPaths(this.#features.lsp)[0]
-        const relativeFilePath = path.relative(workspaceRoot, input.path)
+        // Get just the filename instead of the full path
+        const fileName = path.basename(input.path)
         const changes = diffChanges.reduce(
             (acc, { count = 0, added, removed }) => {
                 if (added) {
@@ -682,8 +681,8 @@ export class AgenticChatController implements ChatHandlers {
             messageId: toolUse.toolUseId,
             header: {
                 fileList: {
-                    filePaths: [relativeFilePath],
-                    details: { [relativeFilePath]: { changes } },
+                    filePaths: [fileName],
+                    details: { [fileName]: { changes } },
                 },
                 buttons: [{ id: 'undo-changes', text: 'Undo', icon: 'undo' }],
             },

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -682,7 +682,12 @@ export class AgenticChatController implements ChatHandlers {
             header: {
                 fileList: {
                     filePaths: [fileName],
-                    details: { [fileName]: { changes } },
+                    details: {
+                        [fileName]: {
+                            changes,
+                            description: input.path, // Show full path in description when hovering
+                        },
+                    },
                 },
                 buttons: [{ id: 'undo-changes', text: 'Undo', icon: 'undo' }],
             },


### PR DESCRIPTION
## Problem
We would show the full path for the modified file, which makes users sometimes hard to read
## Solution

https://github.com/user-attachments/assets/1ea7c9a0-59fc-4b7a-80f0-175e5695323e



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
