### PR TITLE
fix: output validation is incorrect for json output

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -997,8 +997,9 @@ export class AgenticChatController implements ChatHandlers {
         let maxToolResponseSize
         switch (toolUse.name) {
             case 'fsRead':
-                maxToolResponseSize = 200_000
-                break
+            case 'executeBash':
+                // fsRead and executeBash already have truncation logic
+                return
             case 'listDirectory':
                 maxToolResponseSize = 30_000
                 break


### PR DESCRIPTION
## Problem

FsRead and ExecuteBash output already has truncation logic. Since we are checking the size of the overall JSON, sometimes the tool can be truncated but still throw an error for character limit exceeded.

## Solution

Skip the validation for FsRead and ExecuteBash for now.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
