### PR TITLE
fix: execute bash output formatting

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -726,13 +726,6 @@ export class AgenticChatController implements ChatHandlers {
             return
         }
         return new WritableStream({
-            start: async () => {
-                await chatResultStream.writeResultBlock({
-                    type: 'tool',
-                    body: '```console',
-                    messageId: toolUse.toolUseId,
-                })
-            },
             write: async chunk => {
                 await chatResultStream.writeResultBlock({
                     type: 'tool',
@@ -754,7 +747,7 @@ export class AgenticChatController implements ChatHandlers {
         return {
             messageId: toolUse.toolUseId,
             type: 'tool',
-            body: '```shell\n' + (toolUse.input as unknown as ExecuteBashParams).command + '\n```',
+            body: '```shell\n' + (toolUse.input as unknown as ExecuteBashParams).command + '\n',
             header: {
                 body: 'shell',
                 status: {
@@ -797,7 +790,7 @@ export class AgenticChatController implements ChatHandlers {
                     buttons,
                 }
                 const commandString = (toolUse.input as unknown as ExecuteBashParams).command
-                body = '```shell\n' + commandString + '\n```'
+                body = '```shell\n' + commandString + '\n'
                 break
 
             case 'fsWrite':


### PR DESCRIPTION
## Problem

Bash command and output should be combined in a single code block

## Solution

<img width="735" alt="image" src="https://github.com/user-attachments/assets/65ee9b0e-e8a2-4129-9a9b-29140e830371" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
