### PR TITLE
fix: make LLM less apologetic, increase listDirectory result size

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
@@ -2,3 +2,4 @@ export const genericErrorMsg = 'An unexpected error occurred, check the logs for
 export const maxAgentLoopIterations = 100
 export const loadingThresholdMs = 2000
 export const generateAssistantResponseInputLimit = 600_000
+export const outputLimitExceedsPartialMsg = 'output exceeds maximum character limit of'


### PR DESCRIPTION
## Problem
- LLM apologizes for when listDirectory fails because project is too big

## Solution
- Make LLM less apologetic, increase listDirectory result size to reduce the chance of this happening

![Screenshot 2025-05-01 at 9 46 17 PM](https://github.com/user-attachments/assets/a160a0d5-dae6-4d75-b076-a883b5dde94f)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
