### PR TITLE
fix: immediate full results not getting rendered e.g /help

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -649,6 +649,19 @@ export const createMynahUi = (
               }
             : {}
 
+        const chatItem = {
+            ...chatResult,
+            body: chatResult.body,
+            type: ChatItemType.ANSWER_STREAM,
+            header: header,
+            buttons: buttons,
+            codeBlockActions: isPairProgrammingMode ? { 'insert-to-cursor': null } : undefined,
+        }
+
+        if (!chatItems.find(ci => ci.messageId === chatResult.messageId)) {
+            mynahUi.addChatItem(tabId, chatItem)
+        }
+
         mynahUi.endMessageStream(tabId, chatResult.messageId ?? '', {
             header: header,
             buttons: buttons,


### PR DESCRIPTION
## Problem

Quick actions like `/help` would be stuck in `thinking ` and not render any response because the `/help` response is hardcoded and immediately streamed without any partial result. With the latest changes in the chat-client, the logic to create a chat item was put inside the `if (partialResult)` block which caused no chat item to be created for cases when there is no partial result.  

## Solution

This is a quick fix to ensure that a chat item is created if no chat message exists when we have a full result. There is now small code repetition and the logic can be cleaned up further in the future 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
