### PR TITLE
feat: add file search tool

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.test.ts
@@ -1,0 +1,211 @@
+import * as assert from 'assert'
+import { FileSearch } from './fileSearch'
+import { testFolder } from '@aws/lsp-core'
+import * as path from 'path'
+import * as fs from 'fs/promises'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+
+describe('FileSearch Tool', () => {
+    let tempFolder: testFolder.TestFolder
+    let testFeatures: TestFeatures
+
+    before(async () => {
+        testFeatures = new TestFeatures()
+        // @ts-ignore does not require all fs operations to be implemented
+        testFeatures.workspace.fs = {
+            exists: path =>
+                fs
+                    .access(path)
+                    .then(() => true)
+                    .catch(() => false),
+            readdir: path => fs.readdir(path, { withFileTypes: true }),
+        } as Features['workspace']['fs']
+        tempFolder = await testFolder.TestFolder.create()
+    })
+
+    after(async () => {
+        await tempFolder.delete()
+    })
+
+    it('invalidates empty path', async () => {
+        const fileSearch = new FileSearch(testFeatures)
+        await assert.rejects(
+            fileSearch.validate({ path: '', pattern: '.*' }),
+            /Path cannot be empty/i,
+            'Expected an error about empty path'
+        )
+    })
+
+    it('invalidates invalid regex pattern', async () => {
+        const fileSearch = new FileSearch(testFeatures)
+        await assert.rejects(
+            fileSearch.validate({ path: tempFolder.path, pattern: '[' }),
+            /Invalid regex pattern/i,
+            'Expected an error about invalid regex pattern'
+        )
+    })
+
+    it('invalidates negative maxDepth', async () => {
+        const fileSearch = new FileSearch(testFeatures)
+        await assert.rejects(
+            fileSearch.validate({ path: '~', pattern: '.*', maxDepth: -1 }),
+            /MaxDepth cannot be negative/i,
+            'Expected an error about negative maxDepth'
+        )
+    })
+
+    it('searches for files matching pattern', async () => {
+        await tempFolder.write('fileA.txt', 'fileA content')
+        await tempFolder.write('fileB.md', '# fileB content')
+        await tempFolder.write('fileC.js', 'console.log("fileC");')
+
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
+            path: tempFolder.path,
+            pattern: '\\.txt$',
+            maxDepth: 0,
+        })
+
+        assert.strictEqual(result.output.kind, 'text')
+        const lines = result.output.content.split('\n')
+        const hasFileA = lines.some(line => line.includes('[F] ') && line.includes('fileA.txt'))
+        const hasFileB = lines.some(line => line.includes('[F] ') && line.includes('fileB.md'))
+
+        assert.ok(hasFileA, 'Should find fileA.txt matching the pattern')
+        assert.ok(!hasFileB, 'Should not find fileB.md as it does not match the pattern')
+    })
+
+    it('searches recursively in subdirectories', async () => {
+        const subfolder = await tempFolder.nest('subfolder')
+        await tempFolder.write('fileA.txt', 'fileA content')
+        await subfolder.write('fileB.txt', 'fileB content')
+        await subfolder.write('fileC.md', '# fileC content')
+
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
+            path: tempFolder.path,
+            pattern: '\\.txt$',
+        })
+
+        assert.strictEqual(result.output.kind, 'text')
+        const lines = result.output.content.split('\n')
+        const hasFileA = lines.some(line => line.includes('[F] ') && line.includes('fileA.txt'))
+        const hasFileB = lines.some(line => line.includes('[F] ') && line.includes('fileB.txt'))
+        const hasFileC = lines.some(line => line.includes('[F] ') && line.includes('fileC.md'))
+
+        assert.ok(hasFileA, 'Should find fileA.txt in root directory')
+        assert.ok(hasFileB, 'Should find fileB.txt in subfolder')
+        assert.ok(!hasFileC, 'Should not find fileC.md as it does not match the pattern')
+    })
+
+    it('respects maxDepth parameter', async () => {
+        const subfolder1 = await tempFolder.nest('subfolder1')
+        const subfolder2 = await subfolder1.nest('subfolder2')
+
+        await tempFolder.write('root.txt', 'root content')
+        await subfolder1.write('level1.txt', 'level1 content')
+        await subfolder2.write('level2.txt', 'level2 content')
+
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
+            path: tempFolder.path,
+            pattern: '\\.txt$',
+            maxDepth: 1,
+        })
+
+        assert.strictEqual(result.output.kind, 'text')
+        const lines = result.output.content.split('\n')
+        const hasRootFile = lines.some(line => line.includes('[F] ') && line.includes('root.txt'))
+        const hasLevel1File = lines.some(line => line.includes('[F] ') && line.includes('level1.txt'))
+        const hasLevel2File = lines.some(line => line.includes('[F] ') && line.includes('level2.txt'))
+
+        assert.ok(hasRootFile, 'Should find root.txt in root directory')
+        assert.ok(hasLevel1File, 'Should find level1.txt in subfolder1')
+        assert.ok(!hasLevel2File, 'Should not find level2.txt as it exceeds maxDepth')
+    })
+
+    it('performs case-insensitive search by default', async () => {
+        await tempFolder.write('FileUpper.txt', 'upper case filename')
+        await tempFolder.write('fileLower.txt', 'lower case filename')
+
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
+            path: tempFolder.path,
+            pattern: 'file',
+            maxDepth: 0,
+        })
+
+        assert.strictEqual(result.output.kind, 'text')
+        const lines = result.output.content.split('\n')
+        const hasUpperFile = lines.some(line => line.includes('[F] ') && line.includes('FileUpper.txt'))
+        const hasLowerFile = lines.some(line => line.includes('[F] ') && line.includes('fileLower.txt'))
+
+        assert.ok(hasUpperFile, 'Should find FileUpper.txt with case-insensitive search')
+        assert.ok(hasLowerFile, 'Should find fileLower.txt with case-insensitive search')
+    })
+
+    it('performs case-sensitive search when specified', async () => {
+        await tempFolder.write('FileUpper.txt', 'upper case filename')
+        await tempFolder.write('fileLower.txt', 'lower case filename')
+
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
+            path: tempFolder.path,
+            pattern: 'file',
+            maxDepth: 0,
+            caseSensitive: true,
+        })
+
+        assert.strictEqual(result.output.kind, 'text')
+        const lines = result.output.content.split('\n')
+        const hasUpperFile = lines.some(line => line.includes('[F] ') && line.includes('FileUpper.txt'))
+        const hasLowerFile = lines.some(line => line.includes('[F] ') && line.includes('fileLower.txt'))
+
+        assert.ok(!hasUpperFile, 'Should not find FileUpper.txt with case-sensitive search')
+        assert.ok(hasLowerFile, 'Should find fileLower.txt with case-sensitive search')
+    })
+
+    it('ignores excluded directories', async () => {
+        const nodeModules = await tempFolder.nest('node_modules')
+        await tempFolder.write('regular.txt', 'regular content')
+        await nodeModules.write('excluded.txt', 'excluded content')
+
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
+            path: tempFolder.path,
+            pattern: '\\.txt$',
+        })
+
+        assert.strictEqual(result.output.kind, 'text')
+        const lines = result.output.content.split('\n')
+        const hasRegularFile = lines.some(line => line.includes('[F] ') && line.includes('regular.txt'))
+        const hasExcludedFile = lines.some(line => line.includes('[F] ') && line.includes('excluded.txt'))
+
+        assert.ok(hasRegularFile, 'Should find regular.txt in root directory')
+        assert.ok(!hasExcludedFile, 'Should not find excluded.txt in node_modules directory')
+    })
+
+    it('throws error if path does not exist', async () => {
+        const missingPath = path.join(tempFolder.path, 'no_such_directory')
+        const fileSearch = new FileSearch(testFeatures)
+
+        await assert.rejects(
+            fileSearch.invoke({ path: missingPath, pattern: '.*' }),
+            /Failed to search directory/i,
+            'Expected an error about non-existent path'
+        )
+    })
+
+    it('expands ~ path', async () => {
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
+            path: '~',
+            pattern: '.*',
+            maxDepth: 0,
+        })
+
+        assert.strictEqual(result.output.kind, 'text')
+        assert.ok(result.output.content.length > 0)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.ts
@@ -1,0 +1,142 @@
+// FileSearch tool based on ListDirectory implementation
+import { CommandValidation, InvokeOutput, validatePath } from './toolShared'
+import { workspaceUtils } from '@aws/lsp-core'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { sanitize } from '@aws/lsp-core/out/util/path'
+import { DEFAULT_EXCLUDE_PATTERNS } from '../../chat/constants'
+import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
+
+export interface FileSearchParams {
+    path: string
+    pattern: string
+    maxDepth?: number
+    caseSensitive?: boolean
+}
+
+export class FileSearch {
+    private readonly logging: Features['logging']
+    private readonly workspace: Features['workspace']
+    private readonly lsp: Features['lsp']
+
+    constructor(features: Pick<Features, 'logging' | 'workspace' | 'lsp'>) {
+        this.logging = features.logging
+        this.workspace = features.workspace
+        this.lsp = features.lsp
+    }
+
+    public async validate(params: FileSearchParams): Promise<void> {
+        if (params.maxDepth !== undefined && params.maxDepth < 0) {
+            throw new Error('MaxDepth cannot be negative.')
+        }
+        await validatePath(params.path, this.workspace.fs.exists)
+
+        // Validate regex pattern
+        try {
+            new RegExp(params.pattern, params.caseSensitive ? '' : 'i')
+        } catch (error) {
+            throw new Error(`Invalid regex pattern: ${(error as Error).message}`)
+        }
+    }
+
+    public async queueDescription(params: FileSearchParams, updates: WritableStream, requiresAcceptance: boolean) {
+        const writer = updates.getWriter()
+        const closeWriter = async (w: WritableStreamDefaultWriter) => {
+            await w.close()
+            w.releaseLock()
+        }
+        if (!requiresAcceptance) {
+            await writer.write('')
+            await closeWriter(writer)
+            return
+        }
+
+        const caseSensitiveText = params.caseSensitive ? 'case-sensitive' : 'case-insensitive'
+        if (params.maxDepth === undefined) {
+            await writer.write(
+                `Searching recursively in ${params.path} for files matching pattern "${params.pattern}" (${caseSensitiveText})`
+            )
+        } else if (params.maxDepth === 0) {
+            await writer.write(
+                `Searching in ${params.path} for files matching pattern "${params.pattern}" (${caseSensitiveText})`
+            )
+        } else {
+            const level = params.maxDepth > 1 ? 'levels' : 'level'
+            await writer.write(
+                `Searching in ${params.path} limited to ${params.maxDepth} subfolder ${level} for files matching pattern "${params.pattern}" (${caseSensitiveText})`
+            )
+        }
+        await closeWriter(writer)
+    }
+
+    public async requiresAcceptance(params: FileSearchParams): Promise<CommandValidation> {
+        return { requiresAcceptance: !workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), params.path) }
+    }
+
+    public async invoke(params: FileSearchParams): Promise<InvokeOutput> {
+        const path = sanitize(params.path)
+        try {
+            // Get all files and directories
+            const listing = await workspaceUtils.readDirectoryRecursively(
+                { workspace: this.workspace, logging: this.logging },
+                path,
+                { maxDepth: params.maxDepth, excludePatterns: DEFAULT_EXCLUDE_PATTERNS }
+            )
+
+            // Create regex pattern for filtering
+            const regex = new RegExp(params.pattern, params.caseSensitive ? '' : 'i')
+
+            // Filter the results based on the pattern
+            const filteredResults = listing.filter(item => regex.test(item))
+
+            if (filteredResults.length === 0) {
+                return this.createOutput(`No files matching pattern "${params.pattern}" found in ${path}`)
+            }
+
+            return this.createOutput(filteredResults.join('\n'))
+        } catch (error: any) {
+            this.logging.error(`Failed to search directory "${path}": ${error.message || error}`)
+            throw new Error(`Failed to search directory "${path}": ${error.message || error}`)
+        }
+    }
+
+    private createOutput(content: string): InvokeOutput {
+        return {
+            output: {
+                kind: 'text',
+                content: content,
+            },
+        }
+    }
+
+    public getSpec() {
+        return {
+            name: 'fileSearch',
+            description:
+                'Search for files in a directory and its subdirectories using regex patterns. It filters out build outputs such as `build/`, `out/` and `dist` and dependency directories such as `node_modules/`.\n * Results are filtered by the provided regex pattern.\n * Case sensitivity can be controlled with the caseSensitive parameter.\n * Results clearly distinguish between files, directories or symlinks with [F], [D] and [L] prefixes.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    path: {
+                        type: 'string',
+                        description: 'Absolute path to a directory, e.g., `/repo`.',
+                    },
+                    pattern: {
+                        type: 'string',
+                        description: 'Regex pattern to match against file and directory names.',
+                    },
+                    maxDepth: {
+                        type: 'number',
+                        description:
+                            'Maximum depth to traverse when searching directories. Use `0` to search only the specified directory, `1` to include immediate subdirectories, etc. If it is not provided, it will search all subdirectories recursively.',
+                    },
+                    caseSensitive: {
+                        type: 'boolean',
+                        description:
+                            'Whether the pattern matching should be case-sensitive. Defaults to false if not provided.',
+                    },
+                },
+                required: ['path', 'pattern'],
+            },
+        } as const
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -8,11 +8,13 @@ import { LspReadDocumentContents, LspReadDocumentContentsParams } from './lspRea
 import { LspApplyWorkspaceEdit, LspApplyWorkspaceEditParams } from './lspApplyWorkspaceEdit'
 import { McpManager } from './mcp/mcpManager'
 import { McpTool } from './mcp/mcpTool'
+import { FileSearch, FileSearchParams } from './fileSearch'
 
 export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     const fsReadTool = new FsRead({ workspace, lsp, logging })
     const fsWriteTool = new FsWrite({ workspace, lsp, logging })
     const listDirectoryTool = new ListDirectory({ workspace, logging, lsp })
+    const fileSearchTool = new FileSearch({ workspace, logging, lsp })
 
     agent.addTool(fsReadTool.getSpec(), async (input: FsReadParams) => {
         // TODO: fill in logic for handling invalid tool invocations
@@ -31,6 +33,8 @@ export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     agent.addTool(listDirectoryTool.getSpec(), (input: ListDirectoryParams, token?: CancellationToken) =>
         listDirectoryTool.invoke(input, token)
     )
+
+    agent.addTool(fileSearchTool.getSpec(), (input: FileSearchParams) => fileSearchTool.invoke(input))
 
     return () => {}
 }


### PR DESCRIPTION

## Problem
Adding the file search tool to support search a directory/subdirectory by regex patterns
## Solution
Adding the file search tool to support search a directory/subdirectory by regex patterns

![Screenshot 2025-04-23 at 4 08 59 PM](https://github.com/user-attachments/assets/57c159ee-152c-4762-be5e-e9e93a046cd3)
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
