### PR TITLE
fix: metric to show tool distribution

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -641,6 +641,10 @@ export class AgenticChatController implements ChatHandlers {
                         })
                         break
                 }
+
+                if (toolUse.name) {
+                    this.#telemetryController.emitToolUseSuggested(toolUse, session.conversationId || '')
+                }
             } catch (err) {
                 // If we did not approve a tool to be used or the user stopped the response, bubble this up to interrupt agentic loop
                 if (CancellationError.isUserCancelled(err) || err instanceof ToolApprovalException) {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -14,7 +14,7 @@ import {
     RelevancyVoteType,
     isClientTelemetryEvent,
 } from './clientTelemetry'
-import { UserIntent } from '@amzn/codewhisperer-streaming'
+import { ToolUse, UserIntent } from '@amzn/codewhisperer-streaming'
 import { TriggerContext } from '../contexts/triggerContext'
 
 import { CredentialsProvider, Logging } from '@aws/language-server-runtimes/server-interface'
@@ -164,6 +164,19 @@ export class ChatTelemetryController {
                 },
             })
         }
+    }
+
+    public emitToolUseSuggested(toolUse: ToolUse, conversationId: string) {
+        this.#telemetry.emitMetric({
+            name: ChatTelemetryEventName.ToolUseSuggested,
+            data: {
+                [CONVERSATION_ID_METRIC_KEY]: conversationId,
+                cwsprChatConversationType: 'AgenticChatWithToolUse',
+                credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
+                cwsprToolName: toolUse.name ?? '',
+                cwsprToolUseId: toolUse.toolUseId ?? '',
+            },
+        })
     }
 
     public emitAddMessageMetric(tabId: string, metric: Partial<CombinedConversationEvent>) {

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -165,6 +165,7 @@ export enum ChatTelemetryEventName {
     RunCommand = 'amazonq_runCommand',
     MessageResponseError = 'amazonq_messageResponseError',
     ModifyCode = 'amazonq_modifyCode',
+    ToolUseSuggested = 'amazonq_toolUseSuggested',
 }
 
 export interface ChatTelemetryEventMap {
@@ -178,6 +179,15 @@ export interface ChatTelemetryEventMap {
     [ChatTelemetryEventName.RunCommand]: RunCommandEvent
     [ChatTelemetryEventName.MessageResponseError]: MessageResponseErrorEvent
     [ChatTelemetryEventName.ModifyCode]: ModifyCodeEvent
+    [ChatTelemetryEventName.ToolUseSuggested]: ToolUseSuggestedEvent
+}
+
+export type ToolUseSuggestedEvent = {
+    credentialStartUrl?: string
+    cwsprChatConversationId: string
+    cwsprChatConversationType: ChatConversationType
+    cwsprToolName: string
+    cwsprToolUseId: string
 }
 
 export type ModifyCodeEvent = {
@@ -242,7 +252,7 @@ export enum ChatInteractionType {
     ClickBodyLink = 'clickBodyLink',
 }
 
-export type ChatConversationType = 'Chat' | 'Assign' | 'Transform' | 'AgenticChat'
+export type ChatConversationType = 'Chat' | 'Assign' | 'Transform' | 'AgenticChat' | 'AgenticChatWithToolUse'
 
 export type InteractWithMessageEvent = {
     credentialStartUrl?: string


### PR DESCRIPTION
#### for context, here is the agentic branch pr which i am porting over from: 
- https://github.com/aws/aws-toolkit-vscode/pull/7081
- https://github.com/aws/aws-toolkit-common/pull/1014


## Problem
- Want to see the distribution of tools that LLM either used directly or suggested

## Solution
- Emit metric toolUseSuggested after LLM invokes any tool
- also bump toolkit commons version in hybridChat branch so that these events from flare actually get sent to kibana: https://github.com/aws/aws-toolkit-vscode/pull/7147


### Tested in Kibana


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
