### PR TITLE
fix: add formatChatHistoryMessage to chatDb

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -314,6 +314,7 @@ export class ChatDatabase {
             const tabTitle =
                 (message.type === 'prompt' && message.body.trim().length > 0 ? message.body : tabData?.title) ||
                 'Amazon Q Chat'
+            message = this.formatChatHistoryMessage(message)
             if (tabData) {
                 this.#features.logging.log(`Updating existing tab with historyId=${historyId}`)
                 tabData.conversations = updateOrCreateConversation(
@@ -337,6 +338,19 @@ export class ChatDatabase {
                 })
             }
         }
+    }
+
+    formatChatHistoryMessage(message: Message): Message {
+        if (message.type === ('prompt' as ChatItemType)) {
+            return {
+                ...message,
+                userInputMessageContext: {
+                    // Only keep toolResults in history
+                    toolResults: message.userInputMessageContext?.toolResults,
+                },
+            }
+        }
+        return message
     }
 
     /**


### PR DESCRIPTION
## Related Code on Agentic Chat
https://github.com/aws/aws-toolkit-vscode/blob/feature/agentic-chat/packages/core/src/shared/db/chatDb/chatDb.ts#L298

## Problem
We only need the toolResult in the userMessageContext. This is causing validation exceptions as we are not taking the other fields into account when calculating the character count in the history



## Solution
Only store the toolResult in userMessageContext


## Testing
Verified that the history file now only stores toolResult in userMessageContext:

```
"messages": [
                    {
                        "body": "run ls &amp;&amp; pwd",
                        "type": "prompt",
                        "origin": "IDE",
                        "userInputMessageContext": {}
                    },
                    {
                        "body": "I'll run the `ls` command to list the files in the current directory and then `pwd` to show the current working directory.",
                        "type": "answer",
                        "toolUses": [
                            {
                                "toolUseId": "tooluse_eFrk87EMQ9GSwENNdhvhvw",
                                "name": "executeBash",
                                "input": {
                                    "command": "ls && pwd",
                                    "cwd": "/Users/tsmithsz/Downloads/Metrics",
                                    "explanation": "Running ls to list files and pwd to show the current working directory"
                                }
                            }
                        ]
                    },
                    {
                        "body": "",
                        "type": "prompt",
                        "origin": "IDE",
                        "userInputMessageContext": {
                            "toolResults": [
                                {
                                    "toolUseId": "tooluse_eFrk87EMQ9GSwENNdhvhvw",
                                    "status": "success",
                                    "content": [
                                        {
                                            "json": {
                                                "output": {
                                                    "kind": "json",
                                                    "content": {
                                                        "exitStatus": "0",
                                                        "stdout": "AmazonQ.md\nREADME.md\nSYSTEMPROMPTOVERRIDE.md\ncontroller.ts\ndata\ndata_transform\ninfra\nmanifest_monthly.json\nmanifest_weekly.json\nrequirements.txt\ntable.md\ntests\ntrust-policy.json\n\n/Users/tsmithsz/Downloads/Metrics\n",
                                                        "stderr": ""
                                                    },
                                                    "success": true
                                                }
                                            }
                                        }
                                    ]
                                }
                            ]
                        }
                    },
                    {
                        "body": "\n\nThe command executed successfully. You're currently in the `/Users/tsmithsz/Downloads/Metrics` directory, which contains:\n\nFiles:\n- AmazonQ.md\n- README.md\n- SYSTEMPROMPTOVERRIDE.md\n- controller.ts\n- manifest_monthly.json\n- manifest_weekly.json\n- requirements.txt\n- table.md\n- trust-policy.json\n\nDirectories:\n- data\n- data_transform\n- infra\n- tests\n\nIs there anything specific about this project you'd like to explore or work on?",
                        "type": "answer",
                        "toolUses": []
                    }
                ]
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
