### PR TITLE
fix: add result field for agentic chat interaction telemetry

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -188,10 +188,11 @@ export class ChatTelemetryController {
         this.#telemetry.emitMetric({
             name: ChatTelemetryEventName.InteractWithAgenticChat,
             data: {
-                [CONVERSATION_ID_METRIC_KEY]: this.getConversationId(tabId),
+                [CONVERSATION_ID_METRIC_KEY]: this.getConversationId(tabId) ?? '',
                 cwsprChatConversationType: 'AgenticChat',
                 credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
                 cwsprAgenticChatInteractionType: interactionType,
+                result: 'Succeeded',
             },
         })
     }


### PR DESCRIPTION
## Problem
- `amazonq_interactWithAgenticChat` metric is missing result field
- cwsprChatConversationId field is sometimes empty

```
[warning] telemetry: invalid Metric: "amazonq_interactWithAgenticChat" emitted without the `result` property, which is always required. Consider using `.run()` instead of `.emit()`, which will set these properties automatically. See https://github.com/aws/aws-toolkit-vscode/blob/master/docs/telemetry.md#guidelines
```

```
[debug] telemetry: amazonq_interactWithAgenticChat {
  Metadata: {
    missingFields: 'cwsprChatConversationId',
    metricId: '7c7f05c6-e94b-47c2-a72a-90302dcd56e2',
    traceId: '3f8f394a-3960-4b28-950d-a1e6f803ae80',
    parentId: '5926c802-8732-4894-8ff0-6d512fd24814',
    cwsprChatConversationType: 'AgenticChat',
    credentialStartUrl: 'https://amzn.awsapps.com/start',
    cwsprAgenticChatInteractionType: 'GeneratedDiff',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}
```

## Solution
- add result field
- cwsprChatConversationId is empty string if value doesn't exist

```
[debug] telemetry: amazonq_interactWithAgenticChat {
  Metadata: {
    metricId: '4a98ea7b-a2bc-4df7-8309-7c63bafc824b',
    traceId: 'b5f7a385-855f-4fb4-89e4-2d605797739f',
    parentId: 'a0e14b56-b227-42d5-a1da-6d0b5f9ccdbd',
    cwsprChatConversationType: 'AgenticChat',
    credentialStartUrl: 'https://amzn.awsapps.com/start',
    cwsprAgenticChatInteractionType: 'GeneratedDiff',
    result: 'Succeeded',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
