### PR TITLE
feat(amazonq): add error code handling for transformation jobs

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -1,6 +1,17 @@
 import { ExecuteCommandParams } from 'vscode-languageserver'
 import { TransformationJob, TransformationPlan } from '../../client/token/codewhispererbearertokenclient'
 
+/**
+ * Error codes for transformation job failures.
+ * Additional error codes can be added here as needed for different failure scenarios.
+ */
+export enum TransformationErrorCode {
+    NONE = 'NONE',
+    QUOTA_EXCEEDED = 'QUOTA_EXCEEDED',
+    UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+    // TODO: Add more error codes as needed for different failure scenarios
+}
+
 export interface StartTransformRequest extends ExecuteCommandParams {
     SolutionRootPath: string
     SolutionFilePath: string
@@ -28,8 +39,20 @@ export interface GetTransformRequest extends ExecuteCommandParams {
     TransformationJobId: string
 }
 
+/**
+ * Response for a get transformation request.
+ * Contains the transformation job details and any error information.
+ */
 export interface GetTransformResponse {
+    /**
+     * The transformation job details
+     */
     TransformationJob: TransformationJob
+
+    /**
+     * Error code if the transformation job failed
+     */
+    ErrorCode: TransformationErrorCode
 }
 
 export interface GetTransformPlanRequest extends ExecuteCommandParams {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.getTransformationErrorCode.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.getTransformationErrorCode.test.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai'
+import { TransformationErrorCode } from '../models'
+import { getTransformationErrorCode } from '../validation'
+import { TransformationJob } from '../../../client/token/codewhispererbearertokenclient'
+
+describe('getTransformationErrorCode', () => {
+    it('should return NONE when transformationJob is undefined', () => {
+        const result = getTransformationErrorCode(undefined)
+        expect(result).to.equal(TransformationErrorCode.NONE)
+    })
+
+    it('should return NONE when status is not a failure state', () => {
+        const job: TransformationJob = {
+            jobId: 'test-job-id',
+            status: 'COMPLETED',
+            creationTime: new Date(),
+        }
+        const result = getTransformationErrorCode(job)
+        expect(result).to.equal(TransformationErrorCode.NONE)
+    })
+
+    it('should return QUOTA_EXCEEDED when status is FAILED and reason contains "would exceed your remaining quota"', () => {
+        const job: TransformationJob = {
+            jobId: 'test-job-id',
+            status: 'FAILED',
+            reason: 'the project was stopped because the projected resource usage would exceed your remaining quota.',
+            creationTime: new Date(),
+        }
+        const result = getTransformationErrorCode(job)
+        expect(result).to.equal(TransformationErrorCode.QUOTA_EXCEEDED)
+    })
+
+    it('should return UNKNOWN_ERROR when status is FAILED but reason does not match any patterns', () => {
+        const job: TransformationJob = {
+            jobId: 'test-job-id',
+            status: 'FAILED',
+            reason: 'Some other error occurred',
+            creationTime: new Date(),
+        }
+        const result = getTransformationErrorCode(job)
+        expect(result).to.equal(TransformationErrorCode.UNKNOWN_ERROR)
+    })
+
+    it('should return UNKNOWN_ERROR when status is FAILED and reason is undefined', () => {
+        const job: TransformationJob = {
+            jobId: 'test-job-id',
+            status: 'FAILED',
+            creationTime: new Date(),
+        }
+        const result = getTransformationErrorCode(job)
+        expect(result).to.equal(TransformationErrorCode.UNKNOWN_ERROR)
+    })
+
+    it('should return UNKNOWN_ERROR when status is STOPPED', () => {
+        const job: TransformationJob = {
+            jobId: 'test-job-id',
+            status: 'STOPPED',
+            creationTime: new Date(),
+        }
+        const result = getTransformationErrorCode(job)
+        expect(result).to.equal(TransformationErrorCode.UNKNOWN_ERROR)
+    })
+
+    it('should return UNKNOWN_ERROR when status is REJECTED', () => {
+        const job: TransformationJob = {
+            jobId: 'test-job-id',
+            status: 'REJECTED',
+            creationTime: new Date(),
+        }
+        const result = getTransformationErrorCode(job)
+        expect(result).to.equal(TransformationErrorCode.UNKNOWN_ERROR)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -184,6 +184,13 @@ export class TransformHandler {
         }
         return headersObj
     }
+    /**
+     * Retrieves the status and details of a transformation job.
+     * Includes error code when the job has failed.
+     *
+     * @param request - The request containing the transformation job ID
+     * @returns The transformation job details with error code if applicable, or null if the request fails
+     */
     async getTransformation(request: GetTransformRequest) {
         try {
             const getCodeTransformationRequest = {
@@ -193,8 +200,13 @@ export class TransformHandler {
                 .getCodewhispererService()
                 .codeModernizerGetCodeTransformation(getCodeTransformationRequest)
             this.logging.log('Transformation status: ' + response.transformationJob?.status)
+
+            // Use validation function to determine the error code
+            const errorCode = validation.getTransformationErrorCode(response.transformationJob)
+
             return {
                 TransformationJob: response.transformationJob,
+                ErrorCode: errorCode,
             } as GetTransformResponse
         } catch (e: any) {
             const errorMessage = (e as Error).message ?? 'Error in GetTransformation API call'

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/validation.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/validation.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs'
 import { StartTransformRequest, TransformProjectMetadata } from './models'
 import { supportedProjects, unsupportedViewComponents } from './resources/SupportedProjects'
 import { Logging } from '@aws/language-server-runtimes/server-interface'
+import { TransformationJob } from '../../client/token/codewhispererbearertokenclient'
+import { TransformationErrorCode } from './models'
 
 export function isProject(userInputrequest: StartTransformRequest): boolean {
     return userInputrequest.SelectedProjectPath.endsWith('.csproj')
@@ -97,4 +99,46 @@ export function parseAndCheckUnsupportedComponents(htmlString: string): boolean 
         }
     })
     return containsUnsupportedComponents
+}
+
+/**
+ * Determines the appropriate error code for a transformation job based on its status and reason.
+ *
+ * @param transformationJob - The transformation job to analyze
+ * @returns An error code representing the job's error state, or NONE if no error
+ *
+ * TODO: Expand this function to handle additional error patterns as they are identified
+ */
+export function getTransformationErrorCode(transformationJob: TransformationJob | undefined): TransformationErrorCode {
+    if (!transformationJob) {
+        return TransformationErrorCode.NONE
+    }
+
+    // Check for failure states
+    if (
+        transformationJob.status === 'FAILED' ||
+        transformationJob.status === 'STOPPED' ||
+        transformationJob.status === 'REJECTED'
+    ) {
+        if (transformationJob.reason) {
+            // Check for quota exceeded error
+            if (
+                transformationJob.reason
+                    .toLowerCase()
+                    .includes(
+                        'the project was stopped because the projected resource usage would exceed your remaining quota.'
+                    )
+            ) {
+                return TransformationErrorCode.QUOTA_EXCEEDED
+            }
+
+            // TODO: Add more error pattern matching here as needed
+        }
+
+        // If we get here, there was a failure but we don't have a specific error code for it
+        return TransformationErrorCode.UNKNOWN_ERROR
+    }
+
+    // No error
+    return TransformationErrorCode.NONE
 }


### PR DESCRIPTION
## Problem

Currently, our backend language server emits detailed failure reason messages (as strings), but doesn't include standardized failure codes. This creates several challenges:
- Frontend code must rely on string matching against error messages to determine appropriate UI responses
- String matching is fragile - any wording changes to error messages can break frontend behavior
- When issues occur in production, it's difficult to trace which specific error condition triggered a given frontend response
- Inconsistent error handling across the frontend codebase

## Solution

This PR implements a standardized failure code system in the language server:

- Added a FailureCode enum in the language server
-  Enhanced error responses to include both:
        - Human-readable failure reasons (existing)
        - failure codes (new)
- Initially implemented the SERVICE_QUOTA_EXCEEDED failure code
- Maintained backward compatibility with existing clients


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
