### PR TITLE
fix: telemetry for agentic chat interactions

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -1,6 +1,7 @@
 import { MetricEvent, Telemetry } from '@aws/language-server-runtimes/server-interface/telemetry'
 import { TriggerType } from '@aws/chat-client-ui-types'
 import {
+    AgenticChatInteractionType,
     ChatInteractionType,
     ChatTelemetryEventMap,
     ChatTelemetryEventName,
@@ -179,6 +180,18 @@ export class ChatTelemetryController {
                 cwsprToolUseId: toolUse.toolUseId ?? '',
                 result: 'Succeeded',
                 languageServerVersion: languageServerVersion,
+            },
+        })
+    }
+
+    public emitInteractWithAgenticChat(interactionType: AgenticChatInteractionType, tabId: string) {
+        this.#telemetry.emitMetric({
+            name: ChatTelemetryEventName.InteractWithAgenticChat,
+            data: {
+                [CONVERSATION_ID_METRIC_KEY]: this.getConversationId(tabId),
+                cwsprChatConversationType: 'AgenticChat',
+                credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
+                cwsprAgenticChatInteractionType: interactionType,
             },
         })
     }

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -166,6 +166,7 @@ export enum ChatTelemetryEventName {
     MessageResponseError = 'amazonq_messageResponseError',
     ModifyCode = 'amazonq_modifyCode',
     ToolUseSuggested = 'amazonq_toolUseSuggested',
+    InteractWithAgenticChat = 'amazonq_interactWithAgenticChat',
 }
 
 export interface ChatTelemetryEventMap {
@@ -180,6 +181,7 @@ export interface ChatTelemetryEventMap {
     [ChatTelemetryEventName.MessageResponseError]: MessageResponseErrorEvent
     [ChatTelemetryEventName.ModifyCode]: ModifyCodeEvent
     [ChatTelemetryEventName.ToolUseSuggested]: ToolUseSuggestedEvent
+    [ChatTelemetryEventName.InteractWithAgenticChat]: InteractWithAgenticChatEvent
 }
 
 export type ToolUseSuggestedEvent = {
@@ -189,6 +191,13 @@ export type ToolUseSuggestedEvent = {
     cwsprToolName: string
     cwsprToolUseId: string
     languageServerVersion?: string
+}
+
+export type InteractWithAgenticChatEvent = {
+    credentialStartUrl?: string
+    cwsprChatConversationId: string
+    cwsprChatConversationType: ChatConversationType
+    cwsprAgenticChatInteractionType: AgenticChatInteractionType
 }
 
 export type ModifyCodeEvent = {
@@ -255,6 +264,8 @@ export enum ChatInteractionType {
 }
 
 export type ChatConversationType = 'Chat' | 'Assign' | 'Transform' | 'AgenticChat' | 'AgenticChatWithToolUse'
+
+export type AgenticChatInteractionType = 'RejectDiff' | 'GeneratedDiff' | 'RunCommand' | 'GeneratedCommand' | 'StopChat'
 
 export type InteractWithMessageEvent = {
     credentialStartUrl?: string


### PR DESCRIPTION
- For context, here is the agentic-chat branch PR which I am porting over to language-servers: https://github.com/aws/aws-toolkit-vscode/pull/6979


## Problem
- We would like metrics based on these **product requirement definitions**:
    1) Command execution acceptance rate: 
        - [#Commands that users click run on] / [#Commands generated that required user to click run on]
    2) Diff acceptance rate: 
        - As all diffs are auto-accepted, the acceptance rate is calculated by: 1 - [#Diffs rejected] / [#Diffs generated]
        - Rejection is defined as user specifically pressing the Undo button
    3) Stop chat: 
        - User specifically clicks Stop button
        - Implicit stop: user interrupts current ongoing message with new message 

## Solution
- emit `amazonq_interactWithAgenticChat` metric


## Testing
- tested in kibana

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
