### PR TITLE
feat: add param to listDirectory for pattern

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
@@ -105,6 +105,27 @@ describe('ListDirectory Tool', () => {
         assert.ok(!hasFileC, 'Should not list fileC.md under node_modules in the directory output')
     })
 
+    it('lists directory contents with pattern argument', async () => {
+        await tempFolder.write('testZZZfile', 'some content')
+        await tempFolder.write('anotherZZZtest', 'some content')
+        await tempFolder.write('anotherZtest', 'some content')
+
+        const listDirectory = new ListDirectory(testFeatures)
+        await listDirectory.validate({ path: tempFolder.path, pattern: /.*ZZZ.*/ })
+        const result = await listDirectory.invoke({ path: tempFolder.path, pattern: /.*ZZZ.*/ })
+
+        assert.strictEqual(result.output.kind, 'text')
+        const lines = result.output.content.split('\n')
+        const hasFile = (f: string) => lines.some((l: string) => l.includes('[F] ') && l.includes(f))
+
+        assert.ok(!hasFile('testZZZfile'), 'Should not list testZZZfile in the directory output')
+        assert.ok(
+            !hasFile('anotherZZZtest'),
+            'Should not list anotherZZZtest under node_modules in the directory output'
+        )
+        assert.ok(hasFile('anotherZtest'), 'Should list anotherZtest under node_modules in the directory output')
+    })
+
     it('throws error if path does not exist', async () => {
         const missingPath = path.join(tempFolder.path, 'no_such_file.txt')
         const listDirectory = new ListDirectory(testFeatures)


### PR DESCRIPTION
## Problem
Alternative approach to https://github.com/aws/language-servers/pull/1074

## Solution
- add an optional parameter to listDirectory that applies a regex pattern. 

## Testing
Just started testing, but seeing solid results. 
<img width="546" alt="image" src="https://github.com/user-attachments/assets/155256fb-9148-4b80-ad54-be2b9bf8a480" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
