### PR TITLE
fix: ensure chat history consistency by fixing database state before each request

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -429,6 +429,15 @@ describe('AgenticChatController', () => {
                 },
             ]
 
+            getMessagesStub
+                .onFirstCall()
+                .returns([])
+                .onSecondCall()
+                .returns([
+                    { userInputMessage: { content: 'Hello with tool' } },
+                    { assistantResponseMessage: { content: 'I need to use a tool. ' } },
+                ])
+
             // Reset the stub and set up to return different responses on consecutive calls
             generateAssistantResponseStub.restore()
             generateAssistantResponseStub = sinon.stub(CodeWhispererStreaming.prototype, 'generateAssistantResponse')
@@ -553,6 +562,15 @@ describe('AgenticChatController', () => {
                     },
                 },
             ]
+
+            getMessagesStub
+                .onFirstCall()
+                .returns([])
+                .onSecondCall()
+                .returns([
+                    { userInputMessage: { content: 'Hello with failing tool' } },
+                    { assistantResponseMessage: { content: 'I need to use a tool that will fail. ' } },
+                ])
 
             // Reset the stub and set up to return different responses on consecutive calls
             generateAssistantResponseStub.restore()
@@ -722,6 +740,24 @@ describe('AgenticChatController', () => {
                     },
                 },
             ]
+
+            const historyAfterTool1 = [
+                { userInputMessage: { content: 'Hello with multiple tools' } },
+                { assistantResponseMessage: { content: 'I need to use tool 1. ' } },
+            ]
+            const historyAfterTool2 = [
+                ...historyAfterTool1,
+                { userInputMessage: { content: 'Hello with multiple tools' } },
+                { assistantResponseMessage: { content: 'Now I need to use tool 2. ' } },
+            ]
+
+            getMessagesStub
+                .onFirstCall()
+                .returns([])
+                .onSecondCall()
+                .returns(historyAfterTool1)
+                .onThirdCall()
+                .returns(historyAfterTool2)
 
             // Reset the stub and set up to return different responses on consecutive calls
             generateAssistantResponseStub.restore()

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
@@ -218,7 +218,7 @@ export class TabBarController {
     async restoreTab(selectedTab?: Tab | null) {
         if (selectedTab) {
             const messages = selectedTab.conversations.flatMap((conv: Conversation) =>
-                conv.messages.map(msg => messageToChatMessage(msg))
+                conv.messages.flatMap(msg => messageToChatMessage(msg))
             )
 
             const { tabId } = await this.#features.chat.openTab({ newTabOptions: { data: { messages } } })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
@@ -69,12 +69,16 @@ describe('ChatDb Utilities', () => {
 
             const result = messageToChatMessage(message)
 
-            assert.deepStrictEqual(result, {
-                body: 'Hello',
-                type: 'prompt',
-                codeReference: [{ url: 'test.js', recommendationContentSpan: { start: 10, end: 15 }, information: '' }],
-                relatedContent: { content: [{ title: 'Sources', url: 'google.com' }] },
-            })
+            assert.deepStrictEqual(result, [
+                {
+                    body: 'Hello',
+                    type: 'prompt',
+                    codeReference: [
+                        { url: 'test.js', recommendationContentSpan: { start: 10, end: 15 }, information: '' },
+                    ],
+                    relatedContent: { content: [{ title: 'Sources', url: 'google.com' }] },
+                },
+            ])
         })
 
         it('should omit relatedContent when content array is empty', () => {
@@ -86,12 +90,14 @@ describe('ChatDb Utilities', () => {
 
             const result = messageToChatMessage(message)
 
-            assert.deepStrictEqual(result, {
-                body: 'Hello',
-                type: 'prompt',
-                relatedContent: undefined,
-                codeReference: undefined,
-            })
+            assert.deepStrictEqual(result, [
+                {
+                    body: 'Hello',
+                    type: 'prompt',
+                    relatedContent: undefined,
+                    codeReference: undefined,
+                },
+            ])
         })
     })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
@@ -95,13 +95,32 @@ export function messageToStreamingMessage(msg: Message): StreamingMessage {
 /**
  * Converts Message to LSP Protocol ChatMessage
  */
-export function messageToChatMessage(msg: Message): ChatMessage {
-    return {
-        body: msg.body,
-        type: msg.type,
-        codeReference: msg.codeReference,
-        relatedContent: msg.relatedContent && msg.relatedContent?.content.length > 0 ? msg.relatedContent : undefined,
+export function messageToChatMessage(msg: Message): ChatMessage[] {
+    const chatMessages: ChatMessage[] = [
+        {
+            body: msg.body,
+            type: msg.type,
+            codeReference: msg.codeReference,
+            relatedContent:
+                msg.relatedContent && msg.relatedContent?.content.length > 0 ? msg.relatedContent : undefined,
+        },
+    ]
+
+    // Check if there are any toolUses with explanations that should be displayed as directive messages
+    if (msg.toolUses && msg.toolUses.length > 0) {
+        for (const toolUse of msg.toolUses) {
+            if (toolUse.input && typeof toolUse.input === 'object') {
+                const input = toolUse.input as any
+                if (input.explanation) {
+                    chatMessages.push({
+                        body: input.explanation,
+                        type: 'directive',
+                    })
+                }
+            }
+        }
     }
+    return chatMessages
 }
 
 /**


### PR DESCRIPTION
## Related commit in agetic-chat branch

- https://github.com/aws/aws-toolkit-vscode/commit/67a3b4bd0a0b484a5bb5929446aa077070d359aa
- https://github.com/aws/aws-toolkit-vscode/commit/62f6ac5de345f7408d02251d2d957e146b3eaffc

## Problem
- Inconsistent History Sources: Initial request gets history from DB, subsequent requests build history in memory. History is manually built in memory rather than consistently using the database as source of truth
- Incomplete History Storage: `#handleFinalResult` only saves initial prompt and final answer, losing all intermediate steps when re-loading history. We also don't store the toolUses


## Solution

- Fix the history to maintain invariants before each request
- Retrieve the history from DB instead of in-memory
- Do not include chatHistory for requests going to Mynah
- Store all user and assitantResponse Messages


## Testing
- Manually tested
    - All messages are restored when loading history
    
<img width="721" alt="Screenshot 2025-04-23 at 2 13 39 AM" src="https://github.com/user-attachments/assets/fca28556-4000-439a-ad6b-ae9694643250" />

- History now stores toolResults. Verified json history file


## TODO
- File diffs and execute bash tool executions also need to be restored when loading history


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
