### PR TITLE
fix: fix project root not passed to buildIndex

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -204,6 +204,10 @@ export class LocalProjectContextController {
     async buildIndex(): Promise<void> {
         try {
             if (this._vecLib) {
+                if (!this.workspaceFolders.length) {
+                    this.log.info('skip building index because no workspace folder found')
+                    return
+                }
                 const sourceFiles = await this.processWorkspaceFolders(
                     this.workspaceFolders,
                     this.ignoreFilePatterns,
@@ -213,7 +217,9 @@ export class LocalProjectContextController {
                     this.maxFileSizeMB,
                     this.maxIndexSizeMB
                 )
-                await this._vecLib?.buildIndex(sourceFiles, this.indexCacheDirPath, 'all')
+
+                const projectRoot = this.workspaceFolders.sort()[0].uri
+                await this._vecLib?.buildIndex(sourceFiles, projectRoot, 'all')
                 this.log.info('Context index built successfully')
             }
         } catch (error) {


### PR DESCRIPTION
## Problem
`indexCacheDirPath` was passed to buildIndex incorrectly instead of project root path
this will result in index of different projects overwrite each other, @workspace might respond with a different project's code
## Solution
pass in project root
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
