### PR TITLE
fix: updated spacings through mynah-ui update

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.32",
         "@aws/language-server-runtimes-types": "^0.1.25",
-        "@aws/mynah-ui": "^4.32.1"
+        "@aws/mynah-ui": "^4.33.0"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -739,7 +739,10 @@ export const createMynahUi = (
         if (message.type === 'tool') {
             processedHeader = { ...header }
             if (header?.buttons) {
-                processedHeader.buttons = header.buttons.map(button => ({ ...button, status: 'clear' }))
+                processedHeader.buttons = header.buttons.map(button => ({
+                    ...button,
+                    status: button.status ?? 'clear',
+                }))
             }
             if (header?.fileList) {
                 processedHeader.fileList = {

--- a/chat-client/src/client/texts/pairProgramming.ts
+++ b/chat-client/src/client/texts/pairProgramming.ts
@@ -26,11 +26,13 @@ export const pairProgrammingPromptInput: ChatItemFormItem = {
 export const pairProgrammingModeOn: ChatItem = {
     type: ChatItemType.DIRECTIVE,
     contentHorizontalAlignment: 'center',
+    fullWidth: true,
     body: 'Pair programmer mode ON',
 }
 
 export const pairProgrammingModeOff: ChatItem = {
     type: ChatItemType.DIRECTIVE,
     contentHorizontalAlignment: 'center',
+    fullWidth: true,
     body: 'Pair programmer mode OFF',
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.32",
                 "@aws/language-server-runtimes-types": "^0.1.25",
-                "@aws/mynah-ui": "^4.32.1"
+                "@aws/mynah-ui": "^4.33.0"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4063,9 +4063,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.32.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.32.1.tgz",
-            "integrity": "sha512-M1gINX+HfTxInXKv5B6fZTH3sKQeoRdpAdElTbdbuN41joLJSmkU9Up3pro4nl/Q5JVqbpZ8itwu5VCFAmLKYg==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.33.0.tgz",
+            "integrity": "sha512-RDYzi4W4DvX5Dgo8xWVMAlhWaGcTIWT2U8XBifcwqBUYrBwJSO/D9/0tYwZh3yj2kMohkO9KyCvOzYfQKhs18g==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1207,7 +1207,19 @@ export class AgenticChatController implements ChatHandlers {
         toolType?: string
     ): ChatResult {
         let buttons: Button[] = []
-        let header: { body: string; buttons: Button[]; icon?: string; iconForegroundStatus?: string }
+        let header: {
+            body: string
+            buttons: Button[]
+            icon?: string
+            iconForegroundStatus?: string
+            status?: {
+                status?: Status
+                position?: 'left' | 'right'
+                description?: string
+                icon?: string
+                text?: string
+            }
+        }
         let body: string
 
         switch (toolType || toolUse.name) {
@@ -1228,8 +1240,12 @@ export class AgenticChatController implements ChatHandlers {
                       ]
                     : []
                 header = {
-                    icon: 'warning',
-                    iconForegroundStatus: 'warning',
+                    status: {
+                        icon: 'warning',
+                        status: 'warning',
+                        position: 'left',
+                        // TODO: Add `description` if necessary to show a tooltip
+                    },
                     body: 'shell',
                     buttons,
                 }


### PR DESCRIPTION
## Problem
- Spacings are not properly adjusted
- Header button status `dimmed-clear` was not being applied

## Solution
- Updated mynahui to refine spacings and the switch component
- Updated fixed static button status handling on header.


## MynahUI Updates
## Problems addressed
- `header` status fields without a status color applied should get the `disabled` color instead of the `weak` color.
- `header` is not possible to update partially, it requires all or none
- `switch` component styles are not matching
- `status` for the `header` is only available on the right side, it should be optional to put it on the left
- spacings are not matching the expected designs
- spacing after a DIRECTIVE without lines or horizontally center aligned was wrong
- no option to horizontally align the DIRECTIVE card to center without having the side lines
- Refreshing content on the header causes a flickr jump

## Solutions applied
- Color of the `header.status` is changed in case of no specific `header.status.status` value is given for `muted` cards
- `header` can be updated partially, it helps keeping the user triggered collapsed/uncollapsed state of the `fileList` inside a header too. Basically every item in header can be updated partially. To update the buttons, you don't need to send the whole `header` object with its all previous values anymore.
- `switch` component is created as an individual component with its own new styles.
-  Added `position` option to `header.status` to allow consumer to put the status field to the left of the header or keep it on right.
- All spacings readjusted depending on the expected values
- Spacing after DIRECTIVE card depending on its state is updated.
- side lines for the DIRECTIVE card are being added only if the card is horizontally center and `fullWidth: true`
- Removed the reveal animation from the header blocks

![image](https://github.com/user-attachments/assets/764f6777-7021-400c-b12f-c21267910cab)
<img width="258" alt="image" src="https://github.com/user-attachments/assets/a98dd3ca-3b67-4eef-935d-636e395673d5" />
<img width="253" alt="image" src="https://github.com/user-attachments/assets/e936fde1-bae1-4b52-aae9-961fd8c63e23" />
<img width="591" alt="image" src="https://github.com/user-attachments/assets/c1194592-e1f0-4406-82db-7801ee994d9a" />
<img width="575" alt="image" src="https://github.com/user-attachments/assets/f2d8ae33-5fe3-4e93-8fd1-b70fb41dabbd" />
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
