### PR TITLE
Dogusata/fix ppm mode switch texts

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.28",
         "@aws/language-server-runtimes-types": "^0.1.25",
-        "@aws/mynah-ui": "^4.32.0"
+        "@aws/mynah-ui": "^4.32.1"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/texts/pairProgramming.ts
+++ b/chat-client/src/client/texts/pairProgramming.ts
@@ -25,10 +25,12 @@ export const pairProgrammingPromptInput: ChatItemFormItem = {
 
 export const pairProgrammingModeOn: ChatItem = {
     type: ChatItemType.DIRECTIVE,
-    body: 'You are using **pair programming**: Q can now list files, preview code diffs and allow you to run shell commands.',
+    contentHorizontalAlignment: 'center',
+    body: 'Pair programmer mode ON',
 }
 
 export const pairProgrammingModeOff: ChatItem = {
     type: ChatItemType.DIRECTIVE,
-    body: 'You turned off **pair programming**. Q will not include code diffs or run commands in the chat.',
+    contentHorizontalAlignment: 'center',
+    body: 'Pair programmer mode OFF',
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.28",
                 "@aws/language-server-runtimes-types": "^0.1.25",
-                "@aws/mynah-ui": "^4.32.0"
+                "@aws/mynah-ui": "^4.32.1"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4064,9 +4064,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.32.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.32.0.tgz",
-            "integrity": "sha512-M8NAp8Pr7h/z0HS202aQkDhI9tVZngEQQB5poR8GSINSJ0NNLnJ2nKbBgqw6RAwxVSkk/7CId2nPkgpTO/jaEw==",
+            "version": "4.32.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.32.1.tgz",
+            "integrity": "sha512-M1gINX+HfTxInXKv5B6fZTH3sKQeoRdpAdElTbdbuN41joLJSmkU9Up3pro4nl/Q5JVqbpZ8itwu5VCFAmLKYg==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -20,6 +20,7 @@ import {
 } from '@amzn/codewhisperer-streaming'
 import {
     Button,
+    Status,
     ButtonClickParams,
     ButtonClickResult,
     ChatMessage,
@@ -1168,6 +1169,7 @@ export class AgenticChatController implements ChatHandlers {
                           },
                           {
                               id: 'reject-shell-command',
+                              status: 'dimmed-clear' as Status,
                               text: 'Reject',
                               icon: 'cancel',
                           },


### PR DESCRIPTION
## Problem
- PPM switch information was not configured as expected.
- Reject button doesn't show up as slightly dimmed.
<img width="534" alt="Screenshot 2025-04-29 at 17 03 43" src="https://github.com/user-attachments/assets/264cb8b6-40de-4cd0-b225-ec3c11276191" />
<img width="542" alt="Screenshot 2025-04-29 at 16 13 02" src="https://github.com/user-attachments/assets/8771542c-8912-4d84-a6a3-e8c11aacaad9" />

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
