### PR TITLE
fix: typo in response code metric field

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -282,7 +282,7 @@ export class ChatTelemetryController {
                 cwsprChatProgrammingLanguage: metric.cwsprChatProgrammingLanguage,
                 cwsprChatActiveEditorTotalCharacters: metric.cwsprChatActiveEditorTotalCharacters,
                 cwsprChatActiveEditorImportCount: metric.cwsprChatActiveEditorImportCount,
-                cwsprChatRepsonseCode: metric.cwsprChatRepsonseCode,
+                cwsprChatResponseCode: metric.cwsprChatResponseCode,
                 cwsprChatRequestLength: metric.cwsprChatRequestLength,
                 cwsprChatConversationType: metric.cwsprChatConversationType,
                 requestId: requestId,


### PR DESCRIPTION
## Problem
This metric was not being emitted on the VSC side because it contained missing fields. This is due to a typo in the metric name. 

## Solution
- fix the typo

## Testing and Verification
- verified this is emitted via IDE logs. 
```
[debug] telemetry: amazonq_messageResponseError {
  Metadata: {
    metricId: '0355b2b6-53fa-4d6e-9a8b-bb23d57ff8c2',
    traceId: 'd4fe8c26-7f0e-406d-8e69-538d45c17478',
    parentId: '8165cc0a-1852-45a7-b0d7-79a9ee3de2e8',
    cwsprChatHasCodeSnippet: 'false',
    cwsprChatTriggerInteraction: 'click',
    cwsprChatActiveEditorTotalCharacters: '0',
    cwsprChatResponseCode: '500',
    cwsprChatRequestLength: '4',
    cwsprChatConversationType: 'AgenticChat',
    requestId: 'eb03a038-f468-44d6-966e-6356827e4b68',
    reasonDesc: 'Encountered an unexpected error when processing the request, please try again.',
    credentialStartUrl: 'https://amzn.awsapps.com/start',
    result: 'Succeeded',
    languageServerVersion: '0.1.0',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}
```
## Follow Up Work
- VSC-side telemetry is validated against a schema, so this doesn't happen. However, in Flare there is no validation for metric shape, allowing for typos like this to slip through. Now that VSC is forwarding Flare telemetry, we should add logging to warn about invalid metrics. These changes will be made on the client side. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
