### PR TITLE
fix(amazonq): add validation for create a saved prompt UX

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -351,12 +351,26 @@ export const createMynahUi = (
                             autoFocus: true,
                             title: 'Prompt name',
                             placeholder: 'Enter prompt name',
+                            validationPatterns: {
+                                patterns: [
+                                    {
+                                        pattern: /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,99}$/,
+                                        errorMessage:
+                                            'Use only letters, numbers, hyphens, and underscores, starting with a letter or number. Maximum 100 characters.',
+                                    },
+                                ],
+                            },
                             description: "Use this prompt by typing '@' followed by the prompt name.",
                         },
                     ],
                     [
                         { id: ContextPrompt.CancelButtonId, text: 'Cancel', status: 'clear' },
-                        { id: ContextPrompt.SubmitButtonId, text: 'Create', status: 'main' },
+                        {
+                            id: ContextPrompt.SubmitButtonId,
+                            text: 'Create',
+                            status: 'main',
+                            waitMandatoryFormItems: true,
+                        },
                     ],
                     `Create a saved prompt`
                 )

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.test.ts
@@ -1,0 +1,93 @@
+import * as path from 'path'
+import * as sinon from 'sinon'
+import * as assert from 'assert'
+import { expect } from 'chai'
+import { getUserPromptsDirectory, getNewPromptFilePath, promptFileExtension } from './contextUtils'
+import * as pathUtils from '@aws/lsp-core/out/util/path'
+import { sanitizeFilename } from '@aws/lsp-core/out/util/text'
+
+describe('contextUtils', () => {
+    let getUserHomeDirStub: sinon.SinonStub
+
+    beforeEach(() => {
+        getUserHomeDirStub = sinon.stub(pathUtils, 'getUserHomeDir')
+
+        // Default behavior
+        getUserHomeDirStub.returns('/home/user')
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('getUserPromptsDirectory', () => {
+        it('should return the correct prompts directory path', () => {
+            const result = getUserPromptsDirectory()
+            assert.strictEqual(result, path.join('/home/user', '.aws', 'amazonq', 'prompts'))
+        })
+    })
+
+    describe('getNewPromptFilePath', () => {
+        it('should use default name when promptName is empty', () => {
+            const result = getNewPromptFilePath('')
+            assert.strictEqual(
+                result,
+                path.join('/home/user', '.aws', 'amazonq', 'prompts', `default${promptFileExtension}`)
+            )
+        })
+
+        it('should use default name when promptName is undefined', () => {
+            const result = getNewPromptFilePath(undefined as unknown as string)
+            assert.strictEqual(
+                result,
+                path.join('/home/user', '.aws', 'amazonq', 'prompts', `default${promptFileExtension}`)
+            )
+        })
+
+        it('should trim whitespace from promptName', () => {
+            const result = getNewPromptFilePath('  test-prompt  ')
+            const expectedSanitized = sanitizeFilename('test-prompt')
+            assert.strictEqual(
+                result,
+                path.join('/home/user', '.aws', 'amazonq', 'prompts', `${expectedSanitized}${promptFileExtension}`)
+            )
+        })
+
+        it('should truncate promptName if longer than 100 characters', () => {
+            const longName = 'a'.repeat(150)
+            const truncatedName = 'a'.repeat(100)
+
+            const result = getNewPromptFilePath(longName)
+            const expectedSanitized = sanitizeFilename(truncatedName)
+
+            assert.strictEqual(
+                result,
+                path.join('/home/user', '.aws', 'amazonq', 'prompts', `${expectedSanitized}${promptFileExtension}`)
+            )
+        })
+
+        it('should sanitize the filename using sanitizeFilename', () => {
+            const unsafeName = 'unsafe/name?with:invalid*chars'
+            const expectedSanitized = sanitizeFilename(path.basename(unsafeName))
+
+            const result = getNewPromptFilePath(unsafeName)
+
+            assert.strictEqual(
+                result,
+                path.join('/home/user', '.aws', 'amazonq', 'prompts', `${expectedSanitized}${promptFileExtension}`)
+            )
+        })
+
+        it('should handle path traversal attempts', () => {
+            const traversalPath = '../../../etc/passwd'
+            const expectedSanitized = sanitizeFilename(path.basename(traversalPath))
+
+            const result = getNewPromptFilePath(traversalPath)
+
+            assert.strictEqual(
+                result,
+                path.join('/home/user', '.aws', 'amazonq', 'prompts', `${expectedSanitized}${promptFileExtension}`)
+            )
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
@@ -1,5 +1,6 @@
 import { getUserHomeDir } from '@aws/lsp-core/out/util/path'
 import * as path from 'path'
+import { sanitizeFilename } from '@aws/lsp-core/out/util/text'
 
 export const promptFileExtension = '.md'
 export const additionalContentInnerContextLimit = 8192
@@ -9,10 +10,22 @@ export const getUserPromptsDirectory = (): string => {
     return path.join(getUserHomeDir(), '.aws', 'amazonq', 'prompts')
 }
 
+/**
+ * Creates a secure file path for a new prompt file.
+ *
+ * @param promptName - The user-provided name for the prompt
+ * @returns A sanitized file path within the user prompts directory
+ */
 export const getNewPromptFilePath = (promptName: string): string => {
     const userPromptsDirectory = getUserPromptsDirectory()
-    return path.join(
-        userPromptsDirectory,
-        promptName ? `${promptName}${promptFileExtension}` : `default${promptFileExtension}`
-    )
+
+    const trimmedName = promptName?.trim() || ''
+
+    const truncatedName = trimmedName.slice(0, 100)
+
+    const safePromptName = truncatedName ? sanitizeFilename(path.basename(truncatedName)) : 'default'
+
+    const finalPath = path.join(userPromptsDirectory, `${safePromptName}${promptFileExtension}`)
+
+    return finalPath
 }


### PR DESCRIPTION
## Problem
The "create a saved prompt" user experience was lacking proper validation, allowing users to input an invalid file name. If an invalid name was entered and creation failed, no validation error message was shown.

## Solution
Add validation logic to the saved prompt creation flow with regex enforcement, and display an error message if user input is not valid.



https://github.com/user-attachments/assets/49f8f93e-c9f8-4d8f-8c51-8fd9602170c9



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
