### PR TITLE
fix: context transparency list not displayed

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1369,6 +1369,7 @@ export class AgenticChatController implements ChatHandlers {
         const chatEventParser = new AgenticChatEventParser(requestId, metric)
         const streamWriter = chatResultStream.getResultStreamWriter()
 
+        // Display context transparency list once at the beginning of response
         if (contextList) {
             await streamWriter.write({ body: '', contextList })
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1349,8 +1349,12 @@ export class AgenticChatController implements ChatHandlers {
         const chatEventParser = new AgenticChatEventParser(requestId, metric)
         const streamWriter = chatResultStream.getResultStreamWriter()
 
+        if (contextList) {
+            await streamWriter.write({ body: '', contextList })
+        }
+
         for await (const chatEvent of response.generateAssistantResponseResponse!) {
-            const result = chatEventParser.processPartialEvent(chatEvent, contextList)
+            const result = chatEventParser.processPartialEvent(chatEvent)
 
             // terminate early when there is an error
             if (!result.success) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -80,10 +80,7 @@ export class AgenticChatEventParser implements ChatResult {
         return this.#totalEvents
     }
 
-    public processPartialEvent(
-        chatEvent: ChatResponseStream,
-        contextList?: FileList
-    ): Result<ChatResultWithMetadata, string> {
+    public processPartialEvent(chatEvent: ChatResponseStream): Result<ChatResultWithMetadata, string> {
         const {
             messageMetadataEvent,
             followupPromptEvent,
@@ -113,9 +110,6 @@ export class AgenticChatEventParser implements ChatResult {
         } else if (invalidStateEvent) {
             this.error = invalidStateEvent.message ?? invalidStateEvent.reason ?? 'Invalid state'
         } else if (assistantResponseEvent?.content) {
-            if (contextList?.filePaths?.length) {
-                this.contextList = contextList
-            }
             this.#totalEvents.assistantResponseEvent += 1
             this.body = (this.body ?? '') + assistantResponseEvent.content
         } else if (toolUseEvent) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -84,6 +84,7 @@ export class AgenticChatResultStream {
                         ...acc,
                         buttons: [...(acc.buttons ?? []), ...(c.buttons ?? [])],
                         body: acc.body + AgenticChatResultStream.resultDelimiter + c.body,
+                        ...(c.contextList && { contextList: c.contextList }),
                     }
                 } else if (acc.additionalMessages!.some(am => am.messageId === c.messageId)) {
                     return {


### PR DESCRIPTION
## Problem
context transparency list was not being sent, due to changes to joinResults in https://github.com/aws/language-servers/pull/1039

## Solution
Send Context transparency list just once, at the beginning of the assistant response. This avoids conflicts between context transparency list and any context lists returned from assistant

https://github.com/user-attachments/assets/a28568f3-560a-4fa3-b9ce-c62a1af7d16f




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
