### PR TITLE
fix: telemetry for `@Files`, `@Folders`, `@Prompts`, `@Code`

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1402,6 +1402,8 @@ export class AgenticChatController implements ChatHandlers {
                 cwsprChatFileContextLength: triggerContext.contextInfo.contextLength.fileContextLength,
                 cwsprChatRuleContextLength: triggerContext.contextInfo.contextLength.ruleContextLength,
                 cwsprChatPromptContextLength: triggerContext.contextInfo.contextLength.promptContextLength,
+                cwsprChatCodeContextCount: triggerContext.contextInfo.contextCount.codeContextCount,
+                cwsprChatCodeContextLength: triggerContext.contextInfo.contextLength.codeContextLength,
             })
         }
         await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1404,6 +1404,7 @@ export class AgenticChatController implements ChatHandlers {
                 cwsprChatPromptContextLength: triggerContext.contextInfo.contextLength.promptContextLength,
                 cwsprChatCodeContextCount: triggerContext.contextInfo.contextCount.codeContextCount,
                 cwsprChatCodeContextLength: triggerContext.contextInfo.contextLength.codeContextLength,
+                cwsprChatFocusFileContextLength: triggerContext.text?.length,
             })
         }
         await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
@@ -50,6 +50,9 @@ export class AdditionalContextProvider {
     }
 
     getContextType(prompt: AdditionalContextPrompt): string {
+        if (prompt.name === 'symbol') {
+            return 'code'
+        }
         if (prompt.filePath.endsWith(promptFileExtension)) {
             if (pathUtils.isInDirectory(path.join('.amazonq', 'rules'), prompt.relativePath)) {
                 return 'rule'
@@ -81,15 +84,18 @@ export class AdditionalContextProvider {
             let fileContextCount = 0
             let folderContextCount = 0
             let promptContextCount = 0
+            let codeContextCount = 0
             additionalContextCommands.push(...this.mapToContextCommandItems(context, workspaceFolderPath))
             for (const c of context) {
                 if (typeof context !== 'string') {
-                    if (c.id === 'file') {
-                        fileContextCount++
-                    } else if (c.id === 'folder') {
-                        folderContextCount++
-                    } else if (c.id === 'prompt') {
+                    if (c.id === 'prompt') {
                         promptContextCount++
+                    } else if (c.label === 'file') {
+                        fileContextCount++
+                    } else if (c.label === 'folder') {
+                        folderContextCount++
+                    } else if (c.label === 'code') {
+                        codeContextCount++
                     }
                 }
             }
@@ -98,6 +104,7 @@ export class AdditionalContextProvider {
                 fileContextCount,
                 folderContextCount,
                 promptContextCount,
+                codeContextCount,
             }
         }
 
@@ -117,6 +124,7 @@ export class AdditionalContextProvider {
         let ruleContextLength = 0
         let fileContextLength = 0
         let promptContextLength = 0
+        let codeContextLength = 0
         for (const prompt of prompts.slice(0, 20)) {
             const contextType = this.getContextType(prompt)
             const description =
@@ -140,17 +148,20 @@ export class AdditionalContextProvider {
             contextEntry.push(entry)
 
             if (contextType === 'rule') {
-                fileContextLength += prompt.content.length
+                ruleContextLength += prompt.content.length
             } else if (contextType === 'prompt') {
                 promptContextLength += prompt.content.length
+            } else if (contextType === 'code') {
+                codeContextLength += prompt.content.length
             } else {
-                ruleContextLength += prompt.content.length
+                fileContextLength += prompt.content.length
             }
         }
         triggerContext.contextInfo.contextLength = {
             ruleContextLength,
             fileContextLength,
             promptContextLength,
+            codeContextLength,
         }
         return contextEntry
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
@@ -8,11 +8,13 @@ export interface ContextInfo {
         folderContextCount: number
         promptContextCount: number
         ruleContextCount: number
+        codeContextCount: number
     }
     contextLength: {
         fileContextLength: number
         ruleContextLength: number
         promptContextLength: number
+        codeContextLength: number
     }
 }
 
@@ -22,11 +24,13 @@ export const initialContextInfo: ContextInfo = {
         folderContextCount: 0,
         promptContextCount: 0,
         ruleContextCount: 0,
+        codeContextCount: 0,
     },
     contextLength: {
         fileContextLength: 0,
         ruleContextLength: 0,
         promptContextLength: 0,
+        codeContextLength: 0,
     },
 }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -239,6 +239,7 @@ export class ChatTelemetryController {
                 cwsprChatPromptContextLength: metric.cwsprChatPromptContextLength,
                 cwsprChatCodeContextLength: metric.cwsprChatCodeContextLength,
                 cwsprChatCodeContextCount: metric.cwsprChatCodeContextCount,
+                cwsprChatFocusFileContextLength: metric.cwsprChatFocusFileContextLength,
                 languageServerVersion: metric.languageServerVersion,
             }
         )

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -237,6 +237,8 @@ export class ChatTelemetryController {
                 cwsprChatFileContextLength: metric.cwsprChatFileContextLength,
                 cwsprChatRuleContextLength: metric.cwsprChatRuleContextLength,
                 cwsprChatPromptContextLength: metric.cwsprChatPromptContextLength,
+                cwsprChatCodeContextLength: metric.cwsprChatCodeContextLength,
+                cwsprChatCodeContextCount: metric.cwsprChatCodeContextCount,
                 languageServerVersion: metric.languageServerVersion,
             }
         )

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -740,9 +740,11 @@ describe('TelemetryService', () => {
                     cwsprChatFileContextCount: 0,
                     cwsprChatRuleContextCount: 0,
                     cwsprChatPromptContextCount: 0,
+                    cwsprChatCodeContextCount: 2,
                     cwsprChatFileContextLength: 0,
                     cwsprChatRuleContextLength: 0,
                     cwsprChatPromptContextLength: 0,
+                    cwsprChatCodeContextLength: 500,
                     cwsprChatFocusFileContextLength: 0,
                 }
             )
@@ -802,9 +804,11 @@ describe('TelemetryService', () => {
                     cwsprChatFileContextCount: 0,
                     cwsprChatRuleContextCount: 0,
                     cwsprChatPromptContextCount: 0,
+                    cwsprChatCodeContextCount: 2,
                     cwsprChatFileContextLength: 0,
                     cwsprChatRuleContextLength: 0,
                     cwsprChatPromptContextLength: 0,
+                    cwsprChatCodeContextLength: 500,
                     cwsprChatFocusFileContextLength: 0,
                 },
             })

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -442,7 +442,7 @@ export class TelemetryService {
                     cwsprChatFileContextLength: additionalParams.cwsprChatFileContextLength,
                     cwsprChatRuleContextLength: additionalParams.cwsprChatRuleContextLength,
                     cwsprChatPromptContextLength: additionalParams.cwsprChatPromptContextLength,
-                    cwsprChatFocusFileContextLength: additionalParams.cwsprChatFileContextLength,
+                    cwsprChatFocusFileContextLength: additionalParams.cwsprChatFocusFileContextLength,
                     cwsprChatCodeContextCount: additionalParams.cwsprChatCodeContextCount,
                     cwsprChatCodeContextLength: additionalParams.cwsprChatCodeContextLength,
                     result: 'Succeeded',

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -399,6 +399,8 @@ export class TelemetryService {
             cwsprChatRuleContextLength: number
             cwsprChatPromptContextCount: number
             cwsprChatPromptContextLength: number
+            cwsprChatCodeContextCount: number
+            cwsprChatCodeContextLength: number
             cwsprChatFocusFileContextLength: number
             languageServerVersion?: string
         }>
@@ -441,6 +443,8 @@ export class TelemetryService {
                     cwsprChatRuleContextLength: additionalParams.cwsprChatRuleContextLength,
                     cwsprChatPromptContextLength: additionalParams.cwsprChatPromptContextLength,
                     cwsprChatFocusFileContextLength: additionalParams.cwsprChatFileContextLength,
+                    cwsprChatCodeContextCount: additionalParams.cwsprChatCodeContextCount,
+                    cwsprChatCodeContextLength: additionalParams.cwsprChatCodeContextLength,
                     result: 'Succeeded',
                     languageServerVersion: additionalParams.languageServerVersion,
                 },

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -242,6 +242,8 @@ export type AddMessageEvent = {
     cwsprChatPromptContextCount?: number
     cwsprChatPromptContextLength?: number
     cwsprChatFocusFileContextLength?: number
+    cwsprChatCodeContextCount?: number
+    cwsprChatCodeContextLength?: number
 }
 
 export type EnterFocusChatEvent = {


### PR DESCRIPTION
## Problem
Telemetry was being incorrectly reported for `@Files`, `@Folders`, `@Prompts`. Missing telemetry for `@Code`

## Solution
Fix metrics being emitted for `@Files`, `@Folders`, `@Prompts` and metric for length of open file (`cwsprChatFocusFileContextLength`). add metrics for `@Code` count and length

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
