### PR TITLE
fix: fix the extra line on executeBash and wrong warning msg for outs…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1257,7 +1257,7 @@ export class AgenticChatController implements ChatHandlers {
                     buttons,
                 }
                 const commandString = (toolUse.input as unknown as ExecuteBashParams).command
-                body = '```shell\n' + commandString + '\n'
+                body = '```shell\n' + commandString
                 break
 
             case 'fsWrite':

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -226,7 +226,7 @@ export class ExecuteBash {
 
                         const isInWorkspace = workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.lsp), fullPath)
                         if (!isInWorkspace) {
-                            return { requiresAcceptance: true, warning: destructiveCommandWarningMessage }
+                            return { requiresAcceptance: true, warning: outOfWorkspaceWarningmessage }
                         }
                     }
                 }


### PR DESCRIPTION
…ide workspace

## Problem
There was an extra line after command in executeBash and the wrong warning message for normal command outside the current workspace
![image](https://github.com/user-attachments/assets/9773d5a6-7840-465b-830a-d087e10abdb1)

## Solution
<img width="405" alt="Screenshot 2025-05-01 at 6 12 26 PM" src="https://github.com/user-attachments/assets/0ad5c98d-3912-4e6b-baeb-5ce5c8cf154f" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
