### PR TITLE
fix: fix for status duplicates for permission checks

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -617,7 +617,7 @@ export const createMynahUi = (
                             : am.type === 'directive'
                               ? ChatItemType.DIRECTIVE
                               : ChatItemType.ANSWER_STREAM,
-                    ...prepareChatItemFromMessage(am, isPairProgrammingMode),
+                    ...prepareChatItemFromMessage(am, isPairProgrammingMode, isPartialResult),
                 }
 
                 if (!chatItems.find(ci => ci.messageId === am.messageId)) {
@@ -847,7 +847,11 @@ export const createMynahUi = (
         })
     }
 
-    const prepareChatItemFromMessage = (message: ChatMessage, isPairProgrammingMode: boolean): Partial<ChatItem> => {
+    const prepareChatItemFromMessage = (
+        message: ChatMessage,
+        isPairProgrammingMode: boolean,
+        isPartialResult?: boolean
+    ): Partial<ChatItem> => {
         const contextHeader = contextListToHeader(message.contextList)
         const header = contextHeader || toMynahHeader(message.header) // Is this mutually exclusive?
         const fileList = toMynahFileList(message.fileList)
@@ -867,6 +871,11 @@ export const createMynahUi = (
                     fileTreeTitle: '',
                     hideFileCount: true,
                     details: toDetailsWithoutIcon(header.fileList.details),
+                }
+            }
+            if (!isPartialResult) {
+                if (processedHeader) {
+                    processedHeader.status = undefined
                 }
             }
         }


### PR DESCRIPTION
## Problem
- Permission check card status are duplicating after agentic loop completion.

## Solution
- fixes this removing status for additional messages in final result overwrite.

https://github.com/user-attachments/assets/0602b93d-187f-4752-8425-c697f7f5b33b



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
