### PR TITLE
feat: add request id to default log level

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -560,7 +560,7 @@ export class AgenticChatController implements ChatHandlers {
             this.#validateRequest(currentRequestInput)
             const response = await session.generateAssistantResponse(currentRequestInput)
             this.#features.logging.info(
-                `generateAssistantResponse Response: ${loggingUtils.formatObj(response.$metadata)}`
+                `generateAssistantResponse ResponseMetadata: ${loggingUtils.formatObj(response.$metadata)}`
             )
             await chatResultStream.removeResultBlock(loadingMessageId)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -559,8 +559,9 @@ export class AgenticChatController implements ChatHandlers {
             // Phase 3: Request Execution
             this.#validateRequest(currentRequestInput)
             const response = await session.generateAssistantResponse(currentRequestInput)
-            this.#debug(`Q Model Response: ${loggingUtils.formatObj(response, { depth: 5 })}`)
-
+            this.#features.logging.info(
+                `generateAssistantResponse Response: ${loggingUtils.formatObj(response.$metadata)}`
+            )
             await chatResultStream.removeResultBlock(loadingMessageId)
 
             //  Add the current user message to the history DB
@@ -659,7 +660,7 @@ export class AgenticChatController implements ChatHandlers {
      */
     #validateRequest(request: GenerateAssistantResponseCommandInput) {
         // Note: these logs are very noisy, but contain information redacted on the backend.
-        this.#debug(`Q Model Request: ${JSON.stringify(request, undefined, 2)}`)
+        this.#debug(`generateAssistantResponse Request: ${JSON.stringify(request, undefined, 2)}`)
         const message = request.conversationState?.currentMessage?.userInputMessage?.content
         if (message && message.length > generateAssistantResponseInputLimit) {
             throw new AgenticChatError(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -143,7 +143,9 @@ export class AgenticChatEventParser implements ChatResult {
                             parsedInput = finalInput
                         }
                     } catch (err) {
-                        console.error(`Error parsing tool use input: ${this.toolUses[toolUseId].input}`, err)
+                        this.#logging.error(
+                            `Error parsing tool use input: ${this.toolUses[toolUseId].input}:${loggingUtils.formatErr(err)}`
+                        )
                         this.error = `ToolUse input is invalid JSON: "${this.toolUses[toolUseId].input}".`
                         parsedInput = {}
                     }


### PR DESCRIPTION
## Problem
requestId is the single most important piece of information for the backend team in order to effectively debug these issues and its only visible at the `trace` level. 
## Solution
log it by default at `info` level, along with the rest of the response metadata. 

### Example Logs
```
2025-04-30 19:06:55.971 [info] [Info  - 7:06:55 PM] [2025-04-30T23:06:55.966Z] generateAssistantResponse Response: {
  "httpStatusCode": 200,
  "requestId": "1e8a80f1-4d78-47fe-933d-ffe9f29efafe",
  "attempts": 1,
  "totalRetryDelay": 0
}
```
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
