### PR TITLE
fix: remove undefined header from followup authenticate button

### DIFF
--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -217,7 +217,7 @@ describe('Chat', () => {
         window.dispatchEvent(chatEvent)
 
         assert.calledOnceWithExactly(endMessageStreamStub, tabId, '', {
-            header: { icon: undefined, buttons: undefined, status: { icon: undefined } },
+            header: undefined,
             buttons: undefined,
             body: 'some response',
             followUp: {},

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -115,7 +115,8 @@ export const createChat = (
 
     const parseFeatureConfig = (featureConfigSerialized?: string): Map<string, FeatureContext> => {
         try {
-            return new Map<string, FeatureContext>(JSON.parse(featureConfigSerialized || '{}'))
+            const parsed = JSON.parse(featureConfigSerialized || '[]')
+            return new Map<string, FeatureContext>(parsed)
         } catch (error) {
             console.error('Error parsing feature config:', featureConfigSerialized, error)
         }

--- a/chat-client/src/client/utils.ts
+++ b/chat-client/src/client/utils.ts
@@ -11,11 +11,12 @@ export function toMynahButtons(buttons: Button[] | undefined): ChatItemButton[] 
 }
 
 export function toMynahHeader(header: ChatMessage['header']): ChatItemContent['header'] {
+    if (!header) return undefined
     return {
         ...header,
-        icon: toMynahIcon(header?.icon),
-        buttons: toMynahButtons(header?.buttons),
-        status: { ...header?.status, icon: toMynahIcon(header?.status?.icon) },
+        icon: toMynahIcon(header.icon),
+        buttons: toMynahButtons(header.buttons),
+        status: header.status ? { ...header.status, icon: toMynahIcon(header.status.icon) } : undefined,
     }
 }
 


### PR DESCRIPTION
## Problem

We were seeing empty yellow header on top of followup buttons, like "Authenticate"

## Solution

Do not set header with empty properties.

Also fixed: TypeError: object is not iterable

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
