### PR TITLE
fix: update header ignore status

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1937,7 +1937,7 @@ export class AgenticChatController implements ChatHandlers {
                             body: `\`\`\`shell\n${command}\n\`\`\``,
                             header: {
                                 body: 'shell',
-                                status: { status: 'info', icon: 'info', text: 'Ignored' },
+                                status: { icon: 'block', text: 'Ignored' },
                                 buttons: [],
                             },
                         },


### PR DESCRIPTION
## Problem
- the shell command header ignored status is not correct.
## Solution
- update header ignore status based on figma doc: https://www.figma.com/design/DNKqLHITCpqAv9RGHKnWQQ/Agentic-Chat-Experience-2025?node-id=1923-25197&p=f&t=3vRozznGwps0u62q-0

Before change:
<img width="439" alt="image" src="https://github.com/user-attachments/assets/7ca7e909-d8b5-4a68-b86b-40553b815e7c" />

After change:
![image](https://github.com/user-attachments/assets/baaf3a60-f32f-447a-8ef8-42a380a98e91)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
