### PR TITLE
fix: pair programming mode toggle is not respected

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -173,7 +173,14 @@ describe('AgenticChatController', () => {
         // Add agent with runTool method to testFeatures
         testFeatures.agent = {
             runTool: sinon.stub().resolves({}),
-            getTools: sinon.stub().returns([]),
+            getTools: sinon.stub().returns([
+                {
+                    toolSpecification: {
+                        name: 'mock-tool-name',
+                        description: 'Mock tool for testing',
+                    },
+                },
+            ]),
             addTool: sinon.stub().resolves(),
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -173,14 +173,11 @@ describe('AgenticChatController', () => {
         // Add agent with runTool method to testFeatures
         testFeatures.agent = {
             runTool: sinon.stub().resolves({}),
-            getTools: sinon.stub().returns([
-                {
-                    toolSpecification: {
-                        name: 'mock-tool-name',
-                        description: 'Mock tool for testing',
-                    },
-                },
-            ]),
+            getTools: sinon.stub().returns(
+                ['mock-tool-name', 'mock-tool-name-1', 'mock-tool-name-2'].map(toolName => ({
+                    toolSpecification: { name: toolName, description: 'Mock tool for testing' },
+                }))
+            ),
             addTool: sinon.stub().resolves(),
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -620,6 +620,11 @@ export class AgenticChatController implements ChatHandlers {
             this.#triggerContext.getToolUseLookup().set(toolUse.toolUseId, toolUse)
 
             try {
+                // TODO: Can we move this check in the event parser before the stream completes?
+                const availableToolNames = this.#getTools(session).map(tool => tool.toolSpecification.name)
+                if (!availableToolNames.includes(toolUse.name)) {
+                    throw new Error(`Tool ${toolUse.name} is not available in the current mode`)
+                }
                 const { explanation } = toolUse.input as unknown as ExplanatoryParams
                 if (explanation) {
                     await chatResultStream.writeResultBlock({


### PR DESCRIPTION
## Problem

LLM can sometimes hallucinate and think it has access to tools it shouldn't in the current mode.

## Solution

Add client side check to verify if a tool can be executed depending on the current mode. When this happen, we tell the LLM implicitly that this tool use is not allowed in the current mode and the LLM will correct itself and avoid using that tool.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
