### PR TITLE
fix: prompt options override

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.28",
         "@aws/language-server-runtimes-types": "^0.1.25",
-        "@aws/mynah-ui": "^4.31.1"
+        "@aws/mynah-ui": "^4.32.0"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -97,26 +97,9 @@ const openTabKey = 'openTab'
 export const handlePromptInputChange = (mynahUi: MynahUI, tabId: string, optionsValues: Record<string, string>) => {
     const promptTypeValue = optionsValues['pair-programmer-mode']
 
-    const store = mynahUi.getTabData(tabId)?.getStore()
-    const currentPromptInputOptions = store?.promptInputOptions ?? []
-    const updatedPromptInputOptions: ChatItemFormItem[] = currentPromptInputOptions.map(item =>
-        item.id === 'pair-programmer-mode' ? ({ ...item, value: promptTypeValue } as ChatItemFormItem) : item
-    )
-    // If the option wasn't found, add it
-    if (!updatedPromptInputOptions.some(item => item.id === 'pair-programmer-mode')) {
-        updatedPromptInputOptions.push({ ...pairProgrammingPromptInput, value: promptTypeValue } as ChatItemFormItem)
+    if (promptTypeValue != null) {
+        mynahUi.addChatItem(tabId, promptTypeValue === 'true' ? pairProgrammingModeOn : pairProgrammingModeOff)
     }
-
-    if (promptTypeValue === 'true') {
-        mynahUi.addChatItem(tabId, pairProgrammingModeOn)
-    } else {
-        mynahUi.addChatItem(tabId, pairProgrammingModeOff)
-    }
-
-    // Update the store with the new promptInputOptions array
-    mynahUi.updateStore(tabId, {
-        promptInputOptions: updatedPromptInputOptions,
-    })
 }
 
 export const handleChatPrompt = (

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -767,7 +767,7 @@ export const createMynahUi = (
             // file diffs in the header need space
             fullWidth: message.type === 'tool' && message.header?.buttons ? true : undefined,
             padding,
-
+            wrapCodes: message.type === 'tool',
             codeBlockActions:
                 message.type === 'tool'
                     ? { 'insert-to-cursor': null, copy: null }

--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.28",
                 "@aws/language-server-runtimes-types": "^0.1.25",
-                "@aws/mynah-ui": "^4.31.1"
+                "@aws/mynah-ui": "^4.32.0"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4064,10 +4064,11 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.31.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.31.1.tgz",
-            "integrity": "sha512-4VXzpd9Jg1igQFZslANcDttf4KPRC7quW9wiTEcvq9xKIvxRawM4OsX0or2+/PO3QdRkWC1j3ibv0rDA6/rjPg==",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.32.0.tgz",
+            "integrity": "sha512-M8NAp8Pr7h/z0HS202aQkDhI9tVZngEQQB5poR8GSINSJ0NNLnJ2nKbBgqw6RAwxVSkk/7CId2nPkgpTO/jaEw==",
             "hasInstallScript": true,
+            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "highlight.js": "^11.11.0",


### PR DESCRIPTION
## Problem
- Tooltip remains if there is a prompt option value change.
- Codes are not wrapping in tool use

## Solution
- Removed unnecessary handling which overrides the prompt options after value change. Options keep their values, it doesn't require an override. 
- With new version of mynah-ui, used the option `wrapCodes` to wrap the codes for tool uses.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
