### PR TITLE
fix(amazonq): recursively create directory for saved user prompts

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -402,7 +402,12 @@ export const createMynahUi = (
                         },
                     ],
                     [
-                        { id: ContextPrompt.CancelButtonId, text: 'Cancel', status: 'clear' },
+                        {
+                            id: ContextPrompt.CancelButtonId,
+                            text: 'Cancel',
+                            status: 'clear',
+                            waitMandatoryFormItems: false,
+                        },
                         {
                             id: ContextPrompt.SubmitButtonId,
                             text: 'Create',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -1185,25 +1185,20 @@ describe('AgenticChatController', () => {
     })
 
     describe('onCreatePrompt', () => {
-        it('should create prompt file with given name and ensure directory exists', async () => {
+        it('should create prompt file with given name', async () => {
             const promptName = 'testPrompt'
             const expectedPath = path.join(getUserPromptsDirectory(), `testPrompt${promptFileExtension}`)
-            const mkdirStub = testFeatures.workspace.fs.mkdir as sinon.SinonStub
 
             await chatController.onCreatePrompt({ promptName })
 
-            sinon.assert.calledOnceWithExactly(mkdirStub, getUserPromptsDirectory(), { recursive: true })
             sinon.assert.calledOnceWithExactly(fsWriteFileStub, expectedPath, '', { mode: 0o600 })
         })
 
         it('should create default prompt file when no name provided', async () => {
             const expectedPath = path.join(getUserPromptsDirectory(), `default${promptFileExtension}`)
-            const mkdirStub = testFeatures.workspace.fs.mkdir as sinon.SinonStub
-            mkdirStub.resetHistory()
 
             await chatController.onCreatePrompt({ promptName: '' })
 
-            sinon.assert.calledOnceWithExactly(mkdirStub, getUserPromptsDirectory(), { recursive: true })
             sinon.assert.calledOnceWithExactly(fsWriteFileStub, expectedPath, '', { mode: 0o600 })
         })
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -1185,20 +1185,25 @@ describe('AgenticChatController', () => {
     })
 
     describe('onCreatePrompt', () => {
-        it('should create prompt file with given name', async () => {
+        it('should create prompt file with given name and ensure directory exists', async () => {
             const promptName = 'testPrompt'
             const expectedPath = path.join(getUserPromptsDirectory(), `testPrompt${promptFileExtension}`)
+            const mkdirStub = testFeatures.workspace.fs.mkdir as sinon.SinonStub
 
             await chatController.onCreatePrompt({ promptName })
 
+            sinon.assert.calledOnceWithExactly(mkdirStub, getUserPromptsDirectory(), { recursive: true })
             sinon.assert.calledOnceWithExactly(fsWriteFileStub, expectedPath, '', { mode: 0o600 })
         })
 
         it('should create default prompt file when no name provided', async () => {
             const expectedPath = path.join(getUserPromptsDirectory(), `default${promptFileExtension}`)
+            const mkdirStub = testFeatures.workspace.fs.mkdir as sinon.SinonStub
+            mkdirStub.resetHistory()
 
             await chatController.onCreatePrompt({ promptName: '' })
 
+            sinon.assert.calledOnceWithExactly(mkdirStub, getUserPromptsDirectory(), { recursive: true })
             sinon.assert.calledOnceWithExactly(fsWriteFileStub, expectedPath, '', { mode: 0o600 })
         })
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -251,6 +251,7 @@ export class AgenticChatController implements ChatHandlers {
         const newFilePath = getNewPromptFilePath(params.promptName)
         const newFileContent = ''
         try {
+            await this.#features.workspace.fs.mkdir(getUserPromptsDirectory(), { recursive: true })
             await this.#features.workspace.fs.writeFile(newFilePath, newFileContent, { mode: 0o600 })
             await this.#features.lsp.window.showDocument({ uri: newFilePath })
         } catch (e) {


### PR DESCRIPTION
## Problem
If a user tried to create a saved prompt but the `~/.aws/amazonq/prompts` directory did not already exist, server would error with `Error creating prompt file: Error: ENOENT: no such file or directory, open '/Users/ammathu/.aws/amazonq/prompts/test.md'`

## Solution
Recursively create user prompts directory

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
