### PR TITLE
fix: onFileClick logic is crashing the whole process if no workspace …

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -13,7 +13,7 @@
         "test": "node scripts/test-runner.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.74"
+        "@aws/language-server-runtimes": "^0.2.76"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -22,8 +22,8 @@
     },
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.28",
-        "@aws/language-server-runtimes-types": "^0.1.23",
-        "@aws/mynah-ui": "^4.31.0-beta.6"
+        "@aws/language-server-runtimes-types": "^0.1.25",
+        "@aws/mynah-ui": "^4.31.0-beta.7"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -202,8 +202,8 @@ export const createMynahUi = (
             messager.onUiReady()
             messager.onTabAdd(initialTabId)
         },
-        onFileClick: (tabId, filePath, deleted, messageId, eventId) => {
-            messager.onFileClick({ tabId, filePath, messageId })
+        onFileClick: (tabId, filePath, deleted, messageId, eventId, fileDetails) => {
+            messager.onFileClick({ tabId, filePath, messageId, fullPath: fileDetails?.data?.['fullPath'] })
         },
         onTabAdd: (tabId: string) => {
             const defaultTabBarData = tabFactory.getDefaultTabData()
@@ -499,6 +499,9 @@ export const createMynahUi = (
                                     .join(', ') || '',
                             description: filePath,
                             clickable: true,
+                            data: {
+                                fullPath: fileDetails.fullPath || '',
+                            },
                         },
                     ])
                 ),

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -341,7 +341,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.28",
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -44,7 +44,6 @@ import {
 } from 'vscode-languageclient/node'
 import * as jose from 'jose'
 import * as vscode from 'vscode'
-import * as fs from 'fs'
 
 export function registerChat(languageClient: LanguageClient, extensionUri: Uri, encryptionKey?: Buffer) {
     const webviewInitialized: Promise<Webview> = new Promise(resolveWebview => {
@@ -189,6 +188,7 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri, 
                         default:
                             if (isServerEvent(message.command))
                                 languageClient.sendNotification(message.command, message.params)
+                            else languageClient.info(`[VSCode Client]  Unhandled command: ${message.command}`)
                             break
                     }
                 }, undefined)

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -78,7 +78,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -111,7 +111,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -119,7 +119,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -139,7 +139,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -183,7 +183,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -203,7 +203,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -225,7 +225,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.74"
+                "@aws/language-server-runtimes": "^0.2.76"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -246,8 +246,8 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.28",
-                "@aws/language-server-runtimes-types": "^0.1.23",
-                "@aws/mynah-ui": "^4.31.0-beta.6"
+                "@aws/language-server-runtimes-types": "^0.1.25",
+                "@aws/mynah-ui": "^4.31.0-beta.7"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -269,7 +269,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.28",
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -3903,15 +3903,15 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.75",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.75.tgz",
-            "integrity": "sha512-5Eg00G96YTSOAg9bP2kyNxe01YbBiv95YL2LDINhcl3Y1MdH48Y3GhlFQviIyCSbzGfdgJoC/jGpd0khqrSs/Q==",
+            "version": "0.2.76",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.76.tgz",
+            "integrity": "sha512-HHFHuLXG+6+wZkgI34MzP3FG/h6JqZcIjCRIYn22tuEd/mHQ24043jvnCMUfiUXNA9pkw5NT4vg/hA0jMR8xAw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@apidevtools/json-schema-ref-parser": "^11.9.3",
                 "@aws-crypto/sha256-js": "^5.2.0",
                 "@aws-sdk/client-cognito-identity": "^3.758.0",
-                "@aws/language-server-runtimes-types": "^0.1.24",
+                "@aws/language-server-runtimes-types": "^0.1.25",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/resources": "^1.30.1",
                 "@opentelemetry/sdk-metrics": "^1.30.1",
@@ -3937,9 +3937,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.24",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.24.tgz",
-            "integrity": "sha512-iCeKvTclpxEKiXEOaBRSHUN10xsG8lZnzHlVtf75avACOm+34jvTDIz12I6aHibmLTHVY09qzWvUipsiT63htw==",
+            "version": "0.1.25",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.25.tgz",
+            "integrity": "sha512-MJyFHf0r+QafObvtRfj+Y9V0okmhmnpPDSbHqCPo90/visVKrmfHGolK4NWYKM8Ca1mroflMYWlkGLMarHNS6g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -4064,9 +4064,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.31.0-beta.6",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.31.0-beta.6.tgz",
-            "integrity": "sha512-M9zX6yjl2bJl+D6Q06ByvfLY207QyuMJyvKOGYZ5I8ZWXM8WU45EVUcN00IL5M+b1vqJl8jUVjg7khaiiLQeUw==",
+            "version": "4.31.0-beta.7",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.31.0-beta.7.tgz",
+            "integrity": "sha512-Q8CWR7nsP7fm3dPy6bg7hsRwjncILhWBUjxCLoiXzD0e+6qp6xo1LndchHKahIdwUxL4wyL+jbwOdBGlkuWqlg==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {
@@ -26939,7 +26939,7 @@
             "version": "0.1.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-core": "^0.0.3"
             },
             "devDependencies": {
@@ -27144,7 +27144,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-core": "^0.0.3",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -27190,7 +27190,7 @@
             "version": "0.1.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-core": "^0.0.3",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -27204,7 +27204,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-core": "0.0.3",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -27246,7 +27246,7 @@
             "version": "0.0.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -27279,7 +27279,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "@aws/lsp-core": "^0.0.3",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -27293,7 +27293,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -27304,7 +27304,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.74",
+                "@aws/language-server-runtimes": "^0.2.76",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-core": "^0.0.3"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1211,12 +1211,9 @@ export class AgenticChatController implements ChatHandlers {
     }
 
     async onFileClicked(params: FileClickParams) {
-        // TODO: also pass in selection and handle on client side
-        const workspaceRoot = workspaceUtils.getWorkspaceFolderPaths(this.#features.lsp)[0]
-        let absolutePath = path.join(workspaceRoot, params.filePath)
-
         const toolUseId = params.messageId
         const toolUse = toolUseId ? this.#triggerContext.getToolUseLookup().get(toolUseId) : undefined
+
         if (toolUse?.name === 'fsWrite') {
             const input = toolUse.input as unknown as FsWriteParams
             // TODO: since the tool already executed, we need to reverse the old/new content for the diff
@@ -1228,14 +1225,10 @@ export class AgenticChatController implements ChatHandlers {
         } else if (toolUse?.name === 'fsRead') {
             await this.#features.lsp.window.showDocument({ uri: params.filePath })
         } else {
-            // handle prompt file outside of workspace
-            if (params.filePath.endsWith(promptFileExtension)) {
-                const existsInWorkspace = await this.#features.workspace.fs.exists(absolutePath)
-                if (!existsInWorkspace) {
-                    absolutePath = path.join(getUserPromptsDirectory(), params.filePath)
-                }
+            const absolutePath = params.fullPath ?? (await this.#resolveAbsolutePath(params.filePath))
+            if (absolutePath) {
+                await this.#features.lsp.window.showDocument({ uri: absolutePath })
             }
-            await this.#features.lsp.window.showDocument({ uri: absolutePath })
         }
     }
 
@@ -1352,6 +1345,29 @@ export class AgenticChatController implements ChatHandlers {
     async #getInlineChatTriggerContext(params: InlineChatParams) {
         let triggerContext: TriggerContext = await this.#triggerContext.getNewTriggerContext(params)
         return triggerContext
+    }
+
+    async #resolveAbsolutePath(relativePath: string): Promise<string | undefined> {
+        try {
+            const workspaceFolders = workspaceUtils.getWorkspaceFolderPaths(this.#features.lsp)
+            for (const workspaceRoot of workspaceFolders) {
+                const candidatePath = path.join(workspaceRoot, relativePath)
+                if (await this.#features.workspace.fs.exists(candidatePath)) {
+                    return candidatePath
+                }
+            }
+
+            // handle prompt file outside of workspace
+            if (relativePath.endsWith(promptFileExtension)) {
+                return path.join(getUserPromptsDirectory(), relativePath)
+            }
+
+            this.#features.logging.error(`File not found: ${relativePath}`)
+        } catch (e: any) {
+            this.#features.logging.error(`Error resolving absolute path: ${e.message}`)
+        }
+
+        return undefined
     }
 
     async #getTriggerContext(params: ChatParams, metric: Metric<CombinedConversationEvent>) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
@@ -96,6 +96,7 @@ describe('AdditionalContextProvider', () => {
                     type: 'code',
                     description: 'test',
                     innerContext: 'test',
+                    path: '1/test/path.ts',
                 },
             ]
 
@@ -120,6 +121,7 @@ describe('AdditionalContextProvider', () => {
                     type: 'file',
                     description: 'test',
                     innerContext: 'test',
+                    path: '1/test/path.ts',
                 },
             ]
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
@@ -106,6 +106,7 @@ export class AdditionalContextProvider {
                 description: description.substring(0, additionalContentNameLimit),
                 innerContext: prompt.content.substring(0, additionalContentInnerContextLimit),
                 type: contextType,
+                path: prompt.filePath,
                 relativePath: relativePath,
                 startLine: prompt.startLine,
                 endLine: prompt.endLine,
@@ -126,6 +127,7 @@ export class AdditionalContextProvider {
                         second: item.name === 'symbol' ? item.endLine : -1,
                     },
                 ],
+                fullPath: item.path,
             }
         }
         const fileList: FileList = {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -30,7 +30,6 @@ import { LocalProjectContextController } from '../../../shared/localProjectConte
 import * as path from 'path'
 import { RelevantTextDocument } from '@amzn/codewhisperer-streaming'
 import { AgenticChatResultStream } from '../agenticChatResultStream'
-import { randomUUID } from 'crypto'
 
 export interface TriggerContext extends Partial<DocumentContext> {
     userIntent?: UserIntent
@@ -40,7 +39,11 @@ export interface TriggerContext extends Partial<DocumentContext> {
 }
 export type LineInfo = { startLine: number; endLine: number }
 
-export type AdditionalContentEntryAddition = AdditionalContentEntry & { type: string; relativePath: string } & LineInfo
+export type AdditionalContentEntryAddition = AdditionalContentEntry & {
+    type: string
+    relativePath: string
+    path: string
+} & LineInfo
 
 export type RelevantTextDocumentAddition = RelevantTextDocument & LineInfo
 

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -80,8 +80,8 @@ export class LocalProjectContextController {
     public static async getInstance(): Promise<LocalProjectContextController> {
         try {
             await waitUntil(async () => this.instance, {
-                interval: 1000,
-                timeout: 60_000,
+                interval: 100,
+                timeout: 600,
                 truthy: true,
             })
 
@@ -91,7 +91,12 @@ export class LocalProjectContextController {
 
             return this.instance
         } catch (error) {
-            throw new Error(`Failed to get LocalProjectContextController instance: ${error}`)
+            // throw new Error(`Failed to get LocalProjectContextController instance: ${error}`)
+            return {
+                isEnabled: true,
+                getContextCommandItems: () => [],
+                shouldUpdateContextCommandSymbolsOnce: () => false,
+            } as unknown as LocalProjectContextController
         }
     }
 

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-core": "^0.0.3",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-core": "^0.0.3",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-core": "0.0.3",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "@aws/lsp-core": "^0.0.3",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.74",
+        "@aws/language-server-runtimes": "^0.2.76",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
…is open

## Problem

This logic was throwing exception and crashing the whole process:
```
        const workspaceRoot = workspaceUtils.getWorkspaceFolderPaths(this.#features.lsp)[0]
        let absolutePath = path.join(workspaceRoot, params.filePath) <--- HERE, because workspaceRoot is undefined if no workspace is open
```

## Solution

- Move the code for workspace resolution to the proper condition inside of `onFileClick`
- For context items, pass the full path to client, so that client can return the fullpath back, and full path resolution is not needed anymore
- For cases, where fullpath is not known or not passed for some reason (there can be cases - I did not go through the whole codebase), we still have this full path resolve logic, but now we search in all the workspaces and more importantly - catch the errors

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
