### PR TITLE
fix: execute command should show when no approval required & add more…

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -515,6 +515,9 @@ export const createMynahUi = (
         const chatItems = store.chatItems || []
 
         if (chatResult.additionalMessages?.length) {
+            mynahUi.updateStore(tabId, {
+                loadingChat: true,
+            })
             chatResult.additionalMessages.forEach(am => {
                 const chatItem: ChatItem = {
                     messageId: am.messageId,
@@ -538,7 +541,7 @@ export const createMynahUi = (
         if (isPartialResult) {
             const chatItem = {
                 ...chatResult,
-                body: chatResult.body === undefined || chatResult.body === '' ? 'Thinking...' : chatResult.body,
+                body: chatResult.body,
                 type: ChatItemType.ANSWER_STREAM,
                 header: header,
                 buttons: buttons,
@@ -604,6 +607,10 @@ export const createMynahUi = (
     }
 
     const updateChat = (params: ChatUpdateParams) => {
+        const isChatLoading = params.state?.inProgress
+        mynahUi.updateStore(params.tabId, {
+            loadingChat: isChatLoading,
+        })
         if (params.data?.messages.length) {
             const { tabId } = params
             const store = mynahUi.getTabData(tabId).getStore() || {}
@@ -649,10 +656,7 @@ export const createMynahUi = (
         }
 
         return {
-            body:
-                message.type !== 'tool' && (message.body === undefined || message.body === '')
-                    ? 'Thinking...'
-                    : message.body,
+            body: message.body,
             header: processedHeader,
             buttons: toMynahButtons(message.buttons),
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -482,7 +482,7 @@ export class AgenticChatController implements ChatHandlers {
             }
 
             // Process tool uses and update the request input for the next iteration
-            const toolResults = await this.#processToolUses(pendingToolUses, chatResultStream, session, token)
+            const toolResults = await this.#processToolUses(pendingToolUses, chatResultStream, session, tabId, token)
             currentRequestInput = this.#updateRequestInputWithToolResults(currentRequestInput, toolResults)
         }
 
@@ -536,6 +536,7 @@ export class AgenticChatController implements ChatHandlers {
         toolUses: Array<ToolUse & { stop: boolean }>,
         chatResultStream: AgenticChatResultStream,
         session: ChatSessionService,
+        tabId: string,
         token?: CancellationToken
     ): Promise<ToolResult[]> {
         const results: ToolResult[] = []
@@ -570,10 +571,17 @@ export class AgenticChatController implements ChatHandlers {
                         const tool = new Tool(this.#features)
                         const { requiresAcceptance, warning } = await tool.requiresAcceptance(toolUse.input as any)
 
-                        if (requiresAcceptance) {
-                            const confirmationResult = this.#processToolConfirmation(toolUse, warning)
-                            buttonBlockId = await chatResultStream.writeResultBlock(confirmationResult)
-                            await this.waitForToolApproval(toolUse, chatResultStream, buttonBlockId, session)
+                        if (requiresAcceptance || toolUse.name === 'executeBash') {
+                            // for executeBash, we till send the confirmation message without action buttons
+                            const confirmationResult = this.#processToolConfirmation(
+                                toolUse,
+                                requiresAcceptance,
+                                warning
+                            )
+                            const buttonBlockId = await chatResultStream.writeResultBlock(confirmationResult)
+                            if (requiresAcceptance) {
+                                await this.waitForToolApproval(toolUse, chatResultStream, buttonBlockId, session)
+                            }
                         }
                         break
                     }
@@ -599,8 +607,17 @@ export class AgenticChatController implements ChatHandlers {
                         .set(toolUse.toolUseId, { ...toolUse, oldContent: document?.getText() })
                 }
 
+                // show thinking spinner when tool is running
+                const loadingMessageId = `loading-${toolUse.toolUseId}`
+                await chatResultStream.writeResultBlock({ messageId: loadingMessageId })
+                this.#features.chat.sendChatUpdate({ tabId, state: { inProgress: true } })
+
                 const ws = this.#getWritableStream(chatResultStream, toolUse)
                 const result = await this.#features.agent.runTool(toolUse.name, toolUse.input, token, ws)
+
+                // remove the temp loading message when tool finishes
+                await chatResultStream.removeResultBlock(loadingMessageId)
+                this.#features.chat.sendChatUpdate({ tabId, state: { inProgress: false } })
                 let toolResultContent: ToolResultContentBlock
 
                 if (typeof result === 'string') {
@@ -717,36 +734,32 @@ export class AgenticChatController implements ChatHandlers {
         }
     }
 
-    #getBashExecutionChatResult(toolUse: ToolUse, result: InvokeOutput): ChatResult {
-        const outputString = result.output.success
-            ? (result.output.content as ExecuteBashOutput).stdout
-            : (result.output.content as ExecuteBashOutput).stderr
-        return {
-            type: 'tool',
-            messageId: toolUse.toolUseId,
-            body: outputString,
-        }
-    }
-
-    #processToolConfirmation(toolUse: ToolUse, warning?: string, toolType?: string): ChatResult {
+    #processToolConfirmation(
+        toolUse: ToolUse,
+        requiresAcceptance: Boolean,
+        warning?: string,
+        toolType?: string
+    ): ChatResult {
         let buttons: Button[] = []
         let header: { body: string; buttons: Button[] }
         let body: string
 
         switch (toolType || toolUse.name) {
             case 'executeBash':
-                buttons = [
-                    {
-                        id: 'reject-shell-command',
-                        text: 'Reject',
-                        icon: 'cancel',
-                    },
-                    {
-                        id: 'run-shell-command',
-                        text: 'Run',
-                        icon: 'play',
-                    },
-                ]
+                buttons = requiresAcceptance
+                    ? [
+                          {
+                              id: 'reject-shell-command',
+                              text: 'Reject',
+                              icon: 'cancel',
+                          },
+                          {
+                              id: 'run-shell-command',
+                              text: 'Run',
+                              icon: 'play',
+                          },
+                      ]
+                    : []
                 header = {
                     body: 'shell',
                     buttons,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -136,12 +136,21 @@ export class AgenticChatResultStream {
 
     /**
      * Overwrites a specific blockId and re-sends the resulting blocks to the client.
-     * @param result
-     * @param blockId
+     * @param messageId
      */
     async overwriteResultBlock(result: ChatMessage, blockId: number) {
         this.#state.chatResultBlocks[blockId] = result
         await this.#sendProgress(this.getResult(result.messageId))
+    }
+
+    /**
+     * Removes a specific messageId and re-sends the result to the client.
+     * @param result
+     * @param blockId
+     */
+    async removeResultBlock(messageId: string) {
+        this.#state.chatResultBlocks = this.#state.chatResultBlocks.filter(block => block.messageId !== messageId)
+        await this.#sendProgress(this.getResult(messageId))
     }
 
     getResultStreamWriter(): ResultStreamWriter {


### PR DESCRIPTION
… loading

## Problem
- thinking spinner is missing when tool execution in progress
- command is not shown to user in no approval required case when it should
## Solution
<img width="479" alt="Screenshot 2025-04-23 at 10 57 44 AM" src="https://github.com/user-attachments/assets/32978caf-82ae-411e-9768-393e416faa7f" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
