### PR TITLE
fix: clicking files on Windows doesn't work

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -108,6 +108,7 @@ import { ModelServiceException } from './errors'
 import { FileSearch, FileSearchParams } from './tools/fileSearch'
 import { diffLines } from 'diff'
 import { CodeSearch } from './tools/codeSearch'
+import { URI } from 'vscode-uri'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -287,7 +288,7 @@ export class AgenticChatController implements ChatHandlers {
         try {
             await this.#features.workspace.fs.mkdir(getUserPromptsDirectory(), { recursive: true })
             await this.#features.workspace.fs.writeFile(newFilePath, newFileContent, { mode: 0o600 })
-            await this.#features.lsp.window.showDocument({ uri: newFilePath })
+            await this.#features.lsp.window.showDocument({ uri: URI.file(newFilePath).toString() })
         } catch (e) {
             this.#features.logging.warn(`Error creating prompt file: ${e}`)
         }
@@ -1601,11 +1602,11 @@ export class AgenticChatController implements ChatHandlers {
                 fileContent: toolUse.fileChange?.after,
             })
         } else if (toolUse?.name === 'fsRead') {
-            await this.#features.lsp.window.showDocument({ uri: params.filePath })
+            await this.#features.lsp.window.showDocument({ uri: URI.file(params.filePath).toString() })
         } else {
             const absolutePath = params.fullPath ?? (await this.#resolveAbsolutePath(params.filePath))
             if (absolutePath) {
-                await this.#features.lsp.window.showDocument({ uri: absolutePath })
+                await this.#features.lsp.window.showDocument({ uri: URI.file(absolutePath).toString() })
             }
         }
     }


### PR DESCRIPTION
## Problem
Clicking on file link in Q message response doesn't work on Windows machine. This breaks Create a saved prompt UX, and clicking on file links in context transparency list/ fsRead tools responses.

## Solution
Pass the proper URI string to window/showDocument request

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
