### PR TITLE
fix: add code reference to response stream

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -347,6 +347,7 @@ describe('AgenticChatController', () => {
                 body: '\n\nHello World!',
                 messageId: 'mock-message-id',
                 buttons: [],
+                codeReference: [],
                 header: undefined,
             })
         })
@@ -911,6 +912,7 @@ describe('AgenticChatController', () => {
                 additionalMessages: [],
                 body: '\n\nHello World!',
                 messageId: 'mock-message-id',
+                codeReference: [],
                 buttons: [],
                 header: undefined,
             })
@@ -930,6 +932,7 @@ describe('AgenticChatController', () => {
                 body: '\n\nHello World!',
                 messageId: 'mock-message-id',
                 buttons: [],
+                codeReference: [],
                 header: undefined,
             })
         })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1972,7 +1972,8 @@ export class AgenticChatController implements ChatHandlers {
                 return result
             }
 
-            if (chatEvent.assistantResponseEvent) {
+            // make sure to save code reference events
+            if (chatEvent.assistantResponseEvent || chatEvent.codeReferenceEvent) {
                 await streamWriter.write(result.data.chatResult)
             }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -112,6 +112,7 @@ export class AgenticChatResultStream {
                         body: acc.body + AgenticChatResultStream.resultDelimiter + c.body,
                         ...(c.contextList && { contextList: c.contextList }),
                         header: Object.prototype.hasOwnProperty.call(c, 'header') ? c.header : acc.header,
+                        codeReference: [...(acc.codeReference ?? []), ...(c.codeReference ?? [])],
                     }
                 } else if (acc.additionalMessages!.some(am => am.messageId === c.messageId)) {
                     return {


### PR DESCRIPTION
## Problem
When we get a code reference event we aren't writing the chat result to the result stream, causing the code reference to not get sent back to the editors

## Solution
Handle code reference events and send them back to the editors

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
