### PR TITLE
fix(chat-client): workspace checks for permission cards

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.test.ts
@@ -130,6 +130,9 @@ describe('FsRead Tool', () => {
                 ...features.lsp,
                 getClientInitializeParams: () => ({
                     workspaceFolders: [{ uri: 'file:///workspace/folder', name: 'workspace' }],
+                    processId: 123,
+                    rootUri: 'file:///workspace/folder',
+                    capabilities: {},
                 }),
             },
             workspace: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.test.ts
@@ -126,6 +126,12 @@ describe('FsRead Tool', () => {
     it('should not require acceptance if fsPath is inside the workspace', async () => {
         const fsRead = new FsRead({
             ...features,
+            lsp: {
+                ...features.lsp,
+                getClientInitializeParams: () => ({
+                    workspaceFolders: [{ uri: 'file:///workspace/folder', name: 'workspace' }],
+                }),
+            },
             workspace: {
                 ...features.workspace,
                 getTextDocument: async s => ({}) as TextDocument,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
@@ -1,6 +1,6 @@
 import { sanitize } from '@aws/lsp-core/out/util/path'
 import { URI } from 'vscode-uri'
-import { CommandValidation, InvokeOutput, validatePath } from './toolShared'
+import { CommandValidation, InvokeOutput, requiresPathAcceptance, validatePath } from './toolShared'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { workspaceUtils } from '@aws/lsp-core'
 import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
@@ -55,15 +55,7 @@ export class FsRead {
     }
 
     public async requiresAcceptance(params: FsReadParams): Promise<CommandValidation> {
-        // true when the file is not resolvable within our workspace. i.e. is outside of our workspace.
-        try {
-            const isInWorkspace = workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), params.path)
-            return { requiresAcceptance: !isInWorkspace }
-        } catch (error) {
-            console.error('Error checking file acceptance:', error)
-            // In case of error, safer to require acceptance
-            return { requiresAcceptance: true }
-        }
+        return requiresPathAcceptance(params.path, this.lsp, this.logging)
     }
 
     public async invoke(params: FsReadParams): Promise<InvokeOutput> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -42,10 +42,12 @@ export interface FsWriteBackup {
 }
 
 export class FsWrite {
+    private readonly logging: Features['logging']
     private readonly workspace: Features['workspace']
     private readonly lsp: Features['lsp']
 
-    constructor(features: Pick<Features, 'workspace' | 'lsp'> & Partial<Features>) {
+    constructor(features: Pick<Features, 'workspace' | 'logging' | 'lsp'> & Partial<Features>) {
+        this.logging = features.logging
         this.workspace = features.workspace
         this.lsp = features.lsp
     }
@@ -129,7 +131,7 @@ export class FsWrite {
     }
 
     public async requiresAcceptance(params: FsWriteParams): Promise<CommandValidation> {
-        return requiresPathAcceptance(params.path, this.lsp)
+        return requiresPathAcceptance(params.path, this.lsp, this.logging)
     }
 
     private async handleCreate(params: CreateParams, sanitizedPath: string): Promise<void> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -1,5 +1,5 @@
 import { workspaceUtils } from '@aws/lsp-core'
-import { CommandValidation, ExplanatoryParams, InvokeOutput } from './toolShared'
+import { CommandValidation, ExplanatoryParams, InvokeOutput, requiresPathAcceptance } from './toolShared'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
 import { Change, diffLines } from 'diff'
@@ -129,15 +129,7 @@ export class FsWrite {
     }
 
     public async requiresAcceptance(params: FsWriteParams): Promise<CommandValidation> {
-        // true when the file is not resolvable within our workspace. i.e. is outside of our workspace.
-        try {
-            const isInWorkspace = workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), params.path)
-            return { requiresAcceptance: !isInWorkspace }
-        } catch (error) {
-            console.error('Error checking file acceptance:', error)
-            // In case of error, safer to require acceptance
-            return { requiresAcceptance: true }
-        }
+        return requiresPathAcceptance(params.path, this.lsp)
     }
 
     private async handleCreate(params: CreateParams, sanitizedPath: string): Promise<void> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -1,5 +1,5 @@
 // Port from VSC: https://github.com/aws/aws-toolkit-vscode/blob/0eea1d8ca6e25243609a07dc2a2c31886b224baa/packages/core/src/codewhispererChat/tools/listDirectory.ts#L19
-import { CommandValidation, InvokeOutput, validatePath } from './toolShared'
+import { CommandValidation, InvokeOutput, requiresPathAcceptance, validatePath } from './toolShared'
 import { CancellationError, workspaceUtils } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
@@ -53,14 +53,7 @@ export class ListDirectory {
     }
 
     public async requiresAcceptance(params: ListDirectoryParams): Promise<CommandValidation> {
-        try {
-            const isInWorkspace = workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), params.path)
-            return { requiresAcceptance: !isInWorkspace }
-        } catch (error) {
-            console.error('Error checking file acceptance:', error)
-            // In case of error, safer to require acceptance
-            return { requiresAcceptance: true }
-        }
+        return requiresPathAcceptance(params.path, this.lsp, this.logging)
     }
 
     public async invoke(params: ListDirectoryParams, token?: CancellationToken): Promise<InvokeOutput> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -53,7 +53,14 @@ export class ListDirectory {
     }
 
     public async requiresAcceptance(params: ListDirectoryParams): Promise<CommandValidation> {
-        return { requiresAcceptance: !workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), params.path) }
+        try {
+            const isInWorkspace = workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), params.path)
+            return { requiresAcceptance: !isInWorkspace }
+        } catch (error) {
+            console.error('Error checking file acceptance:', error)
+            // In case of error, safer to require acceptance
+            return { requiresAcceptance: true }
+        }
     }
 
     public async invoke(params: ListDirectoryParams, token?: CancellationToken): Promise<InvokeOutput> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -10,8 +10,8 @@ import { McpManager } from './mcp/mcpManager'
 import { McpTool } from './mcp/mcpTool'
 
 export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
-    const fsReadTool = new FsRead({ workspace, logging })
-    const fsWriteTool = new FsWrite({ workspace, logging })
+    const fsReadTool = new FsRead({ workspace, lsp, logging })
+    const fsWriteTool = new FsWrite({ workspace, lsp, logging })
     const listDirectoryTool = new ListDirectory({ workspace, logging, lsp })
 
     agent.addTool(fsReadTool.getSpec(), async (input: FsReadParams) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.test.ts
@@ -60,7 +60,7 @@ describe('toolShared', () => {
                 true,
                 'Should require acceptance when workspace folders are empty'
             )
-            sinon.assert.calledOnce(mockLogging.warn as sinon.SinonSpy)
+            sinon.assert.calledOnce(mockLogging.debug as sinon.SinonSpy)
         })
 
         it('should require acceptance if workspace folders are undefined', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.test.ts
@@ -61,7 +61,7 @@ describe('toolShared', () => {
                 true,
                 'Should require acceptance when workspace folders are empty'
             )
-            sinon.assert.calledOnce(mockLogging.warn as sinon.SinonSpy)
+            sinon.assert.calledOnce(mockLogging.debug as sinon.SinonSpy)
         })
 
         it('should require acceptance if workspace folders are undefined', async () => {
@@ -77,7 +77,7 @@ describe('toolShared', () => {
                 true,
                 'Should require acceptance when workspace folders are undefined'
             )
-            sinon.assert.calledOnce(mockLogging.warn as sinon.SinonSpy)
+            sinon.assert.calledOnce(mockLogging.debug as sinon.SinonSpy)
         })
 
         it('should require acceptance if getClientInitializeParams returns undefined', async () => {
@@ -91,7 +91,7 @@ describe('toolShared', () => {
                 true,
                 'Should require acceptance when getClientInitializeParams returns undefined'
             )
-            sinon.assert.calledOnce(mockLogging.warn as sinon.SinonSpy)
+            sinon.assert.calledOnce(mockLogging.debug as sinon.SinonSpy)
         })
 
         it('should require acceptance and log error if an exception occurs', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.test.ts
@@ -1,0 +1,122 @@
+import * as assert from 'assert'
+import { requiresPathAcceptance } from './toolShared'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { URI } from 'vscode-uri'
+import * as sinon from 'sinon'
+
+describe('toolShared', () => {
+    describe('requiresPathAcceptance', () => {
+        let features: TestFeatures
+        let mockLsp: Features['lsp']
+        let mockLogging: Features['logging']
+
+        beforeEach(() => {
+            features = new TestFeatures()
+
+            // Mock LSP with workspace folders
+            mockLsp = {
+                getClientInitializeParams: sinon.stub().returns({
+                    workspaceFolders: [
+                        { uri: 'file:///workspace/folder1', name: 'workspace1' },
+                        { uri: 'file:///workspace/folder2', name: 'workspace2' },
+                    ],
+                }),
+            } as unknown as Features['lsp']
+
+            // Mock logging
+            mockLogging = {
+                info: sinon.spy(),
+                warn: sinon.spy(),
+                error: sinon.spy(),
+                log: sinon.spy(),
+            } as unknown as Features['logging']
+        })
+
+        afterEach(() => {
+            sinon.restore()
+        })
+
+        it('should not require acceptance if path is inside workspace folder', async () => {
+            const result = await requiresPathAcceptance('/workspace/folder1/file.txt', mockLsp, mockLogging)
+            assert.strictEqual(result.requiresAcceptance, false, 'Path inside workspace should not require acceptance')
+        })
+
+        it('should require acceptance if path is outside workspace folders', async () => {
+            const result = await requiresPathAcceptance('/outside/workspace/file.txt', mockLsp, mockLogging)
+            assert.strictEqual(result.requiresAcceptance, true, 'Path outside workspace should require acceptance')
+        })
+
+        it('should require acceptance if workspace folders are empty', async () => {
+            const emptyLsp = {
+                getClientInitializeParams: sinon.stub().returns({
+                    workspaceFolders: [],
+                }),
+            } as unknown as Features['lsp']
+
+            const result = await requiresPathAcceptance('/any/path/file.txt', emptyLsp, mockLogging)
+            assert.strictEqual(
+                result.requiresAcceptance,
+                true,
+                'Should require acceptance when workspace folders are empty'
+            )
+            sinon.assert.calledOnce(mockLogging.warn as sinon.SinonSpy)
+        })
+
+        it('should require acceptance if workspace folders are undefined', async () => {
+            const undefinedLsp = {
+                getClientInitializeParams: sinon.stub().returns({
+                    workspaceFolders: undefined,
+                }),
+            } as unknown as Features['lsp']
+
+            const result = await requiresPathAcceptance('/any/path/file.txt', undefinedLsp, mockLogging)
+            assert.strictEqual(
+                result.requiresAcceptance,
+                true,
+                'Should require acceptance when workspace folders are undefined'
+            )
+            sinon.assert.calledOnce(mockLogging.warn as sinon.SinonSpy)
+        })
+
+        it('should require acceptance if getClientInitializeParams returns undefined', async () => {
+            const nullLsp = {
+                getClientInitializeParams: sinon.stub().returns(undefined),
+            } as unknown as Features['lsp']
+
+            const result = await requiresPathAcceptance('/any/path/file.txt', nullLsp, mockLogging)
+            assert.strictEqual(
+                result.requiresAcceptance,
+                true,
+                'Should require acceptance when getClientInitializeParams returns undefined'
+            )
+            sinon.assert.calledOnce(mockLogging.warn as sinon.SinonSpy)
+        })
+
+        it('should require acceptance and log error if an exception occurs', async () => {
+            const errorLsp = {
+                getClientInitializeParams: sinon.stub().throws(new Error('Test error')),
+            } as unknown as Features['lsp']
+
+            const result = await requiresPathAcceptance('/any/path/file.txt', errorLsp, mockLogging)
+            assert.strictEqual(result.requiresAcceptance, true, 'Should require acceptance when an error occurs')
+            sinon.assert.calledOnce(mockLogging.error as sinon.SinonSpy)
+        })
+
+        it('should work without logging parameter', async () => {
+            // This test ensures the function doesn't throw when logging is not provided
+            const result = await requiresPathAcceptance('/workspace/folder1/file.txt', mockLsp)
+            assert.strictEqual(result.requiresAcceptance, false, 'Path inside workspace should not require acceptance')
+        })
+
+        it('should handle errors without logging parameter', async () => {
+            const errorLsp = {
+                getClientInitializeParams: sinon.stub().throws(new Error('Test error')),
+            } as unknown as Features['lsp']
+
+            // This test ensures the function handles errors gracefully when logging is not provided
+            const result = await requiresPathAcceptance('/any/path/file.txt', errorLsp)
+            assert.strictEqual(result.requiresAcceptance, true, 'Should require acceptance when an error occurs')
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.test.ts
@@ -30,6 +30,7 @@ describe('toolShared', () => {
                 warn: sinon.spy(),
                 error: sinon.spy(),
                 log: sinon.spy(),
+                debug: sinon.spy(),
             } as unknown as Features['logging']
         })
 
@@ -60,7 +61,7 @@ describe('toolShared', () => {
                 true,
                 'Should require acceptance when workspace folders are empty'
             )
-            sinon.assert.calledOnce(mockLogging.debug as sinon.SinonSpy)
+            sinon.assert.calledOnce(mockLogging.warn as sinon.SinonSpy)
         })
 
         it('should require acceptance if workspace folders are undefined', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.test.ts
@@ -103,21 +103,5 @@ describe('toolShared', () => {
             assert.strictEqual(result.requiresAcceptance, true, 'Should require acceptance when an error occurs')
             sinon.assert.calledOnce(mockLogging.error as sinon.SinonSpy)
         })
-
-        it('should work without logging parameter', async () => {
-            // This test ensures the function doesn't throw when logging is not provided
-            const result = await requiresPathAcceptance('/workspace/folder1/file.txt', mockLsp)
-            assert.strictEqual(result.requiresAcceptance, false, 'Path inside workspace should not require acceptance')
-        })
-
-        it('should handle errors without logging parameter', async () => {
-            const errorLsp = {
-                getClientInitializeParams: sinon.stub().throws(new Error('Test error')),
-            } as unknown as Features['lsp']
-
-            // This test ensures the function handles errors gracefully when logging is not provided
-            const result = await requiresPathAcceptance('/any/path/file.txt', errorLsp)
-            assert.strictEqual(result.requiresAcceptance, true, 'Should require acceptance when an error occurs')
-        })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -1,3 +1,7 @@
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { workspaceUtils } from '@aws/lsp-core'
+import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
+
 interface Output<Kind, Content> {
     kind: Kind
     content: Content
@@ -40,4 +44,37 @@ export interface ExplanatoryParams {
 export enum OutputKind {
     Text = 'text',
     Json = 'json',
+}
+
+/**
+ * Shared implementation to check if a file path requires user acceptance.
+ * Returns true when the file is not resolvable within our workspace (i.e., is outside of our workspace).
+ *
+ * @param path The file path to check
+ * @param lsp The LSP feature to get workspace folders
+ * @param logging Optional logging feature for better error reporting
+ * @returns CommandValidation object with requiresAcceptance flag
+ */
+export async function requiresPathAcceptance(
+    path: string,
+    lsp: Features['lsp'],
+    logging?: Features['logging']
+): Promise<CommandValidation> {
+    try {
+        const workspaceFolders = getWorkspaceFolderPaths(lsp)
+        if (!workspaceFolders || workspaceFolders.length === 0) {
+            if (logging) {
+                logging.debug('No workspace folders found when checking file acceptance')
+            }
+            return { requiresAcceptance: true }
+        }
+        const isInWorkspace = workspaceUtils.isInWorkspace(workspaceFolders, path)
+        return { requiresAcceptance: !isInWorkspace }
+    } catch (error) {
+        if (logging) {
+            logging.debug(`Error checking file acceptance: ${error}`)
+        }
+        // In case of error, safer to require acceptance
+        return { requiresAcceptance: true }
+    }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -72,7 +72,7 @@ export async function requiresPathAcceptance(
         return { requiresAcceptance: !isInWorkspace }
     } catch (error) {
         if (logging) {
-            logging.debug(`Error checking file acceptance: ${error}`)
+            logging.error(`Error checking file acceptance: ${error}`)
         }
         // In case of error, safer to require acceptance
         return { requiresAcceptance: true }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -58,7 +58,7 @@ export enum OutputKind {
 export async function requiresPathAcceptance(
     path: string,
     lsp: Features['lsp'],
-    logging?: Features['logging']
+    logging: Features['logging']
 ): Promise<CommandValidation> {
     try {
         const workspaceFolders = getWorkspaceFolderPaths(lsp)


### PR DESCRIPTION
## Problem
Permission check cards are appearing for all the files inside workspace. This is happening due to regresion in workspace.getTextDocument failure which works only for open documents on editor.

## Solution
- Fixing workspace check for all tools with lsp.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.

https://github.com/user-attachments/assets/3db23dd9-2790-4d18-9b03-6ec643ffab53


    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
