### PR TITLE
fix: override the MynahUi maxUserInput config

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -39,7 +39,6 @@ import {
     NotificationType,
     MynahUIProps,
     QuickActionCommand,
-    ChatItemFormItem,
     ChatItemButton,
 } from '@aws/mynah-ui'
 import { VoteParams } from '../contracts/telemetry'
@@ -57,12 +56,7 @@ import {
     toMynahIcon,
 } from './utils'
 import { ChatHistory, ChatHistoryList } from './features/history'
-import {
-    pairProgrammingModeOff,
-    pairProgrammingModeOn,
-    pairProgrammingPromptInput,
-    programmerModeCard,
-} from './texts/pairProgramming'
+import { pairProgrammingModeOff, pairProgrammingModeOn, programmerModeCard } from './texts/pairProgramming'
 
 export interface InboundChatApi {
     addChatResponse(params: ChatResult, tabId: string, isPartialResult: boolean): void
@@ -474,6 +468,11 @@ export const createMynahUi = (
         },
         config: {
             maxTabs: 10,
+            // RTS max user input is 600k, we need to leave around 500 chars to user to type the question
+            // beside, MynahUI will automatically crop it depending on the available chars left from the prompt field itself by using a 96 chars of threshold
+            // if we want to max user input as 599500, need to configure the maxUserInput as 599596
+            maxUserInput: 599596,
+            userInputLengthWarningThreshold: 550000,
             texts: uiComponentsTexts,
         },
     }


### PR DESCRIPTION
## Problem
there is bug in the input prompt popup UI to display the max prompt chars size as 4000. 
![image](https://github.com/user-attachments/assets/1a26e42a-ca3d-469d-b205-f9691d5328b8)
This is cause as use the default flare chat ui config as following. 

```
  userInputLengthWarningThreshold: 3500,
  maxUserInput: 4096,
```


## Solution
Fix this issue by override the default flare chat ui config in the language server package. verified with a large prompt
![image](https://github.com/user-attachments/assets/49b37662-39cc-4f9e-88d1-26d602720a6e)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
