### PR TITLE
fix: fix for context list flickering ux

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1779,8 +1779,10 @@ export class AgenticChatController implements ChatHandlers {
         const streamWriter = chatResultStream.getResultStreamWriter()
 
         // Display context transparency list once at the beginning of response
-        if (contextList) {
+        // Use a flag to track if contextList has been sent already to avoid ux flickering
+        if (contextList && !session.contextListSent) {
             await streamWriter.write({ body: '', contextList })
+            session.contextListSent = true
         }
 
         for await (const chatEvent of response.generateAssistantResponseResponse!) {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -24,6 +24,7 @@ type DeferredHandler = {
 export class ChatSessionService {
     public shareCodeWhispererContentWithAWS = false
     public pairProgrammingMode: boolean = true
+    public contextListSent: boolean = false
     #abortController?: AbortController
     #conversationId?: string
     #amazonQServiceManager?: AmazonQBaseServiceManager
@@ -126,6 +127,7 @@ export class ChatSessionService {
     public clear(): void {
         this.#abortController?.abort()
         this.#conversationId = undefined
+        this.contextListSent = false
     }
 
     public dispose(): void {


### PR DESCRIPTION
## Problem
- Context list is send to mynah for every execution in runAgentLoop so this shows as flickering ux.
![image](https://github.com/user-attachments/assets/7cc7525f-6380-4c0e-9683-5979b2609572)
## Solution
- Fixed this issue by adding a session variable(`session.contextListSent`) to send context list only once

https://github.com/user-attachments/assets/dca980c2-d2e8-41e3-a265-f804cd720051



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
