### PR TITLE
feat: allow backend errors to be handled seperately

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -47,6 +47,7 @@ import { ChatDatabase } from './tools/chatDb/chatDb'
 import { LocalProjectContextController } from '../../shared/localProjectContextController'
 import { CancellationError } from '@aws/lsp-core'
 import { ToolApprovalException } from './tools/toolShared'
+import { genericErrorMsg } from './constants'
 
 describe('AgenticChatController', () => {
     const mockTabId = 'tab-1'
@@ -925,8 +926,9 @@ describe('AgenticChatController', () => {
         })
 
         it('propagates model error back to client', async () => {
+            const errorMsg = 'This is an error from the backend'
             generateAssistantResponseStub.callsFake(() => {
-                throw new Error('Error')
+                throw new Error(errorMsg)
             })
 
             const chatResult = await chatController.onChatPrompt(
@@ -936,11 +938,8 @@ describe('AgenticChatController', () => {
 
             // These checks will fail if a response error is returned.
             const typedChatResult = chatResult as ResponseError<ChatResult>
-            assert.strictEqual(typedChatResult.message, 'Error')
-            assert.strictEqual(
-                typedChatResult.data?.body,
-                'An error occurred when communicating with the model, check the logs for more information.'
-            )
+            assert.strictEqual(typedChatResult.message, errorMsg)
+            assert.strictEqual(typedChatResult.data?.body, errorMsg)
         })
 
         it('returns an auth follow up action if model request returns an auth error', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -942,6 +942,16 @@ describe('AgenticChatController', () => {
             assert.strictEqual(typedChatResult.data?.body, errorMsg)
         })
 
+        it('shows generic errorMsg on internal errors', async function () {
+            const chatResult = await chatController.onChatPrompt(
+                { tabId: mockTabId, prompt: { prompt: 'Hello' } },
+                undefined as any
+            )
+
+            const typedChatResult = chatResult as ResponseError<ChatResult>
+            assert.strictEqual(typedChatResult.data?.body, genericErrorMsg)
+        })
+
         it('returns an auth follow up action if model request returns an auth error', async () => {
             generateAssistantResponseStub.callsFake(() => {
                 throw new Error('Error')

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -339,24 +339,25 @@ export class AgenticChatController implements ChatHandlers {
             cwsprChatConversationType: 'AgenticChat',
         })
 
-        const triggerContext = await this.#getTriggerContext(params, metric)
-        const isNewConversation = !session.conversationId
-        if (isNewConversation) {
-            // agentic chat does not support conversationId in API response,
-            // so we set it to random UUID per session, as other chat functionality
-            // depends on it
-            session.conversationId = uuid()
-        }
-
-        token.onCancellationRequested(() => {
-            this.#log('cancellation requested')
-            this.#telemetryController.emitInteractWithAgenticChat('StopChat', params.tabId)
-            session.abortRequest()
-            session.rejectAllDeferredToolExecutions(new CancellationError('user'))
-        })
-
-        const chatResultStream = this.#getChatResultStream(params.partialResultToken)
         try {
+            const triggerContext = await this.#getTriggerContext(params, metric)
+            const isNewConversation = !session.conversationId
+            if (isNewConversation) {
+                // agentic chat does not support conversationId in API response,
+                // so we set it to random UUID per session, as other chat functionality
+                // depends on it
+                session.conversationId = uuid()
+            }
+
+            token.onCancellationRequested(() => {
+                this.#log('cancellation requested')
+                this.#telemetryController.emitInteractWithAgenticChat('StopChat', params.tabId)
+                session.abortRequest()
+                session.rejectAllDeferredToolExecutions(new CancellationError('user'))
+            })
+
+            const chatResultStream = this.#getChatResultStream(params.partialResultToken)
+
             const additionalContext = await this.#additionalContextProvider.getAdditionalContext(
                 triggerContext,
                 (params.prompt as any).context

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1403,7 +1403,7 @@ export class AgenticChatController implements ChatHandlers {
 
         // Show backend error messages to the customer.
         if (err.code === 'QModelResponse') {
-            this.#features.logging.error(`QModelResponse Error: ${JSON.stringify(err)}`)
+            this.#features.logging.error(`QModelResponse Error: ${JSON.stringify(err.cause)}`)
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
                 type: 'answer',
                 body: err.message,
@@ -1412,6 +1412,7 @@ export class AgenticChatController implements ChatHandlers {
             })
         }
         this.#features.logging.error(`Unknown Error: ${JSON.stringify(err)}`)
+        this.#features.logging.log(`Error Cause: ${JSON.stringify(err.cause)}`)
         return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
             type: 'answer',
             body: genericErrorMsg,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
@@ -1,0 +1,1 @@
+export const genericErrorMsg = 'An unexpected error occurred, check the logs for more information.'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -1,3 +1,18 @@
-export class ModelServiceException {
-    public constructor(public readonly cause: Error) {}
+type AgenticChatErrorCode = 'QModelResponse' | 'AmazonQServiceManager'
+
+export class AgenticChatError extends Error {
+    constructor(
+        message: string,
+        public readonly code: AgenticChatErrorCode,
+        cause?: Error
+    ) {
+        super(message, { cause: cause })
+    }
+}
+
+export function wrapErrorWithCode(error: unknown, code: AgenticChatErrorCode) {
+    if (error instanceof Error) {
+        return new AgenticChatError(error.message, code, error)
+    }
+    return new AgenticChatError(String(error), code)
 }


### PR DESCRIPTION
## Problem
Backend error messages are expected to be shown directly to the customer in chat. However, there are other error messages we don't want to show, and should show a generic message. 

## Solution
- Implement an error wrapper with a `code` field, that allows each type of error to have its own handling. 
- Expand reach of `try` block such that any internal errors surfaced are caught and returned as `ResponseError`. This also makes this easier to test. 

## Testing and Verification
- updated a unit test, and added another for generic behavior. 
- Backend error (replacing backend call with an error)

https://github.com/user-attachments/assets/12b44857-6a52-4d8f-8e7b-55fcac374429

- generic error (throwing an error elsewhere in the agentic loop)

https://github.com/user-attachments/assets/8ded36f1-018d-401e-8a7f-0a90ee818f59


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
