### PR TITLE
feat(chat-client): open use input prompt for agentic chat and new prompt should st…

### DIFF
--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -127,7 +127,7 @@ describe('MynahUI', () => {
                 tabId,
             })
             assert.calledOnce(updateStoreSpy)
-            assert.calledWith(updateStoreSpy, tabId, { loadingChat: true, promptInputDisabledState: true })
+            assert.calledWith(updateStoreSpy, tabId, { loadingChat: true, promptInputDisabledState: false })
         })
     })
 

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -98,7 +98,7 @@ describe('MynahUI', () => {
             assert.notCalled(onQuickActionSpy)
             assert.calledWith(onChatPromptSpy, { prompt, tabId, context: undefined })
             assert.calledWith(addChatItemSpy, tabId, { type: ChatItemType.PROMPT, body: prompt.escapedPrompt })
-            assert.calledWith(updateStoreSpy, tabId, { loadingChat: true, promptInputDisabledState: true })
+            assert.calledWith(updateStoreSpy, tabId, { loadingChat: true, promptInputDisabledState: false })
             assert.calledWith(addChatItemSpy, tabId, { type: ChatItemType.ANSWER_STREAM })
         })
 
@@ -282,7 +282,7 @@ describe('MynahUI', () => {
 
             sinon.assert.calledOnceWithMatch(updateStoreSpy, tabId, {
                 loadingChat: true,
-                promptInputDisabledState: true,
+                promptInputDisabledState: false,
             })
         })
     })

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -90,6 +90,7 @@ export const handleChatPrompt = (
     _eventId?: string
 ) => {
     let userPrompt = prompt.escapedPrompt
+    messager.onStopChatResponse(tabId)
     if (prompt.command) {
         // Temporary solution to handle clear quick actions on the client side
         if (prompt.command === '/clear') {
@@ -124,7 +125,7 @@ export const handleChatPrompt = (
     // Set UI to loading state
     mynahUi.updateStore(tabId, {
         loadingChat: true,
-        promptInputDisabledState: true,
+        promptInputDisabledState: false,
     })
 
     // Create initial empty response


### PR DESCRIPTION
…op current response

## Problem
- User prompt is closed while agentic chat loop runs, the requirement is to keep it open and stop current running loop incase of new prompt.

## Solution
- promptInputDisabledState is set to false
- Each new prompt triggers stop response, so we can cancel the current loop incase of new prompt.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
