### PR TITLE
fix: implement proper error handling.

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -23,6 +23,8 @@ import {
     InsertToCursorPositionParams,
     TextDocumentEdit,
     InlineChatResult,
+    CancellationToken,
+    CancellationTokenSource,
 } from '@aws/language-server-runtimes/server-interface'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as assert from 'assert'
@@ -1848,13 +1850,21 @@ ${' '.repeat(8)}}
     })
 
     it('determines when an error is a user action', function () {
+        // TODO: add a case for when the token is cancelled
         const nonUserAction = new Error('User action error')
         const cancellationError = new CancellationError('user')
         const rejectionError = new ToolApprovalException()
+        const tokenSource = new CancellationTokenSource()
 
         assert.ok(!chatController.isUserAction(nonUserAction))
         assert.ok(chatController.isUserAction(cancellationError))
         assert.ok(chatController.isUserAction(rejectionError))
+
+        assert.ok(chatController.isUserAction(nonUserAction, tokenSource.token))
+
+        tokenSource.cancel()
+
+        assert.ok(!chatController.isUserAction(nonUserAction, tokenSource.token))
     })
 })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -43,6 +43,8 @@ import { AdditionalContextProvider } from './context/addtionalContextProvider'
 import { ContextCommandsProvider } from './context/contextCommandsProvider'
 import { ChatDatabase } from './tools/chatDb/chatDb'
 import { LocalProjectContextController } from '../../shared/localProjectContextController'
+import { CancellationError } from '@aws/lsp-core'
+import { ToolApprovalException } from './tools/toolShared'
 
 describe('AgenticChatController', () => {
     const mockTabId = 'tab-1'
@@ -1843,6 +1845,16 @@ ${' '.repeat(8)}}
         await chatController.onTabBarAction({ tabId: mockTabId, action: 'export' })
 
         sinon.assert.calledOnce(tabBarActionStub)
+    })
+
+    it('determines when an error is a user action', function () {
+        const nonUserAction = new Error('User action error')
+        const cancellationError = new CancellationError('user')
+        const rejectionError = new ToolApprovalException()
+
+        assert.ok(!chatController.isUserAction(nonUserAction))
+        assert.ok(chatController.isUserAction(cancellationError))
+        assert.ok(chatController.isUserAction(rejectionError))
     })
 })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1144,7 +1144,7 @@ export class AgenticChatController implements ChatHandlers {
             this.#telemetryController.emitMessageResponseError(tabId, metric.metric, err.requestId, err.message)
         }
 
-        // return non-model errors back to the client.
+        // return non-model errors back to the client as errors
         if (!(err instanceof ModelServiceException)) {
             this.#log(`unknown error ${err instanceof Error ? JSON.stringify(err) : 'unknown'}`)
             this.#debug(`stack ${err instanceof Error ? JSON.stringify(err.stack) : 'unknown'}`)
@@ -1177,7 +1177,7 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         const backendError = err.cause
-        // Send the backend error message directly to the client in chat.
+        // Send the backend error message directly to the client to be displayed in chat.
         return {
             type: 'answer',
             body: backendError.message,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1369,7 +1369,7 @@ export class AgenticChatController implements ChatHandlers {
         } else if (toolUse?.name === 'fsRead') {
             await this.#features.lsp.window.showDocument({ uri: params.filePath })
         } else {
-            const absolutePath = params.filePath ?? (await this.#resolveAbsolutePath(params.filePath))
+            const absolutePath = params.fullPath ?? (await this.#resolveAbsolutePath(params.filePath))
             if (absolutePath) {
                 await this.#features.lsp.window.showDocument({ uri: absolutePath })
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -334,7 +334,7 @@ export class AgenticChatController implements ChatHandlers {
                 chatResultStream
             )
         } catch (err) {
-            if (this.#isUserAction(err)) {
+            if (this.isUserAction(err)) {
                 /**
                  * when the session is aborted it generates an error.
                  * we need to resolve this error with an answer so the
@@ -669,7 +669,7 @@ export class AgenticChatController implements ChatHandlers {
                     this.#features.chat.sendChatUpdate({ tabId, state: { inProgress: false } })
                 }
 
-                if (this.#isUserAction(err)) {
+                if (this.isUserAction(err)) {
                     if (err instanceof ToolApprovalException && toolUse.name === 'executeBash') {
                         if (buttonBlockId) {
                             await chatResultStream.overwriteResultBlock(
@@ -700,7 +700,7 @@ export class AgenticChatController implements ChatHandlers {
      * @param err
      * @returns
      */
-    #isUserAction(err: unknown): boolean {
+    isUserAction(err: unknown): boolean {
         return CancellationError.isUserCancelled(err) || err instanceof ToolApprovalException
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1155,12 +1155,12 @@ export class AgenticChatController implements ChatHandlers {
             )
         }
 
-        if (err instanceof ModelServiceException && err.cause instanceof AmazonQServicePendingSigninError) {
+        if (err.cause instanceof AmazonQServicePendingSigninError) {
             this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
             return createAuthFollowUpResult('full-auth')
         }
 
-        if (err instanceof ModelServiceException && err.cause && err instanceof AmazonQServicePendingProfileError) {
+        if (err.cause && err instanceof AmazonQServicePendingProfileError) {
             this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
             const followUpResult = createAuthFollowUpResult('use-supported-auth')
             // Access first element in array

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1175,7 +1175,7 @@ export class AgenticChatController implements ChatHandlers {
             return createAuthFollowUpResult('full-auth')
         }
 
-        if (err.cause && err instanceof AmazonQServicePendingProfileError) {
+        if (err.cause instanceof AmazonQServicePendingProfileError) {
             this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)
             const followUpResult = createAuthFollowUpResult('use-supported-auth')
             // Access first element in array

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -1,0 +1,3 @@
+export class ModelServiceException {
+    public constructor(public readonly cause: Error) {}
+}


### PR DESCRIPTION
## Problem
Error handling for backend requests is non-existent and the existing error handling elsewhere relies on flaky checks. 

Testing these changes with @jpinkney-aws, we identified 3 problems fixed by these changes. 
- backend errors cause chat to hang. 
- the stop button doesn't always stop the action depending on the time it was pressed. 
- the authenticate button doesn't pop-up, its blocked by "thinking...". 

## Solution
- forward backend error message to the client to be displayed in chat. 
- on error, send a progress update to the client to kill the thinking bubble. 
- centralize error handling to minimize flaky checks. 

## Testing
- In addition to unit tests, these changes were tested e2e. See demo below for a demonstration where I have the model always fail on the second iteration of the agentic loop. 

https://github.com/user-attachments/assets/944dd737-a2e9-4b82-9976-a3addc676b42

## Notes
there is a hack implemented to ensure the thinking bubble is killed. This highlights potential bugs in the chat-client and is explained with a comment in the code. 


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
