### PR TITLE
feat(q): builderid "paid tier" flow

### DIFF
--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -390,6 +390,10 @@ export const createChat = (
         promptInputOptionChange: (params: PromptInputOptionChangeParams) => {
             sendMessageToClient({ command: PROMPT_INPUT_OPTION_CHANGE_METHOD, params })
         },
+        promptInputButtonClick: params => {
+            // TODO
+            sendMessageToClient({ command: BUTTON_CLICK_REQUEST_METHOD, params })
+        },
         stopChatResponse: (tabId: string) => {
             sendMessageToClient({ command: STOP_CHAT_RESPONSE, params: { tabId } })
         },

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -92,6 +92,7 @@ export interface OutboundChatApi {
     tabBarAction(params: TabBarActionParams): void
     onGetSerializedChat(requestId: string, result: GetSerializedChatResult | ErrorResult): void
     promptInputOptionChange(params: PromptInputOptionChangeParams): void
+    promptInputButtonClick(params: ButtonClickParams): void
     stopChatResponse(tabId: string): void
     sendButtonClickEvent(params: ButtonClickParams): void
     onOpenSettings(settingKey: string): void
@@ -227,6 +228,10 @@ export class Messager {
 
     onPromptInputOptionChange = (params: PromptInputOptionChangeParams): void => {
         this.chatApi.promptInputOptionChange(params)
+    }
+
+    onPromptInputButtonClick = (params: ButtonClickParams): void => {
+        this.chatApi.promptInputButtonClick(params)
     }
 
     onStopChatResponse = (tabId: string): void => {

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -64,6 +64,7 @@ describe('MynahUI', () => {
             tabBarAction: sinon.stub(),
             onGetSerializedChat: sinon.stub(),
             promptInputOptionChange: sinon.stub(),
+            promptInputButtonClick: sinon.stub(),
             stopChatResponse: sinon.stub(),
             sendButtonClickEvent: sinon.stub(),
             onOpenSettings: sinon.stub(),

--- a/chat-client/src/client/texts/paidTier.ts
+++ b/chat-client/src/client/texts/paidTier.ts
@@ -1,6 +1,33 @@
 import { ChatItem, ChatItemButton, ChatItemFormItem, ChatItemType, TextBasedFormItem } from '@aws/mynah-ui'
 
-export const freeTierLimitReachedCard: ChatItem = {
+export const plansAndPricingTitle = 'Plans &amp; Pricing'
+
+export const upgradeQButton: ChatItemButton = {
+    flash: 'once',
+    fillState: 'hover',
+    position: 'inside',
+    id: 'paidtier-upgrade-q',
+    // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/q.svg
+    // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/rocket.svg
+    // icon: MynahIcons.Q,
+    description: 'Upgrade to Amazon Q Pro',
+    text: 'Upgrade Q',
+    status: 'info',
+    disabled: false,
+}
+
+export const continueUpgradeQButton: ChatItemButton = {
+    id: 'paidtier-upgrade-q-continue',
+    icon: 'rocket',
+    flash: 'once',
+    fillState: 'hover',
+    position: 'inside',
+    // description: 'Link an AWS account to upgrade Amazon Q',
+    text: 'Continue',
+    disabled: false,
+}
+
+export const freeTierLimitCard: ChatItem = {
     type: ChatItemType.ANSWER,
     title: 'FREE TIER LIMIT REACHED',
     header: {
@@ -12,6 +39,63 @@ export const freeTierLimitReachedCard: ChatItem = {
     fullWidth: true,
     canBeDismissed: false,
     body: 'You have reached the free tier limit. Upgrade to Amazon Q Pro.\n\n[Learn More...](https://aws.amazon.com/q/pricing/)',
+}
+
+/** "Banner" (sticky card) shown above the chat prompt. */
+export const freeTierLimitSticky: Partial<ChatItem> = {
+    messageId: 'freetier-limit-banner',
+    title: 'FREE TIER LIMIT REACHED',
+    body: "You've reached your invocation limit for this month. Upgrade to Amazon Q Pro. [Learn More...](https://aws.amazon.com/q/pricing/)",
+    buttons: [upgradeQButton],
+    canBeDismissed: false,
+}
+
+export const upgradePendingSticky: Partial<ChatItem> = {
+    messageId: 'upgrade-pending-banner',
+    body: 'Waiting for subscription status...',
+    status: 'info',
+    buttons: [],
+    canBeDismissed: true,
+}
+
+export const upgradeSuccessSticky: Partial<ChatItem> = {
+    messageId: 'upgrade-success-banner',
+    // body: 'Successfully upgraded to Amazon Q Pro.',
+    status: 'success',
+    buttons: [],
+    // icon: 'q',
+    // iconStatus: 'success',
+    header: {
+        icon: 'ok-circled',
+        iconStatus: 'success',
+        body: 'Successfully upgraded to Amazon Q Pro.',
+        // status: {
+        //     status: 'success',
+        //     position: 'right',
+        //     text: 'Successfully upgraded to Amazon Q Pro.',
+        // },
+    },
+    canBeDismissed: true,
+}
+
+export const paidTierInfoCard: ChatItem = {
+    type: ChatItemType.ANSWER,
+    title: 'UPGRADE TO AMAZON Q PRO',
+    buttons: [upgradeQButton],
+    header: {
+        icon: 'q',
+        iconStatus: 'primary',
+        body: 'This feature requires a subscription to Amazon Q Pro.',
+        status: {
+            status: 'info',
+            icon: 'q',
+        },
+    },
+    body: 'Upgrade to Amazon Q Pro. [Learn More...](https://aws.amazon.com/q/pricing/)',
+    messageId: 'paidtier-info',
+    fullWidth: true,
+    canBeDismissed: true,
+    snapToTop: true,
 }
 
 export const paidTierSuccessCard: ChatItem = {
@@ -31,6 +115,7 @@ export const paidTierSuccessCard: ChatItem = {
     fullWidth: true,
     canBeDismissed: true,
     body: 'Upgraded to Amazon Q Pro\n\n[Learn More...](https://aws.amazon.com/q/)',
+    snapToTop: true,
 }
 
 export const paidTierPromptInput: TextBasedFormItem = {
@@ -52,15 +137,31 @@ export const paidTierStep1: ChatItem = {
     body: 'You have upgraded to Amazon Q Pro',
 }
 
-export const upgradeQButton: ChatItemButton = {
-    flash: 'once',
-    fillState: 'hover',
-    position: 'outside',
-    id: 'upgrade-q',
-    // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/q.svg
-    // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/rocket.svg
-    // icon: MynahIcons.Q,
-    description: 'Upgrade to Amazon Q Pro',
-    text: 'Upgrade Q',
+/** "Upgrade Q" form with a "AWS account id" user-input textbox. */
+export const paidTierUpgradeForm: ChatItem = {
+    type: ChatItemType.ANSWER,
     status: 'info',
+    fullWidth: true,
+    // title: 'Connect AWS account and upgrade',
+    body: `
+# Connect AWS account and upgrade
+
+Provide your AWS account number to enable your Pro subscription. Upon confirming the subscription, your AWS account will begin to be charged.
+
+[Learn More...](https://aws.amazon.com/q/)
+`,
+    formItems: [
+        {
+            id: 'awsAccountId',
+            type: 'textinput',
+            title: 'AWS account ID',
+            description: '12-digit AWS account ID',
+            // tooltip: 'Link an AWS account to upgrade to Amazon Q Pro',
+            validationPatterns: {
+                patterns: [{ pattern: '[0-9]{12}', errorMessage: 'Must be a valid 12-digit AWS account ID' }],
+            },
+        },
+    ],
+    buttons: [continueUpgradeQButton],
+    snapToTop: true,
 }

--- a/chat-client/src/client/texts/paidTier.ts
+++ b/chat-client/src/client/texts/paidTier.ts
@@ -1,8 +1,8 @@
 import { ChatItem, ChatItemButton, ChatItemFormItem, ChatItemType, TextBasedFormItem } from '@aws/mynah-ui'
 
 export const plansAndPricingTitle = 'Plans &amp; Pricing'
-
 export const paidTierLearnMoreUrl = 'https://aws.amazon.com/q/pricing/'
+export const qProName = 'Q Developer Pro'
 
 export const upgradeQButton: ChatItemButton = {
     id: 'paidtier-upgrade-q',
@@ -13,8 +13,8 @@ export const upgradeQButton: ChatItemButton = {
     // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/q.svg
     // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/rocket.svg
     // icon: MynahIcons.Q,
-    description: 'Upgrade to Amazon Q Pro',
-    text: 'Upgrade Q',
+    description: `Upgrade to ${qProName}`,
+    text: `Subscribe to ${qProName}`,
     status: 'primary',
     disabled: false,
 }
@@ -24,7 +24,7 @@ export const learnMoreButton: ChatItemButton = {
     fillState: 'hover',
     // position: 'inside',
     icon: 'external',
-    description: 'Learn about Amazon Q Pro',
+    description: `Learn about ${qProName}`,
     text: 'Learn more',
     status: 'info',
     disabled: false,
@@ -36,45 +36,66 @@ export const continueUpgradeQButton: ChatItemButton = {
     flash: 'once',
     fillState: 'hover',
     position: 'inside',
-    // description: 'Link an AWS account to upgrade Amazon Q',
+    // description: `Link an AWS account to upgrade ${qProName}`,
     text: 'Continue',
     disabled: false,
 }
 
 export const freeTierLimitCard: ChatItem = {
     type: ChatItemType.ANSWER,
-    title: 'FREE TIER LIMIT REACHED',
-    header: {
-        icon: 'q',
-        iconStatus: 'primary',
-        body: 'Upgrade to Amazon Q Pro',
-    },
+    // Note: starts with a non-breaking space to workaround https://github.com/aws/mynah-ui/issues/349
+    title: '  Monthly request limit reached',
     messageId: 'freetier-limit',
-    fullWidth: true,
+    status: 'warning',
+    buttons: [],
+    icon: 'warning',
+    // iconStatus: 'success',
+    header: {
+        icon: 'warning',
+        iconStatus: 'warning',
+        body: `Upgrade to ${qProName}`,
+    },
     canBeDismissed: false,
-    body: `You have reached the free tier limit. Upgrade to Amazon Q Pro.\n\n[Learn More...](${paidTierLearnMoreUrl})`,
+    fullWidth: true,
+    body: `To increase your limit, subscribe to ${qProName}. During the upgrade, you'll be asked to link your Builder ID to the AWS account that will be billed the monthly subscription fee. Learn more about [pricing &gt;](${paidTierLearnMoreUrl})`,
+}
+
+export const freeTierLimitDirective: ChatItem = {
+    type: ChatItemType.DIRECTIVE,
+    // title: '...',
+    // header: { },
+    messageId: 'freetier-limit-directive',
+    fullWidth: true,
+    contentHorizontalAlignment: 'center',
+    canBeDismissed: false,
+    body: 'Unable to send. Monthly invocation limit met for this month.',
 }
 
 /** "Banner" (sticky card) shown above the chat prompt. */
 export const freeTierLimitSticky: Partial<ChatItem> = {
     messageId: 'freetier-limit-banner',
-    title: 'FREE TIER LIMIT REACHED',
-    body: `You've reached your invocation limit for this month. Upgrade to Amazon Q Pro. [Learn More...](${paidTierLearnMoreUrl})`,
-    buttons: [upgradeQButton, learnMoreButton],
+    title: freeTierLimitCard.title,
+    body: freeTierLimitCard.body,
+    buttons: [upgradeQButton],
     canBeDismissed: false,
+    icon: 'warning',
+    // iconStatus: 'warning',
 }
 
 export const upgradePendingSticky: Partial<ChatItem> = {
     messageId: 'upgrade-pending-banner',
-    body: 'Waiting for subscription status...',
+    // Note: starts with a non-breaking space to workaround https://github.com/aws/mynah-ui/issues/349
+    body: '  Waiting for subscription status...',
     status: 'info',
     buttons: [],
     canBeDismissed: true,
+    icon: 'progress',
+    // iconStatus: 'info',
 }
 
 export const upgradeSuccessSticky: Partial<ChatItem> = {
     messageId: 'upgrade-success-banner',
-    // body: 'Successfully upgraded to Amazon Q Pro.',
+    // body: `Successfully upgraded to ${qProName}.`,
     status: 'success',
     buttons: [],
     // icon: 'q',
@@ -82,11 +103,11 @@ export const upgradeSuccessSticky: Partial<ChatItem> = {
     header: {
         icon: 'ok-circled',
         iconStatus: 'success',
-        body: 'Successfully upgraded to Amazon Q Pro.',
+        body: `Successfully upgraded to ${qProName}.`,
         // status: {
         //     status: 'success',
         //     position: 'right',
-        //     text: 'Successfully upgraded to Amazon Q Pro.',
+        //     text: `Successfully upgraded to ${qProName}.`,
         // },
     },
     canBeDismissed: true,
@@ -95,17 +116,17 @@ export const upgradeSuccessSticky: Partial<ChatItem> = {
 export const paidTierInfoCard: ChatItem = {
     type: ChatItemType.ANSWER,
     title: 'UPGRADE TO AMAZON Q PRO',
-    buttons: [upgradeQButton, learnMoreButton],
+    buttons: [upgradeQButton],
     header: {
         icon: 'q',
         iconStatus: 'primary',
-        body: 'This feature requires a subscription to Amazon Q Pro.',
+        body: `This feature requires a subscription to ${qProName}.`,
         status: {
             status: 'info',
             icon: 'q',
         },
     },
-    body: `Upgrade to Amazon Q Pro. [Learn More...](${paidTierLearnMoreUrl})`,
+    body: `Upgrade to ${qProName}. [Learn More...](${paidTierLearnMoreUrl})`,
     messageId: 'paidtier-info',
     fullWidth: true,
     canBeDismissed: true,
@@ -118,7 +139,7 @@ export const paidTierSuccessCard: ChatItem = {
     header: {
         icon: 'q',
         iconStatus: 'primary',
-        body: 'Welcome to Amazon Q Pro',
+        body: `Welcome to ${qProName}`,
         status: {
             status: 'success',
             icon: 'q',
@@ -128,7 +149,7 @@ export const paidTierSuccessCard: ChatItem = {
     messageId: 'paidtier-success',
     fullWidth: true,
     canBeDismissed: true,
-    body: `Upgraded to Amazon Q Pro\n\n[Learn More...](${paidTierLearnMoreUrl})`,
+    body: `Upgraded to ${qProName}\n\n[Learn More...](${paidTierLearnMoreUrl})`,
     snapToTop: true,
 }
 
@@ -136,19 +157,19 @@ export const paidTierPromptInput: TextBasedFormItem = {
     placeholder: '111111111111',
     type: 'textinput',
     id: 'paid-tier',
-    tooltip: 'Upgrade to Amazon Q Pro',
+    tooltip: `Upgrade to ${qProName}`,
     value: 'true',
     icon: 'magic',
 }
 
 export const paidTierStep0: ChatItem = {
     type: ChatItemType.DIRECTIVE,
-    body: 'You have upgraded to Amazon Q Pro',
+    body: `You have upgraded to ${qProName}`,
 }
 
 export const paidTierStep1: ChatItem = {
     type: ChatItemType.DIRECTIVE,
-    body: 'You have upgraded to Amazon Q Pro',
+    body: `You have upgraded to ${qProName}`,
 }
 
 /** "Upgrade Q" form with a "AWS account id" user-input textbox. */
@@ -160,7 +181,7 @@ export const paidTierUpgradeForm: ChatItem = {
     body: `
 # Connect AWS account and upgrade
 
-Provide your AWS account number to enable your Pro subscription. Upon confirming the subscription, your AWS account will begin to be charged.
+Provide your AWS account number to enable your ${qProName} subscription. Upon confirming the subscription, your AWS account will begin to be charged.
 
 [Learn More...](${paidTierLearnMoreUrl})
 `,
@@ -170,7 +191,7 @@ Provide your AWS account number to enable your Pro subscription. Upon confirming
             type: 'textinput',
             title: 'AWS account ID',
             description: '12-digit AWS account ID',
-            // tooltip: 'Link an AWS account to upgrade to Amazon Q Pro',
+            // tooltip: `Link an AWS account to upgrade to ${qProName}`,
             validationPatterns: {
                 patterns: [{ pattern: '[0-9]{12}', errorMessage: 'Must be a valid 12-digit AWS account ID' }],
             },

--- a/chat-client/src/client/texts/paidTier.ts
+++ b/chat-client/src/client/texts/paidTier.ts
@@ -2,16 +2,30 @@ import { ChatItem, ChatItemButton, ChatItemFormItem, ChatItemType, TextBasedForm
 
 export const plansAndPricingTitle = 'Plans &amp; Pricing'
 
+export const paidTierLearnMoreUrl = 'https://aws.amazon.com/q/pricing/'
+
 export const upgradeQButton: ChatItemButton = {
-    flash: 'once',
-    fillState: 'hover',
-    position: 'inside',
     id: 'paidtier-upgrade-q',
+    flash: 'once',
+    fillState: 'always',
+    position: 'inside',
+    icon: 'external',
     // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/q.svg
     // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/rocket.svg
     // icon: MynahIcons.Q,
     description: 'Upgrade to Amazon Q Pro',
     text: 'Upgrade Q',
+    status: 'primary',
+    disabled: false,
+}
+
+export const learnMoreButton: ChatItemButton = {
+    id: 'paidtier-upgrade-q-learnmore',
+    fillState: 'hover',
+    // position: 'inside',
+    icon: 'external',
+    description: 'Learn about Amazon Q Pro',
+    text: 'Learn more',
     status: 'info',
     disabled: false,
 }
@@ -38,15 +52,15 @@ export const freeTierLimitCard: ChatItem = {
     messageId: 'freetier-limit',
     fullWidth: true,
     canBeDismissed: false,
-    body: 'You have reached the free tier limit. Upgrade to Amazon Q Pro.\n\n[Learn More...](https://aws.amazon.com/q/pricing/)',
+    body: `You have reached the free tier limit. Upgrade to Amazon Q Pro.\n\n[Learn More...](${paidTierLearnMoreUrl})`,
 }
 
 /** "Banner" (sticky card) shown above the chat prompt. */
 export const freeTierLimitSticky: Partial<ChatItem> = {
     messageId: 'freetier-limit-banner',
     title: 'FREE TIER LIMIT REACHED',
-    body: "You've reached your invocation limit for this month. Upgrade to Amazon Q Pro. [Learn More...](https://aws.amazon.com/q/pricing/)",
-    buttons: [upgradeQButton],
+    body: `You've reached your invocation limit for this month. Upgrade to Amazon Q Pro. [Learn More...](${paidTierLearnMoreUrl})`,
+    buttons: [upgradeQButton, learnMoreButton],
     canBeDismissed: false,
 }
 
@@ -81,7 +95,7 @@ export const upgradeSuccessSticky: Partial<ChatItem> = {
 export const paidTierInfoCard: ChatItem = {
     type: ChatItemType.ANSWER,
     title: 'UPGRADE TO AMAZON Q PRO',
-    buttons: [upgradeQButton],
+    buttons: [upgradeQButton, learnMoreButton],
     header: {
         icon: 'q',
         iconStatus: 'primary',
@@ -91,7 +105,7 @@ export const paidTierInfoCard: ChatItem = {
             icon: 'q',
         },
     },
-    body: 'Upgrade to Amazon Q Pro. [Learn More...](https://aws.amazon.com/q/pricing/)',
+    body: `Upgrade to Amazon Q Pro. [Learn More...](${paidTierLearnMoreUrl})`,
     messageId: 'paidtier-info',
     fullWidth: true,
     canBeDismissed: true,
@@ -114,7 +128,7 @@ export const paidTierSuccessCard: ChatItem = {
     messageId: 'paidtier-success',
     fullWidth: true,
     canBeDismissed: true,
-    body: 'Upgraded to Amazon Q Pro\n\n[Learn More...](https://aws.amazon.com/q/)',
+    body: `Upgraded to Amazon Q Pro\n\n[Learn More...](${paidTierLearnMoreUrl})`,
     snapToTop: true,
 }
 
@@ -148,7 +162,7 @@ export const paidTierUpgradeForm: ChatItem = {
 
 Provide your AWS account number to enable your Pro subscription. Upon confirming the subscription, your AWS account will begin to be charged.
 
-[Learn More...](https://aws.amazon.com/q/)
+[Learn More...](${paidTierLearnMoreUrl})
 `,
     formItems: [
         {

--- a/chat-client/src/client/texts/paidTier.ts
+++ b/chat-client/src/client/texts/paidTier.ts
@@ -1,0 +1,66 @@
+import { ChatItem, ChatItemButton, ChatItemFormItem, ChatItemType, TextBasedFormItem } from '@aws/mynah-ui'
+
+export const freeTierLimitReachedCard: ChatItem = {
+    type: ChatItemType.ANSWER,
+    title: 'FREE TIER LIMIT REACHED',
+    header: {
+        icon: 'q',
+        iconStatus: 'primary',
+        body: 'Upgrade to Amazon Q Pro',
+    },
+    messageId: 'freetier-limit',
+    fullWidth: true,
+    canBeDismissed: false,
+    body: 'You have reached the free tier limit. Upgrade to Amazon Q Pro.\n\n[Learn More...](https://aws.amazon.com/q/pricing/)',
+}
+
+export const paidTierSuccessCard: ChatItem = {
+    type: ChatItemType.ANSWER,
+    title: 'UPGRADED TO AMAZON Q PRO',
+    header: {
+        icon: 'q',
+        iconStatus: 'primary',
+        body: 'Welcome to Amazon Q Pro',
+        status: {
+            status: 'success',
+            icon: 'q',
+            text: 'Success',
+        },
+    },
+    messageId: 'paidtier-success',
+    fullWidth: true,
+    canBeDismissed: true,
+    body: 'Upgraded to Amazon Q Pro\n\n[Learn More...](https://aws.amazon.com/q/)',
+}
+
+export const paidTierPromptInput: TextBasedFormItem = {
+    placeholder: '111111111111',
+    type: 'textinput',
+    id: 'paid-tier',
+    tooltip: 'Upgrade to Amazon Q Pro',
+    value: 'true',
+    icon: 'magic',
+}
+
+export const paidTierStep0: ChatItem = {
+    type: ChatItemType.DIRECTIVE,
+    body: 'You have upgraded to Amazon Q Pro',
+}
+
+export const paidTierStep1: ChatItem = {
+    type: ChatItemType.DIRECTIVE,
+    body: 'You have upgraded to Amazon Q Pro',
+}
+
+export const upgradeQButton: ChatItemButton = {
+    flash: 'once',
+    fillState: 'hover',
+    position: 'outside',
+    id: 'upgrade-q',
+    // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/q.svg
+    // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/rocket.svg
+    // icon: MynahIcons.Q,
+    description: 'Upgrade to Amazon Q Pro',
+    text: 'Upgrade Q',
+    status: 'info',
+}

--- a/chat-client/src/client/withAdapter.ts
+++ b/chat-client/src/client/withAdapter.ts
@@ -57,6 +57,7 @@ export const withAdapter = (
         onChatPromptProgressActionButtonClicked: addDefaultRouting('onChatPromptProgressActionButtonClicked'),
         onTabbedContentTabChange: addDefaultRouting('onTabbedContentTabChange'),
         onPromptInputOptionChange: addDefaultRouting('onPromptInputOptionChange'),
+        onPromptInputButtonClick: addDefaultRouting('onPromptInputButtonClick'),
         onMessageDismiss: addDefaultRouting('onMessageDismiss'),
 
         /**

--- a/chat-client/src/contracts/chatClientAdapter.ts
+++ b/chat-client/src/contracts/chatClientAdapter.ts
@@ -36,6 +36,7 @@ export interface ChatEventHandler
         | 'onResetStore'
         | 'onReady'
         | 'onPromptInputOptionChange'
+        | 'onPromptInputButtonClick'
         | 'onMessageDismiss'
     > {}
 

--- a/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperersigv4client.d.ts
+++ b/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperersigv4client.d.ts
@@ -4,12 +4,12 @@
  * DO NOT EDIT BY HAND.
  */
 
-import { Request } from 'aws-sdk/lib/request';
-import { Response } from 'aws-sdk/lib/response';
-import { AWSError } from 'aws-sdk/lib/error';
-import { Service } from 'aws-sdk/lib/service';
-import { ServiceConfigurationOptions } from 'aws-sdk/lib/service';
-import { ConfigBase as Config } from 'aws-sdk/lib/config-base';
+import {Request} from 'aws-sdk/lib/request';
+import {Response} from 'aws-sdk/lib/response';
+import {AWSError} from 'aws-sdk/lib/error';
+import {Service} from 'aws-sdk/lib/service';
+import {ServiceConfigurationOptions} from 'aws-sdk/lib/service';
+import {ConfigBase as Config} from 'aws-sdk/lib/config-base';
 interface Blob {}
 declare class CodeWhispererSigV4Client extends Service {
   /**
@@ -18,162 +18,283 @@ declare class CodeWhispererSigV4Client extends Service {
   constructor(options?: CodeWhispererSigV4Client.Types.ClientConfiguration)
   config: Config & CodeWhispererSigV4Client.Types.ClientConfiguration;
   /**
-   * 
+   * Internal API to authorize a CodeWhisperer resource for vended log delivery.
    */
-  createCodeScan(params: CodeWhispererSigV4Client.Types.CreateCodeScanRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateCodeScanResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateCodeScanResponse, AWSError>;
+  allowVendedLogDeliveryForResource(params: CodeWhispererSigV4Client.Types.AllowVendedLogDeliveryForResourceRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.AllowVendedLogDeliveryForResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.AllowVendedLogDeliveryForResourceResponse, AWSError>;
+  /**
+   * Internal API to authorize a CodeWhisperer resource for vended log delivery.
+   */
+  allowVendedLogDeliveryForResource(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.AllowVendedLogDeliveryForResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.AllowVendedLogDeliveryForResourceResponse, AWSError>;
+  /**
+   * Add permission for an Identity Center User/Group to use the Customization.
+   */
+  associateCustomizationPermission(params: CodeWhispererSigV4Client.Types.AssociateCustomizationPermissionRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.AssociateCustomizationPermissionResponse) => void): Request<CodeWhispererSigV4Client.Types.AssociateCustomizationPermissionResponse, AWSError>;
+  /**
+   * Add permission for an Identity Center User/Group to use the Customization.
+   */
+  associateCustomizationPermission(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.AssociateCustomizationPermissionResponse) => void): Request<CodeWhispererSigV4Client.Types.AssociateCustomizationPermissionResponse, AWSError>;
   /**
    * 
    */
-  createCodeScan(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateCodeScanResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateCodeScanResponse, AWSError>;
+  createCustomization(params: CodeWhispererSigV4Client.Types.CreateCustomizationRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateCustomizationResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateCustomizationResponse, AWSError>;
   /**
    * 
    */
-  createCodeScanUploadUrl(params: CodeWhispererSigV4Client.Types.CreateUploadUrlRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateUploadUrlResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateUploadUrlResponse, AWSError>;
+  createCustomization(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateCustomizationResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateCustomizationResponse, AWSError>;
   /**
-   * 
-   */
-  createCodeScanUploadUrl(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateUploadUrlResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateUploadUrlResponse, AWSError>;
-  /**
-   * 
+   * Creates a CodeWhisperer profile which can then be associated to users/groups of an identity source
    */
   createProfile(params: CodeWhispererSigV4Client.Types.CreateProfileRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateProfileResponse, AWSError>;
   /**
-   * 
+   * Creates a CodeWhisperer profile which can then be associated to users/groups of an identity source
    */
   createProfile(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.CreateProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.CreateProfileResponse, AWSError>;
   /**
-   * 
+   * Deletes CodeWhisperer Customization and associated resources
+   */
+  deleteCustomization(params: CodeWhispererSigV4Client.Types.DeleteCustomizationRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.DeleteCustomizationResponse) => void): Request<CodeWhispererSigV4Client.Types.DeleteCustomizationResponse, AWSError>;
+  /**
+   * Deletes CodeWhisperer Customization and associated resources
+   */
+  deleteCustomization(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.DeleteCustomizationResponse) => void): Request<CodeWhispererSigV4Client.Types.DeleteCustomizationResponse, AWSError>;
+  /**
+   * Deletes CodeWhisperer profile and associated resources
    */
   deleteProfile(params: CodeWhispererSigV4Client.Types.DeleteProfileRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.DeleteProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.DeleteProfileResponse, AWSError>;
   /**
-   * 
+   * Deletes CodeWhisperer profile and associated resources
    */
   deleteProfile(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.DeleteProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.DeleteProfileResponse, AWSError>;
   /**
-   * 
+   * Disassociate the permission for a Customization from an Identity Center User/Group.
+   */
+  disassociateCustomizationPermission(params: CodeWhispererSigV4Client.Types.DisassociateCustomizationPermissionRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.DisassociateCustomizationPermissionResponse) => void): Request<CodeWhispererSigV4Client.Types.DisassociateCustomizationPermissionResponse, AWSError>;
+  /**
+   * Disassociate the permission for a Customization from an Identity Center User/Group.
+   */
+  disassociateCustomizationPermission(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.DisassociateCustomizationPermissionResponse) => void): Request<CodeWhispererSigV4Client.Types.DisassociateCustomizationPermissionResponse, AWSError>;
+  /**
+   * Generates recommendations based on the provided file context.
    */
   generateRecommendations(params: CodeWhispererSigV4Client.Types.GenerateRecommendationsRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GenerateRecommendationsResponse) => void): Request<CodeWhispererSigV4Client.Types.GenerateRecommendationsResponse, AWSError>;
   /**
-   * 
+   * Generates recommendations based on the provided file context.
    */
   generateRecommendations(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GenerateRecommendationsResponse) => void): Request<CodeWhispererSigV4Client.Types.GenerateRecommendationsResponse, AWSError>;
   /**
    * 
    */
-  getAccessToken(params: CodeWhispererSigV4Client.Types.GetAccessTokenRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GetAccessTokenResponse) => void): Request<CodeWhispererSigV4Client.Types.GetAccessTokenResponse, AWSError>;
+  getCustomization(params: CodeWhispererSigV4Client.Types.GetCustomizationRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GetCustomizationResponse) => void): Request<CodeWhispererSigV4Client.Types.GetCustomizationResponse, AWSError>;
   /**
    * 
    */
-  getAccessToken(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GetAccessTokenResponse) => void): Request<CodeWhispererSigV4Client.Types.GetAccessTokenResponse, AWSError>;
+  getCustomization(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GetCustomizationResponse) => void): Request<CodeWhispererSigV4Client.Types.GetCustomizationResponse, AWSError>;
+  /**
+   * List User(s)/Group(s) who have permissions to use a Customization.
+   */
+  listCustomizationPermissions(params: CodeWhispererSigV4Client.Types.ListCustomizationPermissionsRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListCustomizationPermissionsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListCustomizationPermissionsResponse, AWSError>;
+  /**
+   * List User(s)/Group(s) who have permissions to use a Customization.
+   */
+  listCustomizationPermissions(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListCustomizationPermissionsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListCustomizationPermissionsResponse, AWSError>;
+  /**
+   * List actionable versions associated with a Customization.
+   */
+  listCustomizationVersions(params: CodeWhispererSigV4Client.Types.ListCustomizationVersionsRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListCustomizationVersionsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListCustomizationVersionsResponse, AWSError>;
+  /**
+   * List actionable versions associated with a Customization.
+   */
+  listCustomizationVersions(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListCustomizationVersionsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListCustomizationVersionsResponse, AWSError>;
   /**
    * 
    */
-  getCodeScan(params: CodeWhispererSigV4Client.Types.GetCodeScanRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GetCodeScanResponse) => void): Request<CodeWhispererSigV4Client.Types.GetCodeScanResponse, AWSError>;
+  listCustomizations(params: CodeWhispererSigV4Client.Types.ListCustomizationsRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListCustomizationsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListCustomizationsResponse, AWSError>;
   /**
    * 
    */
-  getCodeScan(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.GetCodeScanResponse) => void): Request<CodeWhispererSigV4Client.Types.GetCodeScanResponse, AWSError>;
+  listCustomizations(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListCustomizationsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListCustomizationsResponse, AWSError>;
   /**
-   * 
-   */
-  listCodeScanFindings(params: CodeWhispererSigV4Client.Types.ListCodeScanFindingsRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListCodeScanFindingsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListCodeScanFindingsResponse, AWSError>;
-  /**
-   * 
-   */
-  listCodeScanFindings(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListCodeScanFindingsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListCodeScanFindingsResponse, AWSError>;
-  /**
-   * 
+   * Lists one or more CodeWhisperer profiles that you have created.
    */
   listProfiles(params: CodeWhispererSigV4Client.Types.ListProfilesRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListProfilesResponse) => void): Request<CodeWhispererSigV4Client.Types.ListProfilesResponse, AWSError>;
   /**
-   * 
+   * Lists one or more CodeWhisperer profiles that you have created.
    */
   listProfiles(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListProfilesResponse) => void): Request<CodeWhispererSigV4Client.Types.ListProfilesResponse, AWSError>;
   /**
-   * 
-   */
-  listRecommendations(params: CodeWhispererSigV4Client.Types.ListRecommendationsRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListRecommendationsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListRecommendationsResponse, AWSError>;
-  /**
-   * 
-   */
-  listRecommendations(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListRecommendationsResponse) => void): Request<CodeWhispererSigV4Client.Types.ListRecommendationsResponse, AWSError>;
-  /**
-   * 
+   * List tags of an existing CodeWhisperer profile.
    */
   listTagsForResource(params: CodeWhispererSigV4Client.Types.ListTagsForResourceRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListTagsForResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.ListTagsForResourceResponse, AWSError>;
   /**
-   * 
+   * List tags of an existing CodeWhisperer profile.
    */
   listTagsForResource(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.ListTagsForResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.ListTagsForResourceResponse, AWSError>;
   /**
-   * 
+   * Add tags to an existing CodeWhisperer profile.
    */
   tagResource(params: CodeWhispererSigV4Client.Types.TagResourceRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.TagResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.TagResourceResponse, AWSError>;
   /**
-   * 
+   * Add tags to an existing CodeWhisperer profile.
    */
   tagResource(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.TagResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.TagResourceResponse, AWSError>;
   /**
-   * 
+   * Remove tags from an existing CodeWhisperer profile.
    */
   untagResource(params: CodeWhispererSigV4Client.Types.UntagResourceRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UntagResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.UntagResourceResponse, AWSError>;
   /**
-   * 
+   * Remove tags from an existing CodeWhisperer profile.
    */
   untagResource(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UntagResourceResponse) => void): Request<CodeWhispererSigV4Client.Types.UntagResourceResponse, AWSError>;
   /**
    * 
    */
-  updateProfile(params: CodeWhispererSigV4Client.Types.UpdateProfileRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UpdateProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.UpdateProfileResponse, AWSError>;
+  updateCustomization(params: CodeWhispererSigV4Client.Types.UpdateCustomizationRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UpdateCustomizationResponse) => void): Request<CodeWhispererSigV4Client.Types.UpdateCustomizationResponse, AWSError>;
   /**
    * 
    */
+  updateCustomization(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UpdateCustomizationResponse) => void): Request<CodeWhispererSigV4Client.Types.UpdateCustomizationResponse, AWSError>;
+  /**
+   * Updates an existing CodeWhisperer profile.
+   */
+  updateProfile(params: CodeWhispererSigV4Client.Types.UpdateProfileRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UpdateProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.UpdateProfileResponse, AWSError>;
+  /**
+   * Updates an existing CodeWhisperer profile.
+   */
   updateProfile(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UpdateProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.UpdateProfileResponse, AWSError>;
+  /**
+   * Returns grant details associated with the profile under the input account Id Output includes cmk arn, grant token, and grant id
+   */
+  vendKeyGrant(params: CodeWhispererSigV4Client.Types.VendKeyGrantRequest, callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.VendKeyGrantResponse) => void): Request<CodeWhispererSigV4Client.Types.VendKeyGrantResponse, AWSError>;
+  /**
+   * Returns grant details associated with the profile under the input account Id Output includes cmk arn, grant token, and grant id
+   */
+  vendKeyGrant(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.VendKeyGrantResponse) => void): Request<CodeWhispererSigV4Client.Types.VendKeyGrantResponse, AWSError>;
 }
 declare namespace CodeWhispererSigV4Client {
-  export type ArtifactMap = { [key: string]: UploadId };
-  export type ArtifactType = "SourceCode" | "BuiltJars" | string;
+  export type AWSAccountId = string;
+  export type ActiveFunctionalityList = FunctionalityName[];
+  export interface AllowVendedLogDeliveryForResourceRequest {
+    resourceArnBeingAuthorized: ResourceArn;
+    deliverySourceArn: ResourceArn;
+  }
+  export interface AllowVendedLogDeliveryForResourceResponse {
+    message?: String;
+  }
+  export interface ApplicationProperties {
+    tenantId: TenantId;
+    applicationArn: ResourceArn;
+    tenantUrl: Url;
+    applicationType: FunctionalityName;
+  }
+  export type ApplicationPropertiesList = ApplicationProperties[];
+  export interface AssociateCustomizationPermissionRequest {
+    identifier: CustomizationIdentifier;
+    permission: CustomizationPermission;
+  }
+  export interface AssociateCustomizationPermissionResponse {
+  }
   export type Base64EncodedPaginationToken = string;
-  export type CodeScanFindingsSchema = "codescan/findings/1.0" | string;
-  export type CodeScanStatus = "Completed" | "Pending" | "Failed" | string;
-  export interface CreateCodeScanRequest {
-    artifacts: ArtifactMap;
-    programmingLanguage: ProgrammingLanguage;
-    clientToken?: CreateCodeScanRequestClientTokenString;
+  export type Boolean = boolean;
+  export interface ByUserAnalytics {
+    s3Uri?: S3Uri;
+    toggle: OptInFeatureToggle;
   }
-  export type CreateCodeScanRequestClientTokenString = string;
-  export interface CreateCodeScanResponse {
-    jobId: CreateCodeScanResponseJobIdString;
-    status: CodeScanStatus;
-    errorMessage?: String;
+  export type ClientId = string;
+  export interface CodeStarReference {
+    connectionArn: ResourceArn;
   }
-  export type CreateCodeScanResponseJobIdString = string;
+  export interface CreateCustomizationRequest {
+    dataReference: DataReference;
+    customizationName: CustomizationName;
+    description?: Description;
+    profileArn: ProfileArn;
+    tags?: TagList;
+    clientToken?: IdempotencyToken;
+    includeRepos?: RepositoryList;
+  }
+  export interface CreateCustomizationResponse {
+    customizationArn: CustomizationArn;
+  }
   export interface CreateProfileRequest {
-    identitySource: IdentitySource;
+    identitySource?: IdentitySource;
     profileName: ProfileName;
+    description?: ProfileDescription;
     referenceTrackerConfiguration: ReferenceTrackerConfiguration;
+    activeFunctionalities?: ActiveFunctionalityList;
     clientToken?: IdempotencyToken;
     kmsKeyArn?: ResourceArn;
     tags?: TagList;
+    resourcePolicy?: ResourcePolicy;
+    optInFeatures?: OptInFeatures;
   }
   export interface CreateProfileResponse {
-    profileArn: ResourceArn;
+    profileArn: ProfileArn;
   }
-  export interface CreateUploadUrlRequest {
-    contentMd5?: CreateUploadUrlRequestContentMd5String;
-    artifactType?: ArtifactType;
+  export type CustomizationArn = string;
+  export type CustomizationIdentifier = string;
+  export type CustomizationName = string;
+  export interface CustomizationPermission {
+    user?: IdentityCenterIdentifier;
+    group?: IdentityCenterIdentifier;
   }
-  export type CreateUploadUrlRequestContentMd5String = string;
-  export interface CreateUploadUrlResponse {
-    uploadId: UploadId;
-    uploadUrl: PreSignedUrl;
-    kmsKeyArn?: ResourceArn;
+  export type CustomizationStatus = "CREATED"|"UPDATED"|"CREATING"|"UPDATING"|"DELETING"|"ACTIVATING"|"DEACTIVATING"|"ACTIVATED"|"CREATION_FAILED"|"UPDATE_FAILED"|"DELETION_FAILED"|"ACTIVATION_FAILED"|"DEACTIVATION_FAILED"|string;
+  export interface CustomizationSummary {
+    arn: CustomizationArn;
+    version?: Version;
+    customizationName: CustomizationName;
+    description?: Description;
+    status: CustomizationStatus;
+    updatedAt: Timestamp;
+  }
+  export type CustomizationSummaryList = CustomizationSummary[];
+  export interface CustomizationVersionSummary {
+    version: Version;
+    baseVersion?: Version;
+    status: CustomizationStatus;
+    dataReference: DataReference;
+    updatedAt: Timestamp;
+    evaluationMetrics?: EvaluationMetrics;
+  }
+  export type CustomizationVersionSummaryList = CustomizationVersionSummary[];
+  export interface DashboardAnalytics {
+    toggle: OptInFeatureToggle;
+  }
+  export interface DataReference {
+    codeStarReference?: CodeStarReference;
+    s3Reference?: S3Reference;
+  }
+  export interface DeleteCustomizationRequest {
+    identifier: CustomizationIdentifier;
+    clientToken?: IdempotencyToken;
+  }
+  export interface DeleteCustomizationResponse {
   }
   export interface DeleteProfileRequest {
-    profileArn: ResourceArn;
+    profileArn: ProfileArn;
   }
   export interface DeleteProfileResponse {
   }
+  export type Description = string;
+  export interface DisassociateCustomizationPermissionRequest {
+    identifier: CustomizationIdentifier;
+    permission: CustomizationPermission;
+  }
+  export interface DisassociateCustomizationPermissionResponse {
+  }
+  export type ErrorDetails = string;
+  export interface EvaluationMetrics {
+    compositeScore: Integer;
+  }
+  export interface ExternalIdentityDetails {
+    issuerUrl?: IssuerUrl;
+    clientId?: ClientId;
+    scimEndpoint?: String;
+  }
+  export interface ExternalIdentitySource {
+    issuerUrl: IssuerUrl;
+    clientId: ClientId;
+  }
+  export type FeatureName = string;
   export interface FileContext {
     leftFileContent: FileContextLeftFileContentString;
     rightFileContent: FileContextRightFileContentString;
@@ -185,19 +306,13 @@ declare namespace CodeWhispererSigV4Client {
   export type FileContextFilenameString = string;
   export type FileContextLeftFileContentString = string;
   export type FileContextRightFileContentString = string;
-  export interface SupplementalContext {
-    filePath: SupplementalContextFilePathString;
-    content: SupplementalContextContentString;
-  }
-  export type SupplementalContextFilePathString = string;
-  export type SupplementalContextContentString = string;
-  export type SupplementalContextList = SupplementalContext[];
+  export type FunctionalityName = "COMPLETIONS"|"ANALYSIS"|"CONVERSATIONS"|"TASK_ASSIST"|"TRANSFORMATIONS"|"CHAT_CUSTOMIZATION"|"TRANSFORMATIONS_WEBAPP"|"FEATURE_DEVELOPMENT"|string;
   export interface GenerateRecommendationsRequest {
     fileContext: FileContext;
-    supplementalContexts?: SupplementalContextList;
     maxResults?: GenerateRecommendationsRequestMaxResultsInteger;
     nextToken?: GenerateRecommendationsRequestNextTokenString;
     referenceTrackerConfiguration?: ReferenceTrackerConfiguration;
+    supplementalContexts?: SupplementalContextList;
   }
   export type GenerateRecommendationsRequestMaxResultsInteger = number;
   export type GenerateRecommendationsRequestNextTokenString = string;
@@ -205,45 +320,74 @@ declare namespace CodeWhispererSigV4Client {
     recommendations?: RecommendationsList;
     nextToken?: String;
   }
-  export interface GetAccessTokenRequest {
-    identityToken: GetAccessTokenRequestIdentityTokenString;
+  export interface GetCustomizationRequest {
+    identifier: CustomizationIdentifier;
   }
-  export type GetAccessTokenRequestIdentityTokenString = string;
-  export interface GetAccessTokenResponse {
-    accessToken?: SensitiveString;
+  export interface GetCustomizationResponse {
+    arn: CustomizationArn;
+    version?: Version;
+    status: CustomizationStatus;
+    errorDetails?: ErrorDetails;
+    dataReference: DataReference;
+    customizationName: CustomizationName;
+    description?: Description;
+    profileArn: ProfileArn;
+    updatedAt: Timestamp;
+    evaluationMetrics?: EvaluationMetrics;
+    includeRepos?: RepositoryList;
   }
-  export interface GetCodeScanRequest {
-    jobId: GetCodeScanRequestJobIdString;
-  }
-  export type GetCodeScanRequestJobIdString = string;
-  export interface GetCodeScanResponse {
-    status: CodeScanStatus;
-    errorMessage?: String;
-  }
+  export type GrantId = string;
+  export type GrantToken = string;
   export type IdempotencyToken = string;
+  export type IdentityCenterIdentifier = string;
+  export type IdentityCenterPermissions = CustomizationPermission[];
   export interface IdentityDetails {
     ssoIdentityDetails?: SSOIdentityDetails;
+    externalIdentityDetails?: ExternalIdentityDetails;
   }
   export interface IdentitySource {
     ssoIdentitySource?: SSOIdentitySource;
+    externalIdentitySource?: ExternalIdentitySource;
   }
   export interface Import {
     statement?: ImportStatementString;
   }
   export type ImportStatementString = string;
   export type Imports = Import[];
-  export interface ListCodeScanFindingsRequest {
-    jobId: ListCodeScanFindingsRequestJobIdString;
-    nextToken?: PaginationToken;
-    codeScanFindingsSchema: CodeScanFindingsSchema;
+  export type Integer = number;
+  export type IssuerUrl = string;
+  export interface ListCustomizationPermissionsRequest {
+    identifier: CustomizationIdentifier;
+    maxResults?: ListCustomizationPermissionsRequestMaxResultsInteger;
+    nextToken?: Base64EncodedPaginationToken;
   }
-  export type ListCodeScanFindingsRequestJobIdString = string;
-  export interface ListCodeScanFindingsResponse {
-    nextToken?: PaginationToken;
-    codeScanFindings: String;
+  export type ListCustomizationPermissionsRequestMaxResultsInteger = number;
+  export interface ListCustomizationPermissionsResponse {
+    permissions: IdentityCenterPermissions;
+    nextToken?: Base64EncodedPaginationToken;
+  }
+  export interface ListCustomizationVersionsRequest {
+    identifier: CustomizationIdentifier;
+    maxResults?: ListCustomizationVersionsRequestMaxResultsInteger;
+    nextToken?: Base64EncodedPaginationToken;
+  }
+  export type ListCustomizationVersionsRequestMaxResultsInteger = number;
+  export interface ListCustomizationVersionsResponse {
+    versions: CustomizationVersionSummaryList;
+    nextToken?: Base64EncodedPaginationToken;
+  }
+  export interface ListCustomizationsRequest {
+    maxResults?: ListCustomizationsRequestMaxResultsInteger;
+    nextToken?: Base64EncodedPaginationToken;
+  }
+  export type ListCustomizationsRequestMaxResultsInteger = number;
+  export interface ListCustomizationsResponse {
+    customizations: CustomizationSummaryList;
+    nextToken?: Base64EncodedPaginationToken;
   }
   export interface ListProfilesRequest {
     maxResults?: ListProfilesRequestMaxResultsInteger;
+    includeManagementAccount?: Boolean;
     nextToken?: Base64EncodedPaginationToken;
   }
   export type ListProfilesRequestMaxResultsInteger = number;
@@ -251,40 +395,58 @@ declare namespace CodeWhispererSigV4Client {
     profiles: ProfileList;
     nextToken?: Base64EncodedPaginationToken;
   }
-  export interface ListRecommendationsRequest {
-    fileContext: FileContext;
-    maxResults?: ListRecommendationsRequestMaxResultsInteger;
-    supplementalContexts?: SupplementalContextList;
-    nextToken?: ListRecommendationsRequestNextTokenString;
-    referenceTrackerConfiguration?: ReferenceTrackerConfiguration;
-  }
-  export type ListRecommendationsRequestMaxResultsInteger = number;
-  export type ListRecommendationsRequestNextTokenString = string;
-  export interface ListRecommendationsResponse {
-    recommendations?: RecommendationsList;
-    nextToken?: String;
-  }
   export interface ListTagsForResourceRequest {
-    resourceName: ResourceArn;
+    resourceArn: ResourceArn;
   }
   export interface ListTagsForResourceResponse {
     tags?: TagList;
   }
-  export type PaginationToken = string;
-  export type PreSignedUrl = string;
-  export interface Profile {
-    arn: ResourceArn;
-    identityDetails: IdentityDetails;
-    profileName: ProfileName;
-    referenceTrackerConfiguration: ReferenceTrackerConfiguration;
-    kmsKeyArn?: ResourceArn;
+  export type Notifications = NotificationsFeature[];
+  export interface NotificationsFeature {
+    feature: FeatureName;
+    toggle: OptInFeatureToggle;
   }
+  export type OptInFeatureToggle = "ON"|"OFF"|string;
+  export interface OptInFeatures {
+    promptLogging?: PromptLogging;
+    byUserAnalytics?: ByUserAnalytics;
+    dashboardAnalytics?: DashboardAnalytics;
+    notifications?: Notifications;
+    workspaceContext?: WorkspaceContext;
+  }
+  export interface PreviousEditorStateMetadata {
+    timeOffset: Integer;
+  }
+  export interface Profile {
+    arn: ProfileArn;
+    identityDetails?: IdentityDetails;
+    profileName: ProfileName;
+    description?: ProfileDescription;
+    referenceTrackerConfiguration?: ReferenceTrackerConfiguration;
+    kmsKeyArn?: ResourceArn;
+    activeFunctionalities?: ActiveFunctionalityList;
+    status?: ProfileStatus;
+    errorDetails?: ErrorDetails;
+    resourcePolicy?: ResourcePolicy;
+    profileType?: ProfileType;
+    optInFeatures?: OptInFeatures;
+    permissionUpdateRequired?: Boolean;
+    applicationProperties?: ApplicationPropertiesList;
+  }
+  export type ProfileArn = string;
+  export type ProfileDescription = string;
   export type ProfileList = Profile[];
   export type ProfileName = string;
+  export type ProfileStatus = "ACTIVE"|"CREATING"|"CREATE_FAILED"|"UPDATING"|"UPDATE_FAILED"|"DELETING"|"DELETE_FAILED"|string;
+  export type ProfileType = "Q_DEVELOPER"|"CODEWHISPERER"|string;
   export interface ProgrammingLanguage {
     languageName: ProgrammingLanguageLanguageNameString;
   }
   export type ProgrammingLanguageLanguageNameString = string;
+  export interface PromptLogging {
+    s3Uri: S3Uri;
+    toggle: OptInFeatureToggle;
+  }
   export interface Recommendation {
     content: RecommendationContentString;
     references?: References;
@@ -292,11 +454,23 @@ declare namespace CodeWhispererSigV4Client {
   }
   export type RecommendationContentString = string;
   export type RecommendationsList = Recommendation[];
-  export type RecommendationsWithReferencesPreference = "BLOCK" | "ALLOW" | string;
+  export type RecommendationsWithReferencesPreference = "BLOCK"|"ALLOW"|string;
   export interface Reference {
+    /**
+     * License name
+     */
     licenseName?: ReferenceLicenseNameString;
+    /**
+     * Code Repsitory for the associated reference
+     */
     repository?: ReferenceRepositoryString;
+    /**
+     * Respository URL
+     */
     url?: ReferenceUrlString;
+    /**
+     * Span / Range for the Reference
+     */
     recommendationContentSpan?: Span;
   }
   export type ReferenceLicenseNameString = string;
@@ -306,15 +480,27 @@ declare namespace CodeWhispererSigV4Client {
   }
   export type ReferenceUrlString = string;
   export type References = Reference[];
+  export type RepositoryId = string;
+  export type RepositoryList = RepositoryId[];
   export type ResourceArn = string;
+  export interface ResourcePolicy {
+    effect: ResourcePolicyEffect;
+  }
+  export type ResourcePolicyEffect = "ALLOW"|"DENY"|string;
+  export interface S3Reference {
+    uri: S3Uri;
+  }
+  export type S3Uri = string;
   export interface SSOIdentityDetails {
     instanceArn: ResourceArn;
     oidcClientId: String;
+    ssoRegion?: SSORegion;
   }
   export interface SSOIdentitySource {
     instanceArn: ResourceArn;
+    ssoRegion?: SSORegion;
   }
-  export type SensitiveString = string;
+  export type SSORegion = string;
   export interface Span {
     start?: SpanStartInteger;
     end?: SpanEndInteger;
@@ -322,6 +508,19 @@ declare namespace CodeWhispererSigV4Client {
   export type SpanEndInteger = number;
   export type SpanStartInteger = number;
   export type String = string;
+  export interface SupplementalContext {
+    filePath: SupplementalContextFilePathString;
+    content: SupplementalContextContentString;
+    type?: SupplementalContextType;
+    metadata?: SupplementalContextMetadata;
+  }
+  export type SupplementalContextContentString = string;
+  export type SupplementalContextFilePathString = string;
+  export type SupplementalContextList = SupplementalContext[];
+  export interface SupplementalContextMetadata {
+    previousEditorStateMetadata?: PreviousEditorStateMetadata;
+  }
+  export type SupplementalContextType = "PreviousEditorState"|"WorkspaceContext"|string;
   export interface Tag {
     key: TagKey;
     value: TagValue;
@@ -330,32 +529,65 @@ declare namespace CodeWhispererSigV4Client {
   export type TagKeyList = TagKey[];
   export type TagList = Tag[];
   export interface TagResourceRequest {
-    resourceName: ResourceArn;
+    resourceArn: ResourceArn;
     tags: TagList;
   }
   export interface TagResourceResponse {
   }
   export type TagValue = string;
+  export type TenantId = string;
+  export type Timestamp = Date;
   export interface UntagResourceRequest {
-    resourceName: ResourceArn;
+    resourceArn: ResourceArn;
     tagKeys: TagKeyList;
   }
   export interface UntagResourceResponse {
   }
+  export interface UpdateCustomizationRequest {
+    identifier: CustomizationIdentifier;
+    operation: UpdateOperation;
+    clientToken?: IdempotencyToken;
+    dataReference?: DataReference;
+    version?: Version;
+    includeRepos?: RepositoryList;
+  }
+  export interface UpdateCustomizationResponse {
+  }
+  export type UpdateOperation = "ACTIVATE"|"DEACTIVATE"|"UPDATE"|string;
   export interface UpdateProfileRequest {
-    profileArn: ResourceArn;
+    profileArn: ProfileArn;
+    identitySource?: IdentitySource;
     profileName?: ProfileName;
+    description?: ProfileDescription;
     referenceTrackerConfiguration?: ReferenceTrackerConfiguration;
+    activeFunctionalities?: ActiveFunctionalityList;
     kmsKeyArn?: ResourceArn;
+    resourcePolicy?: ResourcePolicy;
+    targetProfileType?: ProfileType;
+    optInFeatures?: OptInFeatures;
   }
   export interface UpdateProfileResponse {
-    profileArn: ResourceArn;
+    profileArn: ProfileArn;
   }
-  export type UploadId = string;
+  export type Url = string;
+  export interface VendKeyGrantRequest {
+    accountId: AWSAccountId;
+    usecase: VendKeyGrantUseCase;
+  }
+  export interface VendKeyGrantResponse {
+    cmkArn?: ResourceArn;
+    grantId?: GrantToken;
+    grantToken?: GrantId;
+  }
+  export type VendKeyGrantUseCase = "TEST"|"WEAVER_BIRD"|"ELASTIC_GUMBY"|"LOCHNESS"|"BOWER_BIRD"|"ELASTIC_GUMBY_V2_JOB"|"ELASTIC_GUMBY_V2_CHAT"|string;
+  export type Version = number;
+  export interface WorkspaceContext {
+    toggle: OptInFeatureToggle;
+  }
   /**
    * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
    */
-  export type apiVersion = "2022-06-15" | "latest" | string;
+  export type apiVersion = "2024-10-25"|"latest"|string;
   export interface ClientApiVersions {
     /**
      * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
@@ -370,3 +602,4 @@ declare namespace CodeWhispererSigV4Client {
 }
 export = CodeWhispererSigV4Client;
 
+    

--- a/server/aws-lsp-codewhisperer/src/client/sigv4/service.json
+++ b/server/aws-lsp-codewhisperer/src/client/sigv4/service.json
@@ -1,29 +1,62 @@
 {
     "version": "2.0",
     "metadata": {
-        "apiVersion": "2022-06-15",
+        "apiVersion": "2024-10-25",
+        "auth": ["aws.auth#sigv4"],
         "endpointPrefix": "codewhisperer",
         "jsonVersion": "1.0",
         "protocol": "json",
+        "protocols": ["json"],
         "serviceFullName": "AWS CodeWhisperer",
         "serviceId": "CodeWhisperer",
         "signatureVersion": "v4",
         "signingName": "codewhisperer",
         "targetPrefix": "AWSCodeWhispererService",
-        "uid": "codewhisperer-2022-06-15"
+        "uid": "codewhisperer-2024-10-25"
     },
     "operations": {
-        "CreateCodeScan": {
-            "name": "CreateCodeScan",
+        "AllowVendedLogDeliveryForResource": {
+            "name": "AllowVendedLogDeliveryForResource",
             "http": {
                 "method": "POST",
                 "requestUri": "/"
             },
             "input": {
-                "shape": "CreateCodeScanRequest"
+                "shape": "AllowVendedLogDeliveryForResourceRequest"
             },
             "output": {
-                "shape": "CreateCodeScanResponse"
+                "shape": "AllowVendedLogDeliveryForResourceResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>Internal API to authorize a CodeWhisperer resource for vended log delivery.</p>"
+        },
+        "AssociateCustomizationPermission": {
+            "name": "AssociateCustomizationPermission",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "AssociateCustomizationPermissionRequest"
+            },
+            "output": {
+                "shape": "AssociateCustomizationPermissionResponse"
             },
             "errors": [
                 {
@@ -45,23 +78,26 @@
                     "shape": "AccessDeniedException"
                 }
             ],
-            "idempotent": true
+            "documentation": "<p>Add permission for an Identity Center User/Group to use the Customization.</p>"
         },
-        "CreateCodeScanUploadUrl": {
-            "name": "CreateCodeScanUploadUrl",
+        "CreateCustomization": {
+            "name": "CreateCustomization",
             "http": {
                 "method": "POST",
                 "requestUri": "/"
             },
             "input": {
-                "shape": "CreateUploadUrlRequest"
+                "shape": "CreateCustomizationRequest"
             },
             "output": {
-                "shape": "CreateUploadUrlResponse"
+                "shape": "CreateCustomizationResponse"
             },
             "errors": [
                 {
                     "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
                 },
                 {
                     "shape": "InternalServerException"
@@ -72,8 +108,7 @@
                 {
                     "shape": "AccessDeniedException"
                 }
-            ],
-            "idempotent": true
+            ]
         },
         "CreateProfile": {
             "name": "CreateProfile",
@@ -106,7 +141,42 @@
                 {
                     "shape": "AccessDeniedException"
                 }
-            ]
+            ],
+            "documentation": "<p>Creates a CodeWhisperer profile which can then be associated to users/groups of an identity source</p>"
+        },
+        "DeleteCustomization": {
+            "name": "DeleteCustomization",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "DeleteCustomizationRequest"
+            },
+            "output": {
+                "shape": "DeleteCustomizationResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>Deletes CodeWhisperer Customization and associated resources</p>"
         },
         "DeleteProfile": {
             "name": "DeleteProfile",
@@ -139,7 +209,42 @@
                 {
                     "shape": "AccessDeniedException"
                 }
-            ]
+            ],
+            "documentation": "<p>Deletes CodeWhisperer profile and associated resources</p>"
+        },
+        "DisassociateCustomizationPermission": {
+            "name": "DisassociateCustomizationPermission",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "DisassociateCustomizationPermissionRequest"
+            },
+            "output": {
+                "shape": "DisassociateCustomizationPermissionResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>Disassociate the permission for a Customization from an Identity Center User/Group.</p>"
         },
         "GenerateRecommendations": {
             "name": "GenerateRecommendations",
@@ -166,43 +271,20 @@
                 {
                     "shape": "AccessDeniedException"
                 }
-            ]
+            ],
+            "documentation": "<p>Generates recommendations based on the provided file context.</p>"
         },
-        "GetAccessToken": {
-            "name": "GetAccessToken",
+        "GetCustomization": {
+            "name": "GetCustomization",
             "http": {
                 "method": "POST",
                 "requestUri": "/"
             },
             "input": {
-                "shape": "GetAccessTokenRequest"
+                "shape": "GetCustomizationRequest"
             },
             "output": {
-                "shape": "GetAccessTokenResponse"
-            },
-            "errors": [
-                {
-                    "shape": "InternalServerException"
-                },
-                {
-                    "shape": "ValidationException"
-                },
-                {
-                    "shape": "AccessDeniedException"
-                }
-            ]
-        },
-        "GetCodeScan": {
-            "name": "GetCodeScan",
-            "http": {
-                "method": "POST",
-                "requestUri": "/"
-            },
-            "input": {
-                "shape": "GetCodeScanRequest"
-            },
-            "output": {
-                "shape": "GetCodeScanResponse"
+                "shape": "GetCustomizationResponse"
             },
             "errors": [
                 {
@@ -222,17 +304,17 @@
                 }
             ]
         },
-        "ListCodeScanFindings": {
-            "name": "ListCodeScanFindings",
+        "ListCustomizationPermissions": {
+            "name": "ListCustomizationPermissions",
             "http": {
                 "method": "POST",
                 "requestUri": "/"
             },
             "input": {
-                "shape": "ListCodeScanFindingsRequest"
+                "shape": "ListCustomizationPermissionsRequest"
             },
             "output": {
-                "shape": "ListCodeScanFindingsResponse"
+                "shape": "ListCustomizationPermissionsResponse"
             },
             "errors": [
                 {
@@ -240,6 +322,65 @@
                 },
                 {
                     "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>List User(s)/Group(s) who have permissions to use a Customization.</p>"
+        },
+        "ListCustomizationVersions": {
+            "name": "ListCustomizationVersions",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "ListCustomizationVersionsRequest"
+            },
+            "output": {
+                "shape": "ListCustomizationVersionsResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>List actionable versions associated with a Customization.</p>"
+        },
+        "ListCustomizations": {
+            "name": "ListCustomizations",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "ListCustomizationsRequest"
+            },
+            "output": {
+                "shape": "ListCustomizationsResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
                 },
                 {
                     "shape": "InternalServerException"
@@ -277,34 +418,8 @@
                 {
                     "shape": "AccessDeniedException"
                 }
-            ]
-        },
-        "ListRecommendations": {
-            "name": "ListRecommendations",
-            "http": {
-                "method": "POST",
-                "requestUri": "/"
-            },
-            "input": {
-                "shape": "ListRecommendationsRequest"
-            },
-            "output": {
-                "shape": "ListRecommendationsResponse"
-            },
-            "errors": [
-                {
-                    "shape": "ThrottlingException"
-                },
-                {
-                    "shape": "InternalServerException"
-                },
-                {
-                    "shape": "ValidationException"
-                },
-                {
-                    "shape": "AccessDeniedException"
-                }
-            ]
+            ],
+            "documentation": "<p>Lists one or more CodeWhisperer profiles that you have created.</p>"
         },
         "ListTagsForResource": {
             "name": "ListTagsForResource",
@@ -334,7 +449,8 @@
                 {
                     "shape": "AccessDeniedException"
                 }
-            ]
+            ],
+            "documentation": "<p>List tags of an existing CodeWhisperer profile.</p>"
         },
         "TagResource": {
             "name": "TagResource",
@@ -364,7 +480,8 @@
                 {
                     "shape": "AccessDeniedException"
                 }
-            ]
+            ],
+            "documentation": "<p>Add tags to an existing CodeWhisperer profile.</p>"
         },
         "UntagResource": {
             "name": "UntagResource",
@@ -381,6 +498,40 @@
             "errors": [
                 {
                     "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>Remove tags from an existing CodeWhisperer profile.</p>"
+        },
+        "UpdateCustomization": {
+            "name": "UpdateCustomization",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "UpdateCustomizationRequest"
+            },
+            "output": {
+                "shape": "UpdateCustomizationResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
                 },
                 {
                     "shape": "ResourceNotFoundException"
@@ -427,34 +578,133 @@
                 {
                     "shape": "AccessDeniedException"
                 }
-            ]
+            ],
+            "documentation": "<p>Updates an existing CodeWhisperer profile.</p>"
+        },
+        "VendKeyGrant": {
+            "name": "VendKeyGrant",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "VendKeyGrantRequest"
+            },
+            "output": {
+                "shape": "VendKeyGrantResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>Returns grant details associated with the profile under the input account Id Output includes cmk arn, grant token, and grant id</p>"
         }
     },
     "shapes": {
+        "AWSAccountId": {
+            "type": "string",
+            "documentation": "<p>Represents the AWS account ID of the customer</p>",
+            "pattern": "[0-9]{12}"
+        },
         "AccessDeniedException": {
             "type": "structure",
             "required": ["message"],
             "members": {
                 "message": {
                     "shape": "String"
+                },
+                "reason": {
+                    "shape": "AccessDeniedExceptionReason"
                 }
             },
+            "documentation": "<p>This exception is thrown when the user does not have sufficient access to perform this action.</p>",
             "exception": true
         },
-        "ArtifactMap": {
-            "type": "map",
-            "key": {
-                "shape": "ArtifactType"
-            },
-            "value": {
-                "shape": "UploadId"
-            },
-            "max": 64,
-            "min": 1
-        },
-        "ArtifactType": {
+        "AccessDeniedExceptionReason": {
             "type": "string",
-            "enum": ["SourceCode", "BuiltJars"]
+            "documentation": "<p>Reason for AccessDeniedException</p>",
+            "enum": ["UNAUTHORIZED_CUSTOMIZATION_RESOURCE_ACCESS", "UNAUTHORIZED_WORKSPACE_CONTEXT_FEATURE_ACCESS"]
+        },
+        "ActiveFunctionalityList": {
+            "type": "list",
+            "member": {
+                "shape": "FunctionalityName"
+            },
+            "max": 10,
+            "min": 0
+        },
+        "AllowVendedLogDeliveryForResourceRequest": {
+            "type": "structure",
+            "required": ["resourceArnBeingAuthorized", "deliverySourceArn"],
+            "members": {
+                "resourceArnBeingAuthorized": {
+                    "shape": "ResourceArn"
+                },
+                "deliverySourceArn": {
+                    "shape": "ResourceArn"
+                }
+            }
+        },
+        "AllowVendedLogDeliveryForResourceResponse": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "shape": "String"
+                }
+            }
+        },
+        "ApplicationProperties": {
+            "type": "structure",
+            "required": ["tenantId", "applicationArn", "tenantUrl", "applicationType"],
+            "members": {
+                "tenantId": {
+                    "shape": "TenantId"
+                },
+                "applicationArn": {
+                    "shape": "ResourceArn"
+                },
+                "tenantUrl": {
+                    "shape": "Url"
+                },
+                "applicationType": {
+                    "shape": "FunctionalityName"
+                }
+            }
+        },
+        "ApplicationPropertiesList": {
+            "type": "list",
+            "member": {
+                "shape": "ApplicationProperties"
+            }
+        },
+        "AssociateCustomizationPermissionRequest": {
+            "type": "structure",
+            "required": ["identifier", "permission"],
+            "members": {
+                "identifier": {
+                    "shape": "CustomizationIdentifier"
+                },
+                "permission": {
+                    "shape": "CustomizationPermission"
+                }
+            }
+        },
+        "AssociateCustomizationPermissionResponse": {
+            "type": "structure",
+            "members": {}
         },
         "Base64EncodedPaginationToken": {
             "type": "string",
@@ -462,13 +712,35 @@
             "min": 1,
             "pattern": "(?:[A-Za-z0-9\\+/]{4})*(?:[A-Za-z0-9\\+/]{2}\\=\\=|[A-Za-z0-9\\+/]{3}\\=)?"
         },
-        "CodeScanFindingsSchema": {
-            "type": "string",
-            "enum": ["codescan/findings/1.0"]
+        "Boolean": {
+            "type": "boolean",
+            "box": true
         },
-        "CodeScanStatus": {
+        "ByUserAnalytics": {
+            "type": "structure",
+            "required": ["toggle"],
+            "members": {
+                "s3Uri": {
+                    "shape": "S3Uri"
+                },
+                "toggle": {
+                    "shape": "OptInFeatureToggle"
+                }
+            }
+        },
+        "ClientId": {
             "type": "string",
-            "enum": ["Completed", "Pending", "Failed"]
+            "max": 255,
+            "min": 1
+        },
+        "CodeStarReference": {
+            "type": "structure",
+            "required": ["connectionArn"],
+            "members": {
+                "connectionArn": {
+                    "shape": "ResourceArn"
+                }
+            }
         },
         "ConflictException": {
             "type": "structure",
@@ -476,54 +748,58 @@
             "members": {
                 "message": {
                     "shape": "String"
+                },
+                "reason": {
+                    "shape": "ConflictExceptionReason"
                 }
             },
+            "documentation": "<p>This exception is thrown when the action to perform could not be completed because the resource is in a conflicting state.</p>",
             "exception": true
         },
-        "CreateCodeScanRequest": {
+        "ConflictExceptionReason": {
+            "type": "string",
+            "documentation": "<p>Reason for ConflictException</p>",
+            "enum": ["CUSTOMER_KMS_KEY_INVALID_KEY_POLICY", "CUSTOMER_KMS_KEY_DISABLED", "MISMATCHED_KMS_KEY"]
+        },
+        "CreateCustomizationRequest": {
             "type": "structure",
-            "required": ["artifacts", "programmingLanguage"],
+            "required": ["dataReference", "customizationName", "profileArn"],
             "members": {
-                "artifacts": {
-                    "shape": "ArtifactMap"
+                "dataReference": {
+                    "shape": "DataReference"
                 },
-                "programmingLanguage": {
-                    "shape": "ProgrammingLanguage"
+                "customizationName": {
+                    "shape": "CustomizationName"
+                },
+                "description": {
+                    "shape": "Description"
+                },
+                "profileArn": {
+                    "shape": "ProfileArn"
+                },
+                "tags": {
+                    "shape": "TagList"
                 },
                 "clientToken": {
-                    "shape": "CreateCodeScanRequestClientTokenString",
-                    "idempotencyToken": true
+                    "shape": "IdempotencyToken"
+                },
+                "includeRepos": {
+                    "shape": "RepositoryList"
                 }
             }
         },
-        "CreateCodeScanRequestClientTokenString": {
-            "type": "string",
-            "max": 256,
-            "min": 1
-        },
-        "CreateCodeScanResponse": {
+        "CreateCustomizationResponse": {
             "type": "structure",
-            "required": ["jobId", "status"],
+            "required": ["customizationArn"],
             "members": {
-                "jobId": {
-                    "shape": "CreateCodeScanResponseJobIdString"
-                },
-                "status": {
-                    "shape": "CodeScanStatus"
-                },
-                "errorMessage": {
-                    "shape": "String"
+                "customizationArn": {
+                    "shape": "CustomizationArn"
                 }
             }
-        },
-        "CreateCodeScanResponseJobIdString": {
-            "type": "string",
-            "max": 256,
-            "min": 1
         },
         "CreateProfileRequest": {
             "type": "structure",
-            "required": ["identitySource", "profileName", "referenceTrackerConfiguration"],
+            "required": ["profileName", "referenceTrackerConfiguration"],
             "members": {
                 "identitySource": {
                     "shape": "IdentitySource"
@@ -531,8 +807,14 @@
                 "profileName": {
                     "shape": "ProfileName"
                 },
+                "description": {
+                    "shape": "ProfileDescription"
+                },
                 "referenceTrackerConfiguration": {
                     "shape": "ReferenceTrackerConfiguration"
+                },
+                "activeFunctionalities": {
+                    "shape": "ActiveFunctionalityList"
                 },
                 "clientToken": {
                     "shape": "IdempotencyToken",
@@ -543,6 +825,12 @@
                 },
                 "tags": {
                     "shape": "TagList"
+                },
+                "resourcePolicy": {
+                    "shape": "ResourcePolicy"
+                },
+                "optInFeatures": {
+                    "shape": "OptInFeatures"
                 }
             }
         },
@@ -551,53 +839,235 @@
             "required": ["profileArn"],
             "members": {
                 "profileArn": {
-                    "shape": "ResourceArn"
+                    "shape": "ProfileArn"
                 }
             }
         },
-        "CreateUploadUrlRequest": {
-            "type": "structure",
-            "members": {
-                "contentMd5": {
-                    "shape": "CreateUploadUrlRequestContentMd5String"
-                },
-                "artifactType": {
-                    "shape": "ArtifactType"
-                }
-            }
-        },
-        "CreateUploadUrlRequestContentMd5String": {
+        "CustomizationArn": {
             "type": "string",
-            "max": 128,
-            "min": 1
+            "max": 950,
+            "min": 0,
+            "pattern": "arn:[-.a-z0-9]{1,63}:codewhisperer:([-.a-z0-9]{0,63}:){2}([a-zA-Z0-9-_:/]){1,1023}"
         },
-        "CreateUploadUrlResponse": {
+        "CustomizationIdentifier": {
+            "type": "string",
+            "max": 950,
+            "min": 1,
+            "pattern": ".*[a-zA-Z0-9-:/]*.*"
+        },
+        "CustomizationName": {
+            "type": "string",
+            "max": 100,
+            "min": 1,
+            "pattern": "[a-zA-Z][a-zA-Z0-9_-]*"
+        },
+        "CustomizationPermission": {
             "type": "structure",
-            "required": ["uploadId", "uploadUrl"],
             "members": {
-                "uploadId": {
-                    "shape": "UploadId"
+                "user": {
+                    "shape": "IdentityCenterIdentifier"
                 },
-                "uploadUrl": {
-                    "shape": "PreSignedUrl"
+                "group": {
+                    "shape": "IdentityCenterIdentifier"
+                }
+            },
+            "union": true
+        },
+        "CustomizationStatus": {
+            "type": "string",
+            "enum": [
+                "CREATED",
+                "UPDATED",
+                "CREATING",
+                "UPDATING",
+                "DELETING",
+                "ACTIVATING",
+                "DEACTIVATING",
+                "ACTIVATED",
+                "CREATION_FAILED",
+                "UPDATE_FAILED",
+                "DELETION_FAILED",
+                "ACTIVATION_FAILED",
+                "DEACTIVATION_FAILED"
+            ]
+        },
+        "CustomizationSummary": {
+            "type": "structure",
+            "required": ["arn", "customizationName", "status", "updatedAt"],
+            "members": {
+                "arn": {
+                    "shape": "CustomizationArn"
                 },
-                "kmsKeyArn": {
-                    "shape": "ResourceArn"
+                "version": {
+                    "shape": "Version"
+                },
+                "customizationName": {
+                    "shape": "CustomizationName"
+                },
+                "description": {
+                    "shape": "Description"
+                },
+                "status": {
+                    "shape": "CustomizationStatus"
+                },
+                "updatedAt": {
+                    "shape": "Timestamp"
                 }
             }
+        },
+        "CustomizationSummaryList": {
+            "type": "list",
+            "member": {
+                "shape": "CustomizationSummary"
+            }
+        },
+        "CustomizationVersionSummary": {
+            "type": "structure",
+            "required": ["version", "status", "dataReference", "updatedAt"],
+            "members": {
+                "version": {
+                    "shape": "Version"
+                },
+                "baseVersion": {
+                    "shape": "Version"
+                },
+                "status": {
+                    "shape": "CustomizationStatus"
+                },
+                "dataReference": {
+                    "shape": "DataReference"
+                },
+                "updatedAt": {
+                    "shape": "Timestamp"
+                },
+                "evaluationMetrics": {
+                    "shape": "EvaluationMetrics"
+                }
+            }
+        },
+        "CustomizationVersionSummaryList": {
+            "type": "list",
+            "member": {
+                "shape": "CustomizationVersionSummary"
+            }
+        },
+        "DashboardAnalytics": {
+            "type": "structure",
+            "required": ["toggle"],
+            "members": {
+                "toggle": {
+                    "shape": "OptInFeatureToggle"
+                }
+            }
+        },
+        "DataReference": {
+            "type": "structure",
+            "members": {
+                "codeStarReference": {
+                    "shape": "CodeStarReference"
+                },
+                "s3Reference": {
+                    "shape": "S3Reference"
+                }
+            },
+            "union": true
+        },
+        "DeleteCustomizationRequest": {
+            "type": "structure",
+            "required": ["identifier"],
+            "members": {
+                "identifier": {
+                    "shape": "CustomizationIdentifier"
+                },
+                "clientToken": {
+                    "shape": "IdempotencyToken"
+                }
+            }
+        },
+        "DeleteCustomizationResponse": {
+            "type": "structure",
+            "members": {}
         },
         "DeleteProfileRequest": {
             "type": "structure",
             "required": ["profileArn"],
             "members": {
                 "profileArn": {
-                    "shape": "ResourceArn"
+                    "shape": "ProfileArn"
                 }
             }
         },
         "DeleteProfileResponse": {
             "type": "structure",
             "members": {}
+        },
+        "Description": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "[\\sa-zA-Z0-9_-]*"
+        },
+        "DisassociateCustomizationPermissionRequest": {
+            "type": "structure",
+            "required": ["identifier", "permission"],
+            "members": {
+                "identifier": {
+                    "shape": "CustomizationIdentifier"
+                },
+                "permission": {
+                    "shape": "CustomizationPermission"
+                }
+            }
+        },
+        "DisassociateCustomizationPermissionResponse": {
+            "type": "structure",
+            "members": {}
+        },
+        "ErrorDetails": {
+            "type": "string",
+            "max": 2048,
+            "min": 0
+        },
+        "EvaluationMetrics": {
+            "type": "structure",
+            "required": ["compositeScore"],
+            "members": {
+                "compositeScore": {
+                    "shape": "Integer"
+                }
+            }
+        },
+        "ExternalIdentityDetails": {
+            "type": "structure",
+            "members": {
+                "issuerUrl": {
+                    "shape": "IssuerUrl"
+                },
+                "clientId": {
+                    "shape": "ClientId"
+                },
+                "scimEndpoint": {
+                    "shape": "String"
+                }
+            }
+        },
+        "ExternalIdentitySource": {
+            "type": "structure",
+            "required": ["issuerUrl", "clientId"],
+            "members": {
+                "issuerUrl": {
+                    "shape": "IssuerUrl"
+                },
+                "clientId": {
+                    "shape": "ClientId"
+                }
+            }
+        },
+        "FeatureName": {
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "[-a-zA-Z0-9._]*"
         },
         "FileContext": {
             "type": "structure",
@@ -623,12 +1093,14 @@
         "FileContextFileUriString": {
             "type": "string",
             "max": 1024,
-            "min": 1
+            "min": 1,
+            "sensitive": true
         },
         "FileContextFilenameString": {
             "type": "string",
             "max": 1024,
-            "min": 1
+            "min": 1,
+            "sensitive": true
         },
         "FileContextLeftFileContentString": {
             "type": "string",
@@ -642,37 +1114,20 @@
             "min": 0,
             "sensitive": true
         },
-        "SupplementalContext": {
-            "type": "structure",
-            "required": ["filePath", "content"],
-            "members": {
-                "filePath": {
-                    "shape": "SupplementalContextFilePathString"
-                },
-                "content": {
-                    "shape": "SupplementalContextContentString"
-                }
-            }
-        },
-        "SupplementalContextFilePathString": {
+        "FunctionalityName": {
             "type": "string",
-            "max": 1024,
-            "min": 1,
-            "sensitive": true
-        },
-        "SupplementalContextContentString": {
-            "type": "string",
-            "max": 5120,
-            "min": 0,
-            "sensitive": true
-        },
-        "SupplementalContextList": {
-            "type": "list",
-            "member": {
-                "shape": "SupplementalContext"
-            },
-            "max": 10,
-            "min": 0
+            "enum": [
+                "COMPLETIONS",
+                "ANALYSIS",
+                "CONVERSATIONS",
+                "TASK_ASSIST",
+                "TRANSFORMATIONS",
+                "CHAT_CUSTOMIZATION",
+                "TRANSFORMATIONS_WEBAPP",
+                "FEATURE_DEVELOPMENT"
+            ],
+            "max": 64,
+            "min": 1
         },
         "GenerateRecommendationsRequest": {
             "type": "structure",
@@ -680,9 +1135,6 @@
             "members": {
                 "fileContext": {
                     "shape": "FileContext"
-                },
-                "supplementalContexts": {
-                    "shape": "SupplementalContextList"
                 },
                 "maxResults": {
                     "shape": "GenerateRecommendationsRequestMaxResultsInteger"
@@ -692,6 +1144,9 @@
                 },
                 "referenceTrackerConfiguration": {
                     "shape": "ReferenceTrackerConfiguration"
+                },
+                "supplementalContexts": {
+                    "shape": "SupplementalContextList"
                 }
             }
         },
@@ -718,65 +1173,89 @@
                 }
             }
         },
-        "GetAccessTokenRequest": {
+        "GetCustomizationRequest": {
             "type": "structure",
-            "required": ["identityToken"],
+            "required": ["identifier"],
             "members": {
-                "identityToken": {
-                    "shape": "GetAccessTokenRequestIdentityTokenString"
+                "identifier": {
+                    "shape": "CustomizationIdentifier"
                 }
             }
         },
-        "GetAccessTokenRequestIdentityTokenString": {
+        "GetCustomizationResponse": {
+            "type": "structure",
+            "required": ["arn", "status", "dataReference", "customizationName", "profileArn", "updatedAt"],
+            "members": {
+                "arn": {
+                    "shape": "CustomizationArn"
+                },
+                "version": {
+                    "shape": "Version"
+                },
+                "status": {
+                    "shape": "CustomizationStatus"
+                },
+                "errorDetails": {
+                    "shape": "ErrorDetails"
+                },
+                "dataReference": {
+                    "shape": "DataReference"
+                },
+                "customizationName": {
+                    "shape": "CustomizationName"
+                },
+                "description": {
+                    "shape": "Description"
+                },
+                "profileArn": {
+                    "shape": "ProfileArn"
+                },
+                "updatedAt": {
+                    "shape": "Timestamp"
+                },
+                "evaluationMetrics": {
+                    "shape": "EvaluationMetrics"
+                },
+                "includeRepos": {
+                    "shape": "RepositoryList"
+                }
+            }
+        },
+        "GrantId": {
             "type": "string",
-            "max": 1024,
-            "min": 0,
-            "sensitive": true
-        },
-        "GetAccessTokenResponse": {
-            "type": "structure",
-            "members": {
-                "accessToken": {
-                    "shape": "SensitiveString"
-                }
-            }
-        },
-        "GetCodeScanRequest": {
-            "type": "structure",
-            "required": ["jobId"],
-            "members": {
-                "jobId": {
-                    "shape": "GetCodeScanRequestJobIdString"
-                }
-            }
-        },
-        "GetCodeScanRequestJobIdString": {
-            "type": "string",
-            "max": 256,
+            "max": 128,
             "min": 1
         },
-        "GetCodeScanResponse": {
-            "type": "structure",
-            "required": ["status"],
-            "members": {
-                "status": {
-                    "shape": "CodeScanStatus"
-                },
-                "errorMessage": {
-                    "shape": "String"
-                }
-            }
+        "GrantToken": {
+            "type": "string",
+            "max": 8192,
+            "min": 1
         },
         "IdempotencyToken": {
             "type": "string",
             "max": 256,
             "min": 1
         },
+        "IdentityCenterIdentifier": {
+            "type": "string",
+            "max": 64,
+            "min": 1,
+            "pattern": "([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}"
+        },
+        "IdentityCenterPermissions": {
+            "type": "list",
+            "member": {
+                "shape": "CustomizationPermission"
+            }
+        },
         "IdentityDetails": {
             "type": "structure",
             "members": {
                 "ssoIdentityDetails": {
                     "shape": "SSOIdentityDetails"
+                },
+                "externalIdentityDetails": {
+                    "shape": "ExternalIdentityDetails"
                 }
             },
             "union": true
@@ -786,6 +1265,9 @@
             "members": {
                 "ssoIdentitySource": {
                     "shape": "SSOIdentitySource"
+                },
+                "externalIdentitySource": {
+                    "shape": "ExternalIdentitySource"
                 }
             },
             "union": true
@@ -812,49 +1294,130 @@
             "max": 10,
             "min": 0
         },
+        "Integer": {
+            "type": "integer",
+            "box": true
+        },
         "InternalServerException": {
             "type": "structure",
             "required": ["message"],
             "members": {
                 "message": {
                     "shape": "String"
+                },
+                "reason": {
+                    "shape": "InternalServerExceptionReason"
                 }
             },
+            "documentation": "<p>This exception is thrown when an unexpected error occurred during the processing of a request.</p>",
             "exception": true,
             "fault": true,
             "retryable": {
                 "throttling": false
             }
         },
-        "ListCodeScanFindingsRequest": {
+        "InternalServerExceptionReason": {
+            "type": "string",
+            "documentation": "<p>Reason for InternalServerException</p>",
+            "enum": ["MODEL_TEMPORARILY_UNAVAILABLE"]
+        },
+        "IssuerUrl": {
+            "type": "string",
+            "max": 255,
+            "min": 1
+        },
+        "ListCustomizationPermissionsRequest": {
             "type": "structure",
-            "required": ["jobId", "codeScanFindingsSchema"],
+            "required": ["identifier"],
             "members": {
-                "jobId": {
-                    "shape": "ListCodeScanFindingsRequestJobIdString"
+                "identifier": {
+                    "shape": "CustomizationIdentifier"
+                },
+                "maxResults": {
+                    "shape": "ListCustomizationPermissionsRequestMaxResultsInteger"
                 },
                 "nextToken": {
-                    "shape": "PaginationToken"
-                },
-                "codeScanFindingsSchema": {
-                    "shape": "CodeScanFindingsSchema"
+                    "shape": "Base64EncodedPaginationToken"
                 }
             }
         },
-        "ListCodeScanFindingsRequestJobIdString": {
-            "type": "string",
-            "max": 256,
+        "ListCustomizationPermissionsRequestMaxResultsInteger": {
+            "type": "integer",
+            "box": true,
+            "max": 50,
             "min": 1
         },
-        "ListCodeScanFindingsResponse": {
+        "ListCustomizationPermissionsResponse": {
             "type": "structure",
-            "required": ["codeScanFindings"],
+            "required": ["permissions"],
             "members": {
-                "nextToken": {
-                    "shape": "PaginationToken"
+                "permissions": {
+                    "shape": "IdentityCenterPermissions"
                 },
-                "codeScanFindings": {
-                    "shape": "String"
+                "nextToken": {
+                    "shape": "Base64EncodedPaginationToken"
+                }
+            }
+        },
+        "ListCustomizationVersionsRequest": {
+            "type": "structure",
+            "required": ["identifier"],
+            "members": {
+                "identifier": {
+                    "shape": "CustomizationIdentifier"
+                },
+                "maxResults": {
+                    "shape": "ListCustomizationVersionsRequestMaxResultsInteger"
+                },
+                "nextToken": {
+                    "shape": "Base64EncodedPaginationToken"
+                }
+            }
+        },
+        "ListCustomizationVersionsRequestMaxResultsInteger": {
+            "type": "integer",
+            "box": true,
+            "max": 100,
+            "min": 1
+        },
+        "ListCustomizationVersionsResponse": {
+            "type": "structure",
+            "required": ["versions"],
+            "members": {
+                "versions": {
+                    "shape": "CustomizationVersionSummaryList"
+                },
+                "nextToken": {
+                    "shape": "Base64EncodedPaginationToken"
+                }
+            }
+        },
+        "ListCustomizationsRequest": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "shape": "ListCustomizationsRequestMaxResultsInteger"
+                },
+                "nextToken": {
+                    "shape": "Base64EncodedPaginationToken"
+                }
+            }
+        },
+        "ListCustomizationsRequestMaxResultsInteger": {
+            "type": "integer",
+            "box": true,
+            "max": 100,
+            "min": 1
+        },
+        "ListCustomizationsResponse": {
+            "type": "structure",
+            "required": ["customizations"],
+            "members": {
+                "customizations": {
+                    "shape": "CustomizationSummaryList"
+                },
+                "nextToken": {
+                    "shape": "Base64EncodedPaginationToken"
                 }
             }
         },
@@ -863,6 +1426,9 @@
             "members": {
                 "maxResults": {
                     "shape": "ListProfilesRequestMaxResultsInteger"
+                },
+                "includeManagementAccount": {
+                    "shape": "Boolean"
                 },
                 "nextToken": {
                     "shape": "Base64EncodedPaginationToken"
@@ -887,55 +1453,11 @@
                 }
             }
         },
-        "ListRecommendationsRequest": {
-            "type": "structure",
-            "required": ["fileContext"],
-            "members": {
-                "fileContext": {
-                    "shape": "FileContext"
-                },
-                "maxResults": {
-                    "shape": "ListRecommendationsRequestMaxResultsInteger"
-                },
-                "supplementalContexts": {
-                    "shape": "SupplementalContextList"
-                },
-                "nextToken": {
-                    "shape": "ListRecommendationsRequestNextTokenString"
-                },
-                "referenceTrackerConfiguration": {
-                    "shape": "ReferenceTrackerConfiguration"
-                }
-            }
-        },
-        "ListRecommendationsRequestMaxResultsInteger": {
-            "type": "integer",
-            "box": true,
-            "max": 10,
-            "min": 1
-        },
-        "ListRecommendationsRequestNextTokenString": {
-            "type": "string",
-            "max": 2048,
-            "min": 0,
-            "pattern": "(?:[A-Za-z0-9\\+/]{4})*(?:[A-Za-z0-9\\+/]{2}\\=\\=|[A-Za-z0-9\\+/]{3}\\=)?"
-        },
-        "ListRecommendationsResponse": {
-            "type": "structure",
-            "members": {
-                "recommendations": {
-                    "shape": "RecommendationsList"
-                },
-                "nextToken": {
-                    "shape": "String"
-                }
-            }
-        },
         "ListTagsForResourceRequest": {
             "type": "structure",
-            "required": ["resourceName"],
+            "required": ["resourceArn"],
             "members": {
-                "resourceName": {
+                "resourceArn": {
                     "shape": "ResourceArn"
                 }
             }
@@ -948,23 +1470,65 @@
                 }
             }
         },
-        "PaginationToken": {
-            "type": "string",
-            "max": 2048,
-            "min": 1,
-            "pattern": "\\S+"
+        "Notifications": {
+            "type": "list",
+            "member": {
+                "shape": "NotificationsFeature"
+            },
+            "max": 10,
+            "min": 0
         },
-        "PreSignedUrl": {
+        "NotificationsFeature": {
+            "type": "structure",
+            "required": ["feature", "toggle"],
+            "members": {
+                "feature": {
+                    "shape": "FeatureName"
+                },
+                "toggle": {
+                    "shape": "OptInFeatureToggle"
+                }
+            }
+        },
+        "OptInFeatureToggle": {
             "type": "string",
-            "max": 2048,
-            "min": 1
+            "enum": ["ON", "OFF"]
+        },
+        "OptInFeatures": {
+            "type": "structure",
+            "members": {
+                "promptLogging": {
+                    "shape": "PromptLogging"
+                },
+                "byUserAnalytics": {
+                    "shape": "ByUserAnalytics"
+                },
+                "dashboardAnalytics": {
+                    "shape": "DashboardAnalytics"
+                },
+                "notifications": {
+                    "shape": "Notifications"
+                },
+                "workspaceContext": {
+                    "shape": "WorkspaceContext"
+                }
+            }
+        },
+        "PreviousEditorStateMetadata": {
+            "type": "structure",
+            "required": ["timeOffset"],
+            "members": {
+                "timeOffset": {
+                    "shape": "Integer"
+                }
+            }
         },
         "Profile": {
             "type": "structure",
-            "required": ["arn", "identityDetails", "profileName", "referenceTrackerConfiguration"],
+            "required": ["arn", "profileName"],
             "members": {
                 "arn": {
-                    "shape": "ResourceArn"
+                    "shape": "ProfileArn"
                 },
                 "identityDetails": {
                     "shape": "IdentityDetails"
@@ -972,13 +1536,52 @@
                 "profileName": {
                     "shape": "ProfileName"
                 },
+                "description": {
+                    "shape": "ProfileDescription"
+                },
                 "referenceTrackerConfiguration": {
                     "shape": "ReferenceTrackerConfiguration"
                 },
                 "kmsKeyArn": {
                     "shape": "ResourceArn"
+                },
+                "activeFunctionalities": {
+                    "shape": "ActiveFunctionalityList"
+                },
+                "status": {
+                    "shape": "ProfileStatus"
+                },
+                "errorDetails": {
+                    "shape": "ErrorDetails"
+                },
+                "resourcePolicy": {
+                    "shape": "ResourcePolicy"
+                },
+                "profileType": {
+                    "shape": "ProfileType"
+                },
+                "optInFeatures": {
+                    "shape": "OptInFeatures"
+                },
+                "permissionUpdateRequired": {
+                    "shape": "Boolean"
+                },
+                "applicationProperties": {
+                    "shape": "ApplicationPropertiesList"
                 }
             }
+        },
+        "ProfileArn": {
+            "type": "string",
+            "max": 950,
+            "min": 0,
+            "pattern": "arn:aws:(codewhisperer|transform):[-.a-z0-9]{1,63}:\\d{12}:profile/([a-zA-Z0-9]){12}"
+        },
+        "ProfileDescription": {
+            "type": "string",
+            "max": 256,
+            "min": 1,
+            "pattern": "[\\sa-zA-Z0-9_-]*"
         },
         "ProfileList": {
             "type": "list",
@@ -992,6 +1595,14 @@
             "min": 1,
             "pattern": "[a-zA-Z][a-zA-Z0-9_-]*"
         },
+        "ProfileStatus": {
+            "type": "string",
+            "enum": ["ACTIVE", "CREATING", "CREATE_FAILED", "UPDATING", "UPDATE_FAILED", "DELETING", "DELETE_FAILED"]
+        },
+        "ProfileType": {
+            "type": "string",
+            "enum": ["Q_DEVELOPER", "CODEWHISPERER"]
+        },
         "ProgrammingLanguage": {
             "type": "structure",
             "required": ["languageName"],
@@ -999,13 +1610,26 @@
                 "languageName": {
                     "shape": "ProgrammingLanguageLanguageNameString"
                 }
-            }
+            },
+            "documentation": "<p>Programming Languages supported by CodeWhisperer</p>"
         },
         "ProgrammingLanguageLanguageNameString": {
             "type": "string",
             "max": 128,
             "min": 1,
-            "pattern": "(python|javascript|java|csharp|typescript|c|cpp|go|kotlin|php|ruby|rust|scala|shell|sql)"
+            "pattern": "(python|javascript|java|csharp|typescript|c|cpp|go|kotlin|php|ruby|rust|scala|shell|sql|json|yaml|vue|tf|tsx|jsx|plaintext|systemverilog|dart|lua|swift|hcl|powershell|r|abap)"
+        },
+        "PromptLogging": {
+            "type": "structure",
+            "required": ["s3Uri", "toggle"],
+            "members": {
+                "s3Uri": {
+                    "shape": "S3Uri"
+                },
+                "toggle": {
+                    "shape": "OptInFeatureToggle"
+                }
+            }
         },
         "Recommendation": {
             "type": "structure",
@@ -1038,24 +1662,30 @@
         },
         "RecommendationsWithReferencesPreference": {
             "type": "string",
+            "documentation": "<p>Recommendations with references setting for CodeWhisperer</p>",
             "enum": ["BLOCK", "ALLOW"]
         },
         "Reference": {
             "type": "structure",
             "members": {
                 "licenseName": {
-                    "shape": "ReferenceLicenseNameString"
+                    "shape": "ReferenceLicenseNameString",
+                    "documentation": "<p>License name</p>"
                 },
                 "repository": {
-                    "shape": "ReferenceRepositoryString"
+                    "shape": "ReferenceRepositoryString",
+                    "documentation": "<p>Code Repsitory for the associated reference</p>"
                 },
                 "url": {
-                    "shape": "ReferenceUrlString"
+                    "shape": "ReferenceUrlString",
+                    "documentation": "<p>Respository URL</p>"
                 },
                 "recommendationContentSpan": {
-                    "shape": "Span"
+                    "shape": "Span",
+                    "documentation": "<p>Span / Range for the Reference</p>"
                 }
-            }
+            },
+            "documentation": "<p>Code Reference / Repository details</p>"
         },
         "ReferenceLicenseNameString": {
             "type": "string",
@@ -1089,10 +1719,27 @@
             "max": 10,
             "min": 0
         },
+        "RepositoryId": {
+            "type": "string",
+            "max": 255,
+            "min": 1,
+            "pattern": ".*(?x)^([a-zA-Z0-9-_\\.\\s()]+/)+[\\w-\\.\\+_\\s]+",
+            "sensitive": true
+        },
+        "RepositoryList": {
+            "type": "list",
+            "member": {
+                "shape": "RepositoryId"
+            },
+            "max": 100,
+            "min": 1,
+            "sensitive": true
+        },
         "ResourceArn": {
             "type": "string",
             "max": 1224,
-            "min": 0
+            "min": 0,
+            "pattern": "arn:([-.a-z0-9]{1,63}:){2}([-.a-z0-9]{0,63}:){2}([a-zA-Z0-9-_:/]){1,1023}"
         },
         "ResourceNotFoundException": {
             "type": "structure",
@@ -1102,7 +1749,36 @@
                     "shape": "String"
                 }
             },
+            "documentation": "<p>This exception is thrown when describing a resource that does not exist.</p>",
             "exception": true
+        },
+        "ResourcePolicy": {
+            "type": "structure",
+            "required": ["effect"],
+            "members": {
+                "effect": {
+                    "shape": "ResourcePolicyEffect"
+                }
+            }
+        },
+        "ResourcePolicyEffect": {
+            "type": "string",
+            "enum": ["ALLOW", "DENY"]
+        },
+        "S3Reference": {
+            "type": "structure",
+            "required": ["uri"],
+            "members": {
+                "uri": {
+                    "shape": "S3Uri"
+                }
+            }
+        },
+        "S3Uri": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "pattern": "s3://((?!xn--)[a-z0-9](?![^/]*[.]{2})[a-z0-9-.]{1,61}[a-z0-9](?<!-s3alias)(?<!--ol-s3)(?<!([0-9]{1,3}\\.)([0-9]{1,3}\\.)([0-9]{1,3}\\.)([0-9]{1,3})))/(.{0,1024})"
         },
         "SSOIdentityDetails": {
             "type": "structure",
@@ -1113,6 +1789,9 @@
                 },
                 "oidcClientId": {
                     "shape": "String"
+                },
+                "ssoRegion": {
+                    "shape": "SSORegion"
                 }
             }
         },
@@ -1122,12 +1801,17 @@
             "members": {
                 "instanceArn": {
                     "shape": "ResourceArn"
+                },
+                "ssoRegion": {
+                    "shape": "SSORegion"
                 }
             }
         },
-        "SensitiveString": {
+        "SSORegion": {
             "type": "string",
-            "sensitive": true
+            "max": 63,
+            "min": 1,
+            "pattern": "[-a-z0-9]{1,63}"
         },
         "Span": {
             "type": "structure",
@@ -1138,7 +1822,8 @@
                 "end": {
                     "shape": "SpanEndInteger"
                 }
-            }
+            },
+            "documentation": "<p>Represents span in a text.</p>"
         },
         "SpanEndInteger": {
             "type": "integer",
@@ -1152,6 +1837,57 @@
         },
         "String": {
             "type": "string"
+        },
+        "SupplementalContext": {
+            "type": "structure",
+            "required": ["filePath", "content"],
+            "members": {
+                "filePath": {
+                    "shape": "SupplementalContextFilePathString"
+                },
+                "content": {
+                    "shape": "SupplementalContextContentString"
+                },
+                "type": {
+                    "shape": "SupplementalContextType"
+                },
+                "metadata": {
+                    "shape": "SupplementalContextMetadata"
+                }
+            }
+        },
+        "SupplementalContextContentString": {
+            "type": "string",
+            "max": 10240,
+            "min": 1,
+            "sensitive": true
+        },
+        "SupplementalContextFilePathString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
+        },
+        "SupplementalContextList": {
+            "type": "list",
+            "member": {
+                "shape": "SupplementalContext"
+            },
+            "max": 20,
+            "min": 0
+        },
+        "SupplementalContextMetadata": {
+            "type": "structure",
+            "members": {
+                "previousEditorStateMetadata": {
+                    "shape": "PreviousEditorStateMetadata"
+                }
+            },
+            "union": true
+        },
+        "SupplementalContextType": {
+            "type": "string",
+            "enum": ["PreviousEditorState", "WorkspaceContext"]
         },
         "Tag": {
             "type": "structure",
@@ -1175,7 +1911,7 @@
             "member": {
                 "shape": "TagKey"
             },
-            "max": 200,
+            "max": 50,
             "min": 0
         },
         "TagList": {
@@ -1183,14 +1919,14 @@
             "member": {
                 "shape": "Tag"
             },
-            "max": 200,
+            "max": 50,
             "min": 0
         },
         "TagResourceRequest": {
             "type": "structure",
-            "required": ["resourceName", "tags"],
+            "required": ["resourceArn", "tags"],
             "members": {
-                "resourceName": {
+                "resourceArn": {
                     "shape": "ResourceArn"
                 },
                 "tags": {
@@ -1207,24 +1943,41 @@
             "max": 256,
             "min": 0
         },
+        "TenantId": {
+            "type": "string",
+            "max": 1024,
+            "min": 1
+        },
         "ThrottlingException": {
             "type": "structure",
             "required": ["message"],
             "members": {
                 "message": {
                     "shape": "String"
+                },
+                "reason": {
+                    "shape": "ThrottlingExceptionReason"
                 }
             },
+            "documentation": "<p>This exception is thrown when request was denied due to request throttling.</p>",
             "exception": true,
             "retryable": {
-                "throttling": false
+                "throttling": true
             }
+        },
+        "ThrottlingExceptionReason": {
+            "type": "string",
+            "documentation": "<p>Reason for ThrottlingException</p>",
+            "enum": ["MONTHLY_REQUEST_COUNT"]
+        },
+        "Timestamp": {
+            "type": "timestamp"
         },
         "UntagResourceRequest": {
             "type": "structure",
-            "required": ["resourceName", "tagKeys"],
+            "required": ["resourceArn", "tagKeys"],
             "members": {
-                "resourceName": {
+                "resourceArn": {
                     "shape": "ResourceArn"
                 },
                 "tagKeys": {
@@ -1236,21 +1989,71 @@
             "type": "structure",
             "members": {}
         },
+        "UpdateCustomizationRequest": {
+            "type": "structure",
+            "required": ["identifier", "operation"],
+            "members": {
+                "identifier": {
+                    "shape": "CustomizationIdentifier"
+                },
+                "operation": {
+                    "shape": "UpdateOperation"
+                },
+                "clientToken": {
+                    "shape": "IdempotencyToken"
+                },
+                "dataReference": {
+                    "shape": "DataReference"
+                },
+                "version": {
+                    "shape": "Version"
+                },
+                "includeRepos": {
+                    "shape": "RepositoryList"
+                }
+            }
+        },
+        "UpdateCustomizationResponse": {
+            "type": "structure",
+            "members": {}
+        },
+        "UpdateOperation": {
+            "type": "string",
+            "enum": ["ACTIVATE", "DEACTIVATE", "UPDATE"]
+        },
         "UpdateProfileRequest": {
             "type": "structure",
             "required": ["profileArn"],
             "members": {
                 "profileArn": {
-                    "shape": "ResourceArn"
+                    "shape": "ProfileArn"
+                },
+                "identitySource": {
+                    "shape": "IdentitySource"
                 },
                 "profileName": {
                     "shape": "ProfileName"
                 },
+                "description": {
+                    "shape": "ProfileDescription"
+                },
                 "referenceTrackerConfiguration": {
                     "shape": "ReferenceTrackerConfiguration"
                 },
+                "activeFunctionalities": {
+                    "shape": "ActiveFunctionalityList"
+                },
                 "kmsKeyArn": {
                     "shape": "ResourceArn"
+                },
+                "resourcePolicy": {
+                    "shape": "ResourcePolicy"
+                },
+                "targetProfileType": {
+                    "shape": "ProfileType"
+                },
+                "optInFeatures": {
+                    "shape": "OptInFeatures"
                 }
             }
         },
@@ -1259,13 +2062,13 @@
             "required": ["profileArn"],
             "members": {
                 "profileArn": {
-                    "shape": "ResourceArn"
+                    "shape": "ProfileArn"
                 }
             }
         },
-        "UploadId": {
+        "Url": {
             "type": "string",
-            "max": 128,
+            "max": 1024,
             "min": 1
         },
         "ValidationException": {
@@ -1274,9 +2077,69 @@
             "members": {
                 "message": {
                     "shape": "String"
+                },
+                "reason": {
+                    "shape": "ValidationExceptionReason"
                 }
             },
+            "documentation": "<p>This exception is thrown when the input fails to satisfy the constraints specified by the service.</p>",
             "exception": true
+        },
+        "ValidationExceptionReason": {
+            "type": "string",
+            "documentation": "<p>Reason for ValidationException</p>",
+            "enum": ["INVALID_CONVERSATION_ID", "CONTENT_LENGTH_EXCEEDS_THRESHOLD", "INVALID_KMS_GRANT"]
+        },
+        "VendKeyGrantRequest": {
+            "type": "structure",
+            "required": ["accountId", "usecase"],
+            "members": {
+                "accountId": {
+                    "shape": "AWSAccountId"
+                },
+                "usecase": {
+                    "shape": "VendKeyGrantUseCase"
+                }
+            }
+        },
+        "VendKeyGrantResponse": {
+            "type": "structure",
+            "members": {
+                "cmkArn": {
+                    "shape": "ResourceArn"
+                },
+                "grantId": {
+                    "shape": "GrantToken"
+                },
+                "grantToken": {
+                    "shape": "GrantId"
+                }
+            }
+        },
+        "VendKeyGrantUseCase": {
+            "type": "string",
+            "enum": [
+                "TEST",
+                "WEAVER_BIRD",
+                "ELASTIC_GUMBY",
+                "LOCHNESS",
+                "BOWER_BIRD",
+                "ELASTIC_GUMBY_V2_JOB",
+                "ELASTIC_GUMBY_V2_CHAT"
+            ]
+        },
+        "Version": {
+            "type": "long",
+            "box": true
+        },
+        "WorkspaceContext": {
+            "type": "structure",
+            "required": ["toggle"],
+            "members": {
+                "toggle": {
+                    "shape": "OptInFeatureToggle"
+                }
+            }
         }
     }
 }

--- a/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
+++ b/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
@@ -2,9 +2,11 @@
     "version": "2.0",
     "metadata": {
         "apiVersion": "2022-11-11",
+        "auth": ["smithy.api#httpBearerAuth"],
         "endpointPrefix": "amazoncodewhispererservice",
         "jsonVersion": "1.0",
         "protocol": "json",
+        "protocols": ["json"],
         "serviceFullName": "Amazon CodeWhisperer",
         "serviceId": "CodeWhispererRuntime",
         "signingName": "amazoncodewhispererservice",
@@ -39,6 +41,37 @@
                 }
             ],
             "documentation": "<p>Creates a pre-signed, S3 write URL for uploading a repository zip archive.</p>",
+            "idempotent": true
+        },
+        "CreateSubscriptionToken": {
+            "name": "CreateSubscriptionToken",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "CreateSubscriptionTokenRequest"
+            },
+            "output": {
+                "shape": "CreateSubscriptionTokenResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
             "idempotent": true
         },
         "CreateTaskAssistConversation": {
@@ -110,20 +143,72 @@
             "documentation": "<p>Creates a pre-signed, S3 write URL for uploading a repository zip archive.</p>",
             "idempotent": true
         },
+        "CreateUserMemoryEntry": {
+            "name": "CreateUserMemoryEntry",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "CreateUserMemoryEntryInput"
+            },
+            "output": {
+                "shape": "CreateUserMemoryEntryOutput"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ServiceQuotaExceededException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to create a single user memory entry</p>",
+            "idempotent": true
+        },
         "CreateWorkspace": {
             "name": "CreateWorkspace",
             "http": {
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "CreateWorkspaceRequest" },
-            "output": { "shape": "CreateWorkspaceResponse" },
+            "input": {
+                "shape": "CreateWorkspaceRequest"
+            },
+            "output": {
+                "shape": "CreateWorkspaceResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "ConflictException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ConflictException"
+                },
+                {
+                    "shape": "ServiceQuotaExceededException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
             ],
             "documentation": "<p>Create a workspace based on a workspace root</p>"
         },
@@ -158,19 +243,63 @@
             ],
             "documentation": "<p>API to delete task assist conversation.</p>"
         },
+        "DeleteUserMemoryEntry": {
+            "name": "DeleteUserMemoryEntry",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "DeleteUserMemoryEntryInput"
+            },
+            "output": {
+                "shape": "DeleteUserMemoryEntryOutput"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to delete a single user memory entry</p>",
+            "idempotent": true
+        },
         "DeleteWorkspace": {
             "name": "DeleteWorkspace",
             "http": {
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "DeleteWorkspaceRequest" },
-            "output": { "shape": "DeleteWorkspaceResponse" },
+            "input": {
+                "shape": "DeleteWorkspaceRequest"
+            },
+            "output": {
+                "shape": "DeleteWorkspaceResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
             ],
             "documentation": "<p>Delete a workspace based on a workspaceId</p>"
         },
@@ -387,6 +516,34 @@
             ],
             "documentation": "<p>API to get code transformation status.</p>"
         },
+        "GetUsageLimits": {
+            "name": "GetUsageLimits",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "GetUsageLimitsRequest"
+            },
+            "output": {
+                "shape": "GetUsageLimitsResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to get current usage limits</p>"
+        },
         "ListAvailableCustomizations": {
             "name": "ListAvailableCustomizations",
             "http": {
@@ -420,13 +577,25 @@
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "ListAvailableProfilesRequest" },
-            "output": { "shape": "ListAvailableProfilesResponse" },
+            "input": {
+                "shape": "ListAvailableProfilesRequest"
+            },
+            "output": {
+                "shape": "ListAvailableProfilesResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
             ]
         },
         "ListCodeAnalysisFindings": {
@@ -460,6 +629,34 @@
             ],
             "documentation": "<p>Lists the findings from a particular code analysis job.</p>"
         },
+        "ListEvents": {
+            "name": "ListEvents",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "ListEventsRequest"
+            },
+            "output": {
+                "shape": "ListEventsResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>List events for agent activity</p>"
+        },
         "ListFeatureEvaluations": {
             "name": "ListFeatureEvaluations",
             "http": {
@@ -488,21 +685,93 @@
             ],
             "documentation": "<p>Return configruations for each feature that has been setup for A/B testing.</p>"
         },
+        "ListUserMemoryEntries": {
+            "name": "ListUserMemoryEntries",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "ListUserMemoryEntriesInput"
+            },
+            "output": {
+                "shape": "ListUserMemoryEntriesOutput"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "ResourceNotFoundException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to list user memories</p>"
+        },
         "ListWorkspaceMetadata": {
             "name": "ListWorkspaceMetadata",
             "http": {
                 "method": "POST",
                 "requestUri": "/"
             },
-            "input": { "shape": "ListWorkspaceMetadataRequest" },
-            "output": { "shape": "ListWorkspaceMetadataResponse" },
+            "input": {
+                "shape": "ListWorkspaceMetadataRequest"
+            },
+            "output": {
+                "shape": "ListWorkspaceMetadataResponse"
+            },
             "errors": [
-                { "shape": "ThrottlingException" },
-                { "shape": "InternalServerException" },
-                { "shape": "ValidationException" },
-                { "shape": "AccessDeniedException" }
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
             ],
             "documentation": "<p>List workspace metadata based on a workspace root</p>"
+        },
+        "PushTelemetryEvent": {
+            "name": "PushTelemetryEvent",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "PushTelemetryEventRequest"
+            },
+            "output": {
+                "shape": "PushTelemetryEventResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                }
+            ],
+            "documentation": "<p>API to push telemetry events to CloudWatch, DataHub and EventBridge.</p>",
+            "idempotent": true
         },
         "ResumeTransformation": {
             "name": "ResumeTransformation",
@@ -756,6 +1025,37 @@
                 }
             ],
             "documentation": "<p>API to stop code transformation status.</p>"
+        },
+        "UpdateUsageLimits": {
+            "name": "UpdateUsageLimits",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "UpdateUsageLimitsRequest"
+            },
+            "output": {
+                "shape": "UpdateUsageLimitsResponse"
+            },
+            "errors": [
+                {
+                    "shape": "ThrottlingException"
+                },
+                {
+                    "shape": "InternalServerException"
+                },
+                {
+                    "shape": "ValidationException"
+                },
+                {
+                    "shape": "AccessDeniedException"
+                },
+                {
+                    "shape": "UpdateUsageLimitQuotaExceededException"
+                }
+            ],
+            "documentation": "<p>API to update usage limits for enterprise customers</p>"
         }
     },
     "shapes": {
@@ -776,11 +1076,18 @@
         "AccessDeniedExceptionReason": {
             "type": "string",
             "documentation": "<p>Reason for AccessDeniedException</p>",
-            "enum": ["UNAUTHORIZED_CUSTOMIZATION_RESOURCE_ACCESS"]
+            "enum": ["UNAUTHORIZED_CUSTOMIZATION_RESOURCE_ACCESS", "UNAUTHORIZED_WORKSPACE_CONTEXT_FEATURE_ACCESS"]
+        },
+        "ActivationToken": {
+            "type": "string",
+            "max": 16,
+            "min": 8
         },
         "ActiveFunctionalityList": {
             "type": "list",
-            "member": { "shape": "FunctionalityName" },
+            "member": {
+                "shape": "FunctionalityName"
+            },
             "max": 10,
             "min": 0
         },
@@ -824,7 +1131,9 @@
         },
         "AdditionalContentList": {
             "type": "list",
-            "member": { "shape": "AdditionalContentEntry" },
+            "member": {
+                "shape": "AdditionalContentEntry"
+            },
             "documentation": "<p>A list of additional content entries, limited to 20 items</p>",
             "max": 20,
             "min": 0
@@ -884,15 +1193,25 @@
             "type": "structure",
             "required": ["tenantId", "applicationArn", "tenantUrl", "applicationType"],
             "members": {
-                "tenantId": { "shape": "TenantId" },
-                "applicationArn": { "shape": "ResourceArn" },
-                "tenantUrl": { "shape": "Url" },
-                "applicationType": { "shape": "FunctionalityName" }
+                "tenantId": {
+                    "shape": "TenantId"
+                },
+                "applicationArn": {
+                    "shape": "ResourceArn"
+                },
+                "tenantUrl": {
+                    "shape": "Url"
+                },
+                "applicationType": {
+                    "shape": "FunctionalityName"
+                }
             }
         },
         "ApplicationPropertiesList": {
             "type": "list",
-            "member": { "shape": "ApplicationProperties" }
+            "member": {
+                "shape": "ApplicationProperties"
+            }
         },
         "ArtifactId": {
             "type": "string",
@@ -951,6 +1270,21 @@
             "min": 0,
             "sensitive": true
         },
+        "AttributesMap": {
+            "type": "map",
+            "key": {
+                "shape": "AttributesMapKeyString"
+            },
+            "value": {
+                "shape": "StringList"
+            },
+            "documentation": "<p>Attributes is a map of key-value pairs</p>"
+        },
+        "AttributesMapKeyString": {
+            "type": "string",
+            "max": 128,
+            "min": 1
+        },
         "Base64EncodedPaginationToken": {
             "type": "string",
             "max": 2048,
@@ -965,8 +1299,25 @@
             "type": "structure",
             "required": ["toggle"],
             "members": {
-                "s3Uri": { "shape": "S3Uri" },
-                "toggle": { "shape": "OptInFeatureToggle" }
+                "s3Uri": {
+                    "shape": "S3Uri"
+                },
+                "toggle": {
+                    "shape": "OptInFeatureToggle"
+                }
+            }
+        },
+        "ChangeLogGranularityType": {
+            "type": "string",
+            "enum": ["STANDARD", "BUSINESS"]
+        },
+        "ChangeLogOptions": {
+            "type": "structure",
+            "required": ["granularity"],
+            "members": {
+                "granularity": {
+                    "shape": "ChangeLogGranularityType"
+                }
             }
         },
         "ChatAddMessageEvent": {
@@ -1026,7 +1377,7 @@
                 "shape": "ChatMessage"
             },
             "documentation": "<p>Indicates Participant in Chat conversation</p>",
-            "max": 100,
+            "max": 250,
             "min": 0
         },
         "ChatInteractWithMessageEvent": {
@@ -1062,6 +1413,12 @@
                 },
                 "userIntent": {
                     "shape": "UserIntent"
+                },
+                "addedIdeDiagnostics": {
+                    "shape": "IdeDiagnosticList"
+                },
+                "removedIdeDiagnostics": {
+                    "shape": "IdeDiagnosticList"
                 }
             }
         },
@@ -1126,6 +1483,11 @@
                 }
             }
         },
+        "ClientId": {
+            "type": "string",
+            "max": 255,
+            "min": 1
+        },
         "CodeAnalysisFindingsSchema": {
             "type": "string",
             "enum": ["codeanalysis/findings/1.0"]
@@ -1180,8 +1542,15 @@
                 },
                 "userWrittenCodeLineCount": {
                     "shape": "CodeCoverageEventUserWrittenCodeLineCountInteger"
+                },
+                "addedCharacterCount": {
+                    "shape": "CodeCoverageEventAddedCharacterCountInteger"
                 }
             }
+        },
+        "CodeCoverageEventAddedCharacterCountInteger": {
+            "type": "integer",
+            "min": 0
         },
         "CodeCoverageEventUserWrittenCodeCharacterCountInteger": {
             "type": "integer",
@@ -1190,6 +1559,23 @@
         "CodeCoverageEventUserWrittenCodeLineCountInteger": {
             "type": "integer",
             "min": 0
+        },
+        "CodeDescription": {
+            "type": "structure",
+            "required": ["href"],
+            "members": {
+                "href": {
+                    "shape": "CodeDescriptionHrefString",
+                    "documentation": "<p>An URI to open with more information about the diagnostic error.</p>"
+                }
+            },
+            "documentation": "<p>Structure to capture a description for an error code.</p>"
+        },
+        "CodeDescriptionHrefString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
         },
         "CodeFixAcceptanceEvent": {
             "type": "structure",
@@ -1487,6 +1873,11 @@
             "type": "string",
             "enum": ["SHA_256"]
         },
+        "ContentType": {
+            "type": "string",
+            "documentation": "<p>The type of content</p>",
+            "enum": ["FILE", "PROMPT", "CODE", "WORKSPACE"]
+        },
         "ContextTruncationScheme": {
             "type": "string",
             "documentation": "<p>Workspace context truncation schemes based on usecase</p>",
@@ -1527,6 +1918,33 @@
                 }
             },
             "documentation": "<p>Structure to represent the current state of a chat conversation.</p>"
+        },
+        "CreateSubscriptionTokenRequest": {
+            "type": "structure",
+            "members": {
+                "clientToken": {
+                    "shape": "IdempotencyToken",
+                    "idempotencyToken": true
+                },
+                "statusOnly": {
+                    "shape": "Boolean"
+                }
+            }
+        },
+        "CreateSubscriptionTokenResponse": {
+            "type": "structure",
+            "required": ["status"],
+            "members": {
+                "encodedVerificationUrl": {
+                    "shape": "EncodedVerificationUrl"
+                },
+                "token": {
+                    "shape": "ActivationToken"
+                },
+                "status": {
+                    "shape": "SubscriptionStatus"
+                }
+            }
         },
         "CreateTaskAssistConversationRequest": {
             "type": "structure",
@@ -1614,12 +2032,56 @@
                 }
             }
         },
+        "CreateUserMemoryEntryInput": {
+            "type": "structure",
+            "required": ["memoryEntryString", "origin"],
+            "members": {
+                "memoryEntryString": {
+                    "shape": "CreateUserMemoryEntryInputMemoryEntryStringString"
+                },
+                "origin": {
+                    "shape": "Origin"
+                },
+                "profileArn": {
+                    "shape": "CreateUserMemoryEntryInputProfileArnString",
+                    "documentation": "<p>ProfileArn for the managing Q Profile</p>"
+                },
+                "clientToken": {
+                    "shape": "IdempotencyToken",
+                    "idempotencyToken": true
+                }
+            }
+        },
+        "CreateUserMemoryEntryInputMemoryEntryStringString": {
+            "type": "string",
+            "max": 500,
+            "min": 1,
+            "sensitive": true
+        },
+        "CreateUserMemoryEntryInputProfileArnString": {
+            "type": "string",
+            "min": 1,
+            "pattern": "arn:aws:(codewhisperer|transform):[-.a-z0-9]{1,63}:\\d{12}:profile/([a-zA-Z0-9]){12}"
+        },
+        "CreateUserMemoryEntryOutput": {
+            "type": "structure",
+            "required": ["memoryEntry"],
+            "members": {
+                "memoryEntry": {
+                    "shape": "MemoryEntry"
+                }
+            }
+        },
         "CreateWorkspaceRequest": {
             "type": "structure",
             "required": ["workspaceRoot"],
             "members": {
-                "workspaceRoot": { "shape": "CreateWorkspaceRequestWorkspaceRootString" },
-                "profileArn": { "shape": "ProfileArn" }
+                "workspaceRoot": {
+                    "shape": "CreateWorkspaceRequestWorkspaceRootString"
+                },
+                "profileArn": {
+                    "shape": "ProfileArn"
+                }
             }
         },
         "CreateWorkspaceRequestWorkspaceRootString": {
@@ -1632,7 +2094,9 @@
             "type": "structure",
             "required": ["workspace"],
             "members": {
-                "workspace": { "shape": "WorkspaceMetadata" }
+                "workspace": {
+                    "shape": "WorkspaceMetadata"
+                }
             }
         },
         "CursorState": {
@@ -1662,6 +2126,9 @@
                 },
                 "description": {
                     "shape": "Description"
+                },
+                "modelId": {
+                    "shape": "ModelId"
                 }
             }
         },
@@ -1687,15 +2154,21 @@
             "type": "structure",
             "required": ["toggle"],
             "members": {
-                "toggle": { "shape": "OptInFeatureToggle" }
+                "toggle": {
+                    "shape": "OptInFeatureToggle"
+                }
             }
         },
         "DeleteTaskAssistConversationRequest": {
             "type": "structure",
             "required": ["conversationId"],
             "members": {
-                "conversationId": { "shape": "ConversationId" },
-                "profileArn": { "shape": "ProfileArn" }
+                "conversationId": {
+                    "shape": "ConversationId"
+                },
+                "profileArn": {
+                    "shape": "ProfileArn"
+                }
             },
             "documentation": "<p>Structure to represent bootstrap conversation request.</p>"
         },
@@ -1709,12 +2182,44 @@
             },
             "documentation": "<p>Structure to represent bootstrap conversation response.</p>"
         },
+        "DeleteUserMemoryEntryInput": {
+            "type": "structure",
+            "required": ["id"],
+            "members": {
+                "id": {
+                    "shape": "DeleteUserMemoryEntryInputIdString"
+                },
+                "profileArn": {
+                    "shape": "DeleteUserMemoryEntryInputProfileArnString",
+                    "documentation": "<p>ProfileArn for the managing Q Profile</p>"
+                }
+            }
+        },
+        "DeleteUserMemoryEntryInputIdString": {
+            "type": "string",
+            "max": 36,
+            "min": 36,
+            "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+        },
+        "DeleteUserMemoryEntryInputProfileArnString": {
+            "type": "string",
+            "min": 1,
+            "pattern": "arn:aws:(codewhisperer|transform):[-.a-z0-9]{1,63}:\\d{12}:profile/([a-zA-Z0-9]){12}"
+        },
+        "DeleteUserMemoryEntryOutput": {
+            "type": "structure",
+            "members": {}
+        },
         "DeleteWorkspaceRequest": {
             "type": "structure",
             "required": ["workspaceId"],
             "members": {
-                "workspaceId": { "shape": "UUID" },
-                "profileArn": { "shape": "ProfileArn" }
+                "workspaceId": {
+                    "shape": "UUID"
+                },
+                "profileArn": {
+                    "shape": "ProfileArn"
+                }
             }
         },
         "DeleteWorkspaceResponse": {
@@ -1742,10 +2247,73 @@
             "documentation": "<p>Represents a Diagnostic message</p>",
             "union": true
         },
+        "DiagnosticLocation": {
+            "type": "structure",
+            "required": ["uri", "range"],
+            "members": {
+                "uri": {
+                    "shape": "DiagnosticLocationUriString"
+                },
+                "range": {
+                    "shape": "Range"
+                }
+            },
+            "documentation": "<p>Represents a location inside a resource, such as a line inside a text file.</p>"
+        },
+        "DiagnosticLocationUriString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
+        },
+        "DiagnosticRelatedInformation": {
+            "type": "structure",
+            "required": ["location", "message"],
+            "members": {
+                "location": {
+                    "shape": "DiagnosticLocation",
+                    "documentation": "<p>The location of this related diagnostic information.</p>"
+                },
+                "message": {
+                    "shape": "DiagnosticRelatedInformationMessageString",
+                    "documentation": "<p>The message of this related diagnostic information.</p>"
+                }
+            },
+            "documentation": "<p>Represents a related message and source code location for a diagnostic.</p>"
+        },
+        "DiagnosticRelatedInformationList": {
+            "type": "list",
+            "member": {
+                "shape": "DiagnosticRelatedInformation"
+            },
+            "documentation": "<p>List of DiagnosticRelatedInformation</p>",
+            "max": 1024,
+            "min": 0
+        },
+        "DiagnosticRelatedInformationMessageString": {
+            "type": "string",
+            "max": 1024,
+            "min": 0,
+            "sensitive": true
+        },
         "DiagnosticSeverity": {
             "type": "string",
             "documentation": "<p>Diagnostic Error types</p>",
             "enum": ["ERROR", "WARNING", "INFORMATION", "HINT"]
+        },
+        "DiagnosticTag": {
+            "type": "string",
+            "documentation": "<p>The diagnostic tags.</p>",
+            "enum": ["UNNECESSARY", "DEPRECATED"]
+        },
+        "DiagnosticTagList": {
+            "type": "list",
+            "member": {
+                "shape": "DiagnosticTag"
+            },
+            "documentation": "<p>List of DiagnosticTag</p>",
+            "max": 1024,
+            "min": 0
         },
         "Dimension": {
             "type": "structure",
@@ -1931,6 +2499,11 @@
             "type": "integer",
             "min": 0
         },
+        "Document": {
+            "type": "structure",
+            "members": {},
+            "document": true
+        },
         "DocumentSymbol": {
             "type": "structure",
             "required": ["name", "type"],
@@ -1976,6 +2549,9 @@
                 },
                 "type": {
                     "shape": "DocumentationType"
+                },
+                "changeLogOptions": {
+                    "shape": "ChangeLogOptions"
                 }
             }
         },
@@ -1987,11 +2563,29 @@
         },
         "DocumentationType": {
             "type": "string",
-            "enum": ["README"]
+            "enum": ["README", "CHANGE_LOG"]
         },
         "Double": {
             "type": "double",
             "box": true
+        },
+        "Edit": {
+            "type": "structure",
+            "required": ["content"],
+            "members": {
+                "content": {
+                    "shape": "EditContentString"
+                },
+                "references": {
+                    "shape": "References"
+                }
+            }
+        },
+        "EditContentString": {
+            "type": "string",
+            "max": 5120,
+            "min": 1,
+            "sensitive": true
         },
         "EditorState": {
             "type": "structure",
@@ -2011,9 +2605,18 @@
                 "useRelevantDocuments": {
                     "shape": "Boolean",
                     "documentation": "<p>Whether service should use relevant document in prompt</p>"
+                },
+                "workspaceFolders": {
+                    "shape": "WorkspaceFolderList",
+                    "documentation": "<p>Represents IDE provided list of workspace folders</p>"
                 }
             },
             "documentation": "<p>Represents the state of an Editor</p>"
+        },
+        "EncodedVerificationUrl": {
+            "type": "string",
+            "max": 8192,
+            "min": 1
         },
         "EnvState": {
             "type": "structure",
@@ -2094,6 +2697,60 @@
             "type": "string",
             "max": 2048,
             "min": 0
+        },
+        "Event": {
+            "type": "structure",
+            "required": ["eventId", "generationId", "eventTimestamp", "eventType", "eventBlob"],
+            "members": {
+                "eventId": {
+                    "shape": "UUID"
+                },
+                "generationId": {
+                    "shape": "UUID"
+                },
+                "eventTimestamp": {
+                    "shape": "SyntheticTimestamp_date_time"
+                },
+                "eventType": {
+                    "shape": "EventType"
+                },
+                "eventBlob": {
+                    "shape": "EventBlob"
+                }
+            }
+        },
+        "EventBlob": {
+            "type": "blob",
+            "max": 400000,
+            "min": 1,
+            "sensitive": true
+        },
+        "EventList": {
+            "type": "list",
+            "member": {
+                "shape": "Event"
+            },
+            "max": 10,
+            "min": 1
+        },
+        "EventType": {
+            "type": "string",
+            "max": 100,
+            "min": 1
+        },
+        "ExternalIdentityDetails": {
+            "type": "structure",
+            "members": {
+                "issuerUrl": {
+                    "shape": "IssuerUrl"
+                },
+                "clientId": {
+                    "shape": "ClientId"
+                },
+                "scimEndpoint": {
+                    "shape": "String"
+                }
+            }
         },
         "FeatureDevCodeAcceptanceEvent": {
             "type": "structure",
@@ -2289,7 +2946,8 @@
                 "TASK_ASSIST",
                 "TRANSFORMATIONS",
                 "CHAT_CUSTOMIZATION",
-                "TRANSFORMATIONS_WEBAPP"
+                "TRANSFORMATIONS_WEBAPP",
+                "FEATURE_DEVELOPMENT"
             ],
             "max": 64,
             "min": 1
@@ -2298,16 +2956,45 @@
             "type": "structure",
             "required": ["fileContext"],
             "members": {
-                "fileContext": { "shape": "FileContext" },
-                "maxResults": { "shape": "GenerateCompletionsRequestMaxResultsInteger" },
-                "nextToken": { "shape": "GenerateCompletionsRequestNextTokenString" },
-                "referenceTrackerConfiguration": { "shape": "ReferenceTrackerConfiguration" },
-                "supplementalContexts": { "shape": "SupplementalContextList" },
-                "customizationArn": { "shape": "CustomizationArn" },
-                "optOutPreference": { "shape": "OptOutPreference" },
-                "userContext": { "shape": "UserContext" },
-                "profileArn": { "shape": "ProfileArn" },
-                "workspaceId": { "shape": "UUID" }
+                "fileContext": {
+                    "shape": "FileContext"
+                },
+                "editorState": {
+                    "shape": "EditorState"
+                },
+                "maxResults": {
+                    "shape": "GenerateCompletionsRequestMaxResultsInteger"
+                },
+                "predictionTypes": {
+                    "shape": "PredictionTypes"
+                },
+                "nextToken": {
+                    "shape": "GenerateCompletionsRequestNextTokenString"
+                },
+                "referenceTrackerConfiguration": {
+                    "shape": "ReferenceTrackerConfiguration"
+                },
+                "supplementalContexts": {
+                    "shape": "SupplementalContextList"
+                },
+                "customizationArn": {
+                    "shape": "CustomizationArn"
+                },
+                "optOutPreference": {
+                    "shape": "OptOutPreference"
+                },
+                "userContext": {
+                    "shape": "UserContext"
+                },
+                "profileArn": {
+                    "shape": "ProfileArn"
+                },
+                "workspaceId": {
+                    "shape": "UUID"
+                },
+                "modelId": {
+                    "shape": "ModelId"
+                }
             }
         },
         "GenerateCompletionsRequestMaxResultsInteger": {
@@ -2326,11 +3013,17 @@
         "GenerateCompletionsResponse": {
             "type": "structure",
             "members": {
+                "predictions": {
+                    "shape": "Predictions"
+                },
                 "completions": {
                     "shape": "Completions"
                 },
                 "nextToken": {
                     "shape": "SensitiveString"
+                },
+                "modelId": {
+                    "shape": "ModelId"
                 }
             }
         },
@@ -2501,6 +3194,28 @@
             },
             "documentation": "<p>Structure to represent get code transformation response.</p>"
         },
+        "GetUsageLimitsRequest": {
+            "type": "structure",
+            "members": {
+                "profileArn": {
+                    "shape": "ProfileArn",
+                    "documentation": "<p>The ARN of the Q Developer profile. Required for enterprise customers, optional for Builder ID users.</p>"
+                }
+            }
+        },
+        "GetUsageLimitsResponse": {
+            "type": "structure",
+            "required": ["limits", "daysUntilReset"],
+            "members": {
+                "limits": {
+                    "shape": "UsageLimits"
+                },
+                "daysUntilReset": {
+                    "shape": "Integer",
+                    "documentation": "<p>Number of days remaining until the usage metrics reset</p>"
+                }
+            }
+        },
         "GitState": {
             "type": "structure",
             "members": {
@@ -2523,6 +3238,48 @@
             "max": 64,
             "min": 1
         },
+        "IdeDiagnostic": {
+            "type": "structure",
+            "required": ["ideDiagnosticType"],
+            "members": {
+                "range": {
+                    "shape": "Range",
+                    "documentation": "<p>The range at which the message applies.</p>"
+                },
+                "source": {
+                    "shape": "IdeDiagnosticSourceString",
+                    "documentation": "<p>A human-readable string describing the source of the diagnostic</p>"
+                },
+                "severity": {
+                    "shape": "DiagnosticSeverity",
+                    "documentation": "<p>Diagnostic Error type</p>"
+                },
+                "ideDiagnosticType": {
+                    "shape": "IdeDiagnosticType",
+                    "documentation": "<p>Type of the diagnostic</p>"
+                }
+            },
+            "documentation": "<p>Structure to represent metadata about a Diagnostic from user local IDE</p>"
+        },
+        "IdeDiagnosticList": {
+            "type": "list",
+            "member": {
+                "shape": "IdeDiagnostic"
+            },
+            "documentation": "<p>List of IDE Diagnostics</p>",
+            "max": 1024,
+            "min": 0
+        },
+        "IdeDiagnosticSourceString": {
+            "type": "string",
+            "max": 1024,
+            "min": 0,
+            "sensitive": true
+        },
+        "IdeDiagnosticType": {
+            "type": "string",
+            "enum": ["SYNTAX_ERROR", "TYPE_ERROR", "REFERENCE_ERROR", "BEST_PRACTICE", "SECURITY", "OTHER"]
+        },
         "IdempotencyToken": {
             "type": "string",
             "max": 256,
@@ -2533,9 +3290,53 @@
             "members": {
                 "ssoIdentityDetails": {
                     "shape": "SSOIdentityDetails"
+                },
+                "externalIdentityDetails": {
+                    "shape": "ExternalIdentityDetails"
                 }
             },
             "union": true
+        },
+        "ImageBlock": {
+            "type": "structure",
+            "required": ["format", "source"],
+            "members": {
+                "format": {
+                    "shape": "ImageFormat"
+                },
+                "source": {
+                    "shape": "ImageSource"
+                }
+            },
+            "documentation": "<p>Represents the image source itself and the format of the image.</p>"
+        },
+        "ImageBlocks": {
+            "type": "list",
+            "member": {
+                "shape": "ImageBlock"
+            },
+            "max": 10,
+            "min": 0
+        },
+        "ImageFormat": {
+            "type": "string",
+            "enum": ["png", "jpeg", "gif", "webp"]
+        },
+        "ImageSource": {
+            "type": "structure",
+            "members": {
+                "bytes": {
+                    "shape": "ImageSourceBytesBlob"
+                }
+            },
+            "documentation": "<p>Image bytes limited to ~10MB considering overhead of base64 encoding</p>",
+            "sensitive": true,
+            "union": true
+        },
+        "ImageSourceBytesBlob": {
+            "type": "blob",
+            "max": 2800000,
+            "min": 1
         },
         "Import": {
             "type": "structure",
@@ -2631,6 +3432,9 @@
             "members": {
                 "message": {
                     "shape": "String"
+                },
+                "reason": {
+                    "shape": "InternalServerExceptionReason"
                 }
             },
             "documentation": "<p>This exception is thrown when an unexpected error occurred during the processing of a request.</p>",
@@ -2639,6 +3443,16 @@
             "retryable": {
                 "throttling": false
             }
+        },
+        "InternalServerExceptionReason": {
+            "type": "string",
+            "documentation": "<p>Reason for InternalServerException</p>",
+            "enum": ["MODEL_TEMPORARILY_UNAVAILABLE"]
+        },
+        "IssuerUrl": {
+            "type": "string",
+            "max": 255,
+            "min": 1
         },
         "LineRangeList": {
             "type": "list",
@@ -2742,6 +3556,42 @@
                 }
             }
         },
+        "ListEventsRequest": {
+            "type": "structure",
+            "required": ["conversationId"],
+            "members": {
+                "conversationId": {
+                    "shape": "UUID"
+                },
+                "maxResults": {
+                    "shape": "ListEventsRequestMaxResultsInteger"
+                },
+                "nextToken": {
+                    "shape": "NextToken"
+                }
+            }
+        },
+        "ListEventsRequestMaxResultsInteger": {
+            "type": "integer",
+            "box": true,
+            "max": 50,
+            "min": 1
+        },
+        "ListEventsResponse": {
+            "type": "structure",
+            "required": ["conversationId", "events"],
+            "members": {
+                "conversationId": {
+                    "shape": "UUID"
+                },
+                "events": {
+                    "shape": "EventList"
+                },
+                "nextToken": {
+                    "shape": "NextToken"
+                }
+            }
+        },
         "ListFeatureEvaluationsRequest": {
             "type": "structure",
             "required": ["userContext"],
@@ -2763,13 +3613,69 @@
                 }
             }
         },
+        "ListUserMemoryEntriesInput": {
+            "type": "structure",
+            "members": {
+                "maxResults": {
+                    "shape": "ListUserMemoryEntriesInputMaxResultsInteger"
+                },
+                "profileArn": {
+                    "shape": "ListUserMemoryEntriesInputProfileArnString",
+                    "documentation": "<p>ProfileArn for the managing Q Profile</p>"
+                },
+                "nextToken": {
+                    "shape": "ListUserMemoryEntriesInputNextTokenString"
+                }
+            }
+        },
+        "ListUserMemoryEntriesInputMaxResultsInteger": {
+            "type": "integer",
+            "box": true,
+            "max": 100,
+            "min": 1
+        },
+        "ListUserMemoryEntriesInputNextTokenString": {
+            "type": "string",
+            "min": 1,
+            "pattern": "[A-Za-z0-9_-]+"
+        },
+        "ListUserMemoryEntriesInputProfileArnString": {
+            "type": "string",
+            "min": 1,
+            "pattern": "arn:aws:(codewhisperer|transform):[-.a-z0-9]{1,63}:\\d{12}:profile/([a-zA-Z0-9]){12}"
+        },
+        "ListUserMemoryEntriesOutput": {
+            "type": "structure",
+            "required": ["memoryEntries"],
+            "members": {
+                "memoryEntries": {
+                    "shape": "MemoryEntryList"
+                },
+                "nextToken": {
+                    "shape": "ListUserMemoryEntriesOutputNextTokenString"
+                }
+            }
+        },
+        "ListUserMemoryEntriesOutputNextTokenString": {
+            "type": "string",
+            "min": 1,
+            "pattern": "[A-Za-z0-9_-]+"
+        },
         "ListWorkspaceMetadataRequest": {
             "type": "structure",
             "members": {
-                "workspaceRoot": { "shape": "ListWorkspaceMetadataRequestWorkspaceRootString" },
-                "nextToken": { "shape": "String" },
-                "maxResults": { "shape": "Integer" },
-                "profileArn": { "shape": "ProfileArn" }
+                "workspaceRoot": {
+                    "shape": "ListWorkspaceMetadataRequestWorkspaceRootString"
+                },
+                "nextToken": {
+                    "shape": "String"
+                },
+                "maxResults": {
+                    "shape": "Integer"
+                },
+                "profileArn": {
+                    "shape": "ProfileArn"
+                }
             }
         },
         "ListWorkspaceMetadataRequestWorkspaceRootString": {
@@ -2782,13 +3688,80 @@
             "type": "structure",
             "required": ["workspaces"],
             "members": {
-                "workspaces": { "shape": "WorkspaceList" },
-                "nextToken": { "shape": "String" }
+                "workspaces": {
+                    "shape": "WorkspaceList"
+                },
+                "nextToken": {
+                    "shape": "String"
+                }
             }
         },
         "Long": {
             "type": "long",
             "box": true
+        },
+        "MemoryEntry": {
+            "type": "structure",
+            "required": ["id", "memoryEntryString", "metadata"],
+            "members": {
+                "id": {
+                    "shape": "MemoryEntryIdString",
+                    "documentation": "<p>A unique identifier for a single memory entry</p>"
+                },
+                "memoryEntryString": {
+                    "shape": "MemoryEntryMemoryEntryStringString"
+                },
+                "metadata": {
+                    "shape": "MemoryEntryMetadata"
+                }
+            },
+            "documentation": "<p>MemoryEntry corresponds to a single user memory</p>"
+        },
+        "MemoryEntryIdString": {
+            "type": "string",
+            "max": 36,
+            "min": 36,
+            "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+        },
+        "MemoryEntryList": {
+            "type": "list",
+            "member": {
+                "shape": "MemoryEntry"
+            },
+            "documentation": "<p>List of user memories</p>"
+        },
+        "MemoryEntryMemoryEntryStringString": {
+            "type": "string",
+            "max": 500,
+            "min": 1,
+            "sensitive": true
+        },
+        "MemoryEntryMetadata": {
+            "type": "structure",
+            "required": ["origin", "createdAt", "updatedAt"],
+            "members": {
+                "origin": {
+                    "shape": "Origin"
+                },
+                "attributes": {
+                    "shape": "AttributesMap"
+                },
+                "createdAt": {
+                    "shape": "Timestamp"
+                },
+                "updatedAt": {
+                    "shape": "Timestamp"
+                },
+                "memoryStatus": {
+                    "shape": "MemoryStatus"
+                }
+            },
+            "documentation": "<p>Metadata for a single memory entry</p>"
+        },
+        "MemoryStatus": {
+            "type": "string",
+            "documentation": "<p>Status of user memory</p>",
+            "enum": ["DECRYPTION_FAILURE", "VALID"]
         },
         "MessageId": {
             "type": "string",
@@ -2836,6 +3809,11 @@
             "min": 1,
             "pattern": "[a-zA-Z0-9_:.-]+"
         },
+        "NextToken": {
+            "type": "string",
+            "max": 1000,
+            "min": 0
+        },
         "Notifications": {
             "type": "list",
             "member": {
@@ -2869,11 +3847,21 @@
         "OptInFeatures": {
             "type": "structure",
             "members": {
-                "promptLogging": { "shape": "PromptLogging" },
-                "byUserAnalytics": { "shape": "ByUserAnalytics" },
-                "dashboardAnalytics": { "shape": "DashboardAnalytics" },
-                "notifications": { "shape": "Notifications" },
-                "workspaceContext": { "shape": "WorkspaceContext" }
+                "promptLogging": {
+                    "shape": "PromptLogging"
+                },
+                "byUserAnalytics": {
+                    "shape": "ByUserAnalytics"
+                },
+                "dashboardAnalytics": {
+                    "shape": "DashboardAnalytics"
+                },
+                "notifications": {
+                    "shape": "Notifications"
+                },
+                "workspaceContext": {
+                    "shape": "WorkspaceContext"
+                }
             }
         },
         "OptOutPreference": {
@@ -2977,6 +3965,45 @@
             "min": 1,
             "sensitive": true
         },
+        "Prediction": {
+            "type": "structure",
+            "members": {
+                "completion": {
+                    "shape": "Completion"
+                },
+                "edit": {
+                    "shape": "Edit"
+                }
+            },
+            "union": true
+        },
+        "PredictionType": {
+            "type": "string",
+            "enum": ["COMPLETIONS", "EDITS"]
+        },
+        "PredictionTypes": {
+            "type": "list",
+            "member": {
+                "shape": "PredictionType"
+            }
+        },
+        "Predictions": {
+            "type": "list",
+            "member": {
+                "shape": "Prediction"
+            },
+            "max": 10,
+            "min": 0
+        },
+        "PreviousEditorStateMetadata": {
+            "type": "structure",
+            "required": ["timeOffset"],
+            "members": {
+                "timeOffset": {
+                    "shape": "Integer"
+                }
+            }
+        },
         "PrimitiveInteger": {
             "type": "integer"
         },
@@ -2992,6 +4019,9 @@
                 },
                 "profileName": {
                     "shape": "ProfileName"
+                },
+                "description": {
+                    "shape": "ProfileDescription"
                 },
                 "referenceTrackerConfiguration": {
                     "shape": "ReferenceTrackerConfiguration"
@@ -3029,7 +4059,13 @@
             "type": "string",
             "max": 950,
             "min": 0,
-            "pattern": "arn:aws:codewhisperer:[-.a-z0-9]{1,63}:\\d{12}:profile/([a-zA-Z0-9]){12}"
+            "pattern": "arn:aws:(codewhisperer|transform):[-.a-z0-9]{1,63}:\\d{12}:profile/([a-zA-Z0-9]){12}"
+        },
+        "ProfileDescription": {
+            "type": "string",
+            "max": 256,
+            "min": 1,
+            "pattern": "[\\sa-zA-Z0-9_-]*"
         },
         "ProfileList": {
             "type": "list",
@@ -3065,7 +4101,7 @@
             "type": "string",
             "max": 128,
             "min": 1,
-            "pattern": "(python|javascript|java|csharp|typescript|c|cpp|go|kotlin|php|ruby|rust|scala|shell|sql|json|yaml|vue|tf|tsx|jsx|plaintext|systemverilog|dart|lua|swift|powershell|r)"
+            "pattern": "(python|javascript|java|csharp|typescript|c|cpp|go|kotlin|php|ruby|rust|scala|shell|sql|json|yaml|vue|tf|tsx|jsx|plaintext|systemverilog|dart|lua|swift|hcl|powershell|r|abap)"
         },
         "ProgressUpdates": {
             "type": "list",
@@ -3084,6 +4120,26 @@
                     "shape": "OptInFeatureToggle"
                 }
             }
+        },
+        "PushTelemetryEventRequest": {
+            "type": "structure",
+            "required": ["eventType", "event"],
+            "members": {
+                "clientToken": {
+                    "shape": "IdempotencyToken",
+                    "idempotencyToken": true
+                },
+                "eventType": {
+                    "shape": "String"
+                },
+                "event": {
+                    "shape": "Document"
+                }
+            }
+        },
+        "PushTelemetryEventResponse": {
+            "type": "structure",
+            "members": {}
         },
         "Range": {
             "type": "structure",
@@ -3164,7 +4220,7 @@
             "member": {
                 "shape": "RelevantTextDocument"
             },
-            "max": 30,
+            "max": 100,
             "min": 0
         },
         "RelevantTextDocument": {
@@ -3186,6 +4242,10 @@
                 "documentSymbols": {
                     "shape": "DocumentSymbols",
                     "documentation": "<p>DocumentSymbols parsed from a text document</p>"
+                },
+                "type": {
+                    "shape": "ContentType",
+                    "documentation": "<p>The type of content(file, prompt, symbol, or workspace)</p>"
                 }
             },
             "documentation": "<p>Represents an IDE retrieved relevant Text Document / File</p>"
@@ -3321,9 +4381,15 @@
             "type": "structure",
             "required": ["instanceArn", "oidcClientId"],
             "members": {
-                "instanceArn": { "shape": "ResourceArn" },
-                "oidcClientId": { "shape": "String" },
-                "ssoRegion": { "shape": "SSORegion" }
+                "instanceArn": {
+                    "shape": "ResourceArn"
+                },
+                "oidcClientId": {
+                    "shape": "String"
+                },
+                "ssoRegion": {
+                    "shape": "SSORegion"
+                }
             }
         },
         "SSORegion": {
@@ -3377,10 +4443,18 @@
             "members": {
                 "message": {
                     "shape": "String"
+                },
+                "reason": {
+                    "shape": "ServiceQuotaExceededExceptionReason"
                 }
             },
             "documentation": "<p>This exception is thrown when request was denied due to caller exceeding their usage limits</p>",
             "exception": true
+        },
+        "ServiceQuotaExceededExceptionReason": {
+            "type": "string",
+            "documentation": "<p>Reason for ServiceQuotaExceededException</p>",
+            "enum": ["CONVERSATION_LIMIT_EXCEEDED"]
         },
         "ShellHistory": {
             "type": "list",
@@ -3658,6 +4732,9 @@
                 },
                 "profileArn": {
                     "shape": "ProfileArn"
+                },
+                "referenceTrackerConfiguration": {
+                    "shape": "ReferenceTrackerConfiguration"
                 }
             },
             "documentation": "<p>Structure to represent test generation request.</p>"
@@ -3739,6 +4816,25 @@
         "String": {
             "type": "string"
         },
+        "StringList": {
+            "type": "list",
+            "member": {
+                "shape": "StringListMemberString"
+            },
+            "documentation": "<p>A list of strings</p>",
+            "max": 50,
+            "min": 0
+        },
+        "StringListMemberString": {
+            "type": "string",
+            "max": 256,
+            "min": 1,
+            "sensitive": true
+        },
+        "SubscriptionStatus": {
+            "type": "string",
+            "enum": ["INACTIVE", "ACTIVE"]
+        },
         "SuggestedFix": {
             "type": "structure",
             "members": {
@@ -3778,6 +4874,12 @@
                 },
                 "content": {
                     "shape": "SupplementalContextContentString"
+                },
+                "type": {
+                    "shape": "SupplementalContextType"
+                },
+                "metadata": {
+                    "shape": "SupplementalContextMetadata"
                 }
             }
         },
@@ -3798,8 +4900,21 @@
             "member": {
                 "shape": "SupplementalContext"
             },
-            "max": 5,
+            "max": 20,
             "min": 0
+        },
+        "SupplementalContextMetadata": {
+            "type": "structure",
+            "members": {
+                "previousEditorStateMetadata": {
+                    "shape": "PreviousEditorStateMetadata"
+                }
+            },
+            "union": true
+        },
+        "SupplementalContextType": {
+            "type": "string",
+            "enum": ["PreviousEditorState", "WorkspaceContext"]
         },
         "SupplementaryWebLink": {
             "type": "structure",
@@ -3834,7 +4949,7 @@
         },
         "SupplementaryWebLinkUrlString": {
             "type": "string",
-            "max": 1024,
+            "max": 2048,
             "min": 1,
             "sensitive": true
         },
@@ -3849,6 +4964,10 @@
         "SymbolType": {
             "type": "string",
             "enum": ["DECLARATION", "USAGE"]
+        },
+        "SyntheticTimestamp_date_time": {
+            "type": "timestamp",
+            "timestampFormat": "iso8601"
         },
         "TargetCode": {
             "type": "structure",
@@ -4267,9 +5386,41 @@
                 "message": {
                     "shape": "TextDocumentDiagnosticMessageString",
                     "documentation": "<p>The diagnostic's message.</p>"
+                },
+                "code": {
+                    "shape": "TextDocumentDiagnosticCodeString",
+                    "documentation": "<p>The diagnostic's code, which might appear in the user interface.</p>"
+                },
+                "codeDescription": {
+                    "shape": "CodeDescription",
+                    "documentation": "<p>An optional property to describe the error code.</p>"
+                },
+                "tags": {
+                    "shape": "DiagnosticTagList",
+                    "documentation": "<p>Additional metadata about the diagnostic.</p>"
+                },
+                "relatedInformation": {
+                    "shape": "DiagnosticRelatedInformationList",
+                    "documentation": "<p>an array of related diagnostic information, e.g. when symbol-names within a scope collide all definitions can be marked via this property.</p>"
+                },
+                "data": {
+                    "shape": "TextDocumentDiagnosticDataString",
+                    "documentation": "<p>A data entry field that is preserved between a <code>textDocument/publishDiagnostics</code> notification and <code>textDocument/codeAction</code> request.</p>"
                 }
             },
             "documentation": "<p>Structure to represent metadata about a TextDocument Diagnostic</p>"
+        },
+        "TextDocumentDiagnosticCodeString": {
+            "type": "string",
+            "max": 1024,
+            "min": 0,
+            "sensitive": true
+        },
+        "TextDocumentDiagnosticDataString": {
+            "type": "string",
+            "max": 4096,
+            "min": 0,
+            "sensitive": true
         },
         "TextDocumentDiagnosticMessageString": {
             "type": "string",
@@ -4345,7 +5496,7 @@
             "documentation": "<p>The name for the tool.</p>",
             "max": 64,
             "min": 0,
-            "pattern": "[a-zA-Z][a-zA-Z0-9_]*",
+            "pattern": "[a-zA-Z0-9_-]+",
             "sensitive": true
         },
         "ToolResult": {
@@ -4387,7 +5538,7 @@
         },
         "ToolResultContentBlockTextString": {
             "type": "string",
-            "max": 30720,
+            "max": 800000,
             "min": 0,
             "sensitive": true
         },
@@ -4766,6 +5917,53 @@
             "max": 36,
             "min": 36
         },
+        "UpdateUsageLimitQuotaExceededException": {
+            "type": "structure",
+            "required": ["message"],
+            "members": {
+                "message": {
+                    "shape": "String"
+                }
+            },
+            "documentation": "<p>Exception thrown when the number of usage limit update requests exceeds the monthly quota (default 3 requests per month)</p>",
+            "exception": true
+        },
+        "UpdateUsageLimitsRequest": {
+            "type": "structure",
+            "required": ["accountId", "featureType", "requestedLimit"],
+            "members": {
+                "accountId": {
+                    "shape": "String"
+                },
+                "accountlessUserId": {
+                    "shape": "String"
+                },
+                "featureType": {
+                    "shape": "UsageLimitType"
+                },
+                "requestedLimit": {
+                    "shape": "Long"
+                },
+                "justification": {
+                    "shape": "String"
+                }
+            }
+        },
+        "UpdateUsageLimitsResponse": {
+            "type": "structure",
+            "required": ["status"],
+            "members": {
+                "status": {
+                    "shape": "UsageLimitUpdateRequestStatus"
+                },
+                "approvedLimit": {
+                    "shape": "Long"
+                },
+                "remainingRequestsThisMonth": {
+                    "shape": "Integer"
+                }
+            }
+        },
         "UploadContext": {
             "type": "structure",
             "members": {
@@ -4810,6 +6008,40 @@
             "type": "string",
             "max": 1024,
             "min": 1
+        },
+        "UsageLimitList": {
+            "type": "structure",
+            "required": ["type", "currentUsage", "totalUsageLimit"],
+            "members": {
+                "type": {
+                    "shape": "UsageLimitType"
+                },
+                "currentUsage": {
+                    "shape": "Long"
+                },
+                "totalUsageLimit": {
+                    "shape": "Long"
+                },
+                "percentUsed": {
+                    "shape": "Double"
+                }
+            }
+        },
+        "UsageLimitType": {
+            "type": "string",
+            "enum": ["CODE_COMPLETIONS", "AGENTIC_REQUEST", "AI_EDITOR", "TRANSFORM"]
+        },
+        "UsageLimitUpdateRequestStatus": {
+            "type": "string",
+            "enum": ["APPROVED", "PENDING_REVIEW", "REJECTED"]
+        },
+        "UsageLimits": {
+            "type": "list",
+            "member": {
+                "shape": "UsageLimitList"
+            },
+            "max": 10,
+            "min": 0
         },
         "UserContext": {
             "type": "structure",
@@ -4857,13 +6089,21 @@
                 "origin": {
                     "shape": "Origin",
                     "documentation": "<p>User Input Origin.</p>"
+                },
+                "images": {
+                    "shape": "ImageBlocks",
+                    "documentation": "<p>Images associated with the Chat Message.</p>"
+                },
+                "modelId": {
+                    "shape": "ModelId",
+                    "documentation": "<p>Unique identifier for the model used in this conversation</p>"
                 }
             },
             "documentation": "<p>Structure to represent a chat input message from User.</p>"
         },
         "UserInputMessageContentString": {
             "type": "string",
-            "max": 160000,
+            "max": 600000,
             "min": 0,
             "sensitive": true
         },
@@ -4968,8 +6208,22 @@
                 },
                 "unmodifiedAcceptedCharacterCount": {
                     "shape": "PrimitiveInteger"
+                },
+                "addedCharacterCount": {
+                    "shape": "UserModificationEventAddedCharacterCountInteger"
+                },
+                "unmodifiedAddedCharacterCount": {
+                    "shape": "UserModificationEventUnmodifiedAddedCharacterCountInteger"
                 }
             }
+        },
+        "UserModificationEventAddedCharacterCountInteger": {
+            "type": "integer",
+            "min": 0
+        },
+        "UserModificationEventUnmodifiedAddedCharacterCountInteger": {
+            "type": "integer",
+            "min": 0
         },
         "UserSettings": {
             "type": "structure",
@@ -5033,8 +6287,35 @@
                 },
                 "acceptedCharacterCount": {
                     "shape": "PrimitiveInteger"
+                },
+                "addedIdeDiagnostics": {
+                    "shape": "IdeDiagnosticList"
+                },
+                "removedIdeDiagnostics": {
+                    "shape": "IdeDiagnosticList"
+                },
+                "addedCharacterCount": {
+                    "shape": "UserTriggerDecisionEventAddedCharacterCountInteger"
+                },
+                "deletedCharacterCount": {
+                    "shape": "UserTriggerDecisionEventDeletedCharacterCountInteger"
+                },
+                "streakLength": {
+                    "shape": "UserTriggerDecisionEventStreakLengthInteger"
                 }
             }
+        },
+        "UserTriggerDecisionEventAddedCharacterCountInteger": {
+            "type": "integer",
+            "min": 0
+        },
+        "UserTriggerDecisionEventDeletedCharacterCountInteger": {
+            "type": "integer",
+            "min": 0
+        },
+        "UserTriggerDecisionEventStreakLengthInteger": {
+            "type": "integer",
+            "min": 0
         },
         "ValidationException": {
             "type": "structure",
@@ -5059,21 +6340,31 @@
             "type": "structure",
             "required": ["toggle"],
             "members": {
-                "toggle": { "shape": "OptInFeatureToggle" }
+                "toggle": {
+                    "shape": "OptInFeatureToggle"
+                }
             }
         },
         "WorkspaceContextUploadContext": {
             "type": "structure",
             "required": ["workspaceId", "relativePath", "programmingLanguage"],
             "members": {
-                "workspaceId": { "shape": "UUID" },
-                "relativePath": { "shape": "SensitiveString" },
-                "programmingLanguage": { "shape": "ProgrammingLanguage" }
+                "workspaceId": {
+                    "shape": "UUID"
+                },
+                "relativePath": {
+                    "shape": "SensitiveString"
+                },
+                "programmingLanguage": {
+                    "shape": "ProgrammingLanguage"
+                }
             }
         },
         "WorkspaceFolderList": {
             "type": "list",
-            "member": { "shape": "WorkspaceFolderListMemberString" },
+            "member": {
+                "shape": "WorkspaceFolderListMemberString"
+            },
             "max": 100,
             "min": 0
         },
@@ -5085,16 +6376,26 @@
         },
         "WorkspaceList": {
             "type": "list",
-            "member": { "shape": "WorkspaceMetadata" }
+            "member": {
+                "shape": "WorkspaceMetadata"
+            }
         },
         "WorkspaceMetadata": {
             "type": "structure",
             "required": ["workspaceId", "workspaceStatus"],
             "members": {
-                "workspaceId": { "shape": "UUID" },
-                "workspaceStatus": { "shape": "WorkspaceStatus" },
-                "environmentAddress": { "shape": "SensitiveString" },
-                "environmentId": { "shape": "SensitiveString" }
+                "workspaceId": {
+                    "shape": "UUID"
+                },
+                "workspaceStatus": {
+                    "shape": "WorkspaceStatus"
+                },
+                "environmentAddress": {
+                    "shape": "SensitiveString"
+                },
+                "environmentId": {
+                    "shape": "SensitiveString"
+                }
             }
         },
         "WorkspaceState": {

--- a/server/aws-lsp-codewhisperer/src/client/token/codewhispererbearertokenclient.d.ts
+++ b/server/aws-lsp-codewhisperer/src/client/token/codewhispererbearertokenclient.d.ts
@@ -4,12 +4,12 @@
  * DO NOT EDIT BY HAND.
  */
 
-import { Request } from 'aws-sdk/lib/request';
-import { Response } from 'aws-sdk/lib/response';
-import { AWSError } from 'aws-sdk/lib/error';
-import { Service } from 'aws-sdk/lib/service';
-import { ServiceConfigurationOptions } from 'aws-sdk/lib/service';
-import { ConfigBase as Config } from 'aws-sdk/lib/config-base';
+import {Request} from 'aws-sdk/lib/request';
+import {Response} from 'aws-sdk/lib/response';
+import {AWSError} from 'aws-sdk/lib/error';
+import {Service} from 'aws-sdk/lib/service';
+import {ServiceConfigurationOptions} from 'aws-sdk/lib/service';
+import {ConfigBase as Config} from 'aws-sdk/lib/config-base';
 interface Blob {}
 declare class CodeWhispererBearerTokenClient extends Service {
   /**
@@ -25,6 +25,14 @@ declare class CodeWhispererBearerTokenClient extends Service {
    * Creates a pre-signed, S3 write URL for uploading a repository zip archive.
    */
   createArtifactUploadUrl(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse, AWSError>;
+  /**
+   * 
+   */
+  createSubscriptionToken(params: CodeWhispererBearerTokenClient.Types.CreateSubscriptionTokenRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateSubscriptionTokenResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateSubscriptionTokenResponse, AWSError>;
+  /**
+   * 
+   */
+  createSubscriptionToken(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateSubscriptionTokenResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateSubscriptionTokenResponse, AWSError>;
   /**
    * API to create task assist conversation.
    */
@@ -42,6 +50,14 @@ declare class CodeWhispererBearerTokenClient extends Service {
    */
   createUploadUrl(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateUploadUrlResponse, AWSError>;
   /**
+   * API to create a single user memory entry
+   */
+  createUserMemoryEntry(params: CodeWhispererBearerTokenClient.Types.CreateUserMemoryEntryInput, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateUserMemoryEntryOutput) => void): Request<CodeWhispererBearerTokenClient.Types.CreateUserMemoryEntryOutput, AWSError>;
+  /**
+   * API to create a single user memory entry
+   */
+  createUserMemoryEntry(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateUserMemoryEntryOutput) => void): Request<CodeWhispererBearerTokenClient.Types.CreateUserMemoryEntryOutput, AWSError>;
+  /**
    * Create a workspace based on a workspace root
    */
   createWorkspace(params: CodeWhispererBearerTokenClient.Types.CreateWorkspaceRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.CreateWorkspaceResponse) => void): Request<CodeWhispererBearerTokenClient.Types.CreateWorkspaceResponse, AWSError>;
@@ -57,6 +73,14 @@ declare class CodeWhispererBearerTokenClient extends Service {
    * API to delete task assist conversation.
    */
   deleteTaskAssistConversation(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.DeleteTaskAssistConversationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.DeleteTaskAssistConversationResponse, AWSError>;
+  /**
+   * API to delete a single user memory entry
+   */
+  deleteUserMemoryEntry(params: CodeWhispererBearerTokenClient.Types.DeleteUserMemoryEntryInput, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.DeleteUserMemoryEntryOutput) => void): Request<CodeWhispererBearerTokenClient.Types.DeleteUserMemoryEntryOutput, AWSError>;
+  /**
+   * API to delete a single user memory entry
+   */
+  deleteUserMemoryEntry(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.DeleteUserMemoryEntryOutput) => void): Request<CodeWhispererBearerTokenClient.Types.DeleteUserMemoryEntryOutput, AWSError>;
   /**
    * Delete a workspace based on a workspaceId
    */
@@ -82,11 +106,11 @@ declare class CodeWhispererBearerTokenClient extends Service {
    */
   getCodeAnalysis(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetCodeAnalysisResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetCodeAnalysisResponse, AWSError>;
   /**
-   *
+   * 
    */
   getCodeFixJob(params: CodeWhispererBearerTokenClient.Types.GetCodeFixJobRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetCodeFixJobResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetCodeFixJobResponse, AWSError>;
   /**
-   *
+   * 
    */
   getCodeFixJob(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetCodeFixJobResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetCodeFixJobResponse, AWSError>;
   /**
@@ -122,19 +146,27 @@ declare class CodeWhispererBearerTokenClient extends Service {
    */
   getTransformationPlan(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetTransformationPlanResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetTransformationPlanResponse, AWSError>;
   /**
-   *
+   * API to get current usage limits
+   */
+  getUsageLimits(params: CodeWhispererBearerTokenClient.Types.GetUsageLimitsRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetUsageLimitsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetUsageLimitsResponse, AWSError>;
+  /**
+   * API to get current usage limits
+   */
+  getUsageLimits(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.GetUsageLimitsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.GetUsageLimitsResponse, AWSError>;
+  /**
+   * 
    */
   listAvailableCustomizations(params: CodeWhispererBearerTokenClient.Types.ListAvailableCustomizationsRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListAvailableCustomizationsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListAvailableCustomizationsResponse, AWSError>;
   /**
-   *
+   * 
    */
   listAvailableCustomizations(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListAvailableCustomizationsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListAvailableCustomizationsResponse, AWSError>;
   /**
-   *
+   * 
    */
   listAvailableProfiles(params: CodeWhispererBearerTokenClient.Types.ListAvailableProfilesRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListAvailableProfilesResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListAvailableProfilesResponse, AWSError>;
   /**
-   *
+   * 
    */
   listAvailableProfiles(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListAvailableProfilesResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListAvailableProfilesResponse, AWSError>;
   /**
@@ -146,6 +178,14 @@ declare class CodeWhispererBearerTokenClient extends Service {
    */
   listCodeAnalysisFindings(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListCodeAnalysisFindingsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListCodeAnalysisFindingsResponse, AWSError>;
   /**
+   * List events for agent activity
+   */
+  listEvents(params: CodeWhispererBearerTokenClient.Types.ListEventsRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListEventsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListEventsResponse, AWSError>;
+  /**
+   * List events for agent activity
+   */
+  listEvents(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListEventsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListEventsResponse, AWSError>;
+  /**
    * Return configruations for each feature that has been setup for A/B testing.
    */
   listFeatureEvaluations(params: CodeWhispererBearerTokenClient.Types.ListFeatureEvaluationsRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListFeatureEvaluationsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListFeatureEvaluationsResponse, AWSError>;
@@ -154,6 +194,14 @@ declare class CodeWhispererBearerTokenClient extends Service {
    */
   listFeatureEvaluations(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListFeatureEvaluationsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListFeatureEvaluationsResponse, AWSError>;
   /**
+   * API to list user memories
+   */
+  listUserMemoryEntries(params: CodeWhispererBearerTokenClient.Types.ListUserMemoryEntriesInput, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListUserMemoryEntriesOutput) => void): Request<CodeWhispererBearerTokenClient.Types.ListUserMemoryEntriesOutput, AWSError>;
+  /**
+   * API to list user memories
+   */
+  listUserMemoryEntries(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListUserMemoryEntriesOutput) => void): Request<CodeWhispererBearerTokenClient.Types.ListUserMemoryEntriesOutput, AWSError>;
+  /**
    * List workspace metadata based on a workspace root
    */
   listWorkspaceMetadata(params: CodeWhispererBearerTokenClient.Types.ListWorkspaceMetadataRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListWorkspaceMetadataResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListWorkspaceMetadataResponse, AWSError>;
@@ -161,6 +209,14 @@ declare class CodeWhispererBearerTokenClient extends Service {
    * List workspace metadata based on a workspace root
    */
   listWorkspaceMetadata(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.ListWorkspaceMetadataResponse) => void): Request<CodeWhispererBearerTokenClient.Types.ListWorkspaceMetadataResponse, AWSError>;
+  /**
+   * API to push telemetry events to CloudWatch, DataHub and EventBridge.
+   */
+  pushTelemetryEvent(params: CodeWhispererBearerTokenClient.Types.PushTelemetryEventRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.PushTelemetryEventResponse) => void): Request<CodeWhispererBearerTokenClient.Types.PushTelemetryEventResponse, AWSError>;
+  /**
+   * API to push telemetry events to CloudWatch, DataHub and EventBridge.
+   */
+  pushTelemetryEvent(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.PushTelemetryEventResponse) => void): Request<CodeWhispererBearerTokenClient.Types.PushTelemetryEventResponse, AWSError>;
   /**
    * API to resume transformation job.
    */
@@ -186,11 +242,11 @@ declare class CodeWhispererBearerTokenClient extends Service {
    */
   startCodeAnalysis(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartCodeAnalysisResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartCodeAnalysisResponse, AWSError>;
   /**
-   *
+   * 
    */
   startCodeFixJob(params: CodeWhispererBearerTokenClient.Types.StartCodeFixJobRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartCodeFixJobResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartCodeFixJobResponse, AWSError>;
   /**
-   *
+   * 
    */
   startCodeFixJob(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StartCodeFixJobResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StartCodeFixJobResponse, AWSError>;
   /**
@@ -225,8 +281,17 @@ declare class CodeWhispererBearerTokenClient extends Service {
    * API to stop code transformation status.
    */
   stopTransformation(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.StopTransformationResponse) => void): Request<CodeWhispererBearerTokenClient.Types.StopTransformationResponse, AWSError>;
+  /**
+   * API to update usage limits for enterprise customers
+   */
+  updateUsageLimits(params: CodeWhispererBearerTokenClient.Types.UpdateUsageLimitsRequest, callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.UpdateUsageLimitsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.UpdateUsageLimitsResponse, AWSError>;
+  /**
+   * API to update usage limits for enterprise customers
+   */
+  updateUsageLimits(callback?: (err: AWSError, data: CodeWhispererBearerTokenClient.Types.UpdateUsageLimitsResponse) => void): Request<CodeWhispererBearerTokenClient.Types.UpdateUsageLimitsResponse, AWSError>;
 }
 declare namespace CodeWhispererBearerTokenClient {
+  export type ActivationToken = string;
   export type ActiveFunctionalityList = FunctionalityName[];
   export interface AdditionalContentEntry {
     /**
@@ -246,7 +311,7 @@ declare namespace CodeWhispererBearerTokenClient {
   export type AdditionalContentEntryInnerContextString = string;
   export type AdditionalContentEntryNameString = string;
   export type AdditionalContentList = AdditionalContentEntry[];
-  export type AgenticChatEventStatus = "SUCCEEDED" | "CANCELLED" | "FAILED" | string;
+  export type AgenticChatEventStatus = "SUCCEEDED"|"CANCELLED"|"FAILED"|string;
   export interface AppStudioState {
     /**
      * The namespace of the context. Examples: 'ui.Button', 'ui.Table.DataSource', 'ui.Table.RowActions.Button', 'logic.invokeAWS', 'logic.JavaScript'
@@ -277,8 +342,8 @@ declare namespace CodeWhispererBearerTokenClient {
   }
   export type ApplicationPropertiesList = ApplicationProperties[];
   export type ArtifactId = string;
-  export type ArtifactMap = { [key: string]: UploadId };
-  export type ArtifactType = "SourceCode" | "BuiltJars" | string;
+  export type ArtifactMap = {[key: string]: UploadId};
+  export type ArtifactType = "SourceCode"|"BuiltJars"|string;
   export interface AssistantResponseMessage {
     messageId?: MessageId;
     /**
@@ -303,11 +368,17 @@ declare namespace CodeWhispererBearerTokenClient {
     toolUses?: ToolUses;
   }
   export type AssistantResponseMessageContentString = string;
+  export type AttributesMap = {[key: string]: StringList};
+  export type AttributesMapKeyString = string;
   export type Base64EncodedPaginationToken = string;
   export type Boolean = boolean;
   export interface ByUserAnalytics {
     s3Uri?: S3Uri;
     toggle: OptInFeatureToggle;
+  }
+  export type ChangeLogGranularityType = "STANDARD"|"BUSINESS"|string;
+  export interface ChangeLogOptions {
+    granularity: ChangeLogGranularityType;
   }
   export interface ChatAddMessageEvent {
     conversationId: ConversationId;
@@ -338,14 +409,16 @@ declare namespace CodeWhispererBearerTokenClient {
     acceptedSnippetHasReference?: Boolean;
     hasProjectLevelContext?: Boolean;
     userIntent?: UserIntent;
+    addedIdeDiagnostics?: IdeDiagnosticList;
+    removedIdeDiagnostics?: IdeDiagnosticList;
   }
   export type ChatInteractWithMessageEventInteractionTargetString = string;
   export interface ChatMessage {
     userInputMessage?: UserInputMessage;
     assistantResponseMessage?: AssistantResponseMessage;
   }
-  export type ChatMessageInteractionType = "INSERT_AT_CURSOR" | "COPY_SNIPPET" | "COPY" | "CLICK_LINK" | "CLICK_BODY_LINK" | "CLICK_FOLLOW_UP" | "HOVER_REFERENCE" | "UPVOTE" | "DOWNVOTE" | string;
-  export type ChatTriggerType = "MANUAL" | "DIAGNOSTIC" | "INLINE_CHAT" | string;
+  export type ChatMessageInteractionType = "INSERT_AT_CURSOR"|"COPY_SNIPPET"|"COPY"|"CLICK_LINK"|"CLICK_BODY_LINK"|"CLICK_FOLLOW_UP"|"HOVER_REFERENCE"|"UPVOTE"|"DOWNVOTE"|string;
+  export type ChatTriggerType = "MANUAL"|"DIAGNOSTIC"|"INLINE_CHAT"|string;
   export interface ChatUserModificationEvent {
     conversationId: ConversationId;
     customizationArn?: CustomizationArn;
@@ -354,9 +427,10 @@ declare namespace CodeWhispererBearerTokenClient {
     modificationPercentage: Double;
     hasProjectLevelContext?: Boolean;
   }
-  export type CodeAnalysisFindingsSchema = "codeanalysis/findings/1.0" | string;
-  export type CodeAnalysisScope = "FILE" | "PROJECT" | string;
-  export type CodeAnalysisStatus = "Completed" | "Pending" | "Failed" | string;
+  export type ClientId = string;
+  export type CodeAnalysisFindingsSchema = "codeanalysis/findings/1.0"|string;
+  export type CodeAnalysisScope = "FILE"|"PROJECT"|string;
+  export type CodeAnalysisStatus = "Completed"|"Pending"|"Failed"|string;
   export interface CodeAnalysisUploadContext {
     codeScanName: CodeScanName;
   }
@@ -371,9 +445,18 @@ declare namespace CodeWhispererBearerTokenClient {
     totalNewCodeLineCount?: PrimitiveInteger;
     userWrittenCodeCharacterCount?: CodeCoverageEventUserWrittenCodeCharacterCountInteger;
     userWrittenCodeLineCount?: CodeCoverageEventUserWrittenCodeLineCountInteger;
+    addedCharacterCount?: CodeCoverageEventAddedCharacterCountInteger;
   }
+  export type CodeCoverageEventAddedCharacterCountInteger = number;
   export type CodeCoverageEventUserWrittenCodeCharacterCountInteger = number;
   export type CodeCoverageEventUserWrittenCodeLineCountInteger = number;
+  export interface CodeDescription {
+    /**
+     * An URI to open with more information about the diagnostic error.
+     */
+    href: CodeDescriptionHrefString;
+  }
+  export type CodeDescriptionHrefString = string;
   export interface CodeFixAcceptanceEvent {
     jobId: String;
     ruleId?: String;
@@ -392,7 +475,7 @@ declare namespace CodeWhispererBearerTokenClient {
     linesOfCodeGenerated?: Integer;
     charsOfCodeGenerated?: Integer;
   }
-  export type CodeFixJobStatus = "Succeeded" | "InProgress" | "Failed" | string;
+  export type CodeFixJobStatus = "Succeeded"|"InProgress"|"Failed"|string;
   export type CodeFixName = string;
   export interface CodeFixUploadContext {
     codeFixName: CodeFixName;
@@ -403,8 +486,8 @@ declare namespace CodeWhispererBearerTokenClient {
     currentStage: CodeGenerationWorkflowStage;
   }
   export type CodeGenerationStatusDetail = string;
-  export type CodeGenerationWorkflowStage = "InitialCodeGeneration" | "CodeRefinement" | string;
-  export type CodeGenerationWorkflowStatus = "InProgress" | "Complete" | "Failed" | string;
+  export type CodeGenerationWorkflowStage = "InitialCodeGeneration"|"CodeRefinement"|string;
+  export type CodeGenerationWorkflowStatus = "InProgress"|"Complete"|"Failed"|string;
   export interface CodeScanEvent {
     programmingLanguage: ProgrammingLanguage;
     codeScanJobId: CodeScanJobId;
@@ -431,7 +514,7 @@ declare namespace CodeWhispererBearerTokenClient {
     result?: String;
     includesFix?: Boolean;
   }
-  export type CodeScanRemediationsEventType = "CODESCAN_ISSUE_HOVER" | "CODESCAN_ISSUE_APPLY_FIX" | "CODESCAN_ISSUE_VIEW_DETAILS" | string;
+  export type CodeScanRemediationsEventType = "CODESCAN_ISSUE_HOVER"|"CODESCAN_ISSUE_APPLY_FIX"|"CODESCAN_ISSUE_VIEW_DETAILS"|string;
   export interface CodeScanSucceededEvent {
     programmingLanguage: ProgrammingLanguage;
     codeScanJobId: CodeScanJobId;
@@ -445,7 +528,7 @@ declare namespace CodeWhispererBearerTokenClient {
     mostRelevantMissingImports?: Imports;
   }
   export type CompletionContentString = string;
-  export type CompletionType = "BLOCK" | "LINE" | string;
+  export type CompletionType = "BLOCK"|"LINE"|string;
   export type Completions = Completion[];
   export interface ConsoleState {
     region?: String;
@@ -455,8 +538,9 @@ declare namespace CodeWhispererBearerTokenClient {
     serviceSubconsolePage?: String;
     taskName?: SensitiveString;
   }
-  export type ContentChecksumType = "SHA_256" | string;
-  export type ContextTruncationScheme = "ANALYSIS" | "GUMBY" | string;
+  export type ContentChecksumType = "SHA_256"|string;
+  export type ContentType = "FILE"|"PROMPT"|"CODE"|"WORKSPACE"|string;
+  export type ContextTruncationScheme = "ANALYSIS"|"GUMBY"|string;
   export type ConversationId = string;
   export interface ConversationState {
     /**
@@ -480,6 +564,15 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     chatTriggerType: ChatTriggerType;
     customizationArn?: ResourceArn;
+  }
+  export interface CreateSubscriptionTokenRequest {
+    clientToken?: IdempotencyToken;
+    statusOnly?: Boolean;
+  }
+  export interface CreateSubscriptionTokenResponse {
+    encodedVerificationUrl?: EncodedVerificationUrl;
+    token?: ActivationToken;
+    status: SubscriptionStatus;
   }
   export interface CreateTaskAssistConversationRequest {
     profileArn?: ProfileArn;
@@ -507,6 +600,20 @@ declare namespace CodeWhispererBearerTokenClient {
     kmsKeyArn?: ResourceArn;
     requestHeaders?: RequestHeaders;
   }
+  export interface CreateUserMemoryEntryInput {
+    memoryEntryString: CreateUserMemoryEntryInputMemoryEntryStringString;
+    origin: Origin;
+    /**
+     * ProfileArn for the managing Q Profile
+     */
+    profileArn?: CreateUserMemoryEntryInputProfileArnString;
+    clientToken?: IdempotencyToken;
+  }
+  export type CreateUserMemoryEntryInputMemoryEntryStringString = string;
+  export type CreateUserMemoryEntryInputProfileArnString = string;
+  export interface CreateUserMemoryEntryOutput {
+    memoryEntry: MemoryEntry;
+  }
   export interface CreateWorkspaceRequest {
     workspaceRoot: CreateWorkspaceRequestWorkspaceRootString;
     profileArn?: ProfileArn;
@@ -529,6 +636,7 @@ declare namespace CodeWhispererBearerTokenClient {
     arn: CustomizationArn;
     name?: CustomizationName;
     description?: Description;
+    modelId?: ModelId;
   }
   export type CustomizationArn = string;
   export type CustomizationName = string;
@@ -542,6 +650,17 @@ declare namespace CodeWhispererBearerTokenClient {
   }
   export interface DeleteTaskAssistConversationResponse {
     conversationId: ConversationId;
+  }
+  export interface DeleteUserMemoryEntryInput {
+    id: DeleteUserMemoryEntryInputIdString;
+    /**
+     * ProfileArn for the managing Q Profile
+     */
+    profileArn?: DeleteUserMemoryEntryInputProfileArnString;
+  }
+  export type DeleteUserMemoryEntryInputIdString = string;
+  export type DeleteUserMemoryEntryInputProfileArnString = string;
+  export interface DeleteUserMemoryEntryOutput {
   }
   export interface DeleteWorkspaceRequest {
     workspaceId: UUID;
@@ -560,7 +679,26 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     runtimeDiagnostic?: RuntimeDiagnostic;
   }
-  export type DiagnosticSeverity = "ERROR" | "WARNING" | "INFORMATION" | "HINT" | string;
+  export interface DiagnosticLocation {
+    uri: DiagnosticLocationUriString;
+    range: Range;
+  }
+  export type DiagnosticLocationUriString = string;
+  export interface DiagnosticRelatedInformation {
+    /**
+     * The location of this related diagnostic information.
+     */
+    location: DiagnosticLocation;
+    /**
+     * The message of this related diagnostic information.
+     */
+    message: DiagnosticRelatedInformationMessageString;
+  }
+  export type DiagnosticRelatedInformationList = DiagnosticRelatedInformation[];
+  export type DiagnosticRelatedInformationMessageString = string;
+  export type DiagnosticSeverity = "ERROR"|"WARNING"|"INFORMATION"|"HINT"|string;
+  export type DiagnosticTag = "UNNECESSARY"|"DEPRECATED"|string;
+  export type DiagnosticTagList = DiagnosticTag[];
   export interface Dimension {
     name?: DimensionNameString;
     value?: DimensionValueString;
@@ -568,7 +706,7 @@ declare namespace CodeWhispererBearerTokenClient {
   export type DimensionList = Dimension[];
   export type DimensionNameString = string;
   export type DimensionValueString = string;
-  export type DocFolderLevel = "SUB_FOLDER" | "ENTIRE_WORKSPACE" | string;
+  export type DocFolderLevel = "SUB_FOLDER"|"ENTIRE_WORKSPACE"|string;
   export interface DocGenerationEvent {
     conversationId: ConversationId;
     numberOfAddChars?: PrimitiveInteger;
@@ -580,8 +718,8 @@ declare namespace CodeWhispererBearerTokenClient {
     numberOfNavigation?: PrimitiveInteger;
     folderLevel?: DocFolderLevel;
   }
-  export type DocInteractionType = "GENERATE_README" | "UPDATE_README" | "EDIT_README" | string;
-  export type DocUserDecision = "ACCEPT" | "REJECT" | string;
+  export type DocInteractionType = "GENERATE_README"|"UPDATE_README"|"EDIT_README"|string;
+  export type DocUserDecision = "ACCEPT"|"REJECT"|string;
   export interface DocV2AcceptanceEvent {
     conversationId: ConversationId;
     numberOfAddedChars: DocV2AcceptanceEventNumberOfAddedCharsInteger;
@@ -609,6 +747,8 @@ declare namespace CodeWhispererBearerTokenClient {
   export type DocV2GenerationEventNumberOfGeneratedFilesInteger = number;
   export type DocV2GenerationEventNumberOfGeneratedLinesInteger = number;
   export type DocV2GenerationEventNumberOfNavigationsInteger = number;
+  export interface Document {
+  }
   export interface DocumentSymbol {
     /**
      * Name of the Document Symbol
@@ -629,10 +769,16 @@ declare namespace CodeWhispererBearerTokenClient {
   export interface DocumentationIntentContext {
     scope?: DocumentationIntentContextScopeString;
     type: DocumentationType;
+    changeLogOptions?: ChangeLogOptions;
   }
   export type DocumentationIntentContextScopeString = string;
-  export type DocumentationType = "README" | string;
+  export type DocumentationType = "README"|"CHANGE_LOG"|string;
   export type Double = number;
+  export interface Edit {
+    content: EditContentString;
+    references?: References;
+  }
+  export type EditContentString = string;
   export interface EditorState {
     /**
      * Represents currently edited file
@@ -650,7 +796,12 @@ declare namespace CodeWhispererBearerTokenClient {
      * Whether service should use relevant document in prompt
      */
     useRelevantDocuments?: Boolean;
+    /**
+     * Represents IDE provided list of workspace folders
+     */
+    workspaceFolders?: WorkspaceFolderList;
   }
+  export type EncodedVerificationUrl = string;
   export interface EnvState {
     /**
      * The name of the operating system in use
@@ -686,6 +837,21 @@ declare namespace CodeWhispererBearerTokenClient {
   export type EnvironmentVariableValueString = string;
   export type EnvironmentVariables = EnvironmentVariable[];
   export type ErrorDetails = string;
+  export interface Event {
+    eventId: UUID;
+    generationId: UUID;
+    eventTimestamp: SyntheticTimestamp_date_time;
+    eventType: EventType;
+    eventBlob: EventBlob;
+  }
+  export type EventBlob = Buffer|Uint8Array|Blob|string;
+  export type EventList = Event[];
+  export type EventType = string;
+  export interface ExternalIdentityDetails {
+    issuerUrl?: IssuerUrl;
+    clientId?: ClientId;
+    scimEndpoint?: String;
+  }
   export interface FeatureDevCodeAcceptanceEvent {
     conversationId: ConversationId;
     linesOfCodeAccepted: FeatureDevCodeAcceptanceEventLinesOfCodeAcceptedInteger;
@@ -742,10 +908,12 @@ declare namespace CodeWhispererBearerTokenClient {
     userIntent?: UserIntent;
   }
   export type FollowupPromptContentString = string;
-  export type FunctionalityName = "COMPLETIONS" | "ANALYSIS" | "CONVERSATIONS" | "TASK_ASSIST" | "TRANSFORMATIONS" | "CHAT_CUSTOMIZATION" | "TRANSFORMATIONS_WEBAPP" | string;
+  export type FunctionalityName = "COMPLETIONS"|"ANALYSIS"|"CONVERSATIONS"|"TASK_ASSIST"|"TRANSFORMATIONS"|"CHAT_CUSTOMIZATION"|"TRANSFORMATIONS_WEBAPP"|"FEATURE_DEVELOPMENT"|string;
   export interface GenerateCompletionsRequest {
     fileContext: FileContext;
+    editorState?: EditorState;
     maxResults?: GenerateCompletionsRequestMaxResultsInteger;
+    predictionTypes?: PredictionTypes;
     nextToken?: GenerateCompletionsRequestNextTokenString;
     referenceTrackerConfiguration?: ReferenceTrackerConfiguration;
     supplementalContexts?: SupplementalContextList;
@@ -754,12 +922,15 @@ declare namespace CodeWhispererBearerTokenClient {
     userContext?: UserContext;
     profileArn?: ProfileArn;
     workspaceId?: UUID;
+    modelId?: ModelId;
   }
   export type GenerateCompletionsRequestMaxResultsInteger = number;
   export type GenerateCompletionsRequestNextTokenString = string;
   export interface GenerateCompletionsResponse {
+    predictions?: Predictions;
     completions?: Completions;
     nextToken?: SensitiveString;
+    modelId?: ModelId;
   }
   export interface GetCodeAnalysisRequest {
     jobId: GetCodeAnalysisRequestJobIdString;
@@ -813,6 +984,19 @@ declare namespace CodeWhispererBearerTokenClient {
   export interface GetTransformationResponse {
     transformationJob: TransformationJob;
   }
+  export interface GetUsageLimitsRequest {
+    /**
+     * The ARN of the Q Developer profile. Required for enterprise customers, optional for Builder ID users.
+     */
+    profileArn?: ProfileArn;
+  }
+  export interface GetUsageLimitsResponse {
+    limits: UsageLimits;
+    /**
+     * Number of days remaining until the usage metrics reset
+     */
+    daysUntilReset: Integer;
+  }
   export interface GitState {
     /**
      * The output of the command git status --porcelain=v1 -b
@@ -820,11 +1004,43 @@ declare namespace CodeWhispererBearerTokenClient {
     status?: GitStateStatusString;
   }
   export type GitStateStatusString = string;
-  export type IdeCategory = "JETBRAINS" | "VSCODE" | "CLI" | "JUPYTER_MD" | "JUPYTER_SM" | "ECLIPSE" | "VISUAL_STUDIO" | string;
+  export type IdeCategory = "JETBRAINS"|"VSCODE"|"CLI"|"JUPYTER_MD"|"JUPYTER_SM"|"ECLIPSE"|"VISUAL_STUDIO"|string;
+  export interface IdeDiagnostic {
+    /**
+     * The range at which the message applies.
+     */
+    range?: Range;
+    /**
+     * A human-readable string describing the source of the diagnostic
+     */
+    source?: IdeDiagnosticSourceString;
+    /**
+     * Diagnostic Error type
+     */
+    severity?: DiagnosticSeverity;
+    /**
+     * Type of the diagnostic
+     */
+    ideDiagnosticType: IdeDiagnosticType;
+  }
+  export type IdeDiagnosticList = IdeDiagnostic[];
+  export type IdeDiagnosticSourceString = string;
+  export type IdeDiagnosticType = "SYNTAX_ERROR"|"TYPE_ERROR"|"REFERENCE_ERROR"|"BEST_PRACTICE"|"SECURITY"|"OTHER"|string;
   export type IdempotencyToken = string;
   export interface IdentityDetails {
     ssoIdentityDetails?: SSOIdentityDetails;
+    externalIdentityDetails?: ExternalIdentityDetails;
   }
+  export interface ImageBlock {
+    format: ImageFormat;
+    source: ImageSource;
+  }
+  export type ImageBlocks = ImageBlock[];
+  export type ImageFormat = "png"|"jpeg"|"gif"|"webp"|string;
+  export interface ImageSource {
+    bytes?: ImageSourceBytesBlob;
+  }
+  export type ImageSourceBytesBlob = Buffer|Uint8Array|Blob|string;
   export interface Import {
     statement?: ImportStatementString;
   }
@@ -845,12 +1061,13 @@ declare namespace CodeWhispererBearerTokenClient {
     responseEndLatency?: Double;
     programmingLanguage?: ProgrammingLanguage;
   }
-  export type InlineChatUserDecision = "ACCEPT" | "REJECT" | "DISMISS" | string;
+  export type InlineChatUserDecision = "ACCEPT"|"REJECT"|"DISMISS"|string;
   export type Integer = number;
-  export type Intent = "DEV" | "DOC" | string;
+  export type Intent = "DEV"|"DOC"|string;
   export interface IntentContext {
     documentation?: DocumentationIntentContext;
   }
+  export type IssuerUrl = string;
   export type LineRangeList = Range[];
   export interface ListAvailableCustomizationsRequest {
     maxResults?: ListAvailableCustomizationsRequestMaxResultsInteger;
@@ -882,6 +1099,17 @@ declare namespace CodeWhispererBearerTokenClient {
     nextToken?: PaginationToken;
     codeAnalysisFindings: SensitiveString;
   }
+  export interface ListEventsRequest {
+    conversationId: UUID;
+    maxResults?: ListEventsRequestMaxResultsInteger;
+    nextToken?: NextToken;
+  }
+  export type ListEventsRequestMaxResultsInteger = number;
+  export interface ListEventsResponse {
+    conversationId: UUID;
+    events: EventList;
+    nextToken?: NextToken;
+  }
   export interface ListFeatureEvaluationsRequest {
     userContext: UserContext;
     profileArn?: ProfileArn;
@@ -889,6 +1117,22 @@ declare namespace CodeWhispererBearerTokenClient {
   export interface ListFeatureEvaluationsResponse {
     featureEvaluations: FeatureEvaluationsList;
   }
+  export interface ListUserMemoryEntriesInput {
+    maxResults?: ListUserMemoryEntriesInputMaxResultsInteger;
+    /**
+     * ProfileArn for the managing Q Profile
+     */
+    profileArn?: ListUserMemoryEntriesInputProfileArnString;
+    nextToken?: ListUserMemoryEntriesInputNextTokenString;
+  }
+  export type ListUserMemoryEntriesInputMaxResultsInteger = number;
+  export type ListUserMemoryEntriesInputNextTokenString = string;
+  export type ListUserMemoryEntriesInputProfileArnString = string;
+  export interface ListUserMemoryEntriesOutput {
+    memoryEntries: MemoryEntryList;
+    nextToken?: ListUserMemoryEntriesOutputNextTokenString;
+  }
+  export type ListUserMemoryEntriesOutputNextTokenString = string;
   export interface ListWorkspaceMetadataRequest {
     workspaceRoot?: ListWorkspaceMetadataRequestWorkspaceRootString;
     nextToken?: String;
@@ -901,6 +1145,25 @@ declare namespace CodeWhispererBearerTokenClient {
     nextToken?: String;
   }
   export type Long = number;
+  export interface MemoryEntry {
+    /**
+     * A unique identifier for a single memory entry
+     */
+    id: MemoryEntryIdString;
+    memoryEntryString: MemoryEntryMemoryEntryStringString;
+    metadata: MemoryEntryMetadata;
+  }
+  export type MemoryEntryIdString = string;
+  export type MemoryEntryList = MemoryEntry[];
+  export type MemoryEntryMemoryEntryStringString = string;
+  export interface MemoryEntryMetadata {
+    origin: Origin;
+    attributes?: AttributesMap;
+    createdAt: Timestamp;
+    updatedAt: Timestamp;
+    memoryStatus?: MemoryStatus;
+  }
+  export type MemoryStatus = "DECRYPTION_FAILURE"|"VALID"|string;
   export type MessageId = string;
   export interface MetricData {
     metricName: MetricDataMetricNameString;
@@ -912,13 +1175,14 @@ declare namespace CodeWhispererBearerTokenClient {
   export type MetricDataMetricNameString = string;
   export type MetricDataProductString = string;
   export type ModelId = string;
+  export type NextToken = string;
   export type Notifications = NotificationsFeature[];
   export interface NotificationsFeature {
     feature: FeatureName;
     toggle: OptInFeatureToggle;
   }
-  export type OperatingSystem = "MAC" | "WINDOWS" | "LINUX" | string;
-  export type OptInFeatureToggle = "ON" | "OFF" | string;
+  export type OperatingSystem = "MAC"|"WINDOWS"|"LINUX"|string;
+  export type OptInFeatureToggle = "ON"|"OFF"|string;
   export interface OptInFeatures {
     promptLogging?: PromptLogging;
     byUserAnalytics?: ByUserAnalytics;
@@ -926,8 +1190,8 @@ declare namespace CodeWhispererBearerTokenClient {
     notifications?: Notifications;
     workspaceContext?: WorkspaceContext;
   }
-  export type OptOutPreference = "OPTIN" | "OPTOUT" | string;
-  export type Origin = "CHATBOT" | "CONSOLE" | "DOCUMENTATION" | "MARKETING" | "MOBILE" | "SERVICE_INTERNAL" | "UNIFIED_SEARCH" | "UNKNOWN" | "MD" | "IDE" | "SAGE_MAKER" | "CLI" | "AI_EDITOR" | "OPENSEARCH_DASHBOARD" | "GITLAB" | string;
+  export type OptOutPreference = "OPTIN"|"OPTOUT"|string;
+  export type Origin = "CHATBOT"|"CONSOLE"|"DOCUMENTATION"|"MARKETING"|"MOBILE"|"SERVICE_INTERNAL"|"UNIFIED_SEARCH"|"UNKNOWN"|"MD"|"IDE"|"SAGE_MAKER"|"CLI"|"AI_EDITOR"|"OPENSEARCH_DASHBOARD"|"GITLAB"|string;
   export interface PackageInfo {
     executionCommand?: SensitiveString;
     buildCommand?: SensitiveString;
@@ -953,11 +1217,22 @@ declare namespace CodeWhispererBearerTokenClient {
     character: Integer;
   }
   export type PreSignedUrl = string;
+  export interface Prediction {
+    completion?: Completion;
+    edit?: Edit;
+  }
+  export type PredictionType = "COMPLETIONS"|"EDITS"|string;
+  export type PredictionTypes = PredictionType[];
+  export type Predictions = Prediction[];
+  export interface PreviousEditorStateMetadata {
+    timeOffset: Integer;
+  }
   export type PrimitiveInteger = number;
   export interface Profile {
     arn: ProfileArn;
     identityDetails?: IdentityDetails;
     profileName: ProfileName;
+    description?: ProfileDescription;
     referenceTrackerConfiguration?: ReferenceTrackerConfiguration;
     kmsKeyArn?: ResourceArn;
     activeFunctionalities?: ActiveFunctionalityList;
@@ -970,10 +1245,11 @@ declare namespace CodeWhispererBearerTokenClient {
     applicationProperties?: ApplicationPropertiesList;
   }
   export type ProfileArn = string;
+  export type ProfileDescription = string;
   export type ProfileList = Profile[];
   export type ProfileName = string;
-  export type ProfileStatus = "ACTIVE" | "CREATING" | "CREATE_FAILED" | "UPDATING" | "UPDATE_FAILED" | "DELETING" | "DELETE_FAILED" | string;
-  export type ProfileType = "Q_DEVELOPER" | "CODEWHISPERER" | string;
+  export type ProfileStatus = "ACTIVE"|"CREATING"|"CREATE_FAILED"|"UPDATING"|"UPDATE_FAILED"|"DELETING"|"DELETE_FAILED"|string;
+  export type ProfileType = "Q_DEVELOPER"|"CODEWHISPERER"|string;
   export interface ProgrammingLanguage {
     languageName: ProgrammingLanguageLanguageNameString;
   }
@@ -982,6 +1258,13 @@ declare namespace CodeWhispererBearerTokenClient {
   export interface PromptLogging {
     s3Uri: S3Uri;
     toggle: OptInFeatureToggle;
+  }
+  export interface PushTelemetryEventRequest {
+    clientToken?: IdempotencyToken;
+    eventType: String;
+    event: Document;
+  }
+  export interface PushTelemetryEventResponse {
   }
   export interface Range {
     /**
@@ -993,7 +1276,7 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     end: Position;
   }
-  export type RecommendationsWithReferencesPreference = "BLOCK" | "ALLOW" | string;
+  export type RecommendationsWithReferencesPreference = "BLOCK"|"ALLOW"|string;
   export interface Reference {
     /**
      * License name
@@ -1037,17 +1320,21 @@ declare namespace CodeWhispererBearerTokenClient {
      * DocumentSymbols parsed from a text document
      */
     documentSymbols?: DocumentSymbols;
+    /**
+     * The type of content(file, prompt, symbol, or workspace)
+     */
+    type?: ContentType;
   }
   export type RelevantTextDocumentRelativeFilePathString = string;
   export type RelevantTextDocumentTextString = string;
   export type RequestHeaderKey = string;
   export type RequestHeaderValue = string;
-  export type RequestHeaders = { [key: string]: RequestHeaderValue };
+  export type RequestHeaders = {[key: string]: RequestHeaderValue};
   export type ResourceArn = string;
   export interface ResourcePolicy {
     effect: ResourcePolicyEffect;
   }
-  export type ResourcePolicyEffect = "ALLOW" | "DENY" | string;
+  export type ResourcePolicyEffect = "ALLOW"|"DENY"|string;
   export interface ResumeTransformationRequest {
     transformationJobId: TransformationJobId;
     userActionStatus?: TransformationUserActionStatus;
@@ -1191,6 +1478,7 @@ declare namespace CodeWhispererBearerTokenClient {
     testGenerationJobGroupName?: TestGenerationJobGroupName;
     clientToken?: StartTestGenerationRequestClientTokenString;
     profileArn?: ProfileArn;
+    referenceTrackerConfiguration?: ReferenceTrackerConfiguration;
   }
   export type StartTestGenerationRequestClientTokenString = string;
   export type StartTestGenerationRequestUserInputString = string;
@@ -1214,6 +1502,9 @@ declare namespace CodeWhispererBearerTokenClient {
     transformationStatus: TransformationStatus;
   }
   export type String = string;
+  export type StringList = StringListMemberString[];
+  export type StringListMemberString = string;
+  export type SubscriptionStatus = "INACTIVE"|"ACTIVE"|string;
   export interface SuggestedFix {
     codeDiff?: SuggestedFixCodeDiffString;
     description?: SuggestedFixDescriptionString;
@@ -1221,14 +1512,20 @@ declare namespace CodeWhispererBearerTokenClient {
   }
   export type SuggestedFixCodeDiffString = string;
   export type SuggestedFixDescriptionString = string;
-  export type SuggestionState = "ACCEPT" | "REJECT" | "DISCARD" | "EMPTY" | "MERGE" | string;
+  export type SuggestionState = "ACCEPT"|"REJECT"|"DISCARD"|"EMPTY"|"MERGE"|string;
   export interface SupplementalContext {
     filePath: SupplementalContextFilePathString;
     content: SupplementalContextContentString;
+    type?: SupplementalContextType;
+    metadata?: SupplementalContextMetadata;
   }
   export type SupplementalContextContentString = string;
   export type SupplementalContextFilePathString = string;
   export type SupplementalContextList = SupplementalContext[];
+  export interface SupplementalContextMetadata {
+    previousEditorStateMetadata?: PreviousEditorStateMetadata;
+  }
+  export type SupplementalContextType = "PreviousEditorState"|"WorkspaceContext"|string;
   export interface SupplementaryWebLink {
     /**
      * URL of the web reference link.
@@ -1247,7 +1544,8 @@ declare namespace CodeWhispererBearerTokenClient {
   export type SupplementaryWebLinkTitleString = string;
   export type SupplementaryWebLinkUrlString = string;
   export type SupplementaryWebLinks = SupplementaryWebLink[];
-  export type SymbolType = "DECLARATION" | "USAGE" | string;
+  export type SymbolType = "DECLARATION"|"USAGE"|string;
+  export type SyntheticTimestamp_date_time = Date;
   export interface TargetCode {
     /**
      * The file path relative to the root of the workspace, could be a single file or a folder.
@@ -1294,7 +1592,7 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     action?: TaskAssistPlanStepAction;
   }
-  export type TaskAssistPlanStepAction = "MODIFY" | "CREATE" | "DELETE" | "UNKNOWN" | string;
+  export type TaskAssistPlanStepAction = "MODIFY"|"CREATE"|"DELETE"|"UNKNOWN"|string;
   export type TaskAssistPlanStepDescriptionString = string;
   export type TaskAssistPlanStepEndLineInteger = number;
   export type TaskAssistPlanStepFilePathString = string;
@@ -1339,7 +1637,7 @@ declare namespace CodeWhispererBearerTokenClient {
     isCompletionAccepted?: Boolean;
     cliToolCommand?: String;
   }
-  export type TerminalUserInteractionEventType = "CODEWHISPERER_TERMINAL_TRANSLATION_ACTION" | "CODEWHISPERER_TERMINAL_COMPLETION_INSERTED" | string;
+  export type TerminalUserInteractionEventType = "CODEWHISPERER_TERMINAL_TRANSLATION_ACTION"|"CODEWHISPERER_TERMINAL_COMPLETION_INSERTED"|string;
   export interface TestGenerationEvent {
     jobId: UUID;
     groupName: TestGenerationJobGroupName;
@@ -1369,7 +1667,7 @@ declare namespace CodeWhispererBearerTokenClient {
   export type TestGenerationJobJobPlanString = string;
   export type TestGenerationJobJobSummaryString = string;
   export type TestGenerationJobProgressRateInteger = number;
-  export type TestGenerationJobStatus = "IN_PROGRESS" | "FAILED" | "COMPLETED" | string;
+  export type TestGenerationJobStatus = "IN_PROGRESS"|"FAILED"|"COMPLETED"|string;
   export interface TextDocument {
     /**
      * Filepath relative to the root of the workspace
@@ -1409,7 +1707,29 @@ declare namespace CodeWhispererBearerTokenClient {
      * The diagnostic's message.
      */
     message: TextDocumentDiagnosticMessageString;
+    /**
+     * The diagnostic's code, which might appear in the user interface.
+     */
+    code?: TextDocumentDiagnosticCodeString;
+    /**
+     * An optional property to describe the error code.
+     */
+    codeDescription?: CodeDescription;
+    /**
+     * Additional metadata about the diagnostic.
+     */
+    tags?: DiagnosticTagList;
+    /**
+     * an array of related diagnostic information, e.g. when symbol-names within a scope collide all definitions can be marked via this property.
+     */
+    relatedInformation?: DiagnosticRelatedInformationList;
+    /**
+     * A data entry field that is preserved between a textDocument/publishDiagnostics notification and textDocument/codeAction request.
+     */
+    data?: TextDocumentDiagnosticDataString;
   }
+  export type TextDocumentDiagnosticCodeString = string;
+  export type TextDocumentDiagnosticDataString = string;
   export type TextDocumentDiagnosticMessageString = string;
   export type TextDocumentRelativeFilePathString = string;
   export type TextDocumentTextString = string;
@@ -1442,7 +1762,7 @@ declare namespace CodeWhispererBearerTokenClient {
     json?: SensitiveDocument;
   }
   export type ToolResultContentBlockTextString = string;
-  export type ToolResultStatus = "success" | "error" | string;
+  export type ToolResultStatus = "success"|"error"|string;
   export type ToolResults = ToolResult[];
   export interface ToolSpecification {
     inputSchema: ToolInputSchema;
@@ -1469,14 +1789,14 @@ declare namespace CodeWhispererBearerTokenClient {
     charsOfCodeChanged?: Integer;
     linesOfCodeSubmitted?: Integer;
   }
-  export type TransformationDotNetRuntimeEnv = "NET_5_0" | "NET_6_0" | "NET_7_0" | "NET_8_0" | "NET_9_0" | "NET_STANDARD_2_0" | string;
+  export type TransformationDotNetRuntimeEnv = "NET_5_0"|"NET_6_0"|"NET_7_0"|"NET_8_0"|"NET_9_0"|"NET_STANDARD_2_0"|string;
   export interface TransformationDownloadArtifact {
     downloadArtifactType?: TransformationDownloadArtifactType;
     downloadArtifactId?: ArtifactId;
   }
-  export type TransformationDownloadArtifactType = "ClientInstructions" | "Logs" | "GeneratedCode" | string;
+  export type TransformationDownloadArtifactType = "ClientInstructions"|"Logs"|"GeneratedCode"|string;
   export type TransformationDownloadArtifacts = TransformationDownloadArtifact[];
-  export type TransformationJavaRuntimeEnv = "JVM_8" | "JVM_11" | "JVM_17" | "JVM_21" | string;
+  export type TransformationJavaRuntimeEnv = "JVM_8"|"JVM_11"|"JVM_17"|"JVM_21"|string;
   export interface TransformationJob {
     jobId?: TransformationJobId;
     transformationSpec?: TransformationSpec;
@@ -1487,10 +1807,10 @@ declare namespace CodeWhispererBearerTokenClient {
     endExecutionTime?: Timestamp;
   }
   export type TransformationJobId = string;
-  export type TransformationLanguage = "JAVA_8" | "JAVA_11" | "JAVA_17" | "JAVA_21" | "C_SHARP" | "COBOL" | "PL_I" | "JCL" | string;
+  export type TransformationLanguage = "JAVA_8"|"JAVA_11"|"JAVA_17"|"JAVA_21"|"C_SHARP"|"COBOL"|"PL_I"|"JCL"|string;
   export type TransformationLanguages = TransformationLanguage[];
-  export type TransformationMainframeRuntimeEnv = "MAINFRAME" | string;
-  export type TransformationOperatingSystemFamily = "WINDOWS" | "LINUX" | string;
+  export type TransformationMainframeRuntimeEnv = "MAINFRAME"|string;
+  export type TransformationOperatingSystemFamily = "WINDOWS"|"LINUX"|string;
   export interface TransformationPlan {
     transformationSteps: TransformationSteps;
   }
@@ -1505,7 +1825,7 @@ declare namespace CodeWhispererBearerTokenClient {
     endTime?: Timestamp;
     downloadArtifacts?: TransformationDownloadArtifacts;
   }
-  export type TransformationProgressUpdateStatus = "IN_PROGRESS" | "COMPLETED" | "FAILED" | "PAUSED" | "AWAITING_CLIENT_ACTION" | "SKIPPED" | string;
+  export type TransformationProgressUpdateStatus = "IN_PROGRESS"|"COMPLETED"|"FAILED"|"PAUSED"|"AWAITING_CLIENT_ACTION"|"SKIPPED"|string;
   export interface TransformationProjectArtifactDescriptor {
     sourceCodeArtifact?: TransformationSourceCodeArtifactDescriptor;
   }
@@ -1529,7 +1849,7 @@ declare namespace CodeWhispererBearerTokenClient {
     source?: TransformationProjectState;
     target?: TransformationProjectState;
   }
-  export type TransformationStatus = "CREATED" | "ACCEPTED" | "REJECTED" | "STARTED" | "PREPARING" | "PREPARED" | "PLANNING" | "PLANNED" | "TRANSFORMING" | "TRANSFORMED" | "FAILED" | "COMPLETED" | "PARTIALLY_COMPLETED" | "STOPPING" | "STOPPED" | "PAUSED" | "RESUMED" | string;
+  export type TransformationStatus = "CREATED"|"ACCEPTED"|"REJECTED"|"STARTED"|"PREPARING"|"PREPARED"|"PLANNING"|"PLANNED"|"TRANSFORMING"|"TRANSFORMED"|"FAILED"|"COMPLETED"|"PARTIALLY_COMPLETED"|"STOPPING"|"STOPPED"|"PAUSED"|"RESUMED"|string;
   export interface TransformationStep {
     id: StepId;
     name: String;
@@ -1539,16 +1859,28 @@ declare namespace CodeWhispererBearerTokenClient {
     startTime?: Timestamp;
     endTime?: Timestamp;
   }
-  export type TransformationStepStatus = "CREATED" | "COMPLETED" | "PARTIALLY_COMPLETED" | "STOPPED" | "FAILED" | "PAUSED" | "SKIPPED" | string;
+  export type TransformationStepStatus = "CREATED"|"COMPLETED"|"PARTIALLY_COMPLETED"|"STOPPED"|"FAILED"|"PAUSED"|"SKIPPED"|string;
   export type TransformationSteps = TransformationStep[];
-  export type TransformationType = "LANGUAGE_UPGRADE" | "DOCUMENT_GENERATION" | string;
-  export type TransformationUploadArtifactType = "Dependencies" | "ClientBuildResult" | string;
+  export type TransformationType = "LANGUAGE_UPGRADE"|"DOCUMENT_GENERATION"|string;
+  export type TransformationUploadArtifactType = "Dependencies"|"ClientBuildResult"|string;
   export interface TransformationUploadContext {
     jobId: TransformationJobId;
     uploadArtifactType: TransformationUploadArtifactType;
   }
-  export type TransformationUserActionStatus = "COMPLETED" | "REJECTED" | string;
+  export type TransformationUserActionStatus = "COMPLETED"|"REJECTED"|string;
   export type UUID = string;
+  export interface UpdateUsageLimitsRequest {
+    accountId: String;
+    accountlessUserId?: String;
+    featureType: UsageLimitType;
+    requestedLimit: Long;
+    justification?: String;
+  }
+  export interface UpdateUsageLimitsResponse {
+    status: UsageLimitUpdateRequestStatus;
+    approvedLimit?: Long;
+    remainingRequestsThisMonth?: Integer;
+  }
   export interface UploadContext {
     taskAssistPlanningUploadContext?: TaskAssistPlanningUploadContext;
     transformationUploadContext?: TransformationUploadContext;
@@ -1557,8 +1889,17 @@ declare namespace CodeWhispererBearerTokenClient {
     workspaceContextUploadContext?: WorkspaceContextUploadContext;
   }
   export type UploadId = string;
-  export type UploadIntent = "TRANSFORMATION" | "TASK_ASSIST_PLANNING" | "AUTOMATIC_FILE_SECURITY_SCAN" | "FULL_PROJECT_SECURITY_SCAN" | "UNIT_TESTS_GENERATION" | "CODE_FIX_GENERATION" | "WORKSPACE_CONTEXT" | string;
+  export type UploadIntent = "TRANSFORMATION"|"TASK_ASSIST_PLANNING"|"AUTOMATIC_FILE_SECURITY_SCAN"|"FULL_PROJECT_SECURITY_SCAN"|"UNIT_TESTS_GENERATION"|"CODE_FIX_GENERATION"|"WORKSPACE_CONTEXT"|string;
   export type Url = string;
+  export interface UsageLimitList {
+    type: UsageLimitType;
+    currentUsage: Long;
+    totalUsageLimit: Long;
+    percentUsed?: Double;
+  }
+  export type UsageLimitType = "CODE_COMPLETIONS"|"AGENTIC_REQUEST"|"AI_EDITOR"|"TRANSFORM"|string;
+  export type UsageLimitUpdateRequestStatus = "APPROVED"|"PENDING_REVIEW"|"REJECTED"|string;
+  export type UsageLimits = UsageLimitList[];
   export interface UserContext {
     ideCategory: IdeCategory;
     operatingSystem: OperatingSystem;
@@ -1584,6 +1925,14 @@ declare namespace CodeWhispererBearerTokenClient {
      * User Input Origin.
      */
     origin?: Origin;
+    /**
+     * Images associated with the Chat Message.
+     */
+    images?: ImageBlocks;
+    /**
+     * Unique identifier for the model used in this conversation
+     */
+    modelId?: ModelId;
   }
   export type UserInputMessageContentString = string;
   export interface UserInputMessageContext {
@@ -1632,7 +1981,7 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     tools?: Tools;
   }
-  export type UserIntent = "SUGGEST_ALTERNATE_IMPLEMENTATION" | "APPLY_COMMON_BEST_PRACTICES" | "IMPROVE_CODE" | "SHOW_EXAMPLES" | "CITE_SOURCES" | "EXPLAIN_LINE_BY_LINE" | "EXPLAIN_CODE_SELECTION" | "GENERATE_CLOUDFORMATION_TEMPLATE" | "GENERATE_UNIT_TESTS" | "CODE_GENERATION" | string;
+  export type UserIntent = "SUGGEST_ALTERNATE_IMPLEMENTATION"|"APPLY_COMMON_BEST_PRACTICES"|"IMPROVE_CODE"|"SHOW_EXAMPLES"|"CITE_SOURCES"|"EXPLAIN_LINE_BY_LINE"|"EXPLAIN_CODE_SELECTION"|"GENERATE_CLOUDFORMATION_TEMPLATE"|"GENERATE_UNIT_TESTS"|"CODE_GENERATION"|string;
   export interface UserModificationEvent {
     sessionId: UUID;
     requestId: UUID;
@@ -1642,7 +1991,11 @@ declare namespace CodeWhispererBearerTokenClient {
     timestamp: Timestamp;
     acceptedCharacterCount: PrimitiveInteger;
     unmodifiedAcceptedCharacterCount: PrimitiveInteger;
+    addedCharacterCount?: UserModificationEventAddedCharacterCountInteger;
+    unmodifiedAddedCharacterCount?: UserModificationEventUnmodifiedAddedCharacterCountInteger;
   }
+  export type UserModificationEventAddedCharacterCountInteger = number;
+  export type UserModificationEventUnmodifiedAddedCharacterCountInteger = number;
   export interface UserSettings {
     hasConsentedToCrossRegionCalls?: Boolean;
   }
@@ -1661,7 +2014,15 @@ declare namespace CodeWhispererBearerTokenClient {
     numberOfRecommendations?: PrimitiveInteger;
     perceivedLatencyMilliseconds?: Double;
     acceptedCharacterCount?: PrimitiveInteger;
+    addedIdeDiagnostics?: IdeDiagnosticList;
+    removedIdeDiagnostics?: IdeDiagnosticList;
+    addedCharacterCount?: UserTriggerDecisionEventAddedCharacterCountInteger;
+    deletedCharacterCount?: UserTriggerDecisionEventDeletedCharacterCountInteger;
+    streakLength?: UserTriggerDecisionEventStreakLengthInteger;
   }
+  export type UserTriggerDecisionEventAddedCharacterCountInteger = number;
+  export type UserTriggerDecisionEventDeletedCharacterCountInteger = number;
+  export type UserTriggerDecisionEventStreakLengthInteger = number;
   export interface WorkspaceContext {
     toggle: OptInFeatureToggle;
   }
@@ -1670,6 +2031,8 @@ declare namespace CodeWhispererBearerTokenClient {
     relativePath: SensitiveString;
     programmingLanguage: ProgrammingLanguage;
   }
+  export type WorkspaceFolderList = WorkspaceFolderListMemberString[];
+  export type WorkspaceFolderListMemberString = string;
   export type WorkspaceList = WorkspaceMetadata[];
   export interface WorkspaceMetadata {
     workspaceId: UUID;
@@ -1691,12 +2054,12 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     contextTruncationScheme?: ContextTruncationScheme;
   }
-  export type WorkspaceStatus = "CREATED" | "PENDING" | "READY" | "CONNECTED" | "DELETING" | string;
+  export type WorkspaceStatus = "CREATED"|"PENDING"|"READY"|"CONNECTED"|"DELETING"|string;
   export type timeBetweenChunks = Double[];
   /**
    * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
    */
-  export type apiVersion = "2022-11-11" | "latest" | string;
+  export type apiVersion = "2022-11-11"|"latest"|string;
   export interface ClientApiVersions {
     /**
      * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
@@ -1710,3 +2073,5 @@ declare namespace CodeWhispererBearerTokenClient {
   export import Types = CodeWhispererBearerTokenClient;
 }
 export = CodeWhispererBearerTokenClient;
+
+    

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -83,6 +83,7 @@ import {
     getErrorMsg,
     getHttpStatusCode,
     getRequestID,
+    getSsoConnectionType,
     isFreeTierLimitError,
     isNullish,
 } from '../../shared/utils'
@@ -2504,6 +2505,11 @@ export class AgenticChatController implements ChatHandlers {
      * - 'paidtier': disable any "free-tier limit" UI.
      */
     setPaidTierMode(tabId?: string, mode?: PaidTierMode) {
+        const isBuilderId = getSsoConnectionType(this.#features.credentialsProvider) === 'builderId'
+        if (!isBuilderId) {
+            return
+        }
+
         if (this.#paidTierMode === 'freetier-limit' && mode === 'freetier') {
             // mode = 'freetier-limit' // Sticky while 'freetier'.
         } else if (!mode) {
@@ -2518,7 +2524,6 @@ export class AgenticChatController implements ChatHandlers {
                 .catch(err => {
                     this.#log(`setPaidTierMode: getSubscriptionStatus failed: ${JSON.stringify(err)}`)
                 })
-            // const isFreeTierUser = getSsoConnectionType(this.#features.credentialsProvider) === 'builderId'
             // mode = isFreeTierUser ? 'freetier' : 'paidtier'
 
             return

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2399,6 +2399,20 @@ export class AgenticChatController implements ChatHandlers {
                     messageId: uuid(),
                     body: HELP_MESSAGE,
                 }
+
+            // "Manage Subscription" (paid-tier user), or "Upgrade Q" (free-tier user)
+            case QuickAction.Manage:
+                this.#telemetryController.emitChatMetric({
+                    name: ChatTelemetryEventName.RunCommand,
+                    data: {
+                        cwsprChatCommandType: params.quickAction,
+                        cwsprChatCommandName: '/manage',
+                    },
+                })
+
+                this.onManageSubscription(params.tabId)
+
+                return {}
             default:
                 return {}
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -6,6 +6,7 @@ type AgenticChatErrorCode =
     | 'FailedResult' // general error when processing tool results
     | 'InputTooLong' // too much context given to backend service.
     | 'PromptCharacterLimit' // customer prompt exceeds
+    | 'AmazonQFreeTierLimitError' // Free Tier limit was reached.
     | 'ResponseProcessingTimeout' // response didn't finish streaming in the allowed time
     | 'RequestAborted' // request was aborted by the user
 
@@ -13,6 +14,7 @@ export const customerFacingErrorCodes: AgenticChatErrorCode[] = [
     'QModelResponse',
     'InputTooLong',
     'PromptCharacterLimit',
+    'AmazonQFreeTierLimitError',
 ]
 
 export const unactionableErrorCodes: Partial<Record<AgenticChatErrorCode, string>> = {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -6,7 +6,7 @@
 import { InitializeParams, Server } from '@aws/language-server-runtimes/server-interface'
 import { AgenticChatController } from './agenticChatController'
 import { ChatSessionManagementService } from '../chat/chatSessionManagementService'
-import { CLEAR_QUICK_ACTION, HELP_QUICK_ACTION } from '../chat/quickActions'
+import { CLEAR_QUICK_ACTION, HELP_QUICK_ACTION, MANAGE_QUICK_ACTION } from '../chat/quickActions'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { makeUserContextObject } from '../../shared/telemetryUtils'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
@@ -35,7 +35,7 @@ export const QAgenticChatServer =
                         quickActions: {
                             quickActionsCommandGroups: [
                                 {
-                                    commands: [HELP_QUICK_ACTION, CLEAR_QUICK_ACTION],
+                                    commands: [HELP_QUICK_ACTION, CLEAR_QUICK_ACTION, MANAGE_QUICK_ACTION],
                                 },
                             ],
                         },

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -151,6 +151,10 @@ export const QAgenticChatServer =
             return chatController.onPromptInputOptionChange(params)
         })
 
+        // ;(chat as any).onPromptInputButtonClick((params: any) => {
+        //     chatController.setPaidTierMode(params.tabId, 'paidtier')
+        // })
+
         chat.onButtonClick(params => {
             return chatController.onButtonClick(params)
         })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -29,7 +29,13 @@ export const QAgenticChatServer =
 
         lsp.addInitializer((params: InitializeParams) => {
             return {
-                capabilities: {},
+                capabilities: {
+                    executeCommandProvider: {
+                        commands: [
+                            'aws/chat/manageSubscription',
+                        ],
+                    }
+                },
                 awsServerCapabilities: {
                     chatOptions: {
                         quickActions: {
@@ -76,6 +82,10 @@ export const QAgenticChatServer =
             )
 
             await amazonQServiceManager.addDidChangeConfigurationListener(updateConfigurationHandler)
+        })
+
+        lsp.onExecuteCommand((params, token) => {
+            return chatController.onExecuteCommand(params, token)
         })
 
         chat.onTabAdd(params => {
@@ -141,6 +151,10 @@ export const QAgenticChatServer =
 
         chat.onFileClicked((params) => {
             return chatController.onFileClicked(params)
+        })
+
+        chat.onFollowUpClicked((params) => {
+            return chatController.onFollowUpClicked(params)
         })
 
         chat.onTabBarAction(params => {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/quickActions.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/quickActions.ts
@@ -1,6 +1,7 @@
 export enum QuickAction {
     Clear = '/clear',
     Help = '/help',
+    Manage = '/manage',
 }
 
 export const HELP_QUICK_ACTION = {
@@ -13,4 +14,10 @@ export const CLEAR_QUICK_ACTION = {
     command: QuickAction.Clear,
     description: 'Clear this session',
     icon: 'trash',
+}
+
+export const MANAGE_QUICK_ACTION = {
+    command: QuickAction.Manage,
+    description: 'Manage Amazon Q Subscription',
+    icon: 'menu', // 'check-list'
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/paidTier/paidTier.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/paidTier/paidTier.ts
@@ -1,0 +1,1 @@
+export type PaidTierMode = 'paidtier' | 'paidtier-success' | 'freetier' | 'freetier-limit'

--- a/server/aws-lsp-codewhisperer/src/language-server/paidTier/paidTier.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/paidTier/paidTier.ts
@@ -1,1 +1,7 @@
-export type PaidTierMode = 'paidtier' | 'paidtier-success' | 'freetier' | 'freetier-limit'
+export type PaidTierMode =
+    | 'freetier'
+    | 'freetier-limit'
+    | 'upgrade-start'
+    | 'upgrade-pending'
+    | 'freetier-upgrade-info'
+    | 'paidtier'

--- a/server/aws-lsp-codewhisperer/src/language-server/paidTier/paidTier.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/paidTier/paidTier.ts
@@ -1,3 +1,20 @@
+import * as awsLsp from '@aws/language-server-runtimes/server-interface'
+
 export type PaidTierMode = 'freetier' | 'freetier-limit' | 'upgrade-pending' | 'paidtier'
 
+export const qProName = 'Q Developer Pro'
 export const paidTierLearnMoreUrl = 'https://aws.amazon.com/q/pricing/'
+export const paidTierManageSubscription =
+    'https://us-east-1.console.aws.amazon.com/amazonq/developer/home?region=us-east-1#/subscriptions'
+export const freeTierLimitUserMsg = `Monthly request limit reached. Connect your Builder ID to an AWS account to upgrade to ${qProName} and increase your monthly limits.`
+
+export function onPaidTierLearnMore(lsp: awsLsp.Lsp, log: awsLsp.Logging) {
+    lsp.window
+        .showDocument({
+            external: true, // Client is expected to open the URL in a web browser.
+            uri: paidTierLearnMoreUrl,
+        })
+        .catch(e => {
+            log.log(`onPaidTierLearnMore: showDocument failed: ${(e as Error).message}`)
+        })
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/paidTier/paidTier.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/paidTier/paidTier.ts
@@ -5,3 +5,5 @@ export type PaidTierMode =
     | 'upgrade-pending'
     | 'freetier-upgrade-info'
     | 'paidtier'
+
+export const paidTierLearnMoreUrl = 'https://aws.amazon.com/q/pricing/'

--- a/server/aws-lsp-codewhisperer/src/language-server/paidTier/paidTier.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/paidTier/paidTier.ts
@@ -1,9 +1,3 @@
-export type PaidTierMode =
-    | 'freetier'
-    | 'freetier-limit'
-    | 'upgrade-start'
-    | 'upgrade-pending'
-    | 'freetier-upgrade-info'
-    | 'paidtier'
+export type PaidTierMode = 'freetier' | 'freetier-limit' | 'upgrade-pending' | 'paidtier'
 
 export const paidTierLearnMoreUrl = 'https://aws.amazon.com/q/pricing/'

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
@@ -84,3 +84,10 @@ export class AmazonQServiceConnectionExpiredError extends AmazonQError {
         this.name = 'AmazonQServiceConnectionExpiredError'
     }
 }
+
+export class AmazonQFreeTierLimitError extends AmazonQError {
+    constructor(message: string = 'Free tier limit reached. Upgrade to Amazon Q Pro.') {
+        super(message, 'E_AMAZON_Q_FREE_TIER_LIMIT')
+        this.name = 'AmazonQFreeTierLimitError'
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
@@ -87,7 +87,7 @@ export class AmazonQServiceConnectionExpiredError extends AmazonQError {
 }
 
 export class AmazonQFreeTierLimitError extends AmazonQError {
-    constructor(cause?: unknown, message: string = 'Free tier limit reached. Upgrade to Amazon Q Pro.') {
+    constructor(cause?: unknown, message: string = 'Free tier limit reached.') {
         super(message, 'E_AMAZON_Q_FREE_TIER_LIMIT', cause)
         this.name = 'AmazonQFreeTierLimitError'
     }

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
@@ -1,10 +1,11 @@
 // Base error class for Amazon Q
 export class AmazonQError extends Error {
     public code: string
-    constructor(message: string, code: string) {
+    constructor(message: string, code: string, cause?: unknown) {
         super(message)
         this.name = 'AmazonQError'
         this.code = code
+        this.cause = cause
     }
 }
 
@@ -86,8 +87,8 @@ export class AmazonQServiceConnectionExpiredError extends AmazonQError {
 }
 
 export class AmazonQFreeTierLimitError extends AmazonQError {
-    constructor(message: string = 'Free tier limit reached. Upgrade to Amazon Q Pro.') {
-        super(message, 'E_AMAZON_Q_FREE_TIER_LIMIT')
+    constructor(cause?: unknown, message: string = 'Free tier limit reached. Upgrade to Amazon Q Pro.') {
+        super(message, 'E_AMAZON_Q_FREE_TIER_LIMIT', cause)
         this.name = 'AmazonQFreeTierLimitError'
     }
 }

--- a/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts
@@ -387,7 +387,6 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
         this.#getSubscriptionStatusPromise = (async () => {
             try {
                 const resp = await this.createSubscriptionToken({
-                    accountId: '111111111111', // Special dummy account for checking Subscription status.
                     // clientToken: this.credentialsProvider.getCredentials('bearer').token,
                 })
                 return resp

--- a/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts
@@ -48,6 +48,7 @@ export interface GenerateSuggestionsResponse {
 
 import CodeWhispererSigv4Client = require('../client/sigv4/codewhisperersigv4client')
 import CodeWhispererTokenClient = require('../client/token/codewhispererbearertokenclient')
+import { getErrorId } from './utils'
 
 // Right now the only difference between the token client and the IAM client for codewhsiperer is the difference in function name
 // This abstract class can grow in the future to account for any additional changes across the clients
@@ -156,8 +157,8 @@ export class CodeWhispererServiceIAM extends CodeWhispererServiceBase {
  */
 export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
     client: CodeWhispererTokenClient
-    /** Debounce getSubscriptionStatus by storing the current, pending promise (if any). */
-    #getSubscriptionStatusPromise: ReturnType<typeof this.createSubscriptionToken> | undefined
+    /** Debounce createSubscriptionToken by storing the current, pending promise (if any). */
+    #createSubscriptionTokenPromise: Promise<CodeWhispererTokenClient.CreateSubscriptionTokenResponse> | undefined
 
     constructor(
         private credentialsProvider: CredentialsProvider,
@@ -368,34 +369,70 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
     }
 
     /**
+     * (debounced by default)
+     *
      * cool api you have there 🥹
      */
     async createSubscriptionToken(request: CodeWhispererTokenClient.CreateSubscriptionTokenRequest) {
-        return this.client.createSubscriptionToken(this.withProfileArn(request)).promise()
+        // Debounce.
+        if (this.#createSubscriptionTokenPromise) {
+            // this.logging.debug('createSubscriptionTokenPromise: debounced')
+            return this.#createSubscriptionTokenPromise
+        }
+
+        this.#createSubscriptionTokenPromise = (async () => {
+            try {
+                return this.client.createSubscriptionToken(this.withProfileArn(request)).promise()
+            } finally {
+                this.#createSubscriptionTokenPromise = undefined
+            }
+        })()
+
+        return this.#createSubscriptionTokenPromise
     }
 
     /**
      * Gets the Subscription status of the given user.
+     *
+     * @param statusOnly use this if you don't need the encodedVerificationUrl, else a ConflictException is treated as "ACTIVE"
      */
-    async getSubscriptionStatus(): ReturnType<typeof this.createSubscriptionToken> {
-        // Debounce.
-        if (this.#getSubscriptionStatusPromise) {
-            // this.logging.debug('getSubscriptionStatus: debounced')
-            return this.#getSubscriptionStatusPromise
-        }
+    async getSubscriptionStatus(
+        statusOnly?: boolean
+    ): Promise<{ status: 'active' | 'active-expiring' | 'none'; encodedVerificationUrl?: string }> {
+        // NOTE: The subscription API behaves in a non-intuitive way.
+        // https://github.com/aws/amazon-q-developer-cli-autocomplete/blob/86edd86a338b549b5192de67c9fdef240e6014b7/crates/chat-cli/src/cli/chat/mod.rs#L4079-L4102
+        //
+        // If statusOnly=true, the service only returns "ACTIVE" and "INACTIVE".
+        // If statusOnly=false, the following spec applies:
+        //
+        // 1. "ACTIVE" => 'active-expiring':
+        //    - Active but cancelled. User *has* a subscription, but set to *not auto-renew* (i.e., cancelled).
+        // 2. "INACTIVE" => 'none':
+        //    - User has no subscription at all (no Pro access).
+        // 3. ConflictException => 'active':
+        //    - User has an active subscription *with auto-renewal enabled*.
+        //
+        // Also, it is currently not possible to subscribe or re-subscribe via console, only IDE/CLI.
+        try {
+            const r = await this.createSubscriptionToken({
+                statusOnly: !!statusOnly,
+                // clientToken: this.credentialsProvider.getCredentials('bearer').token,
+            })
+            const status = r.status === 'ACTIVE' ? 'active-expiring' : 'none'
 
-        this.#getSubscriptionStatusPromise = (async () => {
-            try {
-                const resp = await this.createSubscriptionToken({
-                    // clientToken: this.credentialsProvider.getCredentials('bearer').token,
-                })
-                return resp
-            } finally {
-                this.#getSubscriptionStatusPromise = undefined
+            return {
+                status: status,
+                encodedVerificationUrl: r.encodedVerificationUrl,
             }
-        })()
+        } catch (e) {
+            if (getErrorId(e as Error) === 'ConflictException') {
+                return {
+                    status: 'active',
+                }
+            }
 
-        return this.#getSubscriptionStatusPromise
+            throw e
+        }
     }
 
     /**
@@ -409,9 +446,9 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
                 if (cancelToken?.isCancellationRequested) {
                     return false
                 }
-                const s = await this.getSubscriptionStatus()
+                const s = await this.getSubscriptionStatus(true)
                 this.logging.info(`waitUntilSubscriptionActive: ${s.status}`)
-                if (s.status === 'ACTIVE') {
+                if (s.status !== 'none') {
                     return true
                 }
             },

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -13,10 +13,11 @@ import {
     SendMessageCommandOutput as SendMessageCommandOutputQDeveloperStreaming,
 } from '@amzn/amazon-q-developer-streaming-client'
 import { CredentialsProvider, SDKInitializator, Logging } from '@aws/language-server-runtimes/server-interface'
-import { getBearerTokenFromProvider } from './utils'
+import { getBearerTokenFromProvider, isFreeTierLimitError } from './utils'
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { CredentialProviderChain, Credentials } from 'aws-sdk'
 import { clientTimeoutMs } from '../language-server/agenticChat/constants'
+import { AmazonQFreeTierLimitError } from './amazonQServiceManager/errors'
 
 export type SendMessageCommandInput =
     | SendMessageCommandInputCodeWhispererStreaming
@@ -93,16 +94,23 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
 
         this.inflightRequests.add(controller)
 
-        const response = await this.client.sendMessage(
-            { ...request, profileArn: this.profileArn },
-            {
-                abortSignal: controller.signal,
+        try {
+            const response = await this.client.sendMessage(
+                { ...request, profileArn: this.profileArn },
+                {
+                    abortSignal: controller.signal,
+                }
+            )
+
+            return response
+        } catch (e) {
+            if (isFreeTierLimitError(e)) {
+                throw new AmazonQFreeTierLimitError()
             }
-        )
-
-        this.inflightRequests.delete(controller)
-
-        return response
+            throw e
+        } finally {
+            this.inflightRequests.delete(controller)
+        }
     }
 
     public async generateAssistantResponse(
@@ -113,16 +121,23 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
 
         this.inflightRequests.add(controller)
 
-        const response = await this.client.generateAssistantResponse(
-            { ...request, profileArn: this.profileArn },
-            {
-                abortSignal: controller.signal,
+        try {
+            const response = await this.client.generateAssistantResponse(
+                { ...request, profileArn: this.profileArn },
+                {
+                    abortSignal: controller.signal,
+                }
+            )
+
+            return response
+        } catch (e) {
+            if (isFreeTierLimitError(e)) {
+                throw new AmazonQFreeTierLimitError()
             }
-        )
-
-        this.inflightRequests.delete(controller)
-
-        return response
+            throw e
+        } finally {
+            this.inflightRequests.delete(controller)
+        }
     }
 
     public async exportResultArchive(

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -105,7 +105,7 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
             return response
         } catch (e) {
             if (isFreeTierLimitError(e)) {
-                throw new AmazonQFreeTierLimitError()
+                throw new AmazonQFreeTierLimitError(e)
             }
             throw e
         } finally {
@@ -131,8 +131,9 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
 
             return response
         } catch (e) {
+            // TODO add a test for this
             if (isFreeTierLimitError(e)) {
-                throw new AmazonQFreeTierLimitError()
+                throw new AmazonQFreeTierLimitError(e)
             }
             throw e
         } finally {

--- a/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
@@ -1,16 +1,25 @@
-import { CredentialsProvider, InitializeParams, Position } from '@aws/language-server-runtimes/server-interface'
+import {
+    ServiceQuotaExceededException,
+    ThrottlingException,
+    ThrottlingExceptionReason,
+} from '@aws/codewhisperer-streaming-client'
+import { CredentialsProvider, Position } from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
+import { AWSError } from 'aws-sdk'
+import { expect } from 'chai'
 import * as sinon from 'sinon'
+import { BUILDER_ID_START_URL } from './constants'
 import {
     getBearerTokenFromProvider,
+    getEndPositionForAcceptedSuggestion,
     getSsoConnectionType,
     getUnmodifiedAcceptedTokens,
-    getEndPositionForAcceptedSuggestion,
-    safeGet,
+    isAwsThrottlingError,
+    isFreeTierLimitError,
+    isQuotaExceededError,
     isStringOrNull,
+    safeGet,
 } from './utils'
-import { expect } from 'chai'
-import { BUILDER_ID_START_URL } from './constants'
 
 describe('getBearerTokenFromProvider', () => {
     const mockToken = 'mockToken'
@@ -238,5 +247,134 @@ describe('isStringOrNull', () => {
         it(`should return: ${testCase.expected}, when passed: ${JSON.stringify(testCase.input)}`, () => {
             assert(isStringOrNull(testCase.input) === testCase.expected)
         })
+    })
+})
+
+describe('isAwsThrottlingError', function () {
+    it('false for non-error objects', function () {
+        assert.strictEqual(isAwsThrottlingError(undefined), false)
+        assert.strictEqual(isAwsThrottlingError(null), false)
+        assert.strictEqual(isAwsThrottlingError('error string'), false)
+        assert.strictEqual(isAwsThrottlingError({}), false)
+        assert.strictEqual(isAwsThrottlingError(42), false)
+    })
+
+    it('false for regular Error objects', function () {
+        const regularError = new Error('Some error')
+        assert.strictEqual(isAwsThrottlingError(regularError), false)
+    })
+
+    it('false for non-throttling AWS errors', function () {
+        const nonThrottlingError = {
+            name: 'AWSError',
+            message: 'Not a throttling error',
+            code: 'SomeOtherError',
+            time: new Date(),
+        } as AWSError
+
+        assert.strictEqual(isAwsThrottlingError(nonThrottlingError), false)
+    })
+
+    it('true for AWS throttling errors', function () {
+        const sdkV2Error = new Error()
+        ;(sdkV2Error as any).name = 'ThrottlingException'
+        ;(sdkV2Error as any).message = 'Rate exceeded'
+        ;(sdkV2Error as any).code = 'ThrottlingException'
+        ;(sdkV2Error as any).time = new Date()
+        assert.strictEqual(isAwsThrottlingError(sdkV2Error), true)
+
+        const sdkV3Error = new ThrottlingException({
+            message: 'Too many requests',
+            $metadata: {},
+        })
+        assert.strictEqual(isAwsThrottlingError(sdkV3Error), true)
+    })
+})
+
+describe('isFreeTierLimitError', function () {
+    it('false for non-throttling errors', function () {
+        const regularError = new Error('Some error')
+        assert.strictEqual(isFreeTierLimitError(regularError), false)
+
+        const e = new Error()
+        ;(e as any).name = 'AWSError'
+        ;(e as any).message = 'Not a throttling error'
+        ;(e as any).code = 'SomeOtherError'
+        ;(e as any).time = new Date()
+
+        assert.strictEqual(isFreeTierLimitError(e), false)
+    })
+
+    it('false for throttling errors without MONTHLY_REQUEST_COUNT reason', function () {
+        const throttlingError = new Error()
+        ;(throttlingError as any).name = 'ThrottlingException'
+        ;(throttlingError as any).message = 'Rate exceeded'
+        ;(throttlingError as any).code = 'ThrottlingException'
+        ;(throttlingError as any).time = new Date()
+        ;(throttlingError as any).reason = 'SOME_OTHER_REASON'
+
+        assert.strictEqual(isFreeTierLimitError(throttlingError), false)
+    })
+
+    it('true for throttling errors with MONTHLY_REQUEST_COUNT reason', function () {
+        const freeTierLimitError = new Error()
+        ;(freeTierLimitError as any).name = 'ThrottlingException'
+        ;(freeTierLimitError as any).message = 'Free tier limit reached'
+        ;(freeTierLimitError as any).code = 'ThrottlingException'
+        ;(freeTierLimitError as any).time = new Date()
+        ;(freeTierLimitError as any).reason = ThrottlingExceptionReason.MONTHLY_REQUEST_COUNT
+
+        assert.strictEqual(isFreeTierLimitError(freeTierLimitError), true)
+    })
+})
+
+describe('isQuotaExceededError', function () {
+    it('false for non-AWS errors', function () {
+        const regularError = new Error('Some error')
+        assert.strictEqual(isQuotaExceededError(regularError), false)
+
+        assert.strictEqual(isQuotaExceededError(undefined), false)
+        assert.strictEqual(isQuotaExceededError(null), false)
+        assert.strictEqual(isQuotaExceededError('error string'), false)
+    })
+
+    it('true for free tier limit errors', function () {
+        const e = new ThrottlingException({
+            message: 'Free tier limit reached',
+            $metadata: {},
+        })
+
+        assert.strictEqual(isQuotaExceededError(e), true)
+    })
+
+    it('true for ServiceQuotaExceededException errors', function () {
+        const e = new ServiceQuotaExceededException({
+            message: 'Service quota exceeded',
+            $metadata: {},
+        })
+
+        assert.strictEqual(isQuotaExceededError(e), true)
+    })
+
+    it('true for specific messages', function () {
+        const reachedForThisMonth = new Error()
+        ;(reachedForThisMonth as any).name = 'ThrottlingException'
+        ;(reachedForThisMonth as any).message = 'You have reached the limit for this month'
+        ;(reachedForThisMonth as any).code = 'ThrottlingException'
+        ;(reachedForThisMonth as any).time = new Date()
+
+        const limitForIterationsError = new ThrottlingException({
+            message: 'You have reached the limit for number of iterations',
+            $metadata: {},
+        })
+
+        assert.strictEqual(isQuotaExceededError(reachedForThisMonth), true)
+        assert.strictEqual(isQuotaExceededError(limitForIterationsError), true)
+
+        // Invalid cases
+        reachedForThisMonth.message = 'some other messsage'
+        assert.strictEqual(isQuotaExceededError(reachedForThisMonth), false)
+        limitForIterationsError.message = 'foo bar'
+        assert.strictEqual(isQuotaExceededError(limitForIterationsError), false)
     })
 })


### PR DESCRIPTION
## Problem

When "free tier" limit is reached, there are no clear next steps.

## Solution

- Handle "free tier exceeded" throttling/quota service error: show a chat card with an `Upgrade` button, and an IDE message.
- Handle the "Upgrade" button event.
    - Wait for upgrade to complete, show a message on success.
- Handle the `aws/chat/manageSubscription` command, so clients can invoke the "Upgrade" codepath.

Related IDE changes:

- VSC: https://github.com/aws/aws-toolkit-vscode/pull/7379
- JB: todo
- VS: todo

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## Todo

```
  1) MynahUI
       openTab
         should create a new tab with welcome messages if tabId not passed and previous messages not passed:
     AssertError: expected getChatItems to be called once and with exact arguments 
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
