### PR TITLE
fix: fix for permission case for execute bash

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -242,7 +242,7 @@ export class ExecuteBash {
                     case CommandCategory.ReadOnly:
                         continue
                     default:
-                        return { requiresAcceptance: true }
+                        continue
                 }
             }
             // Finally, check if the cwd is outside the workspace


### PR DESCRIPTION
## Problem
In default cases, Shell execution outside of workspace is not showing warning.

## Solution
- Continue in default case and not return requiresAcceptance value.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
