### PR TITLE
fix: stop button showing in non-agentic chat

### DIFF
--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -38,6 +38,7 @@ export class TabFactory {
             ...this.getDefaultTabData(),
             ...(disclaimerCardActive ? { promptInputStickyCard: disclaimerCard } : {}),
             promptInputOptions: this.agenticMode ? [pairProgrammingPromptInput] : [],
+            cancelButtonWhenLoading: this.agenticMode, // supported for agentic chat only
         }
         return tabData
     }

--- a/client/vscode/src/chatActivation.ts
+++ b/client/vscode/src/chatActivation.ts
@@ -437,7 +437,7 @@ function generateJS(webView: Webview, extensionUri: Uri, agenticMode: boolean): 
             stringValue: '@sage',
         },
     })
-    const stringifiedContextCommands = JSON.stringify(Array.from(chatFeatures.entries()))
+    const stringifiedContextCommands = agenticMode ? JSON.stringify(Array.from(chatFeatures.entries())) : '[]'
 
     return `
     <script type="text/javascript" src="${entrypoint.toString()}" defer onload="init()"></script>


### PR DESCRIPTION
## Problem

Stop button showing but not supported in non-agentic chat.
Also, highlight command is confusing in non-agentic chat  in test client.

## Solution

- Show "Stop" button only in agentic chat
- Inject feature flags for agentic chat only, as non-agentic is not supporting this functionality yet

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
