### PR TITLE
fix: typo in cwsprChatTimeToFirstChunk and remove all zeros

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -102,9 +102,12 @@ export class AgenticChatEventParser implements ChatResult {
                 cwsprChatTimeBetweenChunks: [],
             })
         } else {
-            this.#metric.mergeWith({
-                cwsprChatTimeBetweenChunks: [Date.now() - this.#lastChunkTime],
-            })
+            const chatTime = Date.now() - this.#lastChunkTime
+            if (chatTime !== 0) {
+                this.#metric.mergeWith({
+                    cwsprChatTimeBetweenChunks: [chatTime],
+                })
+            }
         }
 
         this.#lastChunkTime = Date.now()

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -788,7 +788,7 @@ describe('TelemetryService', () => {
                     cwsprChatSourceLinkCount: undefined,
                     cwsprChatReferencesCount: undefined,
                     cwsprChatFollowUpCount: undefined,
-                    cwsprTimeToFirstChunk: 100,
+                    cwsprChatTimeToFirstChunk: 100,
                     cwsprChatFullResponseLatency: 400,
                     cwsprChatTimeBetweenChunks: undefined,
                     cwsprChatRequestLength: 100,

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -434,7 +434,7 @@ export class TelemetryService {
                     cwsprChatSourceLinkCount: additionalParams.chatSourceLinkCount,
                     cwsprChatReferencesCount: additionalParams.chatReferencesCount,
                     cwsprChatFollowUpCount: additionalParams.chatFollowUpCount,
-                    cwsprTimeToFirstChunk: params.timeToFirstChunkMilliseconds,
+                    cwsprChatTimeToFirstChunk: params.timeToFirstChunkMilliseconds,
                     cwsprChatFullResponseLatency: params.fullResponselatency,
                     cwsprChatTimeBetweenChunks: timeBetweenChunks,
                     cwsprChatRequestLength: params.requestLength,


### PR DESCRIPTION
## Problem
- `cwsprChatTimeToFirstChunk` field had a typo causing this specific field to be missing when `amazonq_addMessage` metric is emitted
- `cwsprChatTimeBetweenChunks` should not have zeros

## Solution
- fix typo
- don't append value to cwsprChatTimeBetweenChunks if it is 0

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
