### PR TITLE
fix: show context transparency list when using @workspace

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -1149,6 +1149,7 @@ describe('AgenticChatController', () => {
                         relevantDocuments: [
                             {
                                 endLine: -1,
+                                path: '/test/1.ts',
                                 relativeFilePath: '1.ts',
                                 startLine: -1,
                                 text: 'text',
@@ -1156,6 +1157,7 @@ describe('AgenticChatController', () => {
                             },
                             {
                                 endLine: -1,
+                                path: '/test/2.ts',
                                 relativeFilePath: '2.ts',
                                 startLine: -1,
                                 text: 'text2',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1962,7 +1962,7 @@ export class AgenticChatController implements ChatHandlers {
 
         // Display context transparency list once at the beginning of response
         // Use a flag to track if contextList has been sent already to avoid ux flickering
-        if (contextList && !session.contextListSent) {
+        if (contextList?.filePaths && contextList.filePaths.length > 0 && !session.contextListSent) {
             await streamWriter.write({ body: '', contextList })
             session.contextListSent = true
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.test.ts
@@ -2,9 +2,17 @@ import * as path from 'path'
 import * as sinon from 'sinon'
 import * as assert from 'assert'
 import { expect } from 'chai'
-import { getUserPromptsDirectory, getNewPromptFilePath, promptFileExtension } from './contextUtils'
+import {
+    getUserPromptsDirectory,
+    getNewPromptFilePath,
+    promptFileExtension,
+    mergeRelevantTextDocuments,
+    mergeFileLists,
+} from './contextUtils'
 import * as pathUtils from '@aws/lsp-core/out/util/path'
 import { sanitizeFilename } from '@aws/lsp-core/out/util/text'
+import { FileList } from '@aws/language-server-runtimes/server-interface'
+import { RelevantTextDocumentAddition } from './agenticChatTriggerContext'
 
 describe('contextUtils', () => {
     let getUserHomeDirStub: sinon.SinonStub
@@ -88,6 +96,239 @@ describe('contextUtils', () => {
                 result,
                 path.join('/home/user', '.aws', 'amazonq', 'prompts', `${expectedSanitized}${promptFileExtension}`)
             )
+        })
+    })
+
+    describe('mergeRelevantTextDocuments', () => {
+        it('should return empty FileList when input array is empty', () => {
+            const result = mergeRelevantTextDocuments([])
+            expect(result.filePaths).to.be.an('array').that.is.empty
+            expect(result.details).to.deep.equal({})
+        })
+
+        it('should skip documents with missing required fields', () => {
+            const docs: RelevantTextDocumentAddition[] = [
+                {
+                    text: 'content',
+                    path: '/path/to/file.js',
+                    relativeFilePath: undefined, // Missing required field
+                    startLine: 1,
+                    endLine: 5,
+                } as unknown as RelevantTextDocumentAddition,
+                {
+                    text: 'content',
+                    path: '/path/to/file2.js',
+                    relativeFilePath: 'file2.js',
+                    startLine: undefined, // Missing required field
+                    endLine: 10,
+                } as unknown as RelevantTextDocumentAddition,
+            ]
+
+            const result = mergeRelevantTextDocuments(docs)
+            expect(result.filePaths).to.be.an('array').that.is.empty
+            expect(result.details).to.deep.equal({})
+        })
+
+        it('should merge overlapping line ranges for the same file', () => {
+            const docs: RelevantTextDocumentAddition[] = [
+                {
+                    text: 'content1',
+                    path: '/path/to/file.js',
+                    relativeFilePath: 'file.js',
+                    startLine: 1,
+                    endLine: 5,
+                } as RelevantTextDocumentAddition,
+                {
+                    text: 'content2',
+                    path: '/path/to/file.js',
+                    relativeFilePath: 'file.js',
+                    startLine: 4,
+                    endLine: 8,
+                } as RelevantTextDocumentAddition,
+                {
+                    text: 'content3',
+                    path: '/path/to/file.js',
+                    relativeFilePath: 'file.js',
+                    startLine: 10,
+                    endLine: 15,
+                } as RelevantTextDocumentAddition,
+            ]
+
+            const result = mergeRelevantTextDocuments(docs)
+            expect(result.filePaths).to.deep.equal(['file.js'])
+            expect(result.details?.['file.js'].lineRanges).to.deep.equal([
+                { first: 1, second: 8 },
+                { first: 10, second: 15 },
+            ])
+        })
+
+        it('should handle multiple files correctly', () => {
+            const docs: RelevantTextDocumentAddition[] = [
+                {
+                    text: 'content1',
+                    path: '/path/to/file1.js',
+                    relativeFilePath: 'file1.js',
+                    startLine: 1,
+                    endLine: 5,
+                } as RelevantTextDocumentAddition,
+                {
+                    text: 'content2',
+                    path: '/path/to/file2.js',
+                    relativeFilePath: 'file2.js',
+                    startLine: 10,
+                    endLine: 15,
+                } as RelevantTextDocumentAddition,
+            ]
+
+            const result = mergeRelevantTextDocuments(docs)
+            expect(result.filePaths).to.have.members(['file1.js', 'file2.js'])
+            expect(result.details?.['file1.js'].lineRanges).to.deep.equal([{ first: 1, second: 5 }])
+            expect(result.details?.['file2.js'].lineRanges).to.deep.equal([{ first: 10, second: 15 }])
+        })
+    })
+
+    describe('mergeFileLists', () => {
+        it('should return second FileList when first is empty', () => {
+            const fileList1: FileList = { filePaths: [], details: {} }
+            const fileList2: FileList = {
+                filePaths: ['file.js'],
+                details: {
+                    'file.js': {
+                        fullPath: 'file.js',
+                        lineRanges: [{ first: 1, second: 5 }],
+                    },
+                },
+            }
+
+            const result = mergeFileLists(fileList1, fileList2)
+            expect(result).to.deep.equal(fileList2)
+        })
+
+        it('should return first FileList when second is empty', () => {
+            const fileList1: FileList = {
+                filePaths: ['file.js'],
+                details: {
+                    'file.js': {
+                        fullPath: 'file.js',
+                        lineRanges: [{ first: 1, second: 5 }],
+                    },
+                },
+            }
+            const fileList2: FileList = { filePaths: [], details: {} }
+
+            const result = mergeFileLists(fileList1, fileList2)
+            expect(result).to.deep.equal(fileList1)
+        })
+
+        it('should merge non-overlapping files from both lists', () => {
+            const fileList1: FileList = {
+                filePaths: ['file1.js'],
+                details: {
+                    'file1.js': {
+                        fullPath: 'file1.js',
+                        lineRanges: [{ first: 1, second: 5 }],
+                    },
+                },
+            }
+            const fileList2: FileList = {
+                filePaths: ['file2.js'],
+                details: {
+                    'file2.js': {
+                        fullPath: 'file2.js',
+                        lineRanges: [{ first: 10, second: 15 }],
+                    },
+                },
+            }
+
+            const result = mergeFileLists(fileList1, fileList2)
+            expect(result.filePaths).to.have.members(['file1.js', 'file2.js'])
+            expect(result.details?.['file1.js'].lineRanges).to.deep.equal([{ first: 1, second: 5 }])
+            expect(result.details?.['file2.js'].lineRanges).to.deep.equal([{ first: 10, second: 15 }])
+        })
+
+        it('should merge overlapping line ranges for the same file', () => {
+            const fileList1: FileList = {
+                filePaths: ['file.js'],
+                details: {
+                    'file.js': {
+                        fullPath: 'file.js',
+                        lineRanges: [
+                            { first: 1, second: 5 },
+                            { first: 10, second: 15 },
+                        ],
+                    },
+                },
+            }
+            const fileList2: FileList = {
+                filePaths: ['file.js'],
+                details: {
+                    'file.js': {
+                        fullPath: 'file.js',
+                        lineRanges: [
+                            { first: 4, second: 8 },
+                            { first: 20, second: 25 },
+                        ],
+                    },
+                },
+            }
+
+            const result = mergeFileLists(fileList1, fileList2)
+            expect(result.filePaths).to.deep.equal(['file.js'])
+            expect(result.details?.['file.js'].lineRanges).to.deep.equal([
+                { first: 1, second: 8 },
+                { first: 10, second: 15 },
+                { first: 20, second: 25 },
+            ])
+        })
+
+        it('should handle consecutive ranges by merging them', () => {
+            const fileList1: FileList = {
+                filePaths: ['file.js'],
+                details: {
+                    'file.js': {
+                        fullPath: 'file.js',
+                        lineRanges: [{ first: 1, second: 5 }],
+                    },
+                },
+            }
+            const fileList2: FileList = {
+                filePaths: ['file.js'],
+                details: {
+                    'file.js': {
+                        fullPath: 'file.js',
+                        lineRanges: [{ first: 6, second: 10 }],
+                    },
+                },
+            }
+
+            const result = mergeFileLists(fileList1, fileList2)
+            expect(result.filePaths).to.deep.equal(['file.js'])
+            expect(result.details?.['file.js'].lineRanges).to.deep.equal([{ first: 1, second: 10 }])
+        })
+
+        it('should handle undefined lineRanges', () => {
+            const fileList1: FileList = {
+                filePaths: ['file.js'],
+                details: {
+                    'file.js': {
+                        fullPath: 'file.js',
+                        lineRanges: undefined,
+                    },
+                },
+            }
+            const fileList2: FileList = {
+                filePaths: ['file.js'],
+                details: {
+                    'file.js': {
+                        fullPath: 'file.js',
+                        lineRanges: [{ first: 1, second: 5 }],
+                    },
+                },
+            }
+
+            const result = mergeFileLists(fileList1, fileList2)
+            expect(result.filePaths).to.deep.equal(['file.js'])
+            expect(result.details?.['file.js'].lineRanges).to.deep.equal([{ first: 1, second: 5 }])
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
@@ -1,7 +1,8 @@
 import { getUserHomeDir } from '@aws/lsp-core/out/util/path'
 import * as path from 'path'
 import { sanitizeFilename } from '@aws/lsp-core/out/util/text'
-
+import { RelevantTextDocumentAddition } from './agenticChatTriggerContext'
+import { FileDetails, FileList } from '@aws/language-server-runtimes/server-interface'
 export interface ContextInfo {
     contextCount: {
         fileContextCount: number
@@ -60,4 +61,119 @@ export const getNewPromptFilePath = (promptName: string): string => {
     const finalPath = path.join(userPromptsDirectory, `${safePromptName}${promptFileExtension}`)
 
     return finalPath
+}
+
+export function mergeRelevantTextDocuments(documents: RelevantTextDocumentAddition[]): FileList {
+    if (documents.length === 0) {
+        return { filePaths: [], details: {} }
+    }
+
+    const details: Record<string, FileDetails> = {}
+
+    Object.entries(
+        documents.reduce<Record<string, { first: number; second: number }[]>>((acc, doc) => {
+            if (!doc.relativeFilePath || doc.startLine === undefined || doc.endLine === undefined) {
+                return acc // Skip invalid documents
+            }
+
+            if (!acc[doc.relativeFilePath]) {
+                acc[doc.relativeFilePath] = []
+            }
+            acc[doc.relativeFilePath].push({ first: doc.startLine, second: doc.endLine })
+            return acc
+        }, {})
+    ).forEach(([relativeFilePath, ranges]) => {
+        // Sort by startLine
+        const sortedRanges = ranges.sort((a, b) => a.first - b.first)
+
+        const mergedRanges: { first: number; second: number }[] = []
+        for (const { first, second } of sortedRanges) {
+            if (mergedRanges.length === 0 || mergedRanges[mergedRanges.length - 1].second < first - 1) {
+                // If no overlap, add new range
+                mergedRanges.push({ first, second })
+            } else {
+                // Merge overlapping or consecutive ranges
+                mergedRanges[mergedRanges.length - 1].second = Math.max(
+                    mergedRanges[mergedRanges.length - 1].second,
+                    second
+                )
+            }
+        }
+
+        const fullPath = documents.find(doc => doc.relativeFilePath === relativeFilePath)?.path
+        details[relativeFilePath] = {
+            fullPath: fullPath,
+            description: fullPath,
+            lineRanges: mergedRanges,
+        }
+    })
+
+    return {
+        filePaths: Object.keys(details),
+        details: details,
+    }
+}
+
+/**
+ * Merges two FileList objects into a single FileList
+ * @param fileList1 The first FileList
+ * @param fileList2 The second FileList
+ * @returns A merged FileList
+ */
+export function mergeFileLists(fileList1: FileList, fileList2: FileList): FileList {
+    // Handle empty lists
+    if (!fileList1.filePaths?.length) {
+        return fileList2
+    }
+    if (!fileList2.filePaths?.length) {
+        return fileList1
+    }
+
+    // Initialize the result
+    const mergedFilePaths: string[] = []
+    const mergedDetails: Record<string, FileDetails> = {}
+
+    // Process all files from fileList1
+    fileList1.filePaths?.forEach(filePath => {
+        mergedFilePaths.push(filePath)
+        mergedDetails[filePath] = { ...fileList1.details?.[filePath] }
+    })
+
+    // Process all files from fileList2
+    fileList2.filePaths?.forEach(filePath => {
+        // If the file already exists in the merged result, merge the line ranges
+        if (mergedDetails[filePath]) {
+            const existingRanges = mergedDetails[filePath].lineRanges || []
+            const newRanges = fileList2.details?.[filePath].lineRanges || []
+
+            // Combine and sort all ranges
+            const combinedRanges = [...existingRanges, ...newRanges].sort((a, b) => a.first - b.first)
+
+            // Merge overlapping ranges
+            const mergedRanges: Array<{ first: number; second: number }> = []
+            for (const range of combinedRanges) {
+                if (mergedRanges.length === 0 || mergedRanges[mergedRanges.length - 1].second < range.first - 1) {
+                    // No overlap, add new range
+                    mergedRanges.push({ ...range })
+                } else {
+                    // Merge overlapping or consecutive ranges
+                    mergedRanges[mergedRanges.length - 1].second = Math.max(
+                        mergedRanges[mergedRanges.length - 1].second,
+                        range.second
+                    )
+                }
+            }
+
+            mergedDetails[filePath].lineRanges = mergedRanges
+        } else {
+            // If the file doesn't exist in the merged result, add it
+            mergedFilePaths.push(filePath)
+            mergedDetails[filePath] = { ...fileList2.details?.[filePath] }
+        }
+    })
+
+    return {
+        filePaths: mergedFilePaths,
+        details: mergedDetails,
+    }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
@@ -63,6 +63,16 @@ export const getNewPromptFilePath = (promptName: string): string => {
     return finalPath
 }
 
+/**
+ * Merges a RelevantTextDocumentAddition array into a FileList, which is used to display list of context files.
+ * This function combines document fragments from the same file, merging overlapping
+ * or consecutive line ranges to create a more compact representation.
+ *
+ * @param documents - Array of RelevantTextDocumentAddition objects containing file paths and line ranges
+ * @returns A FileList object with merged file paths and consolidated line ranges
+ *
+ * Ported from https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/codewhispererChat/controllers/chat/controller.ts#L1239
+ */
 export function mergeRelevantTextDocuments(documents: RelevantTextDocumentAddition[]): FileList {
     if (documents.length === 0) {
         return { filePaths: [], details: {} }


### PR DESCRIPTION
## Problem
When a user enters `@workspace`, a Context menu should appear in the response listing all the file chunks sent to Q

## Solution
Send relevant text documents to contextList

<img width="703" alt="Screenshot 2025-05-01 at 11 03 52 PM" src="https://github.com/user-attachments/assets/732bc873-1cb3-4c4f-bac9-a422c9da8d00" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
