### PR TITLE
feat: show agentLoop error in chat

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -971,7 +971,7 @@ describe('AgenticChatController', () => {
             assert.deepStrictEqual(chatResult, utils.createAuthFollowUpResult('full-auth'))
         })
 
-        it.only('returns a ResponseError if response streams returns an error event', async () => {
+        it('returns a ResponseError if response streams returns an error event', async () => {
             generateAssistantResponseStub.callsFake(() => {
                 return Promise.resolve({
                     $metadata: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -25,6 +25,7 @@ import {
     InlineChatResult,
     CancellationToken,
     CancellationTokenSource,
+    ErrorCodes,
 } from '@aws/language-server-runtimes/server-interface'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as assert from 'assert'
@@ -991,7 +992,9 @@ describe('AgenticChatController', () => {
                 mockCancellationToken
             )
 
-            assert.deepStrictEqual(chatResult, new ResponseError(LSPErrorCodes.RequestFailed, 'some error'))
+            const typedChatResult = chatResult as ResponseError<ChatResult>
+            assert.strictEqual(typedChatResult.data?.body, genericErrorMsg)
+            assert.strictEqual(typedChatResult.message, 'some error')
         })
 
         it('returns a ResponseError if response streams return an invalid state event', async () => {
@@ -1015,7 +1018,9 @@ describe('AgenticChatController', () => {
                 mockCancellationToken
             )
 
-            assert.deepStrictEqual(chatResult, new ResponseError(LSPErrorCodes.RequestFailed, 'invalid state'))
+            const typedChatResult = chatResult as ResponseError<ChatResult>
+            assert.strictEqual(typedChatResult.data?.body, genericErrorMsg)
+            assert.strictEqual(typedChatResult.message, 'invalid state')
         })
 
         describe('#extractDocumentContext', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -971,7 +971,7 @@ describe('AgenticChatController', () => {
             assert.deepStrictEqual(chatResult, utils.createAuthFollowUpResult('full-auth'))
         })
 
-        it('returns a ResponseError if response streams return an error event', async () => {
+        it.only('returns a ResponseError if response streams returns an error event', async () => {
             generateAssistantResponseStub.callsFake(() => {
                 return Promise.resolve({
                     $metadata: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -580,7 +580,7 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         if (iterationCount >= maxAgentLoopIterations) {
-            throw new AgenticChatError('Agent loop reached maximum iterations limit', 'MaxAgentLoopIterations')
+            throw new AgenticChatError('Agent loop reached iteration limit', 'MaxAgentLoopIterations')
         }
 
         this.#stoppedToolUses.clear()

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1402,7 +1402,7 @@ export class AgenticChatController implements ChatHandlers {
             return createAuthFollowUpResult(authFollowType)
         }
 
-        // Show backend error messages to the customer.
+        // These are errors we want to show custom messages in chat for.
         if (err.code === 'QModelResponse' || err.code === 'MaxAgentLoopIterations') {
             this.#features.logging.error(`${err.code}: ${JSON.stringify(err.cause)}`)
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -107,8 +107,9 @@ import { ExplanatoryParams, InvokeOutput, ToolApprovalException } from './tools/
 import { FileSearch, FileSearchParams } from './tools/fileSearch'
 import { diffLines } from 'diff'
 import { CodeSearch } from './tools/codeSearch'
-import { genericErrorMsg } from './constants'
+import { genericErrorMsg, maxAgentLoopIterations } from './constants'
 import { URI } from 'vscode-uri'
+import { AgenticChatError } from './errors'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -472,10 +473,9 @@ export class AgenticChatController implements ChatHandlers {
         let currentRequestInput = { ...initialRequestInput }
         let finalResult: Result<AgenticChatResultWithMetadata, string> | null = null
         let iterationCount = 0
-        const maxIterations = 100 // Safety limit to prevent infinite loops
         metric.recordStart()
 
-        while (iterationCount < maxIterations) {
+        while (iterationCount < maxAgentLoopIterations) {
             iterationCount++
             this.#debug(`Agent loop iteration ${iterationCount} for conversation id:`, conversationIdentifier || '')
 
@@ -579,8 +579,8 @@ export class AgenticChatController implements ChatHandlers {
             currentRequestInput = this.#updateRequestInputWithToolResults(currentRequestInput, toolResults, content)
         }
 
-        if (iterationCount >= maxIterations) {
-            this.#log('Agent loop reached maximum iterations limit')
+        if (iterationCount >= maxAgentLoopIterations) {
+            throw new AgenticChatError('Agent loop reached maximum iterations limit', 'MaxAgentLoopIterations')
         }
 
         this.#stoppedToolUses.clear()
@@ -1312,9 +1312,9 @@ export class AgenticChatController implements ChatHandlers {
         triggerContext: TriggerContext,
         isNewConversation: boolean,
         chatResultStream: AgenticChatResultStream
-    ): Promise<ChatResult | ResponseError<ChatResult>> {
+    ): Promise<ChatResult> {
         if (!result.success) {
-            return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, result.error)
+            throw new AgenticChatError(result.error, 'FailedResult')
         }
         const conversationId = session.conversationId
         this.#debug('Final session conversation id:', conversationId || '')
@@ -1403,8 +1403,8 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         // Show backend error messages to the customer.
-        if (err.code === 'QModelResponse') {
-            this.#features.logging.error(`QModelResponse Error: ${JSON.stringify(err.cause)}`)
+        if (err.code === 'QModelResponse' || err.code === 'MaxAgentLoopIterations') {
+            this.#features.logging.error(`${err.code}: ${JSON.stringify(err.cause)}`)
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
                 type: 'answer',
                 body: err.message,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
@@ -1,1 +1,2 @@
 export const genericErrorMsg = 'An unexpected error occurred, check the logs for more information.'
+export const maxAgentLoopIterations = 100

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -1,4 +1,4 @@
-type AgenticChatErrorCode = 'QModelResponse' | 'AmazonQServiceManager'
+type AgenticChatErrorCode = 'QModelResponse' | 'AmazonQServiceManager' | 'FailedResult' | 'MaxAgentLoopIterations'
 
 export class AgenticChatError extends Error {
     constructor(


### PR DESCRIPTION
## Problem
When the agent exceeds our threshold (currently 100), the frontend doesn't render anything. This is because we return a ResponseError without a valid ChatResult body. 

## Solution
- Centralize all error handling to the `handleRequestError` method. I.e. do not return response errors from anywhere else. This allows us to ensure we are returning valid ChatResults in the data field. 
- Show a specialized message for agent loop exceeding. 


## Verification

https://github.com/user-attachments/assets/ef4b2ddc-5355-4658-bb85-c77984ebf330


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
