### PR TITLE
refactor: improve instance and index building logic

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1217,7 +1217,7 @@ export class AgenticChatController implements ChatHandlers {
     async onReady() {
         await this.#tabBarController.loadChats()
         try {
-            const localProjectContextController = await LocalProjectContextController.getInstance()
+            const localProjectContextController = LocalProjectContextController.getInstance()
             const contextItems = await localProjectContextController.getContextCommandItems()
             await this.#contextCommandsProvider.processContextCommandUpdate(contextItems)
             void this.#contextCommandsProvider.maybeUpdateCodeSymbols()

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
@@ -83,7 +83,7 @@ export class AdditionalContextProvider {
 
         let prompts: AdditionalContextPrompt[] = []
         try {
-            const localProjectContextController = await LocalProjectContextController.getInstance()
+            const localProjectContextController = LocalProjectContextController.getInstance()
             prompts = await localProjectContextController.getContextCommandPrompt(additionalContextCommands)
         } catch (error) {
             // do nothing

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -218,7 +218,7 @@ export class AgenticChatTriggerContext {
         prompt: string,
         chatResultStream?: AgenticChatResultStream
     ): Promise<RelevantTextDocumentAddition[]> {
-        const localProjectContextController = await LocalProjectContextController.getInstance()
+        const localProjectContextController = LocalProjectContextController.getInstance()
         if (!localProjectContextController.isEnabled && chatResultStream) {
             await chatResultStream.writeResultBlock({
                 body: `To add your workspace as context, enable local indexing in your IDE settings. After enabling, add @workspace to your question, and I'll generate a response using your workspace as context.`,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -171,11 +171,13 @@ export class ContextCommandsProvider implements Disposable {
     }
 
     async maybeUpdateCodeSymbols() {
-        const needUpdate = await (
-            await LocalProjectContextController.getInstance()
-        ).shouldUpdateContextCommandSymbolsOnce()
+        const controller = LocalProjectContextController.getInstance()
+        if (!controller) {
+            return
+        }
+        const needUpdate = await controller.shouldUpdateContextCommandSymbolsOnce()
         if (needUpdate) {
-            const items = await (await LocalProjectContextController.getInstance()).getContextCommandItems()
+            const items = await controller.getContextCommandItems()
             await this.processContextCommandUpdate(items)
         }
     }

--- a/server/aws-lsp-codewhisperer/src/shared/supplementalContextUtil/crossFileContextUtil.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/supplementalContextUtil/crossFileContextUtil.ts
@@ -144,9 +144,8 @@ export async function fetchProjectContext(
         target,
     }
 
-    try {
-        controller = await LocalProjectContextController.getInstance()
-    } catch (e) {
+    controller = LocalProjectContextController.getInstance()
+    if (!controller) {
         return []
     }
     return controller.queryInlineProjectContext(inlineProjectContextRequest)


### PR DESCRIPTION
## Problem
project context controller used an async getInstance method in order to allow consumers to wait on init process completion. This led to the case where an initialization failure would block a consumer calling getInstance the full length of the timeout, even when the failure was known up front.

## Solution
To address this, the getInstance logic has been moved into the constructor, to guarantee its existence and avoid deadlocking consumers for 60 seconds during a failure. Methods isIndexing and waitForIndexBuilt allow consumers the option to wait for index completion prior to executing their code path if need be.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
