### PR TITLE
feat: add the code search tool

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -107,6 +107,7 @@ import { ExplanatoryParams, InvokeOutput, ToolApprovalException } from './tools/
 import { ModelServiceException } from './errors'
 import { FileSearch, FileSearchParams } from './tools/fileSearch'
 import { diffLines } from 'diff'
+import { CodeSearch } from './tools/codeSearch'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -654,6 +655,9 @@ export class AgenticChatController implements ChatHandlers {
                         }
                         break
                     }
+                    case 'codeSearch':
+                        // no need to write tool message for code search.
+                        break
                     default:
                         await chatResultStream.writeResultBlock({
                             type: 'tool',
@@ -715,6 +719,9 @@ export class AgenticChatController implements ChatHandlers {
                     case 'executeBash':
                         // no need to write tool result for listDir and fsRead into chat stream
                         // executeBash will stream the output instead of waiting until the end
+                        break
+                    case 'codeSearch':
+                        // no need to write tool result for code search.
                         break
                     case 'fsWrite':
                         const input = toolUse.input as unknown as FsWriteParams

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/codeSearch.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/codeSearch.test.ts
@@ -1,0 +1,199 @@
+import * as assert from 'assert'
+import { CodeSearch, CodeSearchOutput } from './codeSearch'
+import { testFolder } from '@aws/lsp-core'
+import * as path from 'path'
+import * as fs from 'fs/promises'
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { LocalProjectContextController } from '../../../shared/localProjectContextController'
+import { Chunk } from 'local-indexing'
+import { stub, restore, SinonStub } from 'sinon'
+
+describe('CodeSearch Tool', () => {
+    let tempFolder: testFolder.TestFolder
+    let testFeatures: TestFeatures
+    let mockLocalProjectContextController: Partial<LocalProjectContextController>
+    let getInstanceStub: SinonStub
+
+    before(async () => {
+        testFeatures = new TestFeatures()
+        // @ts-ignore does not require all fs operations to be implemented
+        testFeatures.workspace.fs = {
+            exists: async (path: string): Promise<boolean> => {
+                try {
+                    await fs.access(path)
+                    return true
+                } catch {
+                    return false
+                }
+            },
+        } as Features['workspace']['fs']
+        tempFolder = await testFolder.TestFolder.create()
+
+        testFeatures.workspace.fs = {
+            exists: async (path: string): Promise<boolean> => {
+                try {
+                    await fs.access(path)
+                    return true
+                } catch {
+                    return false
+                }
+            },
+        } as Features['workspace']['fs']
+
+        // Create mock LocalProjectContextController
+        mockLocalProjectContextController = {
+            isEnabled: true,
+            queryVectorIndex: stub().resolves([]),
+        }
+
+        // Stub the getInstance method
+        getInstanceStub = stub(LocalProjectContextController, 'getInstance').resolves(
+            mockLocalProjectContextController as LocalProjectContextController
+        )
+    })
+
+    after(async () => {
+        await tempFolder.delete()
+        restore() // Restore all stubbed methods
+    })
+
+    it('invalidates empty query', async () => {
+        const codeSearch = new CodeSearch(testFeatures)
+        await assert.rejects(
+            codeSearch.validate({ query: '' }),
+            /Code search query cannot be empty/i,
+            'Expected an error about empty query'
+        )
+    })
+
+    it('validates query with path', async () => {
+        const codeSearch = new CodeSearch(testFeatures)
+        await codeSearch.validate({ query: 'function test', path: tempFolder.path })
+        // If no error is thrown, the validation passed
+    })
+
+    it('returns empty results when no matches found', async () => {
+        const codeSearch = new CodeSearch(testFeatures)
+        const result = await codeSearch.invoke({ query: 'nonexistent code' })
+
+        assert.strictEqual(result.output.kind, 'text')
+        assert.strictEqual(result.output.content, 'No code matches found for code search.')
+    })
+
+    it('returns formatted results when matches found', async () => {
+        // Create mock chunks that would be returned from vector search
+        const mockChunks: Chunk[] = [
+            {
+                content: 'function testFunction() { return true; }',
+                filePath: path.join(tempFolder.path, 'test.js'),
+                relativePath: 'test.js',
+                startLine: 1,
+                endLine: 3,
+                programmingLanguage: 'javascript',
+                id: '',
+                index: 0,
+                vec: [],
+            },
+        ]
+
+        // Configure the mock to return our test chunks
+        ;(mockLocalProjectContextController.queryVectorIndex as SinonStub).resolves(mockChunks)
+
+        const codeSearch = new CodeSearch(testFeatures)
+        const result = await codeSearch.invoke({ query: 'testFunction' })
+
+        assert.strictEqual(result.output.kind, 'json')
+        const content = result.output.content as CodeSearchOutput[]
+        assert.strictEqual(Array.isArray(content), true)
+        assert.strictEqual(content.length, 1)
+        assert.strictEqual(content[0].text, 'function testFunction() { return true; }')
+        assert.strictEqual(content[0].relativeFilePath, 'test.js')
+        assert.strictEqual(content[0].startLine, 1)
+        assert.strictEqual(content[0].endLine, 3)
+        assert.strictEqual(content[0].programmingLanguage, 'javascript')
+    })
+
+    it('handles chunks without programming language', async () => {
+        // Create mock chunks that would be returned from vector search
+        const mockChunks: Chunk[] = [
+            {
+                content: 'function testFunction() { return true; }',
+                filePath: path.join(tempFolder.path, 'test.js'),
+                relativePath: 'test.js',
+                id: '',
+                index: 0,
+                vec: [],
+            },
+        ]
+
+        // Configure the mock to return our test chunks
+        ;(mockLocalProjectContextController.queryVectorIndex as SinonStub).resolves(mockChunks)
+
+        const codeSearch = new CodeSearch(testFeatures)
+        const result = await codeSearch.invoke({ query: 'plain text' })
+
+        assert.strictEqual(result.output.kind, 'json')
+        const content = result.output.content as CodeSearchOutput[]
+        assert.strictEqual(content.length, 1)
+        assert.strictEqual(content[0].text, 'function testFunction() { return true; }')
+        assert.strictEqual(content[0].relativeFilePath, 'test.js')
+        assert.strictEqual(content[0].programmingLanguage, undefined)
+    })
+
+    it('uses default workspace folder when path not provided', async () => {
+        const codeSearch = new CodeSearch(testFeatures)
+        await codeSearch.invoke({ query: 'test query' })
+
+        // Verify that queryVectorIndex was called
+        assert.strictEqual((mockLocalProjectContextController.queryVectorIndex as SinonStub).called, true)
+    })
+
+    it('handles errors from LocalProjectContextController', async () => {
+        // Configure the mock to throw an error
+        ;(mockLocalProjectContextController.queryVectorIndex as SinonStub).rejects(new Error('Test error'))
+
+        const codeSearch = new CodeSearch(testFeatures)
+        await assert.rejects(
+            codeSearch.invoke({ query: 'error test' }),
+            /Failed to perform code search/,
+            'Expected an error when vector search fails'
+        )
+    })
+
+    it('does not require acceptance when path is not provided', async () => {
+        const codeSearch = new CodeSearch(testFeatures)
+        const result = await codeSearch.requiresAcceptance({ query: 'test' })
+        assert.strictEqual(result.requiresAcceptance, false)
+    })
+
+    it('provides correct queue description', async () => {
+        const codeSearch = new CodeSearch(testFeatures)
+
+        // Create a mock WritableStream
+        let capturedDescription = ''
+        const mockWriter = {
+            write: async (content: string) => {
+                capturedDescription = content
+                return Promise.resolve()
+            },
+            close: async () => Promise.resolve(),
+            releaseLock: () => {},
+        }
+        const mockStream = {
+            getWriter: () => mockWriter,
+        } as unknown as WritableStream
+
+        await codeSearch.queueDescription({ query: 'test query', path: '/test/path' }, mockStream, true)
+        assert.strictEqual(capturedDescription, 'Performing code search for "test query" in /test/path')
+    })
+
+    it('returns correct tool specification', () => {
+        const codeSearch = new CodeSearch(testFeatures)
+        const spec = codeSearch.getSpec()
+
+        assert.strictEqual(spec.name, 'codeSearch')
+        assert.ok(spec.description.includes('Find snippets of code'))
+        assert.deepStrictEqual(spec.inputSchema.required, ['query'])
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/codeSearch.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/codeSearch.ts
@@ -1,0 +1,204 @@
+import { CommandValidation, InvokeOutput, requiresPathAcceptance, validatePath } from './toolShared'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
+import { LocalProjectContextController } from '../../../shared/localProjectContextController'
+import { Chunk } from 'local-indexing'
+import { RelevantTextDocument } from '@amzn/codewhisperer-streaming'
+import { LineInfo } from '../context/agenticChatTriggerContext'
+import path = require('path')
+
+export interface CodeSearchParams {
+    query: string
+    path?: string
+}
+
+export type CodeSearchOutput = RelevantTextDocument & LineInfo
+
+export class CodeSearch {
+    private readonly logging: Features['logging']
+    private readonly workspace: Features['workspace']
+    private readonly lsp: Features['lsp']
+    constructor(features: Pick<Features, 'logging' | 'workspace' | 'lsp'>) {
+        this.logging = features.logging
+        this.workspace = features.workspace
+        this.lsp = features.lsp
+    }
+
+    public async validate(params: CodeSearchParams): Promise<void> {
+        if (!params.query || params.query.trim().length === 0) {
+            throw new Error('Code search query cannot be empty.')
+        }
+        const searchPath = this.getOrSetSearchPath(params.path)
+
+        if (searchPath) {
+            await validatePath(searchPath, this.workspace.fs.exists)
+        }
+    }
+
+    public async queueDescription(params: CodeSearchParams, updates: WritableStream, requiresAcceptance: boolean) {
+        const writer = updates.getWriter()
+        const closeWriter = async (w: WritableStreamDefaultWriter) => {
+            await w.close()
+            w.releaseLock()
+        }
+        if (!requiresAcceptance) {
+            await writer.write('')
+            await closeWriter(writer)
+            return
+        }
+
+        const path = this.getOrSetSearchPath(params.path)
+        await writer.write(`Performing code search for "${params.query}" in ${path}`)
+        await closeWriter(writer)
+    }
+
+    public async requiresAcceptance(params: CodeSearchParams): Promise<CommandValidation> {
+        if (!params.path) {
+            return { requiresAcceptance: false }
+        }
+        return requiresPathAcceptance(params.path, this.lsp, this.logging)
+    }
+
+    public async invoke(params: CodeSearchParams): Promise<InvokeOutput> {
+        const path = this.getOrSetSearchPath(params.path)
+
+        try {
+            const results = await this.executeCodeSearch(params.query, path)
+            return this.createOutput(
+                !results || results.length === 0 ? 'No code matches found for code search.' : results
+            )
+        } catch (error: any) {
+            this.logging.error(
+                `Failed to perform code search for "${params.query}" in "${path}": ${error.message || error}`
+            )
+            throw new Error(
+                `Failed to perform code search for "${params.query}" in "${path}": ${error.message || error}`
+            )
+        }
+    }
+
+    private getOrSetSearchPath(path?: string): string {
+        let searchPath = ''
+        if (path && path.trim().length !== 0) {
+            searchPath = path
+        } else {
+            // Handle optional path parameter
+            // Use current workspace folder as default if path is not provided
+            const workspaceFolders = getWorkspaceFolderPaths(this.lsp)
+            if (workspaceFolders && workspaceFolders.length !== 0) {
+                this.logging.debug(`Using default workspace folder: ${workspaceFolders[0]}`)
+                searchPath = workspaceFolders[0]
+            }
+        }
+        return searchPath
+    }
+
+    private async executeCodeSearch(query: string, path: string): Promise<CodeSearchOutput[]> {
+        this.logging.info(`Executing code search for "${query}" in "${path}"`)
+        const localProjectContextController = await LocalProjectContextController.getInstance()
+
+        if (!localProjectContextController.isEnabled) {
+            this.logging.warn(`Error during code search: local project context controller is disable`)
+            return []
+        }
+        try {
+            // Use the localProjectContextController to query the vector index
+            const searchResults = await localProjectContextController.queryVectorIndex({ query: query })
+            const sanitizedSearchResults = this.parseChunksToCodeSearchOutput(searchResults)
+            this.logging.info(`Code searched succeed with num of results: "${sanitizedSearchResults.length}"`)
+            return sanitizedSearchResults
+        } catch (error: any) {
+            this.logging.error(`Error during code search: ${error.message || error}`)
+            throw error
+        }
+    }
+
+    /**
+     * Parses chunks from vector index search into CodeSearchOutput format
+     * Based on the queryRelevantDocuments method pattern
+     */
+    private parseChunksToCodeSearchOutput(chunks: Chunk[]): CodeSearchOutput[] {
+        const codeSearchResults: CodeSearchOutput[] = []
+        if (!chunks) {
+            return codeSearchResults
+        }
+
+        for (const chunk of chunks) {
+            // Extract content and context
+            const content = chunk.content || ''
+            const relativeFilePath = chunk.relativePath ?? path.basename(chunk.filePath)
+
+            // Extract line information
+            const startLine = chunk.startLine ?? -1
+            const endLine = chunk.endLine ?? -1
+
+            // Create the base search result
+            const baseSearchResult = {
+                content,
+                relativeFilePath,
+                startLine,
+                endLine,
+            }
+
+            // Add programming language information if available
+            if (chunk.programmingLanguage && chunk.programmingLanguage !== 'unknown') {
+                codeSearchResults.push({
+                    ...baseSearchResult,
+                    programmingLanguage: {
+                        languageName: chunk.programmingLanguage,
+                    },
+                })
+            } else {
+                codeSearchResults.push(baseSearchResult)
+            }
+        }
+
+        return codeSearchResults
+    }
+
+    private createOutput(content: string | any[]): InvokeOutput {
+        if (typeof content === 'string') {
+            return {
+                output: {
+                    kind: 'text',
+                    content: content,
+                },
+            }
+        } else {
+            return {
+                output: {
+                    kind: 'json',
+                    content: content,
+                },
+            }
+        }
+    }
+
+    public getSpec() {
+        return {
+            name: 'codeSearch',
+            description:
+                "Find snippets of code from the codebase most relevant to the search query.\nThis is a semantic search tool, so the query should ask for something semantically matching what is needed.\nIf it makes sense to only search in particular directories, please specify them in the target_directories field.\nUnless there is a clear reason to use your own search query, please just reuse the user's exact query with their wording.\nTheir exact wording/phrasing can often be helpful for the semantic search query. Keeping the same exact question format can also be helpful.",
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    query: {
+                        type: 'string',
+                        description: 'The search query to find relevant code.',
+                    },
+                    path: {
+                        type: 'string',
+                        description:
+                            'Optional absolute path to a directory to search in, e.g., `/repo`. If not provided, the current workspace folder will be used.',
+                    },
+                    explanatio: {
+                        type: 'string',
+                        description:
+                            'One sentence explanation as to why this tool is being used, and how it contributes to the goal',
+                    },
+                },
+                required: ['query'],
+            },
+        } as const
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -9,12 +9,14 @@ import { LspApplyWorkspaceEdit, LspApplyWorkspaceEditParams } from './lspApplyWo
 import { McpManager } from './mcp/mcpManager'
 import { McpTool } from './mcp/mcpTool'
 import { FileSearch, FileSearchParams } from './fileSearch'
+import { CodeSearch, CodeSearchParams } from './codeSearch'
 
 export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     const fsReadTool = new FsRead({ workspace, lsp, logging })
     const fsWriteTool = new FsWrite({ workspace, lsp, logging })
     const listDirectoryTool = new ListDirectory({ workspace, logging, lsp })
     const fileSearchTool = new FileSearch({ workspace, logging, lsp })
+    const codeSearchTool = new CodeSearch({ workspace, logging, lsp })
 
     agent.addTool(fsReadTool.getSpec(), async (input: FsReadParams) => {
         // TODO: fill in logic for handling invalid tool invocations
@@ -35,6 +37,8 @@ export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     )
 
     agent.addTool(fileSearchTool.getSpec(), (input: FileSearchParams) => fileSearchTool.invoke(input))
+
+    agent.addTool(codeSearchTool.getSpec(), (input: CodeSearchParams) => codeSearchTool.invoke(input))
 
     return () => {}
 }


### PR DESCRIPTION
## Problem
To support the semantic search for the code base. 
## Solution
* add this code search tool to using the LocalProjectContextController to support semantic search, similar as the workspace falcon. 
* 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
