### PR TITLE
fix: llm not breaking down requests when input is too large

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -548,6 +548,7 @@ export class AgenticChatController implements ChatHandlers {
                 break
             }
 
+            let content = ''
             let toolResults: ToolResult[]
             if (result.success) {
                 // Process tool uses and update the request input for the next iteration
@@ -559,8 +560,12 @@ export class AgenticChatController implements ChatHandlers {
                     status: ToolResultStatus.ERROR,
                     content: [{ text: result.error }],
                 }))
+                if (result.error.startsWith('ToolUse input is invalid JSON:')) {
+                    content =
+                        'Your toolUse input is incomplete because it is too large. Break this task down into multiple tool uses with smaller input.'
+                }
             }
-            currentRequestInput = this.#updateRequestInputWithToolResults(currentRequestInput, toolResults)
+            currentRequestInput = this.#updateRequestInputWithToolResults(currentRequestInput, toolResults, content)
         }
 
         if (iterationCount >= maxIterations) {
@@ -1204,7 +1209,8 @@ export class AgenticChatController implements ChatHandlers {
      */
     #updateRequestInputWithToolResults(
         requestInput: GenerateAssistantResponseCommandInput,
-        toolResults: ToolResult[]
+        toolResults: ToolResult[],
+        content: string
     ): GenerateAssistantResponseCommandInput {
         // Create a deep copy of the request input
         const updatedRequestInput = JSON.parse(JSON.stringify(requestInput)) as GenerateAssistantResponseCommandInput
@@ -1212,7 +1218,7 @@ export class AgenticChatController implements ChatHandlers {
         // Add tool results to the request
         updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.userInputMessageContext!.toolResults =
             []
-        updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.content = ''
+        updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.content = content
 
         for (const toolResult of toolResults) {
             this.#debug(`ToolResult: ${JSON.stringify(toolResult)}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -140,7 +140,7 @@ export class AgenticChatEventParser implements ChatResult {
                         }
                     } catch (err) {
                         console.error(`Error parsing tool use input: ${this.toolUses[toolUseId].input}`, err)
-                        this.error = `ToolUse input is invalid JSON: "${this.toolUses[toolUseId].input}". Check the syntax and make sure the input is complete. If the input is large, break it down into multiple tool uses with smaller input.`
+                        this.error = `ToolUse input is invalid JSON: "${this.toolUses[toolUseId].input}".`
                         parsedInput = {}
                     }
                     this.toolUses[toolUseId] = {


### PR DESCRIPTION
## Problem

Previous JSON parse fix (https://github.com/aws/language-servers/pull/1141) did not work fully, the LLM keeps retrying the same input and ends up in a loop.

## Solution

Set an explicit userInputMessage to tell the LLM to break the task down when it encounters this exact issue.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
