### PR TITLE
fix: add result attribute when emitting amazonq_toolUseSuggested tele…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -177,6 +177,7 @@ export class ChatTelemetryController {
                 credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
                 cwsprToolName: toolUse.name ?? '',
                 cwsprToolUseId: toolUse.toolUseId ?? '',
+                result: 'Succeeded',
             },
         })
     }


### PR DESCRIPTION
## Problem
Newly introduced telemetry event type `amazonq_toolUseSuggested`  is missing a `result` attribute, causing a warning in the VSCode logs:

```
[warning] telemetry: invalid Metric: "amazonq_exitFocusChat" emitted without the `result` property, which is always required. Consider using `.run()` instead of `.emit()`, which will set these properties automatically. See https://github.com/aws/aws-toolkit-vscode/blob/master/docs/telemetry.md#guidelines
```

This was done for the event types in https://github.com/aws/language-servers/pull/1088, before event type `amazonq_toolUseSuggested` was introduced

## Solution
Add `result: 'Succeeded'` to the data when telemetry metrics are emitted

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
