### PR TITLE
docs: standardize tool descriptions for fsRead, fsWrite, and listDirectory

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -105,7 +105,7 @@ export const commandCategories = new Map<string, CommandCategory>([
 ])
 export const maxBashToolResponseSize: number = 1024 * 1024 // 1MB
 export const lineCount: number = 1024
-export const destructiveCommandWarningMessage = '⚠️ WARNING: Destructive command detected:\n\n'
+export const destructiveCommandWarningMessage = '⚠️ WARNING: Potentially destructive command detected:\n\n'
 export const mutateCommandWarningMessage = 'Mutation command:\n\n'
 
 export interface ExecuteBashParams extends ExplanatoryParams {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
@@ -134,11 +134,15 @@ export class FsRead {
                 '- When you need to read specific line ranges from a file\n' +
                 '- When you need to analyze code or configuration files\n\n' +
                 '## When not to use\n' +
-                '- When the file is very large (>200K characters) and you need the full content\n' +
-                '- When you need to search for patterns across multiple files\n\n' +
+                '- When you need to search for patterns across multiple files\n' +
+                '- When you need to process files in binary format\n\n' +
                 '## Notes\n' +
                 '- This tool is more effective than running a command like `head -n` using `executeBash` tool\n' +
                 '- If the file exceeds 200K characters, this tool will only read the first 200K characters of the file with a `truncated=true` in the output\n' +
+                '- For large files (>200K characters), you may need to make multiple calls with specific `readRange` values, but ONLY do this if:\n' +
+                '  * The initial read was truncated (indicated by `truncated=true` in the output)\n' +
+                '  * A specific `readRange` is needed to focus on relevant sections\n' +
+                '  * The user explicitly asks to read more of the file\n' +
                 '- DO NOT re-read the file again using `readRange` unless explicitly asked by the user\n\n' +
                 '## Related tools\n' +
                 '- fsWrite: Use to modify the file after reading\n' +

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
@@ -126,7 +126,23 @@ export class FsRead {
         return {
             name: 'fsRead',
             description:
-                'A tool for reading a file.\n * This tool returns the contents of a file, and the optional `readRange` determines what range of lines will be read from the specified file.\n * This tool is more effective than running a command like \`head -n\` using `executeBash` tool.\n * If the file exceeds 200K characters, this tool will only read the first 200K characters of the file with a `truncated=true` in the output, DO NOT re-read the file again using `readRange` unless explicitly asked by the user.',
+                'A tool for reading a file.\n\n' +
+                '## Overview\n' +
+                'This tool returns the contents of a file, with optional line range specification.\n\n' +
+                '## When to use\n' +
+                '- When you need to examine the content of a file\n' +
+                '- When you need to read specific line ranges from a file\n' +
+                '- When you need to analyze code or configuration files\n\n' +
+                '## When not to use\n' +
+                '- When the file is very large (>200K characters) and you need the full content\n' +
+                '- When you need to search for patterns across multiple files\n\n' +
+                '## Notes\n' +
+                '- This tool is more effective than running a command like `head -n` using `executeBash` tool\n' +
+                '- If the file exceeds 200K characters, this tool will only read the first 200K characters of the file with a `truncated=true` in the output\n' +
+                '- DO NOT re-read the file again using `readRange` unless explicitly asked by the user\n\n' +
+                '## Related tools\n' +
+                '- fsWrite: Use to modify the file after reading\n' +
+                '- listDirectory: Use to find files before reading them',
             inputSchema: {
                 type: 'object',
                 properties: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -162,20 +162,31 @@ export class FsWrite {
         return {
             name: 'fsWrite',
             description:
-                'A tool for creating and editing a file.\
-                \n * The `create` command will override the file at `path` if it already exists as a file, \
-                and otherwise create a new file. Use this command for initial file creation, such as scaffolding a new project. \
-                You should also use this command when overwriting large boilerplate files where you want to replace the entire content at once.\
-                \n * The `insert` command will insert `newStr` after `insertLine` and place it on its own line.\
-                \n * The `append` command will add content to the end of an existing file, automatically adding a newline if the file does not end with one.\
-                \n * The `strReplace` command will replace `oldStr` in an existing file with `newStr`.\
-                \n IMPORTANT Notes for using the `strReplace` command:\n \
-                * Use this command to delete code by using empty `newStr` parameter.\n \
-                * If you need to make small changes to an existing file, consider using `strReplace` command to avoid unnecessary rewriting the entire file.\n \
-                * Prefer the `create` command if the complexity or number of changes would make `strReplace` unwieldy or error-prone.\n \
-                * The `oldStr` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces! \
-                Include just the changing lines, and a few surrounding lines if needed for uniqueness. Do not include long runs of unchanging lines in `oldStr`.\n \
-                * The `newStr` parameter should contain the edited lines that should replace the `oldStr`.',
+                'A tool for creating and editing a file.\n\n' +
+                '## Overview\n' +
+                'This tool provides multiple commands for file operations including creating, replacing, inserting, and appending content.\n\n' +
+                '## When to use\n' +
+                '- When creating new files (create)\n' +
+                '- When replacing specific text in existing files (strReplace)\n' +
+                '- When inserting text at a specific line (insert)\n' +
+                '- When adding text to the end of a file (append)\n\n' +
+                '## When not to use\n' +
+                '- When you only need to read file content (use fsRead instead)\n' +
+                '- When making complex edits that would be better handled by a dedicated editor\n\n' +
+                '## Command details\n' +
+                '- The `create` command will override the file at `path` if it already exists as a file, and otherwise create a new file. Use this command for initial file creation, such as scaffolding a new project. You should also use this command when overwriting large boilerplate files where you want to replace the entire content at once.\n' +
+                '- The `insert` command will insert `newStr` after `insertLine` and place it on its own line.\n' +
+                '- The `append` command will add content to the end of an existing file, automatically adding a newline if the file does not end with one.\n' +
+                '- The `strReplace` command will replace `oldStr` in an existing file with `newStr`.\n\n' +
+                '## IMPORTANT Notes for using the `strReplace` command\n' +
+                '- Use this command to delete code by using empty `newStr` parameter.\n' +
+                '- If you need to make small changes to an existing file, consider using `strReplace` command to avoid unnecessary rewriting the entire file.\n' +
+                '- Prefer the `create` command if the complexity or number of changes would make `strReplace` unwieldy or error-prone.\n' +
+                '- The `oldStr` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces! Include just the changing lines, and a few surrounding lines if needed for uniqueness. Do not include long runs of unchanging lines in `oldStr`.\n' +
+                '- The `newStr` parameter should contain the edited lines that should replace the `oldStr`.\n\n' +
+                '## Related tools\n' +
+                '- fsRead: Use to read the file before modifying it\n' +
+                '- listDirectory: Use to find files before modifying them',
             inputSchema: {
                 type: 'object',
                 properties: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -172,7 +172,8 @@ export class FsWrite {
                 '- When adding text to the end of a file (append)\n\n' +
                 '## When not to use\n' +
                 '- When you only need to read file content (use fsRead instead)\n' +
-                '- When making complex edits that would be better handled by a dedicated editor\n\n' +
+                '- When you need to delete a file (no delete operation is available)\n' +
+                '- When you need to rename or move a file\n\n' +
                 '## Command details\n' +
                 '- The `create` command will override the file at `path` if it already exists as a file, and otherwise create a new file. Use this command for initial file creation, such as scaffolding a new project. You should also use this command when overwriting large boilerplate files where you want to replace the entire content at once.\n' +
                 '- The `insert` command will insert `newStr` after `insertLine` and place it on its own line.\n' +
@@ -183,7 +184,8 @@ export class FsWrite {
                 '- If you need to make small changes to an existing file, consider using `strReplace` command to avoid unnecessary rewriting the entire file.\n' +
                 '- Prefer the `create` command if the complexity or number of changes would make `strReplace` unwieldy or error-prone.\n' +
                 '- The `oldStr` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces! Include just the changing lines, and a few surrounding lines if needed for uniqueness. Do not include long runs of unchanging lines in `oldStr`.\n' +
-                '- The `newStr` parameter should contain the edited lines that should replace the `oldStr`.\n\n' +
+                '- The `newStr` parameter should contain the edited lines that should replace the `oldStr`.\n' +
+                '- When multiple edits to the same file are needed, combine them into a single call whenever possible. This improves efficiency by reducing the number of tool calls and ensures the file remains in a consistent state.\n\n' +
                 '## Related tools\n' +
                 '- fsRead: Use to read the file before modifying it\n' +
                 '- listDirectory: Use to find files before modifying them',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -89,11 +89,25 @@ export class ListDirectory {
         return {
             name: 'listDirectory',
             description:
-                'List the contents of a directory and its subdirectories, it will ignore directories such as `build/`, `out/`, `dist/` and `node_modules/`.\
-                \n * Use this tool for discovery such as exploring the codebase or project. This tool is more effective than running a command like \`ls\` using `executeBash` tool.\
-                \n * Useful to try to understand the file structure before diving deeper into specific files.\
-                \n * Do not use this tool to confirm the existence of files you may have created, as the user will let you know if the files were created successfully or not.\
-                \n * Results clearly distinguish between files, directories or symlinks with [F], [D] and [L] prefixes.',
+                'List the contents of a directory and its subdirectories.\n\n' +
+                '## Overview\n' +
+                'This tool recursively lists directory contents, ignoring common build and dependency directories.\n\n' +
+                '## When to use\n' +
+                '- When exploring a codebase or project structure\n' +
+                '- When you need to discover files in a directory hierarchy\n' +
+                '- When you need to understand the organization of a project\n\n' +
+                '## When not to use\n' +
+                '- When you already know the exact file path you need\n' +
+                '- When you need to confirm the existence of files you may have created (the user will let you know if files were created successfully)\n' +
+                '- When you need to search for specific file patterns (consider using a search tool instead)\n\n' +
+                '## Notes\n' +
+                '- This tool will ignore directories such as `build/`, `out/`, `dist/` and `node_modules/`\n' +
+                '- This tool is more effective than running a command like `ls` using `executeBash` tool\n' +
+                '- Results clearly distinguish between files, directories or symlinks with [F], [D] and [L] prefixes\n' +
+                '- Use the `maxDepth` parameter to control how deep the directory traversal goes\n\n' +
+                '## Related tools\n' +
+                '- fsRead: Use to examine files after finding them\n' +
+                '- fsWrite: Use to modify files after finding them',
             inputSchema: {
                 type: 'object',
                 properties: {


### PR DESCRIPTION
## Problem

Tool spec descriptions are inconsistent.

## Solution

Make them follow a consistent scheme, and clearly articulate usage.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
