### PR TITLE
fix: extra thinking in the end

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -894,7 +894,7 @@ describe('AgenticChatController', () => {
 
             const chatResult = await chatResultPromise
 
-            sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 2) // response length + 2 loading messages
+            sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 1) // response length + 1 loading messages
             assert.deepStrictEqual(chatResult, {
                 additionalMessages: [],
                 body: '\n\nHello World!',
@@ -911,7 +911,7 @@ describe('AgenticChatController', () => {
 
             const chatResult = await chatResultPromise
 
-            sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 2) // response length + 2 loading message
+            sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 1) // response length + 1 loading message
             assert.deepStrictEqual(chatResult, {
                 additionalMessages: [],
                 body: '\n\nHello World!',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -482,10 +482,6 @@ export class AgenticChatController implements ChatHandlers {
                 documentReference
             )
 
-            // show loading message after we render text response and before processing toolUse
-            loadingMessageId = `loading-${uuid()}-${iterationCount}`
-            await chatResultStream.writeResultBlock({ messageId: loadingMessageId, type: 'answer' })
-
             //  Add the current assistantResponse message to the history DB
             if (result.data?.chatResult.body !== undefined) {
                 this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier ?? '', {
@@ -507,13 +503,6 @@ export class AgenticChatController implements ChatHandlers {
 
             // Check if we have any tool uses that need to be processed
             const pendingToolUses = this.#getPendingToolUses(result.data?.toolUses || {})
-
-            // remove the temp loading message when we are going to process toolUse
-            if (loadingMessageId) {
-                await chatResultStream.removeResultBlock(loadingMessageId)
-                this.#features.chat.sendChatUpdate({ tabId, state: { inProgress: false } })
-                loadingMessageId = undefined
-            }
 
             if (pendingToolUses.length === 0) {
                 // No more tool uses, we're done


### PR DESCRIPTION
## Problem
the loading after streaming text response doesn't get cleared out, causing the extra thinking in the end of response. The issue is the text streaming itself actually takes a long time to resolve. That is still under investigation.
## Solution
- this will remove the extra thinking
- need to followup on the text streaming slowness

<img width="462" alt="Screenshot 2025-04-26 at 8 50 18 AM" src="https://github.com/user-attachments/assets/0f8ca77a-77ac-4fd6-a72b-9120dce807a5" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
