### PR TITLE
fix: invalid json aborts the loop

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -533,10 +533,6 @@ export class AgenticChatController implements ChatHandlers {
                     status: ToolResultStatus.ERROR,
                     content: [{ text: result.error }],
                 }))
-                if (result.error.startsWith('ToolUse input is invalid JSON:')) {
-                    currentRequestInput.conversationState!.currentMessage!.userInputMessage!.content =
-                        "Your toolUse input isn't valid. Please check the syntax and make sure the input is complete. If the input is large, break it down into multiple tool uses with smaller input."
-                }
             }
             currentRequestInput = this.#updateRequestInputWithToolResults(currentRequestInput, toolResults)
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -130,17 +130,17 @@ export class AgenticChatEventParser implements ChatResult {
                 }
 
                 if (toolUseEvent.stop) {
+                    const finalInput = this.toolUses[toolUseId].input
                     let parsedInput
                     try {
-                        parsedInput =
-                            typeof this.toolUses[toolUseId].input === 'string'
-                                ? JSON.parse(
-                                      this.toolUses[toolUseId].input === '' ? '{}' : this.toolUses[toolUseId].input
-                                  )
-                                : this.toolUses[toolUseId].input
+                        if (typeof finalInput === 'string') {
+                            parsedInput = JSON.parse(finalInput === '' ? '{}' : finalInput)
+                        } else {
+                            parsedInput = finalInput
+                        }
                     } catch (err) {
                         console.error(`Error parsing tool use input: ${this.toolUses[toolUseId].input}`, err)
-                        this.error = `ToolUse input is invalid JSON: "${this.toolUses[toolUseId].input}"`
+                        this.error = `ToolUse input is invalid JSON: "${this.toolUses[toolUseId].input}". Check the syntax and make sure the input is complete. If the input is large, break it down into multiple tool uses with smaller input.`
                         parsedInput = {}
                     }
                     this.toolUses[toolUseId] = {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -130,10 +130,19 @@ export class AgenticChatEventParser implements ChatResult {
                 }
 
                 if (toolUseEvent.stop) {
-                    const parsedInput =
-                        typeof this.toolUses[toolUseId].input === 'string'
-                            ? JSON.parse(this.toolUses[toolUseId].input === '' ? '{}' : this.toolUses[toolUseId].input)
-                            : this.toolUses[toolUseId].input
+                    let parsedInput
+                    try {
+                        parsedInput =
+                            typeof this.toolUses[toolUseId].input === 'string'
+                                ? JSON.parse(
+                                      this.toolUses[toolUseId].input === '' ? '{}' : this.toolUses[toolUseId].input
+                                  )
+                                : this.toolUses[toolUseId].input
+                    } catch (err) {
+                        console.error(`Error parsing tool use input: ${this.toolUses[toolUseId].input}`, err)
+                        this.error = `ToolUse input is invalid JSON: "${this.toolUses[toolUseId].input}"`
+                        parsedInput = {}
+                    }
                     this.toolUses[toolUseId] = {
                         ...this.toolUses[toolUseId],
                         input: parsedInput,


### PR DESCRIPTION
## Problem

Sometimes the server can respond with an invalid JSON as input and causing the entire process to stop/hang.

## Solution

1. Handle the error gracefully so that it doesn't stop the agentic loop partway through
2. Send the error back to the server as a valid ToolResult with error

Previous implementation: https://github.com/aws/aws-toolkit-vscode/blob/feature/agentic-chat/packages/core/src/codewhispererChat/controllers/chat/controller.ts#L754-L758

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
