### PR TITLE
feat: remove fileSearch and codeSearch tools from Amazon Q language server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -8,15 +8,11 @@ import { LspReadDocumentContents, LspReadDocumentContentsParams } from './lspRea
 import { LspApplyWorkspaceEdit, LspApplyWorkspaceEditParams } from './lspApplyWorkspaceEdit'
 import { McpManager } from './mcp/mcpManager'
 import { McpTool } from './mcp/mcpTool'
-import { FileSearch, FileSearchParams } from './fileSearch'
-import { CodeSearch, CodeSearchParams } from './codeSearch'
 
 export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     const fsReadTool = new FsRead({ workspace, lsp, logging })
     const fsWriteTool = new FsWrite({ workspace, lsp, logging })
     const listDirectoryTool = new ListDirectory({ workspace, logging, lsp })
-    const fileSearchTool = new FileSearch({ workspace, logging, lsp })
-    const codeSearchTool = new CodeSearch({ workspace, logging, lsp })
 
     agent.addTool(fsReadTool.getSpec(), async (input: FsReadParams) => {
         // TODO: fill in logic for handling invalid tool invocations
@@ -35,10 +31,6 @@ export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     agent.addTool(listDirectoryTool.getSpec(), (input: ListDirectoryParams, token?: CancellationToken) =>
         listDirectoryTool.invoke(input, token)
     )
-
-    agent.addTool(fileSearchTool.getSpec(), (input: FileSearchParams) => fileSearchTool.invoke(input))
-
-    agent.addTool(codeSearchTool.getSpec(), (input: CodeSearchParams) => codeSearchTool.invoke(input))
 
     return () => {}
 }


### PR DESCRIPTION
## Problem

New tools causing regression.

## Solution

Temporarily remove tools from tool server.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
