### PR TITLE
fix: undo all appears between writes

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -665,7 +665,8 @@ export class AgenticChatController implements ChatHandlers {
                 if (!availableToolNames.includes(toolUse.name)) {
                     throw new Error(`Tool ${toolUse.name} is not available in the current mode`)
                 }
-                if (toolUse.name !== 'fsWrite') {
+                // fsRead and listDirectory write to an existing card and could show nothing in the current position
+                if (['fsWrite', 'fsRead', 'listDirectory'].includes(toolUse.name)) {
                     await this.#showUndoAllIfRequired(chatResultStream, session)
                 }
                 const { explanation } = toolUse.input as unknown as ExplanatoryParams
@@ -871,6 +872,9 @@ export class AgenticChatController implements ChatHandlers {
      * Updates the currentUndoAllId state in the session
      */
     #updateUndoAllState(toolUse: ToolUse, session: ChatSessionService) {
+        if (toolUse.name === 'fsRead' || toolUse.name === 'listDirectory') {
+            return
+        }
         if (toolUse.name === 'fsWrite') {
             if (session.currentUndoAllId === undefined) {
                 session.currentUndoAllId = toolUse.toolUseId

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -666,7 +666,7 @@ export class AgenticChatController implements ChatHandlers {
                     throw new Error(`Tool ${toolUse.name} is not available in the current mode`)
                 }
                 // fsRead and listDirectory write to an existing card and could show nothing in the current position
-                if (['fsWrite', 'fsRead', 'listDirectory'].includes(toolUse.name)) {
+                if (!['fsWrite', 'fsRead', 'listDirectory'].includes(toolUse.name)) {
                     await this.#showUndoAllIfRequired(chatResultStream, session)
                 }
                 const { explanation } = toolUse.input as unknown as ExplanatoryParams


### PR DESCRIPTION
## Problem

![image](https://github.com/user-attachments/assets/7c43ed28-a7ae-4f7f-a1ef-695da7b3d86b)

This can happen if there is a read operation between write operations. Since read updates get added to an existing card it can look confusing.

## Solution

Don't reset the undoAll state and don't show the undoAll button when there is a read or list operation. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
