### PR TITLE
fix: update undo-all-changes button icon to undo

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -973,7 +973,7 @@ export class AgenticChatController implements ChatHandlers {
                 {
                     id: 'undo-all-changes',
                     text: 'Undo all changes',
-                    icon: 'revert',
+                    icon: 'undo',
                     status: 'clear',
                     keepCardAfterClick: false,
                 },


### PR DESCRIPTION
## Problem
- the undo-all-changes button needs to use icon undo

## Solution
- update undo-all-changes button icon to undo

Before change:
<img width="396" alt="image" src="https://github.com/user-attachments/assets/0527754b-da7c-4314-9f39-815fea50e363" />

After change:
![image](https://github.com/user-attachments/assets/fe459f32-a583-4bc8-97e5-37724a36018e)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
