### PR TITLE
fix: error message metric now correctly emitted

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1092,7 +1092,7 @@ export class AgenticChatController implements ChatHandlers {
             }
         }
 
-        metric.setDimension('cwsprChatRepsonseCode', getHttpStatusCode(err) ?? 400)
+        metric.setDimension('cwsprChatRepsonseCode', getHttpStatusCode(err) ?? 0)
         this.#telemetryController.emitMessageResponseError(tabId, metric.metric, requestID, errorMessage)
 
         // return non-model errors back to the client as errors

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1092,7 +1092,7 @@ export class AgenticChatController implements ChatHandlers {
             }
         }
 
-        metric.setDimension('cwsprChatRepsonseCode', getHttpStatusCode(err) ?? 0)
+        metric.setDimension('cwsprChatResponseCode', getHttpStatusCode(err) ?? 0)
         this.#telemetryController.emitMessageResponseError(tabId, metric.metric, requestID, errorMessage)
 
         // return non-model errors back to the client as errors

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -6,6 +6,7 @@
 import * as path from 'path'
 import {
     ChatTriggerType,
+    CodeWhispererStreamingServiceException,
     GenerateAssistantResponseCommandInput,
     GenerateAssistantResponseCommandOutput,
     SendMessageCommandInput,
@@ -68,7 +69,7 @@ import { ChatSessionManagementService } from '../chat/chatSessionManagementServi
 import { ChatTelemetryController } from '../chat/telemetry/chatTelemetryController'
 import { QuickAction } from '../chat/quickActions'
 import { Metric } from '../../shared/telemetry/metric'
-import { getErrorMessage, isAwsError, isNullish, isObject } from '../../shared/utils'
+import { getErrorMessage, getHttpStatusCode, isNullish } from '../../shared/utils'
 import { HELP_MESSAGE } from '../chat/constants'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import {
@@ -1023,10 +1024,21 @@ export class AgenticChatController implements ChatHandlers {
         tabId: string,
         metric: Metric<CombinedConversationEvent>
     ): ChatResult | ResponseError<ChatResult> {
-        if (isAwsError(err) || (isObject(err) && 'statusCode' in err && typeof err.statusCode === 'number')) {
-            metric.setDimension('cwsprChatRepsonseCode', err.statusCode ?? 400)
-            this.#telemetryController.emitMessageResponseError(tabId, metric.metric, err.requestId, err.message)
+        let errorMessage: string
+        let requestID: string | undefined
+
+        if (err instanceof CodeWhispererStreamingServiceException) {
+            errorMessage = err.message
+            requestID = err.$metadata.requestId
+        } else {
+            errorMessage = 'Not a CodeWhispererStreamingServiceException.'
+            if (err instanceof Error || err?.message) {
+                errorMessage += ` Error is: ${err.message}`
+            }
         }
+
+        metric.setDimension('cwsprChatRepsonseCode', getHttpStatusCode(err) ?? 400)
+        this.#telemetryController.emitMessageResponseError(tabId, metric.metric, requestID, errorMessage)
 
         if (err instanceof AmazonQServicePendingSigninError) {
             this.#log(`Q Chat SSO Connection error: ${getErrorMessage(err)}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1092,7 +1092,6 @@ export class AgenticChatController implements ChatHandlers {
             }
         }
 
-
         metric.setDimension('cwsprChatRepsonseCode', getHttpStatusCode(err) ?? 400)
         this.#telemetryController.emitMessageResponseError(tabId, metric.metric, requestID, errorMessage)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -250,25 +250,25 @@ export class ChatTelemetryController {
         requestId?: string,
         errorReason?: string
     ) {
-        this.emitConversationMetric(
-            {
-                name: ChatTelemetryEventName.MessageResponseError,
-                data: {
-                    cwsprChatHasCodeSnippet: metric.cwsprChatHasCodeSnippet,
-                    cwsprChatTriggerInteraction: metric.cwsprChatTriggerInteraction,
-                    cwsprChatUserIntent: metric.cwsprChatUserIntent,
-                    cwsprChatProgrammingLanguage: metric.cwsprChatProgrammingLanguage,
-                    cwsprChatActiveEditorTotalCharacters: metric.cwsprChatActiveEditorTotalCharacters,
-                    cwsprChatActiveEditorImportCount: metric.cwsprChatActiveEditorImportCount,
-                    cwsprChatRepsonseCode: metric.cwsprChatRepsonseCode,
-                    cwsprChatRequestLength: metric.cwsprChatRequestLength,
-                    cwsprChatConversationType: metric.cwsprChatConversationType,
-                    requestId: requestId,
-                    reasonDesc: getTelemetryReasonDesc(errorReason),
-                },
+        this.#telemetry.emitMetric({
+            name: ChatTelemetryEventName.MessageResponseError,
+            data: {
+                cwsprChatHasCodeSnippet: metric.cwsprChatHasCodeSnippet,
+                cwsprChatTriggerInteraction: metric.cwsprChatTriggerInteraction,
+                cwsprChatUserIntent: metric.cwsprChatUserIntent,
+                cwsprChatProgrammingLanguage: metric.cwsprChatProgrammingLanguage,
+                cwsprChatActiveEditorTotalCharacters: metric.cwsprChatActiveEditorTotalCharacters,
+                cwsprChatActiveEditorImportCount: metric.cwsprChatActiveEditorImportCount,
+                cwsprChatRepsonseCode: metric.cwsprChatRepsonseCode,
+                cwsprChatRequestLength: metric.cwsprChatRequestLength,
+                cwsprChatConversationType: metric.cwsprChatConversationType,
+                requestId: requestId,
+                reasonDesc: getTelemetryReasonDesc(errorReason),
+                credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
+                result: 'Succeeded',
+                [CONVERSATION_ID_METRIC_KEY]: this.getConversationId(tabId),
             },
-            tabId
-        )
+        })
     }
 
     public enqueueCodeDiffEntry(params: Omit<InsertToCursorPositionParams, 'name'>) {

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -331,5 +331,4 @@ export function hasConnectionExpired(error: any) {
         return authFollowType == 're-auth'
     }
     return false
-
 }

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -324,6 +324,7 @@ function hasResponse<T>(error: T): error is T & Pick<ServiceException, '$respons
 
 function hasMetadata<T>(error: T): error is T & Pick<CodeWhispererStreamingServiceException, '$metadata'> {
     return typeof (error as { $metadata?: unknown })?.$metadata === 'object'
+}
 
 export function hasConnectionExpired(error: any) {
     if (error instanceof Error) {


### PR DESCRIPTION
#### for context, here is the agentic-chat branch pr which i am porting to `language-servers`: https://github.com/aws/aws-toolkit-vscode/pull/7045

## Problem
- error metric not emitted properly 

## Solution
- correctly emit error metric 
- correctly get the requestID and errorMessage for the error
- port over `getHttpStatusCode` and its helpers from here: https://github.com/aws/aws-toolkit-vscode/blob/c22efa03e73b241564c8051c35761eb8620edb83/packages/core/src/shared/errors.ts#L648

### Tested in kibana

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
