### PR TITLE
fix: see if message is apart of agentic loop

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -564,6 +564,7 @@ export class AgenticChatController implements ChatHandlers {
             if (result.success) {
                 // Process tool uses and update the request input for the next iteration
                 toolResults = await this.#processToolUses(pendingToolUses, chatResultStream, session, tabId, token)
+                metric.setDimension('cwsprChatConversationType', 'AgenticChatWithToolUse')
             } else {
                 // Send an error card to UI?
                 toolResults = pendingToolUses.map(toolUse => ({


### PR DESCRIPTION
- reference agenticChat branch pr: https://github.com/aws/aws-toolkit-vscode/pull/7069

## Problem
- want to differentiate between a message without tool use (ex: what time is it) and a message with tool use (ex: write a docstring for my function)

## Solution
- for both successful messages and messages that resulted in error, see if this message was apart of an agentic loop.
- An agentic loop is when the LLM asks to run a tool and the LLM receives the results back of running the tool.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
