### PR TITLE
test(amazonq): add simple flow for selecting Q profile in vscode sample extension

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -103,13 +103,8 @@
                 "category": "Test Amazon Q Extension"
             },
             {
-                "command": "aws.sample-vscode-ext-amazonq.updateProfileIad",
-                "title": "Update Amazon Q IDC Profile IAD",
-                "category": "Test Amazon Q Extension"
-            },
-            {
-                "command": "aws.sample-vscode-ext-amazonq.updateProfileFra",
-                "title": "Update Amazon Q IDC Profile FRA",
+                "command": "aws.sample-vscode-ext-amazonq.selectProfile",
+                "title": "Select an (available) Amazon Q IDC profile",
                 "category": "Test Amazon Q Extension"
             },
             {

--- a/client/vscode/src/selectQProfileActivation.ts
+++ b/client/vscode/src/selectQProfileActivation.ts
@@ -1,20 +1,21 @@
-import { commands } from 'vscode'
+import { commands, window } from 'vscode'
 import { LanguageClient } from 'vscode-languageclient/node'
-import { updateConfigurationRequestType } from '@aws/language-server-runtimes/protocol'
+import {
+    getConfigurationFromServerRequestType,
+    updateConfigurationRequestType,
+} from '@aws/language-server-runtimes/protocol'
 
 export async function registerQProfileSelection(languageClient: LanguageClient): Promise<void> {
     commands.registerCommand(
-        'aws.sample-vscode-ext-amazonq.updateProfileIad',
-        setProfile(languageClient, 'profile-iad')
+        'aws.sample-vscode-ext-amazonq.selectProfile',
+        queryAvailableProfilesAndSelect(languageClient)
     )
-    commands.registerCommand(
-        'aws.sample-vscode-ext-amazonq.updateProfileFra',
-        setProfile(languageClient, 'profile-fra')
-    )
+
     commands.registerCommand(
         'aws.sample-vscode-ext-amazonq.updateProfileInvalid',
         setProfile(languageClient, 'invalid-profile')
     )
+
     commands.registerCommand('aws.sample-vscode-ext-amazonq.updateProfileNull', setProfile(languageClient, null))
 }
 
@@ -27,10 +28,49 @@ function setProfile(languageClient: LanguageClient, profileArn: string | null) {
                     profileArn: profileArn,
                 },
             })
-
             languageClient.info(`Client: Updated Amazon Q Profile`, result)
         } catch (err) {
             console.log('Error when setting Q Developer Profile', err)
+        }
+    }
+}
+
+function queryAvailableProfilesAndSelect(languageClient: LanguageClient) {
+    return async () => {
+        try {
+            const developerProfiles = await languageClient.sendRequest(getConfigurationFromServerRequestType.method, {
+                section: 'aws.q.developerProfiles',
+            })
+
+            if (!(developerProfiles instanceof Array)) {
+                languageClient.error('Retrieved developer profiles not an array, exiting.')
+                return
+            }
+
+            let arns: string[] = []
+
+            developerProfiles.forEach(profile => {
+                const arn = profile.arn
+
+                if (arn && typeof arn === 'string') {
+                    arns.push(arn)
+                }
+            })
+
+            if (arns.length < 1) {
+                languageClient.error('Found no developer profiles, exiting.')
+                return
+            }
+
+            const chosenProfile = await window.showQuickPick(arns, {
+                placeHolder: 'Select profile arn',
+            })
+
+            if (!chosenProfile) return
+
+            await setProfile(languageClient, chosenProfile)()
+        } catch (err) {
+            console.log('Error trying to select Q developer profile', err)
         }
     }
 }


### PR DESCRIPTION
## Problem

There is currently no convenient way to list and select Q developer profiles in the sample vs code extension.

## Solution

Add a new command to the vs code sample extension, which:

1. queries the available q developer profiles (based on the active bearer token)
2. displays a vscode quickpick menu with the retrieved profiles
3. sets active profile to the one selected from the quickpick menu

Testing: verified it works by starting a token server, obtaining IDC credentials and then running the command.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
