### PR TITLE
fix: convert switch to checkbox for PPM mode

### DIFF
--- a/chat-client/src/client/texts/pairProgramming.ts
+++ b/chat-client/src/client/texts/pairProgramming.ts
@@ -15,7 +15,7 @@ export const programmerModeCard: ChatItem = {
 }
 
 export const pairProgrammingPromptInput: ChatItemFormItem = {
-    type: 'switch',
+    type: 'checkbox',
     id: 'pair-programmer-mode',
     tooltip: 'Turn off for read only responses',
     alternateTooltip: 'Turn on to allow Q to run commands and generate code diffs',


### PR DESCRIPTION
## Problem
The mode switch for pair programmer mode has to be checkbox instead of a switch component.

## Solution
Changed `switch` to `checkbox`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
