### PR TITLE
fix: prevent double-writing executeBash command block on Reject button click

### DIFF
--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -29,6 +29,8 @@ import {
     ShowSaveFileDialogRequestType,
     ShowSaveFileDialogParams,
     tabBarActionRequestType,
+    buttonClickRequestType,
+    chatUpdateNotificationType,
 } from '@aws/language-server-runtimes/protocol'
 import { v4 as uuidv4 } from 'uuid'
 import { Uri, Webview, WebviewView, commands, window } from 'vscode'
@@ -172,6 +174,14 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri, 
                                 tabBarActionRequestType.method
                             )
                             break
+                        case buttonClickRequestType.method:
+                            await handleRequest(
+                                languageClient,
+                                message.params,
+                                webviewView,
+                                buttonClickRequestType.method
+                            )
+                            break
                         case followUpClickNotificationType.method:
                             if (!isValidAuthFollowUpType(message.params.followUp.type))
                                 languageClient.sendNotification(followUpClickNotificationType, message.params)
@@ -186,6 +196,13 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri, 
                 languageClient.onNotification(contextCommandsNotificationType, params => {
                     webviewView.webview.postMessage({
                         command: contextCommandsNotificationType.method,
+                        params: params,
+                    })
+                })
+
+                languageClient.onNotification(chatUpdateNotificationType, params => {
+                    webviewView.webview.postMessage({
+                        command: chatUpdateNotificationType.method,
                         params: params,
                     })
                 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -129,6 +129,7 @@ export class AgenticChatResultStream {
     async writeResultBlock(result: ChatMessage): Promise<number> {
         this.#state.chatResultBlocks.push(result)
         await this.#sendProgress(this.getResult(result.messageId))
+        // TODO: We should use chat messageId as blockId instead of nummber for more predictable updates.
         return this.#state.chatResultBlocks.length - 1
     }
 


### PR DESCRIPTION
## Problem
When we click `Reject` button for shell command, that message chat item body is added twice.

## Solution

Prevent writing duplicate block for shell command written on Reject command click

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->


https://github.com/user-attachments/assets/13b65a9b-aade-4e34-ab29-658f4e652feb



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
