### PR TITLE
fix: log entire raw request

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -398,7 +398,7 @@ export class AgenticChatController implements ChatHandlers {
                 await this.#getChatResultStream(params.partialResultToken).writeResultBlock({
                     type: 'directive',
                     messageId: 'stopped' + uuid(),
-                    body: 'You stoppped your current work, please provide additional examples or ask another question.',
+                    body: 'You stopped your current work, please provide additional examples or ask another question.',
                 })
                 this.#telemetryController.emitInteractWithAgenticChat('StopChat', params.tabId)
                 session.abortRequest()

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -654,9 +654,7 @@ export class AgenticChatController implements ChatHandlers {
      */
     #validateRequest(request: GenerateAssistantResponseCommandInput) {
         // Note: these logs are very noisy, but contain information redacted on the backend.
-        this.#debug(
-            `Q Model Request: ${loggingUtils.formatObj(request, { depth: 12, maxStringLength: 1000, omitKeys: ['tools'] })}`
-        )
+        this.#debug(`Q Model Request: ${JSON.stringify(request, undefined, 2)}`)
         const message = request.conversationState?.currentMessage?.userInputMessage?.content
         if (message && message.length > generateAssistantResponseInputLimit) {
             throw new AgenticChatError(


### PR DESCRIPTION
## Problem
The entire request can be useful for debugging customer issues. 

## Solution
- Log the raw request, no truncation, no filtered keys. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
