### PR TITLE
fix: add profileArn for STE and fix timeBetweenChunks

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1392,6 +1392,10 @@ export class AgenticChatController implements ChatHandlers {
 
         metric.setDimension('codewhispererCustomizationArn', this.#customizationArn)
         metric.setDimension('languageServerVersion', this.#features.runtime.serverInfo.version)
+        const profileArn = AmazonQTokenServiceManager.getInstance(this.#features).getActiveProfileArn()
+        if (profileArn) {
+            this.#telemetryService.updateProfileArn(profileArn)
+        }
         if (triggerContext.contextInfo) {
             metric.mergeWith({
                 cwsprChatHasContextList: triggerContext.documentReference?.filePaths?.length ? true : false,

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -414,6 +414,7 @@ export class TelemetryService {
         if (!params.conversationId || !params.messageId) {
             return
         }
+        const timeBetweenChunks = params.timeBetweenChunks?.slice(0, 100)
 
         if (this.enableTelemetryEventsToDestination) {
             this.telemetry.emitMetric({
@@ -433,7 +434,7 @@ export class TelemetryService {
                     cwsprChatFollowUpCount: additionalParams.chatFollowUpCount,
                     cwsprTimeToFirstChunk: params.timeToFirstChunkMilliseconds,
                     cwsprChatFullResponseLatency: params.fullResponselatency,
-                    cwsprChatTimeBetweenChunks: params.timeBetweenChunks,
+                    cwsprChatTimeBetweenChunks: timeBetweenChunks,
                     cwsprChatRequestLength: params.requestLength,
                     cwsprChatResponseLength: params.responseLength,
                     cwsprChatConversationType: additionalParams.chatConversationType,
@@ -462,7 +463,7 @@ export class TelemetryService {
             hasCodeSnippet: params.hasCodeSnippet,
             activeEditorTotalCharacters: params.activeEditorTotalCharacters,
             timeToFirstChunkMilliseconds: params.timeToFirstChunkMilliseconds,
-            timeBetweenChunks: params.timeBetweenChunks,
+            timeBetweenChunks: timeBetweenChunks,
             fullResponselatency: params.fullResponselatency,
             requestLength: params.requestLength,
             responseLength: params.responseLength,

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -40,6 +40,7 @@ export class TelemetryService {
     private telemetry: Telemetry
     private credentialsProvider: CredentialsProvider
     private logging: Logging
+    private profileArn: string | undefined
 
     private readonly cwInteractionTypeMap: Record<ChatInteractionType, ChatMessageInteractionType> = {
         [ChatInteractionType.InsertAtCursor]: 'INSERT_AT_CURSOR',
@@ -72,6 +73,10 @@ export class TelemetryService {
 
     public updateOptOutPreference(optOutPreference: OptOutPreference): void {
         this.optOutPreference = optOutPreference
+    }
+
+    public updateProfileArn(profileArn: string) {
+        this.profileArn = profileArn
     }
 
     public updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination: boolean): void {
@@ -146,6 +151,9 @@ export class TelemetryService {
             }
             if (this.optOutPreference !== undefined) {
                 request.optOutPreference = this.optOutPreference
+            }
+            if (this.profileArn !== undefined) {
+                request.profileArn = this.profileArn
             }
             await this.getService().sendTelemetryEvent(request)
         } catch (error) {


### PR DESCRIPTION
## Problem
STE requests are failing for addMessage because:
- we are not passing profileArn
- timeBetweenChunks has a limit of 100

## Solution
- add profileArn
- cap timeBetweenChunks length

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
