### PR TITLE
fix: stop button kills the shell executions

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -328,28 +328,26 @@ export class ExecuteBash {
 
             this.childProcess = new ChildProcess(this.logging, 'bash', ['-c', params.command], childProcessOptions)
 
-            // Setup a periodic check for trigger cancellation
+            // Set up cancellation listener
             if (cancellationToken) {
                 cancellationToken.onCancellationRequested(() => {
-                    if (cancellationToken.isCancellationRequested) {
-                        this.logging.debug('cancellation detected, killing child process')
+                    this.logging.debug('cancellation detected, killing child process')
 
-                        // Kill the process
-                        this.childProcess?.stop(false, 'SIGTERM')
+                    // Kill the process
+                    this.childProcess?.stop(false, 'SIGTERM')
 
-                        // After a short delay, force kill with SIGKILL if still running
-                        setTimeout(() => {
-                            if (this.childProcess && !this.childProcess.stopped) {
-                                this.logging.debug('Process still running after SIGTERM, sending SIGKILL')
+                    // After a short delay, force kill with SIGKILL if still running
+                    setTimeout(() => {
+                        if (this.childProcess && !this.childProcess.stopped) {
+                            this.logging.debug('Process still running after SIGTERM, sending SIGKILL')
 
-                                // Try to kill the process group with SIGKILL
-                                this.childProcess.stop(true, 'SIGKILL')
-                            }
-                        }, 500)
-                        // Return from the function after cancellation
-                        reject(new CancellationError('user'))
-                        return
-                    }
+                            // Try to kill the process group with SIGKILL
+                            this.childProcess.stop(true, 'SIGKILL')
+                        }
+                    }, 500)
+                    // Return from the function after cancellation
+                    reject(new CancellationError('user'))
+                    return
                 })
             }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -329,9 +329,8 @@ export class ExecuteBash {
             this.childProcess = new ChildProcess(this.logging, 'bash', ['-c', params.command], childProcessOptions)
 
             // Setup a periodic check for trigger cancellation
-            let checkCancellationInterval: NodeJS.Timeout | undefined
             if (cancellationToken) {
-                checkCancellationInterval = setInterval(() => {
+                cancellationToken.onCancellationRequested(() => {
                     if (cancellationToken.isCancellationRequested) {
                         this.logging.debug('cancellation detected, killing child process')
 
@@ -347,16 +346,11 @@ export class ExecuteBash {
                                 this.childProcess.stop(true, 'SIGKILL')
                             }
                         }, 500)
-
-                        if (checkCancellationInterval) {
-                            clearInterval(checkCancellationInterval)
-                        }
-
                         // Return from the function after cancellation
                         reject(new CancellationError('user'))
                         return
                     }
-                }, 500) // Check every 500ms
+                })
             }
 
             try {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -328,12 +328,35 @@ export class ExecuteBash {
 
             this.childProcess = new ChildProcess(this.logging, 'bash', ['-c', params.command], childProcessOptions)
 
-            // Set up cancellation listener
+            // Setup a periodic check for trigger cancellation
+            let checkCancellationInterval: NodeJS.Timeout | undefined
             if (cancellationToken) {
-                cancellationToken.onCancellationRequested(() => {
-                    this.logging.debug('Cancellation requested, killing child process')
-                    this.childProcess?.stop()
-                })
+                checkCancellationInterval = setInterval(() => {
+                    if (cancellationToken.isCancellationRequested) {
+                        this.logging.debug('cancellation detected, killing child process')
+
+                        // Kill the process
+                        this.childProcess?.stop(false, 'SIGTERM')
+
+                        // After a short delay, force kill with SIGKILL if still running
+                        setTimeout(() => {
+                            if (this.childProcess && !this.childProcess.stopped) {
+                                this.logging.debug('Process still running after SIGTERM, sending SIGKILL')
+
+                                // Try to kill the process group with SIGKILL
+                                this.childProcess.stop(true, 'SIGKILL')
+                            }
+                        }, 500)
+
+                        if (checkCancellationInterval) {
+                            clearInterval(checkCancellationInterval)
+                        }
+
+                        // Return from the function after cancellation
+                        reject(new CancellationError('user'))
+                        return
+                    }
+                }, 500) // Check every 500ms
             }
 
             try {


### PR DESCRIPTION


Uploading Screen Recording 2025-04-25 at 5.04.09 PM.mov…

## Problem
Stop button is not killing long running bash executions.

## Solution
- stop button kills the shell executions with periodic listener running for execute bash
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
