### PR TITLE
fix(amazonq): `@Code` items show symbol name instead of file name

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -159,6 +159,7 @@ export class ContextCommandsProvider implements Disposable {
             } else if (item.symbol) {
                 codeCmds.push({
                     ...baseItem,
+                    command: item.symbol.name,
                     description: `${item.symbol.kind}, ${path.join(wsFolderName, item.relativePath)}, L${item.symbol.range.start.line}-${item.symbol.range.end.line}`,
                     label: 'code',
                     icon: 'code-block',


### PR DESCRIPTION
## Problem
`@Code` is showing file names instead of code symbol name 

## Solution
Display code symbol names in list. See corresponding code in https://github.com/aws/aws-toolkit-vscode/blob/3171de5e4a90c9e8b4aec0965fcd5c9bc0235745/packages/core/src/codewhispererChat/controllers/chat/controller.ts#L590

Before
![image](https://github.com/user-attachments/assets/baebda39-ecde-4093-888d-18b5d103350b)


After
![image](https://github.com/user-attachments/assets/0c83f2bd-2e24-4408-9065-8f653755b203)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
