### PR TITLE
fix: remove guessIntentFromPrompt functionality while preserving user Intent property

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -73,7 +73,7 @@ export class AgenticChatTriggerContext {
 
         return {
             ...documentContext,
-            userIntent: this.#guessIntentFromPrompt(params.prompt.prompt),
+            userIntent: undefined,
         }
     }
 
@@ -195,22 +195,6 @@ export class AgenticChatTriggerContext {
         } catch {
             return
         }
-    }
-
-    #guessIntentFromPrompt(prompt?: string): UserIntent | undefined {
-        if (prompt === undefined) {
-            return undefined
-        } else if (/^explain/i.test(prompt)) {
-            return UserIntent.EXPLAIN_CODE_SELECTION
-        } else if (/^refactor/i.test(prompt)) {
-            return UserIntent.SUGGEST_ALTERNATE_IMPLEMENTATION
-        } else if (/^fix/i.test(prompt)) {
-            return UserIntent.APPLY_COMMON_BEST_PRACTICES
-        } else if (/^optimize/i.test(prompt)) {
-            return UserIntent.IMPROVE_CODE
-        }
-
-        return undefined
     }
 
     async #getRelevantDocuments(

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
@@ -38,7 +38,7 @@ export class QChatTriggerContext {
 
         return {
             ...documentContext,
-            userIntent: undefined,
+            userIntent: this.#guessIntentFromPrompt(params.prompt.prompt),
             useRelevantDocuments,
             relevantDocuments,
         }
@@ -128,5 +128,21 @@ export class QChatTriggerContext {
             }
         }
         return []
+    }
+
+    #guessIntentFromPrompt(prompt?: string): UserIntent | undefined {
+        if (prompt === undefined) {
+            return undefined
+        } else if (/^explain/i.test(prompt)) {
+            return UserIntent.EXPLAIN_CODE_SELECTION
+        } else if (/^refactor/i.test(prompt)) {
+            return UserIntent.SUGGEST_ALTERNATE_IMPLEMENTATION
+        } else if (/^fix/i.test(prompt)) {
+            return UserIntent.APPLY_COMMON_BEST_PRACTICES
+        } else if (/^optimize/i.test(prompt)) {
+            return UserIntent.IMPROVE_CODE
+        }
+
+        return undefined
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
@@ -38,7 +38,7 @@ export class QChatTriggerContext {
 
         return {
             ...documentContext,
-            userIntent: this.#guessIntentFromPrompt(params.prompt.prompt),
+            userIntent: undefined,
             useRelevantDocuments,
             relevantDocuments,
         }
@@ -128,21 +128,5 @@ export class QChatTriggerContext {
             }
         }
         return []
-    }
-
-    #guessIntentFromPrompt(prompt?: string): UserIntent | undefined {
-        if (prompt === undefined) {
-            return undefined
-        } else if (/^explain/i.test(prompt)) {
-            return UserIntent.EXPLAIN_CODE_SELECTION
-        } else if (/^refactor/i.test(prompt)) {
-            return UserIntent.SUGGEST_ALTERNATE_IMPLEMENTATION
-        } else if (/^fix/i.test(prompt)) {
-            return UserIntent.APPLY_COMMON_BEST_PRACTICES
-        } else if (/^optimize/i.test(prompt)) {
-            return UserIntent.IMPROVE_CODE
-        }
-
-        return undefined
     }
 }


### PR DESCRIPTION
## Problem

User intents are no longer relevant for chat.

## Solution

Remove the guessing capability.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
