### PR TITLE
fix: further improvements for thinking/loading

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -433,7 +433,7 @@ export const createMynahUi = (
             const chatItems = store.chatItems || []
             const updatedItems = chatItems.map(item => ({
                 ...item,
-                type: item.type === ChatItemType.ANSWER_STREAM ? ChatItemType.ANSWER : item.type,
+                type: item.type === ChatItemType.ANSWER_STREAM && !item.body ? ChatItemType.ANSWER : item.type,
             }))
             mynahUi.updateStore(tabId, { loadingChat: false, cancelButtonWhenLoading: true, chatItems: updatedItems })
             messager.onStopChatResponse(tabId)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -894,7 +894,7 @@ describe('AgenticChatController', () => {
 
             const chatResult = await chatResultPromise
 
-            sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 1) // response length + loading message
+            sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 2) // response length + 2 loading messages
             assert.deepStrictEqual(chatResult, {
                 additionalMessages: [],
                 body: '\n\nHello World!',
@@ -911,7 +911,7 @@ describe('AgenticChatController', () => {
 
             const chatResult = await chatResultPromise
 
-            sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 1) // response length + loading message
+            sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 2) // response length + 2 loading message
             assert.deepStrictEqual(chatResult, {
                 additionalMessages: [],
                 body: '\n\nHello World!',


### PR DESCRIPTION
## Problem
- thinking don't show up in second round of messages because the ID used wasn't unique
- sometimes it takes a while from us rendering text response to processing toolUse
- listDir/read/search shows result before running the tool
## Solution
- switch to use `uuid` instead in iterations
- add additional loading message between text response to toolUse processing
- move list/read/search result to after tool run

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
