### PR TITLE
feat: undo-all button

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -40,6 +40,7 @@ import {
     MynahUIProps,
     QuickActionCommand,
     ChatItemFormItem,
+    ChatItemButton,
 } from '@aws/mynah-ui'
 import { VoteParams } from '../contracts/telemetry'
 import { Messager } from './messager'
@@ -726,10 +727,14 @@ export const createMynahUi = (
             }
         }
 
+        const processedButtons: ChatItemButton[] | undefined = toMynahButtons(message.buttons)?.map(button =>
+            button.id === 'undo-all-changes' ? { ...button, position: 'outside' } : button
+        )
+
         return {
             body: message.body,
             header: processedHeader,
-            buttons: toMynahButtons(message.buttons),
+            buttons: processedButtons,
 
             // file diffs in the header need space
             fullWidth: message.type === 'tool' && message.header?.buttons ? true : undefined,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -169,12 +169,12 @@ export class AgenticChatController implements ChatHandlers {
 
     async onButtonClick(params: ButtonClickParams): Promise<ButtonClickResult> {
         this.#log(`onButtonClick event with params: ${JSON.stringify(params)}`)
+        const session = this.#chatSessionManagementService.getSession(params.tabId)
         if (
             params.buttonId === 'run-shell-command' ||
             params.buttonId === 'reject-shell-command' ||
             params.buttonId === 'allow-tools'
         ) {
-            const session = this.#chatSessionManagementService.getSession(params.tabId)
             if (!session.data) {
                 return { success: false, failureReason: `could not find chat session for tab: ${params.tabId} ` }
             }
@@ -200,30 +200,17 @@ export class AgenticChatController implements ChatHandlers {
         } else if (params.buttonId === 'undo-changes') {
             const toolUseId = params.messageId
             try {
-                await this.#undoFileChange(toolUseId)
-                const cachedToolUse = this.#triggerContext.getToolUseLookup().get(toolUseId)
-                if (cachedToolUse) {
-                    this.#features.chat.sendChatUpdate({
-                        tabId: params.tabId,
-                        data: {
-                            messages: [
-                                {
-                                    ...cachedToolUse.chatResult,
-                                    header: {
-                                        ...cachedToolUse.chatResult?.header,
-                                        buttons: cachedToolUse.chatResult?.header?.buttons?.filter(
-                                            button => button.id !== 'undo-changes'
-                                        ),
-                                        status: { status: 'error', icon: 'cancel', text: 'Change discarded' },
-                                    },
-                                },
-                            ],
-                        },
-                    })
-                }
+                await this.#undoFileChange(toolUseId, session.data)
+                this.#updateUndoButtonAfterClick(params.tabId, toolUseId, session.data)
             } catch (err: any) {
                 return { success: false, failureReason: err.message }
             }
+            return {
+                success: true,
+            }
+        } else if (params.buttonId === 'undo-all-changes') {
+            const toolUseId = params.messageId.replace('_undoall', '')
+            await this.#undoAllFileChanges(params.tabId, toolUseId, session.data)
             return {
                 success: true,
             }
@@ -235,15 +222,54 @@ export class AgenticChatController implements ChatHandlers {
         }
     }
 
-    async #undoFileChange(toolUseId: string): Promise<void> {
+    async #undoFileChange(toolUseId: string, session: ChatSessionService | undefined): Promise<void> {
         this.#log(`Reverting file change for tooluseId: ${toolUseId}`)
-        const toolUse = this.#triggerContext.getToolUseLookup().get(toolUseId)
+        const toolUse = session?.toolUseLookup.get(toolUseId)
 
         const input = toolUse?.input as unknown as FsWriteParams
         if (toolUse?.fileChange?.before) {
             await this.#features.workspace.fs.writeFile(input.path, toolUse.fileChange.before)
         } else {
             await this.#features.workspace.fs.rm(input.path)
+        }
+    }
+
+    #updateUndoButtonAfterClick(tabId: string, toolUseId: string, session: ChatSessionService | undefined) {
+        const cachedToolUse = session?.toolUseLookup.get(toolUseId)
+        if (!cachedToolUse) {
+            return
+        }
+        this.#features.chat.sendChatUpdate({
+            tabId,
+            data: {
+                messages: [
+                    {
+                        ...cachedToolUse.chatResult,
+                        header: {
+                            ...cachedToolUse.chatResult?.header,
+                            buttons: cachedToolUse.chatResult?.header?.buttons?.filter(
+                                button => button.id !== 'undo-changes'
+                            ),
+                            status: { status: 'error', icon: 'cancel', text: 'Change discarded' },
+                        },
+                    },
+                ],
+            },
+        })
+    }
+
+    async #undoAllFileChanges(
+        tabId: string,
+        toolUseId: string,
+        session: ChatSessionService | undefined
+    ): Promise<void> {
+        this.#log(`Reverting all file changes starting from ${toolUseId}`)
+        const toUndo = session?.toolUseLookup.get(toolUseId)?.relatedToolUses
+        if (!toUndo) {
+            return
+        }
+        for (const messageId of [...toUndo].reverse()) {
+            await this.onButtonClick({ buttonId: 'undo-changes', messageId, tabId })
         }
     }
 
@@ -503,6 +529,7 @@ export class AgenticChatController implements ChatHandlers {
                     cwsprChatMessageId: response.$metadata.requestId,
                 }),
                 chatResultStream,
+                session,
                 documentReference
             )
 
@@ -607,13 +634,16 @@ export class AgenticChatController implements ChatHandlers {
             // Store buttonBlockId to use it in `catch` block if needed
             let cachedButtonBlockId
             if (!toolUse.name || !toolUse.toolUseId) continue
-            this.#triggerContext.getToolUseLookup().set(toolUse.toolUseId, toolUse)
+            session.toolUseLookup.set(toolUse.toolUseId, toolUse)
 
             try {
                 // TODO: Can we move this check in the event parser before the stream completes?
                 const availableToolNames = this.#getTools(session).map(tool => tool.toolSpecification.name)
                 if (!availableToolNames.includes(toolUse.name)) {
                     throw new Error(`Tool ${toolUse.name} is not available in the current mode`)
+                }
+                if (toolUse.name !== 'fsWrite') {
+                    await this.#showUndoAllIfRequired(chatResultStream, session)
                 }
                 const { explanation } = toolUse.input as unknown as ExplanatoryParams
                 if (explanation) {
@@ -671,9 +701,10 @@ export class AgenticChatController implements ChatHandlers {
                 if (toolUse.name === 'fsWrite') {
                     const input = toolUse.input as unknown as FsWriteParams
                     const document = await this.#triggerContext.getTextDocument(input.path)
-                    this.#triggerContext
-                        .getToolUseLookup()
-                        .set(toolUse.toolUseId, { ...toolUse, fileChange: { before: document?.getText() } })
+                    session.toolUseLookup.set(toolUse.toolUseId, {
+                        ...toolUse,
+                        fileChange: { before: document?.getText() },
+                    })
                 }
 
                 const ws = this.#getWritableStream(chatResultStream, toolUse)
@@ -720,11 +751,10 @@ export class AgenticChatController implements ChatHandlers {
                     case 'fsWrite':
                         const input = toolUse.input as unknown as FsWriteParams
                         const doc = await this.#triggerContext.getTextDocument(input.path)
-                        const chatResult = await this.#getFsWriteChatResult(toolUse, doc)
-                        const toolUseLookup = this.#triggerContext.getToolUseLookup()
-                        const cachedToolUse = toolUseLookup.get(toolUse.toolUseId)
+                        const chatResult = await this.#getFsWriteChatResult(toolUse, doc, session)
+                        const cachedToolUse = session.toolUseLookup.get(toolUse.toolUseId)
                         if (cachedToolUse) {
-                            toolUseLookup.set(toolUse.toolUseId, {
+                            session.toolUseLookup.set(toolUse.toolUseId, {
                                 ...cachedToolUse,
                                 chatResult,
                                 fileChange: { ...cachedToolUse.fileChange, after: doc?.getText() },
@@ -740,6 +770,8 @@ export class AgenticChatController implements ChatHandlers {
                         })
                         break
                 }
+                this.#updateUndoAllState(toolUse, session)
+
                 if (toolUse.name) {
                     this.#telemetryController.emitToolUseSuggested(
                         toolUse,
@@ -785,6 +817,61 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         return results
+    }
+
+    /**
+     * Updates the currentUndoAllId state in the session
+     */
+    #updateUndoAllState(toolUse: ToolUse, session: ChatSessionService) {
+        if (toolUse.name === 'fsWrite') {
+            if (session.currentUndoAllId === undefined) {
+                session.currentUndoAllId = toolUse.toolUseId
+            }
+            if (session.currentUndoAllId) {
+                const prev = session.toolUseLookup.get(session.currentUndoAllId)
+                if (prev && toolUse.toolUseId) {
+                    const relatedToolUses = prev.relatedToolUses || new Set()
+                    relatedToolUses.add(toolUse.toolUseId)
+
+                    session.toolUseLookup.set(session.currentUndoAllId, {
+                        ...prev,
+                        relatedToolUses,
+                    })
+                }
+            }
+        } else {
+            session.currentUndoAllId = undefined
+        }
+    }
+
+    /**
+     * Shows an "Undo all changes" button if there are multiple related file changes
+     * that can be undone together.
+     */
+    async #showUndoAllIfRequired(chatResultStream: AgenticChatResultStream, session: ChatSessionService) {
+        if (session.currentUndoAllId === undefined) {
+            return
+        }
+
+        const toUndo = session.toolUseLookup.get(session.currentUndoAllId)?.relatedToolUses
+        if (!toUndo || toUndo.size <= 1) {
+            return
+        }
+
+        await chatResultStream.writeResultBlock({
+            type: 'answer',
+            messageId: `${session.currentUndoAllId}_undoall`,
+            buttons: [
+                {
+                    id: 'undo-all-changes',
+                    text: 'Undo all changes',
+                    icon: 'revert',
+                    status: 'clear',
+                    keepCardAfterClick: false,
+                },
+            ],
+        })
+        session.currentUndoAllId = undefined
     }
 
     /**
@@ -1045,9 +1132,13 @@ export class AgenticChatController implements ChatHandlers {
         }
     }
 
-    async #getFsWriteChatResult(toolUse: ToolUse, doc: TextDocument | undefined): Promise<ChatMessage> {
+    async #getFsWriteChatResult(
+        toolUse: ToolUse,
+        doc: TextDocument | undefined,
+        session: ChatSessionService
+    ): Promise<ChatMessage> {
         const input = toolUse.input as unknown as FsWriteParams
-        const oldContent = this.#triggerContext.getToolUseLookup().get(toolUse.toolUseId!)?.fileChange?.before ?? ''
+        const oldContent = session.toolUseLookup.get(toolUse.toolUseId!)?.fileChange?.before ?? ''
         // Get just the filename instead of the full path
         const fileName = path.basename(input.path)
         const diffChanges = diffLines(oldContent, doc?.getText() ?? '')
@@ -1440,8 +1531,9 @@ export class AgenticChatController implements ChatHandlers {
     }
 
     async onFileClicked(params: FileClickParams) {
+        const session = this.#chatSessionManagementService.getSession(params.tabId)
         const toolUseId = params.messageId
-        const toolUse = toolUseId ? this.#triggerContext.getToolUseLookup().get(toolUseId) : undefined
+        const toolUse = toolUseId ? session.data?.toolUseLookup.get(toolUseId) : undefined
 
         if (toolUse?.name === 'fsWrite') {
             const input = toolUse.input as unknown as FsWriteParams
@@ -1634,6 +1726,7 @@ export class AgenticChatController implements ChatHandlers {
         response: GenerateAssistantResponseCommandOutput,
         metric: Metric<AddMessageEvent>,
         chatResultStream: AgenticChatResultStream,
+        session: ChatSessionService,
         contextList?: FileList
     ): Promise<Result<AgenticChatResultWithMetadata, string>> {
         const requestId = response.$metadata.requestId!
@@ -1646,6 +1739,9 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         for await (const chatEvent of response.generateAssistantResponseResponse!) {
+            if (chatEvent.assistantResponseEvent) {
+                await this.#showUndoAllIfRequired(chatResultStream, session)
+            }
             const result = chatEventParser.processPartialEvent(chatEvent)
 
             // terminate early when there is an error

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -10,7 +10,6 @@ import {
     AdditionalContentEntry,
     GenerateAssistantResponseCommandInput,
     ChatMessage,
-    ToolUse,
 } from '@amzn/codewhisperer-streaming'
 import {
     BedrockTools,
@@ -20,7 +19,6 @@ import {
     FileList,
     TextDocument,
     OPEN_WORKSPACE_INDEX_SETTINGS_BUTTON_ID,
-    ChatResult,
 } from '@aws/language-server-runtimes/server-interface'
 import { Features } from '../../types'
 import { DocumentContext, DocumentContextExtractor } from '../../chat/contexts/documentContext'
@@ -55,8 +53,6 @@ export interface DocumentReference {
     readonly lineRanges: Array<{ first: number; second: number }>
 }
 
-type FileChange = { before?: string; after?: string }
-
 export class AgenticChatTriggerContext {
     private static readonly DEFAULT_CURSOR_STATE: CursorState = { position: { line: 0, character: 0 } }
 
@@ -64,14 +60,12 @@ export class AgenticChatTriggerContext {
     #lsp: Features['lsp']
     #logging: Features['logging']
     #documentContextExtractor: DocumentContextExtractor
-    #toolUseLookup: Map<string, ToolUse & { fileChange?: FileChange; chatResult?: ChatResult }>
 
     constructor({ workspace, lsp, logging }: Pick<Features, 'workspace' | 'lsp' | 'logging'> & Partial<Features>) {
         this.#workspace = workspace
         this.#lsp = lsp
         this.#logging = logging
         this.#documentContextExtractor = new DocumentContextExtractor({ logger: logging, workspace })
-        this.#toolUseLookup = new Map()
     }
 
     async getNewTriggerContext(params: ChatParams | InlineChatParams): Promise<TriggerContext> {
@@ -289,9 +283,5 @@ export class AgenticChatTriggerContext {
             this.#logging.error(`Error querying query vector index to get relevant documents: ${e}`)
             return []
         }
-    }
-
-    getToolUseLookup() {
-        return this.#toolUseLookup
     }
 }


### PR DESCRIPTION
## Problem

Missing "Undo all changes" functionality

## Solution

- Added an "Undo All Changes" button that appears after non-fsWrite tool uses when there are pending file changes
- Refactored the tool use tracking system to store tool use data in the chat session instead of the trigger context
- Implemented tracking of related file changes to group them for the undo-all functionality
- Added new methods to handle the undo-all operation and update UI state accordingly

https://github.com/user-attachments/assets/efb84b85-d6db-4af5-b67b-d10730c3bf15



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
