### PR TITLE
fix: bubble up throttling error for ListAvailableProfiles API to client

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
@@ -8,7 +8,13 @@ import {
 } from './qConfigurationServer'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import { CodeWhispererServiceToken } from '../../shared/codeWhispererService'
-import { CancellationTokenSource, InitializeParams, Server } from '@aws/language-server-runtimes/server-interface'
+import {
+    CancellationTokenSource,
+    InitializeParams,
+    LSPErrorCodes,
+    ResponseError,
+    Server,
+} from '@aws/language-server-runtimes/server-interface'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 import { setCredentialsForAmazonQTokenServiceManagerFactory } from '../../shared/testUtils'
 import { Q_CONFIGURATION_SECTION } from '../../shared/constants'
@@ -164,5 +170,22 @@ describe('ServerConfigurationProvider', () => {
         await serverConfigurationProvider.listAvailableProfiles(tokenSource.token)
 
         sinon.assert.calledOnce(listAvailableProfilesHandlerSpy)
+    })
+
+    it('records error code when listAvailableProfiles throws throttling error', async () => {
+        const awsError = new Error('Throttling') as any
+        awsError.code = 'ThrottlingException'
+        awsError.name = 'ThrottlingException'
+        codeWhispererService.listAvailableProfiles.rejects(awsError)
+
+        try {
+            await serverConfigurationProvider.listAvailableProfiles(tokenSource.token)
+            assert.fail('Expected method to throw')
+        } catch (error) {
+            const responseError = error as ResponseError<{ awsErrorCode: string }>
+            assert.strictEqual(responseError.code, LSPErrorCodes.RequestFailed)
+            assert.strictEqual(responseError.data?.awsErrorCode, 'E_AMAZON_Q_PROFILE_THROTTLING')
+            sinon.assert.calledOnce(listAvailableProfilesHandlerSpy)
+        }
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -16,6 +16,7 @@ import {
 import { Customizations } from '../../client/token/codewhispererbearertokenclient'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 import { Q_CONFIGURATION_SECTION } from '../../shared/constants'
+import { AmazonQError } from '../../shared/amazonQServiceManager/errors'
 
 const Q_CUSTOMIZATIONS = 'customizations'
 const Q_DEVELOPER_PROFILES = 'developerProfiles'
@@ -155,6 +156,16 @@ export class ServerConfigurationProvider {
 
             return profiles
         } catch (error) {
+            if (error instanceof AmazonQError) {
+                this.logging.error(error.message)
+                throw new ResponseError(
+                    LSPErrorCodes.RequestFailed,
+                    `${ON_GET_CONFIGURATION_FROM_SERVER_ERROR_PREFIX}${Q_DEVELOPER_PROFILES}`,
+                    {
+                        awsErrorCode: error.code,
+                    }
+                )
+            }
             throw this.getResponseError(
                 `${ON_GET_CONFIGURATION_FROM_SERVER_ERROR_PREFIX}${Q_DEVELOPER_PROFILES}`,
                 error

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
@@ -63,3 +63,10 @@ export class AmazonQServiceNoProfileSupportError extends AmazonQError {
         this.name = 'AmazonQServiceNoProfileSupportError'
     }
 }
+
+export class AmazonQServiceProfileThrottlingError extends AmazonQError {
+    constructor(message: string = 'Amazon Q Profile has encountered throttling error') {
+        super(message, 'E_AMAZON_Q_PROFILE_THROTTLING')
+        this.name = 'AmazonQServiceProfileThrottlingError'
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
@@ -8,6 +8,7 @@ import {
 import { isBool, isObject, SsoConnectionType } from '../utils'
 import { AWS_Q_ENDPOINTS } from '../../shared/constants'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
+import { AmazonQServiceProfileThrottlingError } from './errors'
 
 export interface AmazonQDeveloperProfile {
     arn: string
@@ -60,12 +61,27 @@ export const getListAllAvailableProfilesHandler =
         }
 
         const fulfilledResults = result.filter(settledResult => settledResult.status === 'fulfilled')
+        const hasThrottlingError = result.some(
+            re => re.status === `rejected` && re.reason?.name == `ThrottlingException`
+        )
+        const throttlingErrorMessage = 'Request was throttled while retrieving profiles'
 
+        // Handle case when no successful results
         if (fulfilledResults.length === 0) {
+            if (hasThrottlingError) {
+                logging.error(throttlingErrorMessage)
+                throw new AmazonQServiceProfileThrottlingError(throttlingErrorMessage)
+            }
             throw new ResponseError(LSPErrorCodes.RequestFailed, `Failed to retrieve profiles from all queried regions`)
         }
 
         fulfilledResults.forEach(fulfilledResult => allProfiles.push(...fulfilledResult.value))
+
+        // Check for partial throttling
+        if (hasThrottlingError && allProfiles.length == 0) {
+            logging.error(throttlingErrorMessage)
+            throw new AmazonQServiceProfileThrottlingError(throttlingErrorMessage)
+        }
 
         return allProfiles
     }


### PR DESCRIPTION
## Problem
When a throttling exception is thrown with the ListAvailableProfiles API, the error is swallowed and client is informed of a generic failure without information on the cause of the failure. Since clients do not have this information, a vague message is shown to the user similar to `Unable to retrieve profiles`. We want this to be bubbled upstream to the client
## Solution
Whenever a throttling exception is thrown with the ListAvailableProfiles API, a ResponseError with a specific awsErrorCode `E_AMAZON_Q_PROFILE_THROTTLING` is now sent back for the client to interpret and use for showing an appropriate message to the user.
Note: When atleast one of the calls fail for ListProfiles invoked for different regions but no profiles are found, a throttling error will be thrown back to the client.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
