### PR TITLE
feat: add the grepSearch tool

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -496,7 +496,9 @@ export const createMynahUi = (
                                             ? ''
                                             : `line ${range.first} - ${range.second}`
                                     )
-                                    .join(', ') || '',
+                                    .join(', ') || fileDetails.description
+                                    ? fileDetails.description
+                                    : '',
                             description: filePath,
                             clickable: true,
                         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9612,6 +9612,18 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@vscode/ripgrep": {
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.11.tgz",
+            "integrity": "sha512-G/VqtA6kR50mJkIH4WA+I2Q78V5blovgPPq0VPYM0QIRp57lYMkdV+U9VrY80b3AvaC72A1z8STmyxc8ZKiTsw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "https-proxy-agent": "^7.0.2",
+                "proxy-from-env": "^1.1.0",
+                "yauzl": "^2.9.2"
+            }
+        },
         "node_modules/@wdio/cli": {
             "version": "9.12.7",
             "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.12.7.tgz",
@@ -15456,7 +15468,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "pend": "~1.2.0"
@@ -21194,7 +21205,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -26823,7 +26833,6 @@
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
@@ -26834,7 +26843,6 @@
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -27017,6 +27025,7 @@
                 "@aws/lsp-core": "^0.0.3",
                 "@modelcontextprotocol/sdk": "^1.9.0",
                 "@smithy/node-http-handler": "^2.5.0",
+                "@vscode/ripgrep": "^1.15.11",
                 "adm-zip": "^0.5.10",
                 "archiver": "^7.0.1",
                 "aws-sdk": "^2.1403.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -52,7 +52,8 @@
         "shlex": "2.1.2",
         "uuid": "^11.0.5",
         "vscode-uri": "^3.1.0",
-        "@modelcontextprotocol/sdk": "^1.9.0"
+        "@modelcontextprotocol/sdk": "^1.9.0",
+        "@vscode/ripgrep": "^1.15.11"
     },
     "devDependencies": {
         "@types/adm-zip": "^0.5.5",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/grepSearch.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/grepSearch.test.ts
@@ -1,0 +1,222 @@
+import { strict as assert } from 'assert'
+import * as mockfs from 'mock-fs'
+import * as sinon from 'sinon'
+import { GrepSearch } from './grepSearch'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { URI } from 'vscode-uri'
+import { InitializeParams } from '@aws/language-server-runtimes/protocol'
+import * as path from 'path'
+import * as childProcess from '@aws/lsp-core/out/util/processUtils'
+
+describe('GrepSearch Tool', () => {
+    let features: TestFeatures
+    const workspaceFolder = '/workspace/folder'
+    let mockChildProcess: sinon.SinonStub
+
+    before(function () {
+        features = new TestFeatures()
+        features.lsp.getClientInitializeParams.returns({
+            workspaceFolders: [{ uri: URI.file(workspaceFolder).toString(), name: 'test' }],
+        } as InitializeParams)
+    })
+
+    beforeEach(() => {
+        mockfs.restore()
+        // Create a mock file system structure for testing
+        mockfs({
+            [workspaceFolder]: {
+                'file1.txt': 'This is a test file with searchable content',
+                'file2.js': 'function test() { return "searchable"; }',
+                node_modules: {
+                    'excluded.js': 'This should be excluded by default',
+                },
+                subfolder: {
+                    'file3.ts': 'const searchable = "found in subfolder";',
+                },
+            },
+        })
+
+        // Mock the ChildProcess class
+        mockChildProcess = sinon.stub(childProcess, 'ChildProcess')
+        mockChildProcess.returns({
+            run: sinon.stub().resolves({
+                exitCode: 0,
+                stdout: `${workspaceFolder}/file1.txt:1:This is a test file with searchable content
+${workspaceFolder}/file2.js:1:function test() { return "searchable"; }
+${workspaceFolder}/subfolder/file3.ts:1:const searchable = "found in subfolder";`,
+            }),
+        })
+    })
+
+    afterEach(() => {
+        mockfs.restore()
+        sinon.restore()
+    })
+
+    it('fails validation if the query is empty', async () => {
+        const grepSearch = new GrepSearch(features)
+        await assert.rejects(
+            grepSearch.validate({ query: '   ' }),
+            /Grep search query cannot be empty/i,
+            'Expected an error for empty query'
+        )
+    })
+
+    it('requires acceptance if the path is outside the workspace', async () => {
+        const grepSearch = new GrepSearch(features)
+        const result = await grepSearch.requiresAcceptance({ query: 'test', path: '/outside/workspace' })
+        assert.equal(result.requiresAcceptance, true, 'Should require acceptance for path outside workspace')
+    })
+
+    it('does not require acceptance if the path is inside the workspace', async () => {
+        const grepSearch = new GrepSearch(features)
+        const result = await grepSearch.requiresAcceptance({ query: 'test', path: workspaceFolder })
+        assert.equal(result.requiresAcceptance, false, 'Should not require acceptance for path inside workspace')
+    })
+
+    it('uses workspace folder as default path if none provided', async () => {
+        const grepSearch = new GrepSearch(features)
+        const result = await grepSearch.invoke({ query: 'searchable' })
+
+        assert.strictEqual(result.output.kind, 'json')
+        const content = result.output.content as any
+        assert.ok('totalMatchCount' in content)
+        assert.ok('fileMatches' in content)
+        assert.equal(content.totalMatchCount, 3)
+        assert.equal(content.fileMatches.length, 3)
+    })
+
+    it('processes ripgrep output correctly', async () => {
+        // Set up specific mock output
+        mockChildProcess.returns({
+            run: sinon.stub().resolves({
+                exitCode: 0,
+                stdout: `${workspaceFolder}/file1.txt:1:match in line 1
+${workspaceFolder}/file1.txt:3:match in line 3
+${workspaceFolder}/file2.js:5:another match`,
+            }),
+        })
+
+        const grepSearch = new GrepSearch(features)
+        const result = await grepSearch.invoke({ query: 'match' })
+
+        assert.strictEqual(result.output.kind, 'json')
+        const content = result.output.content as any
+
+        assert.equal(content.totalMatchCount, 3)
+        assert.equal(content.fileMatches.length, 2)
+
+        // Check file1.txt matches
+        const file1Matches = content.fileMatches.find((f: any) => f.filePath === `${workspaceFolder}/file1.txt`)
+        assert.ok(file1Matches)
+        assert.equal(file1Matches.matchCount, 2)
+        assert.equal(file1Matches.matches['1'], 'match in line 1')
+        assert.equal(file1Matches.matches['3'], 'match in line 3')
+
+        // Check file2.js matches
+        const file2Matches = content.fileMatches.find((f: any) => f.filePath === `${workspaceFolder}/file2.js`)
+        assert.ok(file2Matches)
+        assert.equal(file2Matches.matchCount, 1)
+        assert.equal(file2Matches.matches['5'], 'another match')
+    })
+
+    it('handles empty search results', async () => {
+        mockChildProcess.returns({
+            run: sinon.stub().resolves({
+                exitCode: 1, // ripgrep returns 1 when no matches found
+                stdout: '',
+            }),
+        })
+
+        const grepSearch = new GrepSearch(features)
+        const result = await grepSearch.invoke({ query: 'nonexistent' })
+
+        assert.strictEqual(result.output.kind, 'json')
+        const content = result.output.content as any
+
+        assert.equal(content.totalMatchCount, 0)
+        assert.equal(content.fileMatches.length, 0)
+    })
+
+    it('respects case sensitivity option', async () => {
+        const grepSearch = new GrepSearch(features)
+        await grepSearch.invoke({ query: 'test', caseSensitive: true })
+
+        // Verify that -i flag is NOT included when caseSensitive is true
+        const args = mockChildProcess.firstCall.args[1]
+        assert.ok(!args.includes('-i'))
+    })
+
+    it('applies include patterns correctly', async () => {
+        const grepSearch = new GrepSearch(features)
+        await grepSearch.invoke({
+            query: 'test',
+            includePattern: '*.js,*.ts',
+        })
+
+        // Verify that the ChildProcess constructor was called
+        assert.ok(mockChildProcess.called, 'ChildProcess constructor should be called')
+
+        // Get all arguments passed to the constructor
+        const allArgs = mockChildProcess.firstCall.args
+
+        // The second argument should be the array of command line arguments
+        const args = allArgs[2]
+
+        // Check if --glob is included in the arguments
+        assert.ok(Array.isArray(args), 'args should be an array')
+        assert.ok(args.includes('--glob'), '--glob should be included in arguments')
+
+        // Find all glob patterns
+        const globIndices = []
+        for (let i = 0; i < args.length; i++) {
+            if (args[i] === '--glob') {
+                globIndices.push(i)
+            }
+        }
+
+        // Check if at least one of the glob patterns is for include (not starting with !)
+        const hasIncludePattern = globIndices.some(
+            i => i + 1 < args.length && (args[i + 1] === '*.js' || args[i + 1] === '*.ts')
+        )
+
+        assert.ok(hasIncludePattern, 'Should have include pattern for *.js or *.ts')
+    })
+
+    it('applies exclude patterns correctly', async () => {
+        const grepSearch = new GrepSearch(features)
+        await grepSearch.invoke({
+            query: 'test',
+            excludePattern: '*.min.js,*.d.ts',
+        })
+
+        // Verify that the ChildProcess constructor was called
+        assert.ok(mockChildProcess.called, 'ChildProcess constructor should be called')
+
+        // Get all arguments passed to the constructor
+        const allArgs = mockChildProcess.firstCall.args
+
+        // The second argument should be the array of command line arguments
+        const args = allArgs[2]
+
+        // Check if --glob is included in the arguments
+        assert.ok(Array.isArray(args), 'args should be an array')
+        assert.ok(args.includes('--glob'), '--glob should be included in arguments')
+
+        // Find all glob patterns
+        const globIndices = []
+        for (let i = 0; i < args.length; i++) {
+            if (args[i] === '--glob') {
+                globIndices.push(i)
+            }
+        }
+
+        // Check if at least one of the glob patterns is for exclude (not starting with !)
+        const hasExcludePattern = globIndices.some(
+            i => i + 1 < args.length && (args[i + 1] === '!*.min.js' || args[i + 1] === '!*.d.ts')
+        )
+
+        assert.ok(hasExcludePattern, 'Should have exclude pattern for *.js or *.ts')
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/grepSearch.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/grepSearch.ts
@@ -1,0 +1,298 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { CommandValidation, InvokeOutput, validatePath } from './toolShared'
+import { CancellationError, workspaceUtils } from '@aws/lsp-core'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
+import { CancellationToken } from '@aws/language-server-runtimes/protocol'
+import { DEFAULT_EXCLUDE_PATTERNS } from '../../chat/constants'
+import { ChildProcess, ChildProcessOptions } from '@aws/lsp-core/out/util/processUtils'
+import { rgPath } from '@vscode/ripgrep'
+import path = require('path')
+
+export interface GrepSearchParams {
+    path?: string
+    query: string
+    caseSensitive?: boolean
+    excludePattern?: string
+    includePattern?: string
+}
+
+/**
+ * Represents the structured output from ripgrep search results
+ */
+export interface SanitizedRipgrepOutput {
+    /** Total number of matches across all files */
+    totalMatchCount: number
+
+    /** Array of file match details */
+    fileMatches: Array<{
+        /** Full path to the file */
+        filePath: string
+
+        /** Number of matches in this file */
+        matchCount: number
+
+        /** Record of line numbers to matched content */
+        matches: Record<string, string>
+    }>
+}
+
+export class GrepSearch {
+    private readonly logging: Features['logging']
+    private readonly workspace: Features['workspace']
+    private readonly lsp: Features['lsp']
+
+    constructor(features: Pick<Features, 'logging' | 'workspace' | 'lsp'>) {
+        this.logging = features.logging
+        this.workspace = features.workspace
+        this.lsp = features.lsp
+    }
+
+    public async validate(params: GrepSearchParams): Promise<void> {
+        if (!params.query || params.query.trim().length === 0) {
+            throw new Error('Grep search query cannot be empty.')
+        }
+
+        const path = this.getSearchDirectory(params.path)
+        if (path.trim().length === 0) {
+            throw new Error('Path cannot be empty or no workspace folder is available.')
+        }
+
+        await validatePath(path, this.workspace.fs.exists)
+    }
+
+    public async queueDescription(params: GrepSearchParams, updates: WritableStream, requiresAcceptance: boolean) {
+        const writer = updates.getWriter()
+        const closeWriter = async (w: WritableStreamDefaultWriter) => {
+            await w.close()
+            w.releaseLock()
+        }
+        if (!requiresAcceptance) {
+            await writer.write('')
+            await closeWriter(writer)
+            return
+        }
+        await writer.write(`Searching for \"${params.query}\" in ${params.path || 'workspace'}`)
+        await closeWriter(writer)
+    }
+
+    public async requiresAcceptance(params: GrepSearchParams): Promise<CommandValidation> {
+        const path = this.getSearchDirectory(params.path)
+        return { requiresAcceptance: !workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), path) }
+    }
+
+    public async invoke(params: GrepSearchParams, token?: CancellationToken): Promise<InvokeOutput> {
+        const path = this.getSearchDirectory(params.path)
+        try {
+            const results = await this.executeRipgrep(params, path, token)
+            return this.createOutput(results)
+        } catch (error: any) {
+            if (CancellationError.isUserCancelled(error)) {
+                // bubble this up to the main agentic chat loop
+                throw error
+            }
+            this.logging.error(`Failed to search in \"${path}\": ${error.message || error}`)
+            throw new Error(`Failed to search in \"${path}\": ${error.message || error}`)
+        }
+    }
+
+    private getSearchDirectory(path?: string): string {
+        if (path && path.trim().length !== 0) {
+            return path
+        }
+
+        // Use current workspace folder as default if path is not provided
+        const workspaceFolders = getWorkspaceFolderPaths(this.lsp)
+        if (workspaceFolders && workspaceFolders.length !== 0) {
+            this.logging.debug(`Using default workspace folder: ${workspaceFolders[0]}`)
+            return workspaceFolders[0]
+        }
+
+        return ''
+    }
+
+    private async executeRipgrep(
+        params: GrepSearchParams,
+        path: string,
+        token?: CancellationToken
+    ): Promise<SanitizedRipgrepOutput> {
+        return new Promise(async (resolve, reject) => {
+            const args: string[] = []
+
+            // Add search options
+            if (!(params.caseSensitive ?? false)) {
+                args.push('-i') // Case insensitive search
+            }
+            args.push('--line-number') // Show line numbers
+
+            // No heading (don't group matches by file)
+            args.push('--no-heading')
+
+            // Don't use color in output
+            args.push('--color', 'never')
+
+            // Limit results to prevent overwhelming output
+            args.push('--max-count', '50')
+
+            // Add include/exclude patterns
+            if (params.includePattern) {
+                // Support multiple include patterns
+                const patterns = params.includePattern.split(',')
+                for (const pattern of patterns) {
+                    args.push('--glob', pattern.trim())
+                }
+            }
+
+            if (params.excludePattern) {
+                // Support multiple exclude patterns
+                const patterns = params.excludePattern.split(',')
+                for (const pattern of patterns) {
+                    args.push('--glob', `!${pattern.trim()}`)
+                }
+            }
+
+            // Add default exclude patterns
+            for (const pattern of DEFAULT_EXCLUDE_PATTERNS) {
+                args.push('--glob', `!${pattern}`)
+            }
+
+            // Add search pattern and path
+            args.push(params.query, path)
+
+            this.logging.debug(`Executing ripgrep with args: ${args.join(' ')}`)
+
+            const options: ChildProcessOptions = {
+                collect: true,
+                logging: 'yes',
+                rejectOnErrorCode: code => {
+                    if (code !== 0 && code !== 1) {
+                        this.logging.error(`Ripgrep process exited with code ${code}`)
+                        return new Error(`Ripgrep process exited with code ${code}`)
+                    }
+                    // For exit codes 0 and 1, don't reject
+                    return false as unknown as Error
+                },
+            }
+
+            try {
+                const rg = new ChildProcess(this.logging, rgPath, args, options)
+
+                const result = await rg.run()
+                this.logging.info(`Ripgrep search completed with exit code: ${result.exitCode}`)
+
+                // Process the output to format with file URLs and content previews
+                const sanitizedOutput = this.processRipgrepOutput(result.stdout)
+                resolve(sanitizedOutput)
+            } catch (err) {
+                reject(err)
+            }
+        })
+    }
+
+    /**
+     * Process ripgrep output to:
+     * 1. Group results by file
+     * 2. Return structured match details for each file
+     */
+    private processRipgrepOutput(output: string): SanitizedRipgrepOutput {
+        if (!output || output.trim() === '') {
+            return {
+                totalMatchCount: 0,
+                fileMatches: [],
+            }
+        }
+        const lines = output.split('\n')
+        // Group by file path
+        const fileGroups: Record<string, { lineNumbers: string[]; content: string[] }> = {}
+        let totalMatchCount = 0
+        for (const line of lines) {
+            if (!line || line.trim() === '') {
+                continue
+            }
+            // Extract file path, line number, and content
+            const parts = line.split(':')
+            if (parts.length < 3) {
+                continue
+            }
+            const filePath = parts[0]
+            const lineNumber = parts[1]
+            const content = parts.slice(2).join(':').trim()
+            if (!fileGroups[filePath]) {
+                fileGroups[filePath] = { lineNumbers: [], content: [] }
+            }
+            fileGroups[filePath].lineNumbers.push(lineNumber)
+            fileGroups[filePath].content.push(content)
+            totalMatchCount++
+        }
+        // Sort files by match count (most matches first)
+        const sortedFiles = Object.entries(fileGroups).sort((a, b) => b[1].lineNumbers.length - a[1].lineNumbers.length)
+        // Create structured file matches
+        const fileMatches = sortedFiles.map(([filePath, data]) => {
+            const matchCount = data.lineNumbers.length
+            // Create a regular object instead of a Map for better JSON serialization
+            const matches: Record<string, string> = {}
+            for (const [idx, lineNum] of data.lineNumbers.entries()) {
+                matches[lineNum] = data.content[idx]
+            }
+
+            return {
+                filePath,
+                matchCount,
+                matches,
+            }
+        })
+
+        return {
+            totalMatchCount,
+            fileMatches,
+        }
+    }
+
+    private createOutput(content: SanitizedRipgrepOutput): InvokeOutput {
+        return {
+            output: {
+                kind: 'json',
+                content: content,
+            },
+        }
+    }
+
+    public getSpec() {
+        return {
+            name: 'grepSearch',
+            description:
+                'Search for text content in files within a directory and its subdirectories. It filters out build outputs such as `build/`, `out/` and `dist` and dependency directories such as `node_modules/`.\n * Results include file paths, line numbers, and matching content.\n * Case sensitivity can be controlled with the caseSensitive parameter.\n * Include and exclude patterns can be specified to narrow down the search scope.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    path: {
+                        type: 'string',
+                        description:
+                            'Absolute path to a directory to search in, e.g., `/repo`. If not provided, the current workspace folder will be used.',
+                    },
+                    query: {
+                        type: 'string',
+                        description: 'The text pattern to search for in files.',
+                    },
+                    caseSensitive: {
+                        type: 'boolean',
+                        description: 'Whether the search should be case-sensitive. Defaults to false if not provided.',
+                    },
+                    includePattern: {
+                        type: 'string',
+                        description: 'Comma-separated glob patterns to include in the search, e.g., "*.js,*.ts".',
+                    },
+                    excludePattern: {
+                        type: 'string',
+                        description:
+                            'Comma-separated glob patterns to exclude from the search, e.g., "*.min.js,*.d.ts".',
+                    },
+                },
+                required: ['query'],
+            },
+        } as const
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -8,11 +8,13 @@ import { LspReadDocumentContents, LspReadDocumentContentsParams } from './lspRea
 import { LspApplyWorkspaceEdit, LspApplyWorkspaceEditParams } from './lspApplyWorkspaceEdit'
 import { McpManager } from './mcp/mcpManager'
 import { McpTool } from './mcp/mcpTool'
+import { GrepSearch, GrepSearchParams } from './grepSearch'
 
 export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     const fsReadTool = new FsRead({ workspace, lsp, logging })
     const fsWriteTool = new FsWrite({ workspace, lsp, logging })
     const listDirectoryTool = new ListDirectory({ workspace, logging, lsp })
+    const grepSearchTool = new GrepSearch({ workspace, logging, lsp })
 
     agent.addTool(fsReadTool.getSpec(), async (input: FsReadParams) => {
         // TODO: fill in logic for handling invalid tool invocations
@@ -30,6 +32,10 @@ export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
 
     agent.addTool(listDirectoryTool.getSpec(), (input: ListDirectoryParams, token?: CancellationToken) =>
         listDirectoryTool.invoke(input, token)
+    )
+
+    agent.addTool(grepSearchTool.getSpec(), (input: GrepSearchParams, token?: CancellationToken) =>
+        grepSearchTool.invoke(input, token)
     )
 
     return () => {}


### PR DESCRIPTION
## Problem
## Solution
 1. adding the grepSearch tool to support search for text content in files within a directory and its subdirectories. 
 2. using the vscode-ripgrep npm module to implement the tool: https://github.com/microsoft/vscode-ripgrep
 3. tested the tool local E2E, check the following screenshot
<img width="405" alt="Screenshot 2025-04-23 at 9 57 06 PM" src="https://github.com/user-attachments/assets/ed79e36b-145b-4a87-ae0a-e0a4a7982d08" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
