### PR TITLE
fix: windows chat tries mac path

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -135,6 +135,9 @@ export class AgenticChatTriggerContext {
                                       },
                                       tools,
                                       additionalContext: additionalContent,
+                                      envState: {
+                                          operatingSystem: process.platform,
+                                      },
                                   }
                                 : {
                                       tools,
@@ -143,6 +146,9 @@ export class AgenticChatTriggerContext {
                                           relevantDocuments: relevantDocuments,
                                           useRelevantDocuments: useRelevantDocuments,
                                           ...defaultEditorState,
+                                      },
+                                      envState: {
+                                          operatingSystem: process.platform,
                                       },
                                   },
                         userIntent: triggerContext.userIntent,


### PR DESCRIPTION
## Problem

Agentic tools appear to try to use mac/linux pathing before using Windows paths. I get prompted to allow access to paths two times.

## Solution

Adding back envState variable to input params. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
