### PR TITLE
feat: implement new sendToPrompt params

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -21,7 +21,7 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.1.28",
+        "@aws/chat-client-ui-types": "^0.1.32",
         "@aws/language-server-runtimes-types": "^0.1.25",
         "@aws/mynah-ui": "^4.32.1"
     },

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -131,7 +131,11 @@ export const handleChatPrompt = (
         const context = prompt.context?.map(c => (typeof c === 'string' ? { command: c } : c))
         messager.onChatPrompt({ prompt, tabId, context }, triggerType)
     }
-    // Add user prompt to UI
+
+    initializeChatResponse(mynahUi, tabId, userPrompt)
+}
+
+const initializeChatResponse = (mynahUi: MynahUI, tabId: string, userPrompt?: string) => {
     mynahUi.addChatItem(tabId, {
         type: ChatItemType.PROMPT,
         body: userPrompt,
@@ -772,7 +776,12 @@ export const createMynahUi = (
         const tabId = getOrCreateTabId()
         if (!tabId) return
 
-        mynahUi.addToUserPrompt(tabId, params.selection, 'code')
+        if (params.autoSubmit && params.prompt) {
+            messager.onChatPrompt({ prompt: params.prompt, tabId, context: undefined }, 'contextMenu')
+            initializeChatResponse(mynahUi, tabId, params.prompt.prompt)
+        } else {
+            mynahUi.addToUserPrompt(tabId, params.selection, 'code')
+        }
         messager.onSendToPrompt(params, tabId)
     }
 

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -340,7 +340,7 @@
     "devDependencies": {
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
-        "@aws/chat-client-ui-types": "^0.1.28",
+        "@aws/chat-client-ui-types": "^0.1.32",
         "@aws/language-server-runtimes": "^0.2.77",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,7 +245,7 @@
             "version": "0.1.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.1.28",
+                "@aws/chat-client-ui-types": "^0.1.32",
                 "@aws/language-server-runtimes-types": "^0.1.25",
                 "@aws/mynah-ui": "^4.32.1"
             },
@@ -268,7 +268,7 @@
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
-                "@aws/chat-client-ui-types": "^0.1.28",
+                "@aws/chat-client-ui-types": "^0.1.32",
                 "@aws/language-server-runtimes": "^0.2.77",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
@@ -3886,12 +3886,11 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.28",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.28.tgz",
-            "integrity": "sha512-l6eCjmKdbuQIs9/lEyb8y2yaiUulzZr2RzFxhvhQXuIdUjYRX7vK9W0khYbnOMjLuuXpmAejF+UlnxAf4hREAQ==",
-            "license": "Apache-2.0",
+            "version": "0.1.32",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.32.tgz",
+            "integrity": "sha512-axJymxFQhXh8AOnhek61VL5va917TjIvfHF5sHpyQay+znILAs65osdIMeqHs6VTjZCKtzIEp5iCd6uZbvYRVw==",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.23"
+                "@aws/language-server-runtimes-types": "^0.1.26"
             }
         },
         "node_modules/@aws/hello-world-lsp": {
@@ -27012,7 +27011,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
-                "@aws/chat-client-ui-types": "^0.1.28",
+                "@aws/chat-client-ui-types": "^0.1.32",
                 "@aws/language-server-runtimes": "^0.2.75",
                 "@aws/lsp-core": "^0.0.3",
                 "@modelcontextprotocol/sdk": "^1.9.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -31,7 +31,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.0.tgz",
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
-        "@aws/chat-client-ui-types": "^0.1.28",
+        "@aws/chat-client-ui-types": "^0.1.32",
         "@aws/language-server-runtimes": "^0.2.75",
         "@aws/lsp-core": "^0.0.3",
         "@modelcontextprotocol/sdk": "^1.9.0",


### PR DESCRIPTION
## Problem
we have no way to send an event from the client side and trigger it in flare. This is needed for events like "explain issue" from VSCode's security scan, which triggers a event that gets displayed to the user, and a separate event that gets sent to the backend

## Solution
wire up an autosubmit event that when enabled takes a prompt from sendToPrompt and automatically submits it

**note**: the extended types were for testing, if this API is agreed upon i'll make the changes in the runtimes package

Related VSCode PR: https://github.com/aws/aws-toolkit-vscode/pull/7194

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
