### PR TITLE
fix: falcon context file clicks

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1182,6 +1182,8 @@ export class AgenticChatController implements ChatHandlers {
                 isDeleted: false,
                 fileContent: toolUse.oldContent,
             })
+        } else if (toolUse?.name === 'fsRead') {
+            await this.#features.lsp.window.showDocument({ uri: params.filePath })
         } else {
             // handle prompt file outside of workspace
             if (params.filePath.endsWith(promptFileExtension)) {
@@ -1190,7 +1192,7 @@ export class AgenticChatController implements ChatHandlers {
                     absolutePath = path.join(getUserPromptsDirectory(), params.filePath)
                 }
             }
-            await this.#features.lsp.window.showDocument({ uri: params.filePath })
+            await this.#features.lsp.window.showDocument({ uri: absolutePath })
         }
     }
 


### PR DESCRIPTION
## Problem

Falcon context file clicks was broken by this change https://github.com/aws/language-servers/pull/1059

## Solution

Make the previous PR change for fsRead tool only

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
