### PR TITLE
feat: restore open history tabs from client state after process crash

### DIFF
--- a/chat-client/src/client/features/history.ts
+++ b/chat-client/src/client/features/history.ts
@@ -16,6 +16,7 @@ interface MynahDetailedList {
 
 export class ChatHistoryList {
     historyDetailedList: MynahDetailedList | undefined
+    private tabMapping: Map<string, string> = new Map()
 
     constructor(
         private mynahUi: MynahUI,
@@ -123,5 +124,26 @@ export class ChatHistoryList {
             default:
                 throw new Error(`Unsupported action: ${actionText}`)
         }
+    }
+
+    setTabIdMapping(historyId: string, tabId: string) {
+        this.tabMapping.set(historyId, tabId)
+    }
+
+    deleteTabIdMapping(tabId: string) {
+        // Delete all items by value.
+        for (const [historyId, cachedTabId] of this.tabMapping) {
+            if (tabId === cachedTabId) {
+                this.tabMapping.delete(historyId)
+            }
+        }
+    }
+
+    getTabMapping() {
+        return Object.fromEntries(this.tabMapping)
+    }
+
+    getTabId(historyId: string) {
+        return this.tabMapping.get(historyId)
     }
 }

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -182,6 +182,9 @@ export function registerChat(languageClient: LanguageClient, extensionUri: Uri, 
                                 buttonClickRequestType.method
                             )
                             break
+                        case 'aws/chat/restoreChatState':
+                            languageClient.sendNotification('aws/chat/restoreChatState', message.params)
+                            break
                         case followUpClickNotificationType.method:
                             if (!isValidAuthFollowUpType(message.params.followUp.type))
                                 languageClient.sendNotification(followUpClickNotificationType, message.params)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -183,6 +183,7 @@ describe('AgenticChatController', () => {
 
         additionalContextProviderStub = sinon.stub(AdditionalContextProvider.prototype, 'getAdditionalContext')
         additionalContextProviderStub.resolves([])
+
         // @ts-ignore
         const cachedInitializeParams: InitializeParams = {
             initializationOptions: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1757,7 +1757,7 @@ export class AgenticChatController implements ChatHandlers {
         this.#telemetryController.removeConversation(params.tabId)
     }
 
-    onQuickAction(params: QuickActionParams, _cancellationToken: CancellationToken) {
+    async onQuickAction(params: QuickActionParams, _cancellationToken: CancellationToken) {
         switch (params.quickAction) {
             case QuickAction.Clear: {
                 const sessionResult = this.#chatSessionManagementService.getSession(params.tabId)
@@ -1788,6 +1788,10 @@ export class AgenticChatController implements ChatHandlers {
                     messageId: uuid(),
                     body: HELP_MESSAGE,
                 }
+
+            case '/crash':
+                // throw new Error("FATAL: Planted process crash")
+                process.kill(process.pid, 'SIGINT')
             default:
                 return {}
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -110,6 +110,14 @@ export class ContextCommandsProvider implements Disposable {
 
     async mapContextCommandItems(items: ContextCommandItem[]): Promise<ContextCommandGroup[]> {
         const folderCmds: ContextCommand[] = []
+        folderCmds.push({
+            command: 'Testpath',
+            description: 'somepath',
+            route: ['/somepath'],
+            id: 'somepath',
+            label: 'folder',
+            icon: 'folder',
+        })
         const folderCmdGroup: ContextCommand = {
             command: 'Folders',
             children: [

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -40,7 +40,11 @@ export const QAgenticChatServer =
                         quickActions: {
                             quickActionsCommandGroups: [
                                 {
-                                    commands: [HELP_QUICK_ACTION, CLEAR_QUICK_ACTION],
+                                    commands: [HELP_QUICK_ACTION, CLEAR_QUICK_ACTION, {
+                                        command: '/crash',
+                                        description: 'Crash language server',
+                                        icon: 'cancel',
+                                    }],
                                 },
                             ],
                         },

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -164,6 +164,7 @@ export class ChatDatabase {
                 indices: ['updatedAt', 'isOpen'],
             })
         }
+        // await new Promise((resolve) => setTimeout(resolve, 5000)) // loading delay
         this.#initialized = true
     }
 


### PR DESCRIPTION
## REVERT THIS BEFORE MERGING:

This PR contains code wit example quick command to crash nodejs process for testing. Revert this commit before merging https://github.com/aws/language-servers/pull/1215/commits/df410911e9e2a6d189f68294de5cac2c4fc7964d

## Problem

When language server process crashes, it loses in-memory cache of mapping UI tabs to history IDs. When extension restarts language server automatically, chat client UI stays loaded, but History server does not have mapping to open tabs anymore. This results in inconsistent UI, when using chat after crash:
1. Opening history items from list will always open new UI tab, even if one was opened before crash
2. Sending messages to old open tabs are not stored in history anymore

## Solution

Potential fix: maintain mapping between history items and ui tabs in Chat client, and restore history state in language server process memory after restart. Сhat client can detect that server reconnected when it receives inbound "CHAT_OPTIONS" notification more than once: as CHAT_OPTIONS should be sent from language server once during initialization handshake.

1. Added historyId to tabId mapping in Chat client
2. Added notification to send cached state from chat client to language server when more than one CHAT_OPTIONS request is received
3. Added new `chat.onRestoreState` notification from Chat client to agenticQChat server to restore it's in-memory state from client state data. We can't use `chat.onReady` event, as it is sent once from Chat Client to server during Chat Client and MynahUI initialization. Since Chat Client remains loaded in webview, this event does not happen second time.
4. Extended `chat.openTab` request from server to client to include `historyId` string. History handling server  needs to send `historyId` so chat client can maintain it's own tab to history map.

WIP: to test this E2E, grab wip protocol changes from https://github.com/aws/language-server-runtimes/pull/491 and build runtimes package locally.

#### UX without fix

https://github.com/user-attachments/assets/65c4ce1f-f371-4222-a963-0a379623b300

#### UX with fix

https://github.com/user-attachments/assets/8c817ddf-751e-4b31-a3fb-d966166e3c78

### Alternative

Evaluate if complexity with gracefully restoring state is justified - potentially there might be edge cases that are not handled with this PR. Thorough testing and review is needed.

Alternative solution could be for extension to detect language server process crash, show informative message to customer on language server crash and reload Chat Client in webview together with Language server.

## WIP notes
* [ ] Needs thorough E2E testing
* [ ] New protocol changes (chat.onRestoreState) and in (chat.openTab) need to be added to Runtimes protocol https://github.com/aws/language-server-runtimes/pull/491
* [ ] Needs unit tests
* [ ] Revert commit that adds "/crash" quick action for triggering process exit https://github.com/aws/language-servers/pull/1215/commits/df410911e9e2a6d189f68294de5cac2c4fc7964d

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
