### PR TITLE
fix: emit languageServerVersion and add addtional case for error metric 

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -709,7 +709,11 @@ export class AgenticChatController implements ChatHandlers {
                         break
                 }
                 if (toolUse.name) {
-                    this.#telemetryController.emitToolUseSuggested(toolUse, session.conversationId || '')
+                    this.#telemetryController.emitToolUseSuggested(
+                        toolUse,
+                        session.conversationId ?? '',
+                        this.#features.runtime.serverInfo.version ?? ''
+                    )
                 }
             } catch (err) {
                 if (loadingMessageId) {
@@ -1070,6 +1074,7 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         metric.setDimension('codewhispererCustomizationArn', this.#customizationArn)
+        metric.setDimension('languageServerVersion', this.#features.runtime.serverInfo.version)
         await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric)
 
         this.#telemetryController.updateTriggerInfo(params.tabId, {
@@ -1097,20 +1102,21 @@ export class AgenticChatController implements ChatHandlers {
         metric: Metric<CombinedConversationEvent>
     ): ChatResult | ResponseError<ChatResult> {
         if (isAwsError(err) || (isObject(err) && typeof getHttpStatusCode(err) === 'number')) {
-            let errorMessage: string
+            let errorMessage: string | undefined
             let requestID: string | undefined
 
             if (err instanceof CodeWhispererStreamingServiceException) {
                 errorMessage = err.message
                 requestID = err.$metadata.requestId
-            } else {
-                errorMessage = 'Not a CodeWhispererStreamingServiceException.'
-                if (err instanceof Error || err?.message) {
-                    errorMessage += ` Error is: ${err.message}`
-                }
+            } else if (err?.cause?.message) {
+                errorMessage = err?.cause?.message
+                requestID = err.cause?.$metadata.requestId
+            } else if (err instanceof Error || err?.message) {
+                errorMessage = err.message
             }
 
             metric.setDimension('cwsprChatResponseCode', getHttpStatusCode(err) ?? 0)
+            metric.setDimension('languageServerVersion', this.#features.runtime.serverInfo.version)
             this.#telemetryController.emitMessageResponseError(tabId, metric.metric, requestID, errorMessage)
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -168,7 +168,7 @@ export class ChatTelemetryController {
         }
     }
 
-    public emitToolUseSuggested(toolUse: ToolUse, conversationId: string) {
+    public emitToolUseSuggested(toolUse: ToolUse, conversationId: string, languageServerVersion: string) {
         this.#telemetry.emitMetric({
             name: ChatTelemetryEventName.ToolUseSuggested,
             data: {
@@ -178,6 +178,7 @@ export class ChatTelemetryController {
                 cwsprToolName: toolUse.name ?? '',
                 cwsprToolUseId: toolUse.toolUseId ?? '',
                 result: 'Succeeded',
+                languageServerVersion: languageServerVersion,
             },
         })
     }
@@ -215,6 +216,7 @@ export class ChatTelemetryController {
                 chatFollowUpCount: metric.cwsprChatFollowUpCount,
                 chatConversationType: metric.cwsprChatConversationType,
                 chatActiveEditorImportCount: metric.cwsprChatActiveEditorImportCount,
+                languageServerVersion: metric.languageServerVersion,
             }
         )
     }
@@ -267,6 +269,7 @@ export class ChatTelemetryController {
                 credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
                 result: 'Succeeded',
                 [CONVERSATION_ID_METRIC_KEY]: this.getConversationId(tabId),
+                languageServerVersion: metric.languageServerVersion,
             },
         })
     }

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -877,6 +877,7 @@ describe('TelemetryService', () => {
                     cwsprChatActiveEditorImportCount: undefined,
                     codewhispererCustomizationArn: 'cust-123',
                     result: 'Succeeded',
+                    languageServerVersion: undefined,
                 },
             })
         })

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -391,6 +391,7 @@ export class TelemetryService {
             chatFollowUpCount?: number
             chatConversationType: ChatConversationType
             chatActiveEditorImportCount?: number
+            languageServerVersion?: string
         }>
     ) {
         if (!params.conversationId || !params.messageId) {
@@ -423,6 +424,7 @@ export class TelemetryService {
                     cwsprChatActiveEditorImportCount: additionalParams.chatActiveEditorImportCount,
                     codewhispererCustomizationArn: params.customizationArn,
                     result: 'Succeeded',
+                    languageServerVersion: additionalParams.languageServerVersion,
                 },
             })
         }

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -188,6 +188,7 @@ export type ToolUseSuggestedEvent = {
     cwsprChatConversationType: ChatConversationType
     cwsprToolName: string
     cwsprToolUseId: string
+    languageServerVersion?: string
 }
 
 export type ModifyCodeEvent = {
@@ -220,6 +221,7 @@ export type AddMessageEvent = {
     cwsprChatResponseLength?: number
     cwsprChatConversationType: ChatConversationType
     codewhispererCustomizationArn?: string
+    languageServerVersion?: string
 }
 
 export type EnterFocusChatEvent = {
@@ -289,6 +291,7 @@ export type MessageResponseErrorEvent = {
     cwsprChatRepsonseCode: number
     cwsprChatRequestLength?: number
     cwsprChatConversationType: ChatConversationType
+    languageServerVersion?: string
 }
 
 export type RunCommandEvent = {

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -314,6 +314,9 @@ export function getHttpStatusCode(err: unknown): number | undefined {
     if (hasMetadata(err) && err.$metadata?.httpStatusCode !== undefined) {
         return err.$metadata?.httpStatusCode
     }
+    if (hasCause(err) && err.cause.$metadata?.httpStatusCode !== undefined) {
+        return err.cause.$metadata.httpStatusCode
+    }
 
     return undefined
 }
@@ -324,6 +327,10 @@ function hasResponse<T>(error: T): error is T & Pick<ServiceException, '$respons
 
 function hasMetadata<T>(error: T): error is T & Pick<CodeWhispererStreamingServiceException, '$metadata'> {
     return typeof (error as { $metadata?: unknown })?.$metadata === 'object'
+}
+
+function hasCause<T>(error: T): error is T & { cause: { $metadata?: { httpStatusCode?: number } } } {
+    return typeof (error as { cause?: unknown })?.cause === 'object'
 }
 
 export function hasConnectionExpired(error: any) {


### PR DESCRIPTION
## Problem
- not emitting `languageServerVersion`
- missing one additional case when emitting error metric. `errorMessage` and `requestID` might be nested one level deeper in `err.cause`

## Solution
- emit `languageServerVersion` for agentic chat metrics such as `amazonq_messageResponseError`, `amazonq_addMessage`, `amazonq_toolUseSuggested`
- before emitting error metric, include additional check for setting `errorMessage` and `requestID`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
