### PR TITLE
fix: only keep toolUses with `stop` = true in history

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -597,11 +597,13 @@ export class AgenticChatController implements ChatHandlers {
                         result.data.chatResult.relatedContent.content.length > 0
                             ? result.data?.chatResult.relatedContent
                             : undefined,
-                    toolUses: Object.keys(result.data?.toolUses!).map(k => ({
-                        toolUseId: result.data!.toolUses[k].toolUseId,
-                        name: result.data!.toolUses[k].name,
-                        input: result.data!.toolUses[k].input,
-                    })),
+                    toolUses: Object.keys(result.data?.toolUses!)
+                        .filter(k => result.data!.toolUses[k].stop)
+                        .map(k => ({
+                            toolUseId: result.data!.toolUses[k].toolUseId,
+                            name: result.data!.toolUses[k].name,
+                            input: result.data!.toolUses[k].input,
+                        })),
                 })
             } else {
                 this.#features.logging.warn('No ChatResult body in response, skipping adding to history')


### PR DESCRIPTION
## Problem
Message validation in bedrock occasionally fails due to a mismatch between the number of toolUses and expected number of toolResults in subsequent messages:


```
(ValidationException) when calling the ConverseStream operation: Bedrock error message: The model returned the following errors: messages.54: Did not find 2 `tool_result` block(s) at the beginning of this message. Messages following `tool_use` blocks must begin with a matching number of `tool_result` blocks. 
```


## Solution

We filter out toolUses by this `stop` flag in the response from the model [here](https://github.com/aws/language-servers/blob/main/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts#L676). In the history we store all toolUses regardless of this stop flag [here](https://github.com/aws/language-servers/blob/main/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts#L600) and as a result we may sometimes have less toolResults than toolUses in history messages if some were filtered out.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
