### PR TITLE
feat: extend logging utilts to support errors

### DIFF
--- a/core/aws-lsp-core/src/util/loggingUtils.ts
+++ b/core/aws-lsp-core/src/util/loggingUtils.ts
@@ -20,3 +20,11 @@ export function formatObj(
         2
     )
 }
+
+export function formatErr(err: unknown): string {
+    if (err instanceof Error) {
+        const errObj = { ...err, name: err.name, message: err.message, cause: err.cause }
+        return formatObj(errObj, { maxStringLength: 1000 })
+    }
+    return `Error: ${formatObj(err)}`
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1481,7 +1481,7 @@ export class AgenticChatController implements ChatHandlers {
 
         // These are errors we want to show custom messages in chat for.
         if (['QModelResponse', 'MaxAgentLoopIterations', 'InputTooLong'].includes(err.code)) {
-            this.#features.logging.error(`${err.code}: ${JSON.stringify(err)} `)
+            this.#features.logging.error(`${loggingUtils.formatErr(err)}`)
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
                 type: 'answer',
                 body: err.message,
@@ -1489,8 +1489,7 @@ export class AgenticChatController implements ChatHandlers {
                 buttons: [],
             })
         }
-        this.#features.logging.error(`Unknown Error: ${JSON.stringify(err)}`)
-        this.#features.logging.log(`Error Cause: ${JSON.stringify(err.cause)}`)
+        this.#features.logging.error(`Unknown Error: ${loggingUtils.formatErr(err)}`)
         return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
             type: 'answer',
             body: requestID ? genericErrorMsg + `\n\nRequest ID: ${requestID}` : genericErrorMsg,


### PR DESCRIPTION
## Problem
Logs on errors before:
```
025-04-29 15:09:48.698 [info] [Error - 3:09:48 PM] [2025-04-29T19:09:48.696Z] QModelResponse: {"code":"QModelResponse","requestId":"89eb2f69-a649-4746-a354-72124dc5bb05"} 
2025-04-29 15:09:48.698 [info] [Info  - 3:09:48 PM] Error occurred during chat request: Error: Encountered an unexpected error when processing the request, please try again.
```

## Solution
Logs on errors after:
```
2025-04-29 14:58:04.499 [info] [Error - 2:58:04 PM] [2025-04-29T18:58:04.497Z] {
  "code": "QModelResponse",
  "requestId": "1589319b-a4e8-448c-8814-701c090fd3c1",
  "name": "Error",
  "message": "Encountered an unexpected error when processing the request, please try again.",
  "cause": {
    "name": "InternalFailure",
    "$fault": "client",
    "$metadata": {
      "httpStatusCode": 500,
      "requestId": "1589319b-a4e8-448c-8814-701c090fd3c1",
      "attempts": 1,
      "totalRetryDelay": 0
    },
    "message": "Encountered an unexpected error when processing the request, please try again."
  }
}
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
