### PR TITLE
fix: duplicate explanation

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -576,6 +576,9 @@ export class AgenticChatController implements ChatHandlers {
             if (result.success) {
                 // Process tool uses and update the request input for the next iteration
                 toolResults = await this.#processToolUses(pendingToolUses, chatResultStream, session, tabId, token)
+                if (toolResults.some(toolResult => toolResult.status === ToolResultStatus.ERROR)) {
+                    content = 'There was an error processing one or more tool uses. Please try again.'
+                }
                 metric.setDimension('cwsprChatConversationType', 'AgenticChatWithToolUse')
             } else {
                 // Send an error card to UI?


### PR DESCRIPTION
## Problem
![image](https://github.com/user-attachments/assets/b9c1bcd4-b164-4a14-aa03-f3e5ce785994)

This is happening when there is a tool error which is automatically retried.

## Solution

When this happens, populate the user input content to make the LLM respond with some new response.

![image](https://github.com/user-attachments/assets/22494199-3ffb-45d8-a0d0-abc70eae1923)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
