### PR TITLE
fix: prefix if user reject/stop command, whole card should be dimmed

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -621,9 +621,7 @@ export const createMynahUi = (
                             : am.type === 'directive'
                               ? ChatItemType.DIRECTIVE
                               : ChatItemType.ANSWER_STREAM,
-                    ...prepareChatItemFromMessage(am, isPairProgrammingMode, isPartialResult),
-                    // Apply muted if the message should be muted
-                    ...(shouldMute ? { muted: true } : {}),
+                    ...prepareChatItemFromMessage(am, isPairProgrammingMode, isPartialResult, shouldMute),
                 }
 
                 if (!chatItems.find(ci => ci.messageId === am.messageId)) {
@@ -676,8 +674,6 @@ export const createMynahUi = (
                 ...chatResultWithoutType, // type for MynahUI differs from ChatResult types so we ignore it
                 header: header,
                 buttons: buttons,
-                // Apply muted if the message should be muted
-                ...(shouldMute ? { muted: true } : {}),
             })
 
             // TODO, prompt should be disabled until user is authenticated
@@ -842,9 +838,12 @@ export const createMynahUi = (
 
                 const chatItem: ChatItem = {
                     type: oldMessage.type,
-                    ...prepareChatItemFromMessage(updatedMessage, getTabPairProgrammingMode(mynahUi, tabId)),
+                    ...prepareChatItemFromMessage(
+                        updatedMessage,
+                        getTabPairProgrammingMode(mynahUi, tabId),
+                        shouldMute
+                    ),
                     // Apply muted if the message should be muted
-                    ...(shouldMute ? { muted: true } : {}),
                 }
                 mynahUi.updateChatAnswerWithMessageId(tabId, updatedMessage.messageId, chatItem)
             })
@@ -869,7 +868,8 @@ export const createMynahUi = (
     const prepareChatItemFromMessage = (
         message: ChatMessage,
         isPairProgrammingMode: boolean,
-        isPartialResult?: boolean
+        isPartialResult?: boolean,
+        shouldMute = false
     ): Partial<ChatItem> => {
         const contextHeader = contextListToHeader(message.contextList)
         const header = contextHeader || toMynahHeader(message.header) // Is this mutually exclusive?
@@ -933,6 +933,7 @@ export const createMynahUi = (
                     : isPairProgrammingMode
                       ? { 'insert-to-cursor': null }
                       : undefined,
+            ...(shouldMute ? { muted: true } : {}),
         }
     }
 

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -603,6 +603,10 @@ export const createMynahUi = (
         const chatItems = store.chatItems || []
         const isPairProgrammingMode: boolean = getTabPairProgrammingMode(mynahUi, tabId)
 
+        // Check if this is a stopped or rejected response that should be muted
+        const shouldMute =
+            // Check for status indicating stopped/rejected
+            chatResult.header?.status?.text === 'Stopped' || chatResult.header?.status?.text === 'Rejected'
         if (chatResult.additionalMessages?.length) {
             mynahUi.updateStore(tabId, {
                 loadingChat: true,
@@ -618,6 +622,8 @@ export const createMynahUi = (
                               ? ChatItemType.DIRECTIVE
                               : ChatItemType.ANSWER_STREAM,
                     ...prepareChatItemFromMessage(am, isPairProgrammingMode, isPartialResult),
+                    // Apply muted if the message should be muted
+                    ...(shouldMute ? { muted: true } : {}),
                 }
 
                 if (!chatItems.find(ci => ci.messageId === am.messageId)) {
@@ -641,6 +647,8 @@ export const createMynahUi = (
                 buttons: buttons,
                 fileList,
                 codeBlockActions: isPairProgrammingMode ? { 'insert-to-cursor': null } : undefined,
+                // Apply muted if the message should be muted
+                ...(shouldMute ? { muted: true } : {}),
             }
 
             if (!chatItems.find(ci => ci.messageId === chatResult.messageId)) {
@@ -668,6 +676,8 @@ export const createMynahUi = (
                 ...chatResultWithoutType, // type for MynahUI differs from ChatResult types so we ignore it
                 header: header,
                 buttons: buttons,
+                // Apply muted if the message should be muted
+                ...(shouldMute ? { muted: true } : {}),
             })
 
             // TODO, prompt should be disabled until user is authenticated
@@ -689,6 +699,8 @@ export const createMynahUi = (
             header: header,
             buttons: buttons,
             codeBlockActions: isPairProgrammingMode ? { 'insert-to-cursor': null } : undefined,
+            // Apply muted if the message should be muted
+            ...(shouldMute ? { muted: true } : {}),
         }
 
         if (!chatItems.find(ci => ci.messageId === chatResult.messageId)) {
@@ -822,11 +834,18 @@ export const createMynahUi = (
                 const oldMessage = chatItems.find(ci => ci.messageId === updatedMessage.messageId)
                 if (!oldMessage) return
 
+                // Check if this message should be muted
+                const shouldMute =
+                    // Check for status indicating stopped/rejected
+                    updatedMessage.header?.status?.text === 'Stopped' ||
+                    updatedMessage.header?.status?.text === 'Rejected'
+
                 const chatItem: ChatItem = {
                     type: oldMessage.type,
                     ...prepareChatItemFromMessage(updatedMessage, getTabPairProgrammingMode(mynahUi, tabId)),
+                    // Apply muted if the message should be muted
+                    ...(shouldMute ? { muted: true } : {}),
                 }
-
                 mynahUi.updateChatAnswerWithMessageId(tabId, updatedMessage.messageId, chatItem)
             })
         }

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -689,7 +689,6 @@ export const createMynahUi = (
             header: header,
             buttons: buttons,
             codeBlockActions: isPairProgrammingMode ? { 'insert-to-cursor': null } : undefined,
-            // Apply muted if the message should be muted
         }
 
         if (!chatItems.find(ci => ci.messageId === chatResult.messageId)) {
@@ -853,7 +852,7 @@ export const createMynahUi = (
         isPartialResult?: boolean
     ): Partial<ChatItem> => {
         const contextHeader = contextListToHeader(message.contextList)
-        const header = contextHeader || toMynahHeader(message.header)
+        const header = contextHeader || toMynahHeader(message.header) // Is this mutually exclusive?
         const fileList = toMynahFileList(message.fileList)
 
         let processedHeader = header
@@ -880,9 +879,12 @@ export const createMynahUi = (
             }
         }
 
+        // Check if header should be included
         const includeHeader =
             processedHeader &&
-            ((processedHeader.buttons?.length ?? 0) > 0 ||
+            ((processedHeader.buttons !== undefined &&
+                processedHeader.buttons !== null &&
+                processedHeader.buttons.length > 0) ||
                 processedHeader.status !== undefined ||
                 processedHeader.icon !== undefined)
 
@@ -892,7 +894,7 @@ export const createMynahUi = (
         const processedButtons: ChatItemButton[] | undefined = toMynahButtons(message.buttons)?.map(button =>
             button.id === 'undo-all-changes' ? { ...button, position: 'outside' } : button
         )
-
+        // Adding this conditional check to show the stop message in the center.
         const contentHorizontalAlignment: ChatItem['contentHorizontalAlignment'] =
             message.type === 'directive' && message.messageId?.startsWith('stopped') ? 'center' : undefined
 
@@ -903,6 +905,7 @@ export const createMynahUi = (
             header: includeHeader ? processedHeader : undefined,
             buttons: processedButtons,
             fileList,
+            // file diffs in the header need space
             fullWidth: message.type === 'tool' && message.header?.buttons ? true : undefined,
             padding,
             contentHorizontalAlignment,


### PR DESCRIPTION
## Problem
when user reject/stop command, all other text in the command should also be disabled color. 
![image](https://github.com/user-attachments/assets/f0534e69-694e-41ee-b557-bdecb8177b13)

## Solution
![image](https://github.com/user-attachments/assets/c0bc579f-48d8-4edf-aa32-f2978c15a4e6)


## Notice
This is a prefix, the fix won't work until mynah release the newest version
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
