### PR TITLE
fix: fix the context list bug and show the tooltip

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -374,6 +374,7 @@ export class AgenticChatController implements ChatHandlers {
         try {
             const triggerContext = await this.#getTriggerContext(params, metric)
             const isNewConversation = !session.conversationId
+            session.contextListSent = false
             if (isNewConversation) {
                 // agentic chat does not support conversationId in API response,
                 // so we set it to random UUID per session, as other chat functionality

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
@@ -176,6 +176,7 @@ export class AdditionalContextProvider {
                         second: item.name === 'symbol' ? item.endLine : -1,
                     },
                 ],
+                description: item.path,
                 fullPath: item.path,
             }
         }


### PR DESCRIPTION
## Problem
- Flacon context is shown only in the first conversation per tab.
- No tool tip for the context list filepaths.
## Solution
- Fixed two issues.

https://github.com/user-attachments/assets/d42b44b7-b7a9-4ef4-9ca0-b12f06179371


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
