### PR TITLE
fix: tool cards have the wrong props

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -631,29 +631,35 @@ export const createMynahUi = (
         const contextHeader = contextListToHeader(message.contextList)
         const header = contextHeader || toMynahHeader(message.header) // Is this mutually exclusive?
 
+        let processedHeader = header
+        if (message.type === 'tool') {
+            processedHeader = { ...header }
+            if (header?.buttons) {
+                processedHeader.buttons = header.buttons.map(button => ({ ...button, status: 'clear' }))
+            }
+            if (header?.fileList) {
+                processedHeader.fileList = {
+                    ...header.fileList,
+                    fileTreeTitle: '',
+                    hideFileCount: true,
+                    details: toDetailsWithoutIcon(header.fileList.details),
+                }
+            }
+        }
+
         return {
             body:
                 message.type !== 'tool' && (message.body === undefined || message.body === '')
                     ? 'Thinking...'
                     : message.body,
-            header:
-                message.type === 'tool' && message.header?.fileList && message.header.buttons
-                    ? {
-                          ...header,
-                          fileList: {
-                              ...header?.fileList,
-                              fileTreeTitle: '',
-                              hideFileCount: true,
-                              details: toDetailsWithoutIcon(header?.fileList?.details),
-                          },
-                          buttons: header?.buttons?.map(button => ({ ...button, status: 'clear' })),
-                      }
-                    : header,
+            header: processedHeader,
             buttons: toMynahButtons(message.buttons),
 
             // file diffs in the header need space
-            fullWidth: message.type === 'tool' ? true : undefined,
+            fullWidth: message.type === 'tool' && message.header?.buttons ? true : undefined,
             padding: message.type === 'tool' ? false : undefined,
+
+            codeBlockActions: message.type === 'tool' ? { 'insert-to-cursor': null, copy: null } : undefined,
         }
     }
 


### PR DESCRIPTION
## Problem

- File list cards should not be full width
- Tool cards should never have code block actions
- Tool cards with buttons should have clear status

## Solution

![image](https://github.com/user-attachments/assets/2ec2ba54-2496-4e9d-89cc-a46dc3febe74)
![image](https://github.com/user-attachments/assets/74b74950-0f79-4b31-991a-7e2fb9f68167)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
