### PR TITLE
fix(chat-client): return message for rejecting command

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -170,7 +170,9 @@ export class AgenticChatController implements ChatHandlers {
                     failureReason: `could not find deferred tool execution for message: ${params.messageId} `,
                 }
             }
-            params.buttonId === 'reject-shell-command' ? handler.reject(new ToolApprovalException()) : handler.resolve()
+            params.buttonId === 'reject-shell-command'
+                ? handler.reject(new ToolApprovalException('Command was rejected.', true))
+                : handler.resolve()
             return {
                 success: true,
             }
@@ -725,6 +727,13 @@ export class AgenticChatController implements ChatHandlers {
                                 this.#getUpdateBashConfirmResult(toolUse, false),
                                 cachedButtonBlockId
                             )
+                            if (err.shouldShowMessage) {
+                                await chatResultStream.writeResultBlock({
+                                    type: 'answer',
+                                    messageId: `reject-message-${toolUse.toolUseId}`,
+                                    body: err.message || 'Command was rejected.',
+                                })
+                            }
                         } else {
                             this.#features.logging.log('Failed to update executeBash block: no blockId is available.')
                         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -33,8 +33,13 @@ export interface CommandValidation {
 }
 
 export class ToolApprovalException extends Error {
-    constructor() {
-        super(`Tool execution invalidated`)
+    public override readonly message: string
+    public readonly shouldShowMessage: boolean
+
+    constructor(message: string = 'Tool execution invalidated', shouldShowMessage: boolean = true) {
+        super(message)
+        this.message = message
+        this.shouldShowMessage = shouldShowMessage
     }
 }
 export interface ExplanatoryParams {


### PR DESCRIPTION
## Problem
There is no return message for rejecting command
## Solution

![image](https://github.com/user-attachments/assets/4b5d191b-ec76-42e9-89f5-4b0da84f526d)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
