### PR TITLE
feat: support for project context in Q Chat

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.test.ts
@@ -1,0 +1,196 @@
+import { convertChunksToRelevantTextDocuments } from './relevantTextDocuments'
+import { Chunk } from 'local-indexing'
+import { RelevantTextDocument } from '@amzn/codewhisperer-streaming'
+import * as assert from 'assert'
+
+describe('relevantTextDocuments', () => {
+    it('converts empty array to empty array', () => {
+        const result = convertChunksToRelevantTextDocuments([])
+        assert.deepStrictEqual(result, [])
+    })
+
+    it('combines chunks from same file and sorts by startLine', () => {
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: 'second chunk',
+                startLine: 2,
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+            {
+                id: '2',
+                index: 1,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: 'first chunk',
+                startLine: 1,
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+        ]
+
+        const expected: RelevantTextDocument[] = [
+            {
+                relativeFilePath: 'src/test.ts',
+                programmingLanguage: { languageName: 'typescript' },
+                text: 'first chunk\nsecond chunk',
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.deepStrictEqual(result, expected)
+    })
+
+    it('handles chunks without startLine', () => {
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: 'chunk1',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+            {
+                id: '2',
+                index: 1,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: 'chunk2',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+        ]
+
+        const expected: RelevantTextDocument[] = [
+            {
+                relativeFilePath: 'src/test.ts',
+                programmingLanguage: { languageName: 'typescript' },
+                text: 'chunk1\nchunk2',
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.deepStrictEqual(result, expected)
+    })
+
+    it('handles unknown programming language', () => {
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test.txt',
+                relativePath: 'src/test.txt',
+                content: 'content',
+                programmingLanguage: 'unknown',
+                vec: [],
+            },
+        ]
+
+        const expected: RelevantTextDocument[] = [
+            {
+                relativeFilePath: 'src/test.txt',
+                text: 'content',
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.deepStrictEqual(result, expected)
+    })
+
+    it('filters out empty content', () => {
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: '',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+            {
+                id: '2',
+                index: 1,
+                filePath: 'test.ts',
+                relativePath: 'src/test.ts',
+                content: 'valid content',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+        ]
+
+        const expected: RelevantTextDocument[] = [
+            {
+                relativeFilePath: 'src/test.ts',
+                programmingLanguage: { languageName: 'typescript' },
+                text: 'valid content',
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.deepStrictEqual(result, expected)
+    })
+
+    it('truncates relative file path if too long', () => {
+        const longPath = 'a'.repeat(5000)
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test.ts',
+                relativePath: longPath,
+                content: 'content',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.strictEqual(result[0].relativeFilePath?.length, 4000)
+    })
+
+    it('handles multiple files', () => {
+        const chunks: Chunk[] = [
+            {
+                id: '1',
+                index: 0,
+                filePath: 'test1.ts',
+                relativePath: 'src/test1.ts',
+                content: 'content1',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+            {
+                id: '2',
+                index: 1,
+                filePath: 'test2.ts',
+                relativePath: 'src/test2.ts',
+                content: 'content2',
+                programmingLanguage: 'typescript',
+                vec: [],
+            },
+        ]
+
+        const expected: RelevantTextDocument[] = [
+            {
+                relativeFilePath: 'src/test1.ts',
+                programmingLanguage: { languageName: 'typescript' },
+                text: 'content1',
+            },
+            {
+                relativeFilePath: 'src/test2.ts',
+                programmingLanguage: { languageName: 'typescript' },
+                text: 'content2',
+            },
+        ]
+
+        const result = convertChunksToRelevantTextDocuments(chunks)
+        assert.deepStrictEqual(result, expected)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/tools/relevantTextDocuments.ts
@@ -1,0 +1,53 @@
+import { RelevantTextDocument } from '@amzn/codewhisperer-streaming'
+import { Chunk } from 'local-indexing'
+
+export function convertChunksToRelevantTextDocuments(chunks: Chunk[]): RelevantTextDocument[] {
+    const filePathSizeLimit = 4_000
+
+    const groupedChunks = chunks.reduce(
+        (acc, chunk) => {
+            const key = chunk.filePath
+            if (!acc[key]) {
+                acc[key] = []
+            }
+            acc[key].push(chunk)
+            return acc
+        },
+        {} as Record<string, Chunk[]>
+    )
+
+    return Object.entries(groupedChunks).map(([filePath, fileChunks]) => {
+        fileChunks.sort((a, b) => {
+            if (a.startLine !== undefined && b.startLine !== undefined) {
+                return a.startLine - b.startLine
+            }
+            return 0
+        })
+
+        const firstChunk = fileChunks[0]
+
+        let programmingLanguage
+        if (firstChunk.programmingLanguage && firstChunk.programmingLanguage !== 'unknown') {
+            programmingLanguage = {
+                languageName: firstChunk.programmingLanguage,
+            }
+        }
+
+        const combinedContent = fileChunks
+            .map(chunk => chunk.content)
+            .filter(content => content !== undefined && content !== '')
+            .join('\n')
+
+        const relevantTextDocument: RelevantTextDocument = {
+            relativeFilePath: firstChunk.relativePath
+                ? firstChunk.relativePath.substring(0, filePathSizeLimit)
+                : undefined,
+            programmingLanguage,
+            text: combinedContent || undefined,
+        }
+
+        return Object.fromEntries(
+            Object.entries(relevantTextDocument).filter(([_, value]) => value !== undefined)
+        ) as RelevantTextDocument
+    })
+}


### PR DESCRIPTION
## Problem
Chat requests currently are not set up to accept and include context in chat requests 
## Solution
Support hydrating any chat request containing @workspace command with local project context.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
