### PR TITLE
fix: adding tooltip description to filePaths

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -551,7 +551,7 @@ export const createMynahUi = (
                                             : `line ${range.first} - ${range.second}`
                                     )
                                     .join(', ') || '',
-                            description: filePath,
+                            description: fileDetails.description,
                             clickable: true,
                             data: {
                                 fullPath: fileDetails.fullPath || '',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -991,6 +991,7 @@ export class AgenticChatController implements ChatHandlers {
         for (const item of filePathsPushed) {
             fileDetails[item.relativeFilePath] = {
                 lineRanges: item.lineRanges,
+                description: item.relativeFilePath,
             }
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -109,6 +109,10 @@ export class AgenticChatResultStream {
                                         rootFolderTitle: c.contextList?.rootFolderTitle
                                             ? c.contextList.rootFolderTitle
                                             : (acc.contextList?.rootFolderTitle ?? ''),
+                                        details: {
+                                            ...(acc.contextList?.details ?? {}),
+                                            ...(c.contextList?.details ?? {}),
+                                        },
                                     },
                                 }),
                             header: c.header ? { ...c.header } : { ...am.header },


### PR DESCRIPTION
## Problem
- No tool tip if user hover over folder or files in fileListTree view.
## Solution
- Fixed by passing description in the context list.



https://github.com/user-attachments/assets/d962ead4-2ba3-40f7-974f-585fb4a4e26b


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
