### PR TITLE
fix: hide stop button in legacy chat client mode

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -150,6 +150,7 @@ const initializeChatResponse = (mynahUi: MynahUI, tabId: string, userPrompt?: st
     } else {
         mynahUi.updateStore(tabId, {
             loadingChat: true,
+            cancelButtonWhenLoading: false,
             promptInputDisabledState: true,
         })
     }
@@ -798,6 +799,7 @@ export const createMynahUi = (
 
         mynahUi.updateStore(tabId, {
             loadingChat: false,
+            cancelButtonWhenLoading: false,
             promptInputDisabledState: false,
         })
     }


### PR DESCRIPTION
## Problem
Stop button is shown when chat client is not in agenticMode. This is not in line with legacy mode for extensions that didn't migrate to Agentic chat

## Solution
Do not show stop button in mynahUI in legacy mode

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
