### PR TITLE
fix: related tools in toolSpec causes hallucination

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
@@ -143,10 +143,7 @@ export class FsRead {
                 '  * The initial read was truncated (indicated by `truncated=true` in the output)\n' +
                 '  * A specific `readRange` is needed to focus on relevant sections\n' +
                 '  * The user explicitly asks to read more of the file\n' +
-                '- DO NOT re-read the file again using `readRange` unless explicitly asked by the user\n\n' +
-                '## Related tools\n' +
-                '- fsWrite: Use to modify the file after reading\n' +
-                '- listDirectory: Use to find files before reading them',
+                '- DO NOT re-read the file again using `readRange` unless explicitly asked by the user',
             inputSchema: {
                 type: 'object',
                 properties: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -185,10 +185,7 @@ export class FsWrite {
                 '- Prefer the `create` command if the complexity or number of changes would make `strReplace` unwieldy or error-prone.\n' +
                 '- The `oldStr` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces! Include just the changing lines, and a few surrounding lines if needed for uniqueness. Do not include long runs of unchanging lines in `oldStr`.\n' +
                 '- The `newStr` parameter should contain the edited lines that should replace the `oldStr`.\n' +
-                '- When multiple edits to the same file are needed, combine them into a single call whenever possible. This improves efficiency by reducing the number of tool calls and ensures the file remains in a consistent state.\n\n' +
-                '## Related tools\n' +
-                '- fsRead: Use to read the file before modifying it\n' +
-                '- listDirectory: Use to find files before modifying them',
+                '- When multiple edits to the same file are needed, combine them into a single call whenever possible. This improves efficiency by reducing the number of tool calls and ensures the file remains in a consistent state.',
             inputSchema: {
                 type: 'object',
                 properties: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -104,10 +104,7 @@ export class ListDirectory {
                 '- This tool will ignore directories such as `build/`, `out/`, `dist/` and `node_modules/`\n' +
                 '- This tool is more effective than running a command like `ls` using `executeBash` tool\n' +
                 '- Results clearly distinguish between files, directories or symlinks with [F], [D] and [L] prefixes\n' +
-                '- Use the `maxDepth` parameter to control how deep the directory traversal goes\n\n' +
-                '## Related tools\n' +
-                '- fsRead: Use to examine files after finding them\n' +
-                '- fsWrite: Use to modify files after finding them',
+                '- Use the `maxDepth` parameter to control how deep the directory traversal goes',
             inputSchema: {
                 type: 'object',
                 properties: {


### PR DESCRIPTION
## Problem

It seems like mentioning related tools is causing the LLM to generate incorrect inputs. For instance, it sometimes tries to execute the `fsWrite` tool with `fsRead` as the command input.

<img width="736" alt="Screenshot 2025-04-28 at 6 37 24 PM" src="https://github.com/user-attachments/assets/1263bcd9-ef5b-407f-84c5-b9ea144741d3" />


## Solution

Remove related tools for now.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
