### PR TITLE
feat: show customer facing message for inputTooLong error

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -1,18 +1,43 @@
-type AgenticChatErrorCode = 'QModelResponse' | 'AmazonQServiceManager' | 'FailedResult' | 'MaxAgentLoopIterations'
+import { CodeWhispererStreamingServiceException } from '@amzn/codewhisperer-streaming'
+
+type AgenticChatErrorCode =
+    | 'QModelResponse'
+    | 'AmazonQServiceManager'
+    | 'FailedResult'
+    | 'MaxAgentLoopIterations'
+    | 'InputTooLong'
 
 export class AgenticChatError extends Error {
     constructor(
         message: string,
         public readonly code: AgenticChatErrorCode,
-        cause?: Error
+        cause?: Error,
+        public readonly requestId?: string
     ) {
         super(message, { cause: cause })
     }
 }
 
 export function wrapErrorWithCode(error: unknown, code: AgenticChatErrorCode) {
+    if (error instanceof CodeWhispererStreamingServiceException) {
+        return new AgenticChatError(error.message, code, error, error.$metadata?.requestId)
+    }
+
     if (error instanceof Error) {
         return new AgenticChatError(error.message, code, error)
     }
     return new AgenticChatError(String(error), code)
+}
+
+export function isInputTooLongError(error: unknown): boolean {
+    if (error instanceof AgenticChatError && error.code === 'InputTooLong') {
+        return true
+    }
+
+    if (error instanceof Error) {
+        //  This is fragile (breaks if the backend changes their error message wording)
+        return error.message.includes('Input is too long')
+    }
+
+    return false
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -4,6 +4,7 @@
  */
 import * as Loki from 'lokijs'
 import {
+    chatMessageToMessage,
     Conversation,
     FileSystemAdapter,
     groupTabsByDate,
@@ -356,7 +357,7 @@ export class ChatDatabase {
     /**
      * Fixes the history to maintain the following invariants:
      * 1. The history contains at most MaxConversationHistoryMessages messages. Oldest messages are dropped.
-     * 2. The history character length is <= MaxConversationHistoryCharacters. Oldest messages are dropped.
+     * 2. The history character length is <= MaxConversationHistoryCharacters - newUserMessageCharacterCount. Oldest messages are dropped.
      * 3. The first message is from the user. Oldest messages are dropped if needed.
      * 4. The last message is from the assistant. The last message is dropped if it is from the user.
      * 5. If the last message is from the assistant and it contains tool uses, and a next user
@@ -388,8 +389,8 @@ export class ChatDatabase {
         //  Drop empty assistant partial if it’s the last message
         this.handleEmptyAssistantMessage(allMessages)
 
-        //  Make sure max characters ≤ MaxConversationHistoryCharacters
-        allMessages = this.trimMessagesToMaxLength(allMessages)
+        //  Make sure max characters ≤ MaxConversationHistoryCharacters - newUserMessageCharacterCount
+        allMessages = this.trimMessagesToMaxLength(allMessages, newUserMessage)
 
         //  Ensure messages in history a valid for server side checks
         this.ensureValidMessageSequence(allMessages)
@@ -462,9 +463,15 @@ export class ChatDatabase {
         }
     }
 
-    private trimMessagesToMaxLength(messages: Message[]): Message[] {
-        let totalCharacters = this.calculateCharacterCount(messages)
-        while (totalCharacters > MaxConversationHistoryCharacters && messages.length > 2) {
+    private trimMessagesToMaxLength(messages: Message[], newUserMessage: ChatMessage): Message[] {
+        let totalCharacters = this.calculateHistoryCharacterCount(messages)
+        this.#features.logging.debug(`Current history characters: ${totalCharacters}`)
+        const currentUserInputCharacterCount = this.calculateCurrentMessageCharacterCount(
+            chatMessageToMessage(newUserMessage)
+        )
+        this.#features.logging.debug(`Current user message characters: ${currentUserInputCharacterCount}`)
+        const maxHistoryCharacterSize = Math.max(0, MaxConversationHistoryCharacters - currentUserInputCharacterCount)
+        while (totalCharacters > maxHistoryCharacterSize && messages.length > 2) {
             // Find the next valid user message to start from
             const indexToTrim = this.findIndexToTrim(messages)
             if (indexToTrim !== undefined && indexToTrim > 0) {
@@ -478,12 +485,13 @@ export class ChatDatabase {
                 )
                 return []
             }
-            totalCharacters = this.calculateCharacterCount(messages)
+            totalCharacters = this.calculateHistoryCharacterCount(messages)
+            this.#features.logging.debug(`Current history characters: ${totalCharacters}`)
         }
         return messages
     }
 
-    private calculateCharacterCount(allMessages: Message[]): number {
+    private calculateHistoryCharacterCount(allMessages: Message[]): number {
         let count = 0
         for (const message of allMessages) {
             // Count characters of all message text
@@ -510,7 +518,62 @@ export class ChatDatabase {
                 }
             }
         }
-        this.#features.logging.debug(`Current history characters: ${count}`)
+        return count
+    }
+
+    private calculateCurrentMessageCharacterCount(message: Message): number {
+        let count = 0
+        // Count characters of message text
+        count += message.body.length
+
+        // Count characters in tool uses
+        if (message.toolUses) {
+            try {
+                for (const toolUse of message.toolUses) {
+                    count += JSON.stringify(toolUse).length
+                }
+            } catch (e) {
+                this.#features.logging.error(`Error counting toolUses: ${String(e)}`)
+            }
+        }
+        // Count characters in tool results
+        if (message.userInputMessageContext?.toolResults) {
+            try {
+                for (const toolResul of message.userInputMessageContext.toolResults) {
+                    count += JSON.stringify(toolResul).length
+                }
+            } catch (e) {
+                this.#features.logging.error(`Error counting toolResults: ${String(e)}`)
+            }
+        }
+        // Count characters in tool spec for the current user message
+        if (message.userInputMessageContext?.tools) {
+            try {
+                for (const toolSpec of message.userInputMessageContext.tools) {
+                    count += JSON.stringify(toolSpec).length
+                }
+            } catch (e) {
+                this.#features.logging.error(`Error counting tool spec length: ${String(e)}`)
+            }
+        }
+
+        if (message.userInputMessageContext?.additionalContext) {
+            try {
+                for (const addtionalContext of message.userInputMessageContext.additionalContext) {
+                    count += JSON.stringify(addtionalContext).length
+                }
+            } catch (e) {
+                this.#features.logging.error(`Error counting addtionalContext length: ${String(e)}`)
+            }
+        }
+
+        if (message.userInputMessageContext?.editorState) {
+            try {
+                count += JSON.stringify(message.userInputMessageContext?.editorState).length
+            } catch (e) {
+                this.#features.logging.error(`Error counting editorState length: ${String(e)}`)
+            }
+        }
         return count
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
@@ -10,6 +10,7 @@ import {
     FileSystemAdapter,
     Message,
     TabType,
+    chatMessageToMessage,
     groupTabsByDate,
     messageToChatMessage,
     messageToStreamingMessage,
@@ -17,6 +18,7 @@ import {
 } from './util'
 import { ChatMessage } from '@aws/language-server-runtimes/protocol'
 import { Workspace } from '@aws/language-server-runtimes/server-interface'
+import { ChatMessage as StreamingMessage } from '@amzn/codewhisperer-streaming'
 
 describe('ChatDb Utilities', () => {
     describe('messageToStreamingMessage', () => {
@@ -98,6 +100,62 @@ describe('ChatDb Utilities', () => {
                     codeReference: undefined,
                 },
             ])
+        })
+    })
+
+    describe('chatMessageToMessage', () => {
+        it('should convert userInputMessage to prompt Message', () => {
+            const chatMessage: StreamingMessage = {
+                userInputMessage: {
+                    content: 'Hello',
+                    userInputMessageContext: {
+                        toolResults: [],
+                    },
+                },
+            }
+
+            const result = chatMessageToMessage(chatMessage)
+
+            assert.deepStrictEqual(result, {
+                body: 'Hello',
+                origin: 'IDE',
+                type: 'prompt',
+                userInputMessageContext: {
+                    toolResults: [],
+                },
+                userIntent: undefined,
+            })
+        })
+
+        it('should convert assistantResponseMessage to answer Message', () => {
+            const chatMessage: StreamingMessage = {
+                assistantResponseMessage: {
+                    messageId: 'msg-123',
+                    content: 'Response content',
+                    toolUses: [
+                        {
+                            toolUseId: 'tool-1',
+                            name: 'testTool',
+                            input: { key: 'value' },
+                        },
+                    ],
+                },
+            }
+
+            const result = chatMessageToMessage(chatMessage)
+
+            assert.deepStrictEqual(result, {
+                body: 'Response content',
+                type: 'answer',
+                messageId: 'msg-123',
+                toolUses: [
+                    {
+                        toolUseId: 'tool-1',
+                        name: 'testTool',
+                        input: { key: 'value' },
+                    },
+                ],
+            })
         })
     })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
@@ -17,6 +17,8 @@ import {
     UserInputMessageContext,
     UserIntent,
     ToolUse,
+    UserInputMessage,
+    AssistantResponseMessage,
 } from '@amzn/codewhisperer-streaming'
 import { Workspace } from '@aws/language-server-runtimes/server-interface'
 
@@ -121,6 +123,36 @@ export function messageToChatMessage(msg: Message): ChatMessage[] {
         }
     }
     return chatMessages
+}
+
+/**
+ * Converts codewhisperer-streaming ChatMessage to Message
+ */
+export function chatMessageToMessage(chatMessage: StreamingMessage): Message {
+    if ('userInputMessage' in chatMessage) {
+        const userInputMessage = chatMessage.userInputMessage as UserInputMessage
+        return {
+            body: userInputMessage.content || '',
+            type: 'prompt',
+            userIntent: userInputMessage.userIntent,
+            origin: userInputMessage.origin || 'IDE',
+            userInputMessageContext: userInputMessage.userInputMessageContext || {},
+        }
+    } else if ('assistantResponseMessage' in chatMessage) {
+        const assistantResponseMessage = chatMessage.assistantResponseMessage as AssistantResponseMessage
+        return {
+            body: assistantResponseMessage.content || '',
+            type: 'answer',
+            messageId: assistantResponseMessage.messageId,
+            toolUses: assistantResponseMessage.toolUses || [],
+        }
+    } else {
+        // Default fallback for unexpected message format
+        return {
+            body: '',
+            type: 'prompt',
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## Problem

A customer reported an issue where after gathering too much context, they receive a 4xx exception for the input being too long:

![Screenshot 2025-04-25 at 2 25 50 PM](https://github.com/user-attachments/assets/9af4aac8-0174-4b60-b5b6-3148bb708f9c)


## Solution

- Show a special customer-facing message for this issue


## Testing

- Added unit tests to verify issue
- Reproduced issue and verified message:
![Screenshot 2025-04-28 at 11 55 19 AM](https://github.com/user-attachments/assets/66741842-acc4-493d-97e4-9438192ac48d)




## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
