### PR TITLE
feat: use enableLocalIndexing to control actual indexing

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
@@ -119,26 +119,25 @@ export const LocalProjectContextServer =
         const updateConfigurationHandler = async (updatedConfig: AmazonQWorkspaceConfig) => {
             logging.log('Updating configuration of local context server')
             try {
-                if (localProjectContextEnabled !== updatedConfig.projectContext?.enableLocalIndexing) {
-                    localProjectContextEnabled = updatedConfig.projectContext?.enableLocalIndexing === true
+                localProjectContextEnabled = updatedConfig.projectContext?.enableLocalIndexing === true
 
-                    logging.log(
-                        `Setting project context enabled to ${updatedConfig.projectContext?.enableLocalIndexing}`
-                    )
-                    localProjectContextEnabled
-                        ? await localProjectContextController.init({
-                              enableGpuAcceleration: updatedConfig?.projectContext?.enableGpuAcceleration,
-                              indexWorkerThreads: updatedConfig?.projectContext?.indexWorkerThreads,
-                              ignoreFilePatterns: updatedConfig.projectContext?.localIndexing?.ignoreFilePatterns,
-                              maxFileSizeMB: updatedConfig.projectContext?.localIndexing?.maxFileSizeMB,
-                              maxIndexSizeMB: updatedConfig.projectContext?.localIndexing?.maxIndexSizeMB,
-                          })
-                        : await localProjectContextController.dispose()
-                }
+                logging.log(
+                    `Setting project context indexing enabled to ${updatedConfig.projectContext?.enableLocalIndexing}`
+                )
+                await localProjectContextController.init({
+                    enableGpuAcceleration: updatedConfig?.projectContext?.enableGpuAcceleration,
+                    indexWorkerThreads: updatedConfig?.projectContext?.indexWorkerThreads,
+                    ignoreFilePatterns: updatedConfig.projectContext?.localIndexing?.ignoreFilePatterns,
+                    maxFileSizeMB: updatedConfig.projectContext?.localIndexing?.maxFileSizeMB,
+                    maxIndexSizeMB: updatedConfig.projectContext?.localIndexing?.maxIndexSizeMB,
+                    enableIndexing: localProjectContextEnabled,
+                })
             } catch (error) {
                 logging.error(`Error handling configuration change: ${error}`)
             }
         }
 
-        return () => {}
+        return async () => {
+            await localProjectContextController?.dispose()
+        }
     }

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.test.ts
@@ -76,7 +76,7 @@ describe('LocalProjectContextController', () => {
     describe('init', () => {
         it('should initialize vector library successfully', async () => {
             const buildIndexSpy = spy(controller, 'buildIndex')
-            await controller.init({ vectorLib: vectorLibMock })
+            await controller.init({ vectorLib: vectorLibMock, enableIndexing: true })
 
             sinonAssert.notCalled(logging.error)
             sinonAssert.called(vectorLibMock.start)
@@ -90,6 +90,16 @@ describe('LocalProjectContextController', () => {
             await controller.init({ vectorLib: vectorLibMock })
 
             sinonAssert.called(logging.error)
+        })
+
+        it('should not call buildIndex if not enabled', async () => {
+            const buildIndexSpy = spy(controller, 'buildIndex')
+            await controller.init({ vectorLib: vectorLibMock, enableIndexing: false })
+
+            sinonAssert.notCalled(logging.error)
+            sinonAssert.called(vectorLibMock.start)
+            const vecLib = await vectorLibMock.start()
+            sinonAssert.notCalled(buildIndexSpy)
         })
     })
 

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -151,8 +151,6 @@ export class LocalProjectContextController {
             }
 
             // initialize vecLib and index if needed
-            this._isIndexingEnabled = enableIndexing
-
             const libraryPath = this.getVectorLibraryPath()
             const vecLib = vectorLib ?? (await eval(`import("${libraryPath}")`))
             if (vecLib) {
@@ -161,6 +159,7 @@ export class LocalProjectContextController {
                     void this.buildIndex()
                 }
                 LocalProjectContextController.instance = this
+                this._isIndexingEnabled = enableIndexing
             } else {
                 this.log.warn(`Vector library could not be imported from: ${libraryPath}`)
             }
@@ -235,7 +234,7 @@ export class LocalProjectContextController {
                 }
             }
             if (this._vecLib && this._isIndexingEnabled) {
-                await this.buildIndex()
+                void this.buildIndex()
             }
         } catch (error) {
             this.log.error(`Error in updateWorkspaceFolders: ${error}`)


### PR DESCRIPTION
## Problem
- for some features that doesn't depend on vector indexing, we should still initialize the library but have the setting to control if we build vector index
## Solution
- refactor to always call `init` and add check for if we need to call `buildIndex`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
