### PR TITLE
fix: stop button fix while waiting for permission check

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -290,6 +290,7 @@ export class AgenticChatController implements ChatHandlers {
         token.onCancellationRequested(() => {
             this.#log('cancellation requested')
             session.abortRequest()
+            session.rejectAllDeferredToolExecutions(new CancellationError('user'))
         })
 
         const chatResultStream = this.#getChatResultStream(params.partialResultToken)

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -40,6 +40,17 @@ export class ChatSessionService {
         this.#deferredToolExecution[messageId] = { resolve, reject }
     }
 
+    public rejectAllDeferredToolExecutions(error: Error): void {
+        for (const messageId in this.#deferredToolExecution) {
+            const handler = this.#deferredToolExecution[messageId]
+            if (handler && handler.reject) {
+                handler.reject(error)
+            }
+        }
+        // Clear all handlers after rejecting them
+        this.#deferredToolExecution = {}
+    }
+
     constructor(amazonQServiceManager?: AmazonQBaseServiceManager) {
         this.#amazonQServiceManager = amazonQServiceManager
     }


### PR DESCRIPTION
## Problem
Stop button is not working when user is waiting for permission checks

## Solution
- stop button fix while waiting for permission check by rejecting deferred messages in case of token cancellation

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
