### PR TITLE
feat: add prevalidation step for request

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -961,6 +961,7 @@ describe('AgenticChatController', () => {
             const typedChatResult = chatResult as ResponseError<ChatResult>
             assert.ok(typedChatResult.message.includes('too long'))
             assert.ok(typedChatResult.data?.body?.includes('too long'))
+            assert.ok(generateAssistantResponseStub.notCalled)
         })
 
         it('shows generic errorMsg on internal errors', async function () {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -46,7 +46,7 @@ import { ChatDatabase } from './tools/chatDb/chatDb'
 import { LocalProjectContextController } from '../../shared/localProjectContextController'
 import { CancellationError } from '@aws/lsp-core'
 import { ToolApprovalException } from './tools/toolShared'
-import { genericErrorMsg } from './constants'
+import { generateAssistantResponseInputLimit, genericErrorMsg } from './constants'
 import { MISSING_BEARER_TOKEN_ERROR } from '../../shared/constants'
 import {
     AmazonQError,
@@ -949,6 +949,18 @@ describe('AgenticChatController', () => {
             const typedChatResult = chatResult as ResponseError<ChatResult>
             assert.strictEqual(typedChatResult.message, errorMsg)
             assert.strictEqual(typedChatResult.data?.body, errorMsg)
+        })
+
+        it('does not make backend request when input is too long ', async function () {
+            const input = 'X'.repeat(generateAssistantResponseInputLimit + 1)
+            const chatResult = await chatController.onChatPrompt(
+                { tabId: mockTabId, prompt: { prompt: input } },
+                mockCancellationToken
+            )
+
+            const typedChatResult = chatResult as ResponseError<ChatResult>
+            assert.ok(typedChatResult.message.includes('too long'))
+            assert.ok(typedChatResult.data?.body?.includes('too long'))
         })
 
         it('shows generic errorMsg on internal errors', async function () {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -658,7 +658,7 @@ export class AgenticChatController implements ChatHandlers {
         if (message && message.length > generateAssistantResponseInputLimit) {
             throw new AgenticChatError(
                 `Message is too long with ${message.length} characters, max is ${generateAssistantResponseInputLimit}`,
-                'MessageTooLong'
+                'PromptCharacterLimit'
             )
         }
     }
@@ -1529,7 +1529,7 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         // These are errors we want to show custom messages in chat for.
-        if (['QModelResponse', 'MaxAgentLoopIterations', 'InputTooLong', 'MessageTooLong'].includes(err.code)) {
+        if (['QModelResponse', 'MaxAgentLoopIterations', 'InputTooLong', 'PromptCharacterLimit'].includes(err.code)) {
             this.#features.logging.error(`${loggingUtils.formatErr(err)}`)
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
                 type: 'answer',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -118,7 +118,7 @@ import {
     generateAssistantResponseInputLimit,
 } from './constants'
 import { URI } from 'vscode-uri'
-import { AgenticChatError } from './errors'
+import { AgenticChatError, customerFacingErrorCodes } from './errors'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -1528,8 +1528,7 @@ export class AgenticChatController implements ChatHandlers {
             return createAuthFollowUpResult(authFollowType)
         }
 
-        // These are errors we want to show custom messages in chat for.
-        if (['QModelResponse', 'MaxAgentLoopIterations', 'InputTooLong', 'PromptCharacterLimit'].includes(err.code)) {
+        if (customerFacingErrorCodes.includes(err.code)) {
             this.#features.logging.error(`${loggingUtils.formatErr(err)}`)
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
                 type: 'answer',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
@@ -1,3 +1,4 @@
 export const genericErrorMsg = 'An unexpected error occurred, check the logs for more information.'
 export const maxAgentLoopIterations = 100
 export const loadingThresholdMs = 2000
+export const generateAssistantResponseInputLimit = 600_000

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -1,11 +1,12 @@
 import { CodeWhispererStreamingServiceException } from '@amzn/codewhisperer-streaming'
 
 type AgenticChatErrorCode =
-    | 'QModelResponse'
-    | 'AmazonQServiceManager'
-    | 'FailedResult'
+    | 'QModelResponse' // generic backend error.
+    | 'AmazonQServiceManager' // AmazonQServiceManager failed to initialize.
+    | 'FailedResult' // general error when processing tool results
     | 'MaxAgentLoopIterations'
-    | 'InputTooLong'
+    | 'InputTooLong' // too much context given to backend service.
+    | 'MessageTooLong' // customer prompt exceeds
 
 export class AgenticChatError extends Error {
     constructor(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -8,6 +8,12 @@ type AgenticChatErrorCode =
     | 'InputTooLong' // too much context given to backend service.
     | 'PromptCharacterLimit' // customer prompt exceeds
 
+export const customerFacingErrorCodes: AgenticChatErrorCode[] = [
+    'QModelResponse',
+    'MaxAgentLoopIterations',
+    'InputTooLong',
+    'PromptCharacterLimit',
+]
 export class AgenticChatError extends Error {
     constructor(
         message: string,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -6,7 +6,7 @@ type AgenticChatErrorCode =
     | 'FailedResult' // general error when processing tool results
     | 'MaxAgentLoopIterations'
     | 'InputTooLong' // too much context given to backend service.
-    | 'MessageTooLong' // customer prompt exceeds
+    | 'PromptCharacterLimit' // customer prompt exceeds
 
 export class AgenticChatError extends Error {
     constructor(


### PR DESCRIPTION
## Problem
There are certain requests that we know will fail before they are made. One example is if the prompt message is over 600k characters. 

## Solution
- add a pre-validation step for verifying the request that will throw user-facing error messages. 
- implement check for input message exceeds the backends limit. 

## Verification
- overwrite the message with one of 600,001 characters. 
- unit test for full flow.
<img width="321" alt="image" src="https://github.com/user-attachments/assets/8b572788-7e55-41fb-bd75-3cde6fe10d94" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
