### PR TITLE
fix: removing warning icon for shell commands

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1247,12 +1247,14 @@ export class AgenticChatController implements ChatHandlers {
                       ]
                     : []
                 header = {
-                    status: {
-                        icon: 'warning',
-                        status: 'warning',
-                        position: 'left',
-                        // TODO: Add `description` if necessary to show a tooltip
-                    },
+                    status: requiresAcceptance
+                        ? {
+                              icon: 'warning',
+                              status: 'warning',
+                              position: 'left',
+                              // TODO: Add `description` if necessary to show a tooltip
+                          }
+                        : {},
                     body: 'shell',
                     buttons,
                 }


### PR DESCRIPTION
# DO NOT MERGE
## Problem
- Unnecessary warning for normal shell commands
![image](https://github.com/user-attachments/assets/6344eb04-9f6d-4126-a777-48cc801bbbdb)

## Solution
- Fixed this.
![image](https://github.com/user-attachments/assets/fac8094c-a6c7-4744-9685-04e5dbcd2af0)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
