### PR TITLE
fix: switch to ignore entries over patterns

### DIFF
--- a/core/aws-lsp-core/src/util/workspaceUtils.test.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.test.ts
@@ -178,7 +178,7 @@ describe('workspaceUtils', function () {
             const result = (
                 await readDirectoryRecursively(testFeatures, tempFolder.path, {
                     customFormatCallback: getEntryPath,
-                    excludePatterns: [/.*-bad/],
+                    excludeEntries: [/.*-bad/],
                 })
             ).sort()
             assert.deepStrictEqual(
@@ -202,7 +202,7 @@ describe('workspaceUtils', function () {
             const result = (
                 await readDirectoryRecursively(testFeatures, tempFolder.path, {
                     customFormatCallback: getEntryPath,
-                    excludePatterns: ['-bad'],
+                    excludeEntries: ['-bad'],
                 })
             ).sort()
             assert.deepStrictEqual(

--- a/core/aws-lsp-core/src/util/workspaceUtils.test.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.test.ts
@@ -163,7 +163,7 @@ describe('workspaceUtils', function () {
             )
         })
 
-        it('ignores patterns in the exclude pattern', async function () {
+        it('ignores files in the exclude entries', async function () {
             const subdir1 = await tempFolder.nest('subdir1')
             const file1 = await subdir1.write('file1', 'this is content')
             const subdir2 = await tempFolder.nest('subdir2')
@@ -178,7 +178,7 @@ describe('workspaceUtils', function () {
             const result = (
                 await readDirectoryRecursively(testFeatures, tempFolder.path, {
                     customFormatCallback: getEntryPath,
-                    excludeEntries: [/.*-bad/],
+                    excludeEntries: ['file4-bad', 'file2-bad'],
                 })
             ).sort()
             assert.deepStrictEqual(
@@ -187,28 +187,26 @@ describe('workspaceUtils', function () {
             )
         })
 
-        it('ignores files in the exclude pattern', async function () {
+        it('ignores directories in the exclude entries', async function () {
             const subdir1 = await tempFolder.nest('subdir1')
             const file1 = await subdir1.write('file1', 'this is content')
             const subdir2 = await tempFolder.nest('subdir2')
-            await subdir2.write('file2-bad', 'this is other content')
+            const file2 = await subdir2.write('file2', 'this is other content')
 
             const subdir11 = await subdir1.nest('subdir11')
             const file3 = await subdir11.write('file3', 'this is also content')
-            const subdir12 = await subdir1.nest('subdir12')
+            const subdir12 = await subdir1.nest('subdir12-bad')
             await subdir12.write('file4-bad', 'this is even more content')
-            const file5 = await subdir12.write('file5', 'and this is it')
+            await subdir12.write('file5-bad', 'and this is it')
+            await subdir12.write('file6-bad', 'and this is it')
 
             const result = (
                 await readDirectoryRecursively(testFeatures, tempFolder.path, {
                     customFormatCallback: getEntryPath,
-                    excludeEntries: ['-bad'],
+                    excludeEntries: ['subdir12-bad'],
                 })
             ).sort()
-            assert.deepStrictEqual(
-                result,
-                [subdir1.path, file1, subdir11.path, file3, subdir12.path, file5, subdir2.path].sort()
-            )
+            assert.deepStrictEqual(result, [subdir1.path, file1, subdir11.path, file3, subdir2.path, file2].sort())
         })
     })
 })

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -58,8 +58,7 @@ export async function readDirectoryRecursively(
         }
         for (const entry of entries) {
             const childPath = getEntryPath(entry)
-            const childPathParts = childPath.split(path.sep)
-            if (childPathParts.some(part => excludeEntries.includes(part))) {
+            if (excludeEntries.includes(entry.name)) {
                 features.logging.log(`Skipping path ${childPath} due to match in [${excludeEntries.join(', ')}]`)
                 continue
             }

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -56,9 +56,12 @@ export async function readDirectoryRecursively(
             features.logging.warn(errMsg)
             continue
         }
+        // Apply the pattern to each part individually
+        const excludeParts = options?.excludePatterns ?? []
         for (const entry of entries) {
             const childPath = getEntryPath(entry)
-            if (options?.excludePatterns?.some(pattern => new RegExp(pattern).test(childPath))) {
+            const childPathParts = childPath.split(path.sep)
+            if (childPathParts.some(part => excludeParts.includes(part))) {
                 continue
             }
             results.push(formatter(entry))

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -7,13 +7,12 @@ import { CancellationError } from './awsError'
 type ElementType<T> = T extends (infer U)[] ? U : never
 type Dirent = ElementType<Awaited<ReturnType<Features['workspace']['fs']['readdir']>>>
 
-// Port of https://github.com/aws/aws-toolkit-vscode/blob/dfee9f7a400e677e91a75e9c20d9515a52a6fad4/packages/core/src/shared/utilities/workspaceUtils.ts#L699
 export async function readDirectoryRecursively(
     features: Pick<Features, 'workspace' | 'logging'> & Partial<Features>,
     folderPath: string,
     options?: {
         maxDepth?: number
-        excludePatterns?: (string | RegExp)[]
+        excludeEntries?: (string | RegExp)[]
         customFormatCallback?: (entry: Dirent) => string
         failOnError?: boolean
     },
@@ -56,12 +55,11 @@ export async function readDirectoryRecursively(
             features.logging.warn(errMsg)
             continue
         }
-        // Apply the pattern to each part individually
-        const excludeParts = options?.excludePatterns ?? []
+        const excludeEntries = options?.excludeEntries ?? []
         for (const entry of entries) {
             const childPath = getEntryPath(entry)
             const childPathParts = childPath.split(path.sep)
-            if (childPathParts.some(part => excludeParts.includes(part))) {
+            if (childPathParts.some(part => excludeEntries.includes(part))) {
                 continue
             }
             results.push(formatter(entry))

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -60,6 +60,7 @@ export async function readDirectoryRecursively(
             const childPath = getEntryPath(entry)
             const childPathParts = childPath.split(path.sep)
             if (childPathParts.some(part => excludeEntries.includes(part))) {
+                features.logging.log(`Skipping path ${childPath} due to match in [${excludeEntries.join(', ')}]`)
                 continue
             }
             results.push(formatter(entry))

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -19,6 +19,7 @@ export async function readDirectoryRecursively(
     token?: CancellationToken
 ): Promise<string[]> {
     const dirExists = await features.workspace.fs.exists(folderPath)
+    const excludeEntries = options?.excludeEntries ?? []
     if (!dirExists) {
         throw new Error(`Directory does not exist: ${folderPath}`)
     }
@@ -55,7 +56,6 @@ export async function readDirectoryRecursively(
             features.logging.warn(errMsg)
             continue
         }
-        const excludeEntries = options?.excludeEntries ?? []
         for (const entry of entries) {
             const childPath = getEntryPath(entry)
             const childPathParts = childPath.split(path.sep)

--- a/core/aws-lsp-core/src/util/workspaceUtils.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.ts
@@ -12,7 +12,7 @@ export async function readDirectoryRecursively(
     folderPath: string,
     options?: {
         maxDepth?: number
-        excludeEntries?: (string | RegExp)[]
+        excludeEntries?: string[]
         customFormatCallback?: (entry: Dirent) => string
         failOnError?: boolean
     },

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.ts
@@ -3,8 +3,7 @@ import { CommandValidation, InvokeOutput, requiresPathAcceptance, validatePath }
 import { workspaceUtils } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
-import { DEFAULT_EXCLUDE_PATTERNS } from '../../chat/constants'
-import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
+import { DEFAULT_EXCLUDE_ENTRIES } from '../../chat/constants'
 
 export interface FileSearchParams {
     path: string
@@ -79,7 +78,7 @@ export class FileSearch {
             const listing = await workspaceUtils.readDirectoryRecursively(
                 { workspace: this.workspace, logging: this.logging },
                 path,
-                { maxDepth: params.maxDepth, excludePatterns: DEFAULT_EXCLUDE_PATTERNS }
+                { maxDepth: params.maxDepth, excludeEntries: DEFAULT_EXCLUDE_ENTRIES }
             )
 
             // Create regex pattern for filtering

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
@@ -105,7 +105,7 @@ describe('ListDirectory Tool', () => {
         assert.ok(!hasFileC, 'Should not list fileC.md under node_modules in the directory output')
     })
 
-    it('includes directories that only start with ignored pattern', async () => {
+    it('includes files that only start with ignored pattern', async () => {
         const nestedFolder = await tempFolder.nest('foo')
         await nestedFolder.write('output.md', 'this is some text')
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
@@ -105,6 +105,20 @@ describe('ListDirectory Tool', () => {
         assert.ok(!hasFileC, 'Should not list fileC.md under node_modules in the directory output')
     })
 
+    it('includes directories that only start with ignored pattern', async () => {
+        const nestedFolder = await tempFolder.nest('foo')
+        await nestedFolder.write('output.md', 'this is some text')
+
+        const listDirectory = new ListDirectory(testFeatures)
+        await listDirectory.validate({ path: tempFolder.path })
+        const result = await listDirectory.invoke({ path: tempFolder.path })
+        assert.strictEqual(result.output.kind, 'text')
+        const lines = result.output.content.split('\n')
+        const hasOutput = lines.some((line: string) => line.includes('output.md'))
+
+        assert.ok(hasOutput, 'Should list output.md under foo in the directory output')
+    })
+
     it('throws error if path does not exist', async () => {
         const missingPath = path.join(tempFolder.path, 'no_such_file.txt')
         const listDirectory = new ListDirectory(testFeatures)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.test.ts
@@ -105,7 +105,7 @@ describe('ListDirectory Tool', () => {
         assert.ok(!hasFileC, 'Should not list fileC.md under node_modules in the directory output')
     })
 
-    it('includes files that only start with ignored pattern', async () => {
+    it('includes files that only start with ignored entry', async () => {
         const nestedFolder = await tempFolder.nest('foo')
         await nestedFolder.write('output.md', 'this is some text')
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -4,7 +4,6 @@ import { CancellationError, workspaceUtils } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
 import { DEFAULT_EXCLUDE_PATTERNS } from '../../chat/constants'
-import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
 import { CancellationToken } from '@aws/language-server-runtimes/protocol'
 
 export interface ListDirectoryParams {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/listDirectory.ts
@@ -3,7 +3,7 @@ import { CommandValidation, InvokeOutput, requiresPathAcceptance, validatePath }
 import { CancellationError, workspaceUtils } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
-import { DEFAULT_EXCLUDE_PATTERNS } from '../../chat/constants'
+import { DEFAULT_EXCLUDE_ENTRIES } from '../../chat/constants'
 import { CancellationToken } from '@aws/language-server-runtimes/protocol'
 
 export interface ListDirectoryParams {
@@ -64,7 +64,7 @@ export class ListDirectory {
             const listing = await workspaceUtils.readDirectoryRecursively(
                 { workspace: this.workspace, logging: this.logging },
                 path,
-                { maxDepth: params.maxDepth, excludePatterns: DEFAULT_EXCLUDE_PATTERNS },
+                { maxDepth: params.maxDepth, excludeEntries: DEFAULT_EXCLUDE_ENTRIES },
                 token
             )
             return this.createOutput(listing.join('\n'))

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/constants.ts
@@ -31,7 +31,7 @@ export const HELP_MESSAGE = `I'm Amazon Q, a generative AI assistant. Learn more
 
 export const DEFAULT_HELP_FOLLOW_UP_PROMPT = 'How can Amazon Q help me?'
 
-export const DEFAULT_EXCLUDE_PATTERNS = [
+export const DEFAULT_EXCLUDE_ENTRIES = [
     // Dependency directories
     'node_modules',
     // Build outputs


### PR DESCRIPTION
## Problem
The `readDirectoryRecursively` utility was using the exclude directories as patterns. This results in the listDirectory and fileSearch tool ignoring files that are prefixed by the pattern. For example, `build-test` would be ignored, or a file named `output.txt` since it contains `"out"`. 

## Solution
- use explicit ignore entries that apply at the entry level rather than the entire path level. 
- add a logging statement for when a directory is skipped. 

## Verification
- added a unit test 
- created a demo folder to test e2e:
<img width="411" alt="image" src="https://github.com/user-attachments/assets/8f407b98-ef22-46fa-8e34-d6004523a28f" />

- This folder also contains a `node_modules` folder with some files in it, which are ignored. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
