### PR TITLE
chore: bump mynah-ui version to 4.31.0

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.28",
         "@aws/language-server-runtimes-types": "^0.1.25",
-        "@aws/mynah-ui": "^4.31.0-beta.8"
+        "@aws/mynah-ui": "^4.31.0"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.28",
                 "@aws/language-server-runtimes-types": "^0.1.25",
-                "@aws/mynah-ui": "^4.31.0-beta.8"
+                "@aws/mynah-ui": "^4.31.0"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4064,11 +4064,10 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.31.0-beta.8",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.31.0-beta.8.tgz",
-            "integrity": "sha512-fo9KUl3zg2pyRHqwGCIITbrjNvff0MAkw5USNHc2p5xGEmmpD9cJSi+1XSZ13n3uLWGmhJ8He66HkjQSMOnPTg==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.31.0.tgz",
+            "integrity": "sha512-0tV73UJJK3o498W8PPzid6BVt62yIy4v8woeRg7HQg9y3n4fjedyqcjnECAVr4Nuq2yX4f1Uh5WjW+R1xSA3fA==",
             "hasInstallScript": true,
-            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "highlight.js": "^11.11.0",


### PR DESCRIPTION
## Summary
New mynah-ui version is available in npm now so we no longer need beta versions 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
