### PR TITLE
chore: update runtimes version

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -13,7 +13,7 @@
         "test": "node scripts/test-runner.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.63",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-partiql": "^0.0.5"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.77"
+        "@aws/language-server-runtimes": "^0.2.78"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -341,7 +341,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.32",
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -78,7 +78,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -111,7 +111,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -119,7 +119,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -139,7 +139,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -147,7 +147,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.63",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-partiql": "^0.0.5"
             },
             "devDependencies": {
@@ -183,7 +183,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -203,7 +203,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -225,7 +225,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.77"
+                "@aws/language-server-runtimes": "^0.2.78"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -269,7 +269,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.32",
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -557,23 +557,6 @@
             "resolved": "server/device-sso-auth-lsp",
             "link": true
         },
-        "node_modules/@apidevtools/json-schema-ref-parser": {
-            "version": "11.9.3",
-            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
-            "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@jsdevtools/ono": "^7.1.3",
-                "@types/json-schema": "^7.0.15",
-                "js-yaml": "^4.1.0"
-            },
-            "engines": {
-                "node": ">= 16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/philsturgeon"
-            }
-        },
         "node_modules/@asamuzakjp/css-color": {
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.1.4.tgz",
@@ -801,6 +784,7 @@
             "version": "3.787.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.787.0.tgz",
             "integrity": "sha512-7v6nywZ5wcQxX7qdZ5M1ld15QdkzLU6fAKiEqbvJKu4dM8cFW6As+DbS990Mg46pp1xM/yvme+51xZDTfTfJZA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
@@ -851,6 +835,7 @@
             "version": "3.787.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.787.0.tgz",
             "integrity": "sha512-L8R+Mh258G0DC73ktpSVrG4TT9i2vmDLecARTDR/4q5sRivdDQSL5bUp3LKcK80Bx+FRw3UETIlX6mYMLL9PJQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
@@ -900,6 +885,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
             "integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.775.0",
@@ -922,6 +908,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz",
             "integrity": "sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "3.775.0",
@@ -938,6 +925,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.775.0.tgz",
             "integrity": "sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "3.775.0",
@@ -959,6 +947,7 @@
             "version": "3.787.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.787.0.tgz",
             "integrity": "sha512-hc2taRoDlXn2uuNuHWDJljVWYrp3r9JF1a/8XmOAZhVUNY+ImeeStylHXhXXKEA4JOjW+5PdJj0f1UDkVCHJiQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "3.775.0",
@@ -983,6 +972,7 @@
             "version": "3.787.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.787.0.tgz",
             "integrity": "sha512-JioVi44B1vDMaK2CdzqimwvJD3uzvzbQhaEWXsGMBcMcNHajXAXf08EF50JG3ZhLrhhUsT1ObXpbTaPINOhh+g==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.775.0",
@@ -1006,6 +996,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz",
             "integrity": "sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "3.775.0",
@@ -1023,6 +1014,7 @@
             "version": "3.787.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.787.0.tgz",
             "integrity": "sha512-fHc08bsvwm4+dEMEQKnQ7c1irEQmmxbgS+Fq41y09pPvPh31nAhoMcjBSTWAaPHvvsRbTYvmP4Mf12ZGr8/nfg==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/client-sso": "3.787.0",
@@ -1042,6 +1034,7 @@
             "version": "3.787.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.787.0.tgz",
             "integrity": "sha512-SobmCwNbk6TfEsF283mZPQEI5vV2j6eY5tOCj8Er4Lzraxu9fBPADV+Bib2A8F6jlB1lMPJzOuDCbEasSt/RIw==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "3.775.0",
@@ -1059,6 +1052,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
             "integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.775.0",
@@ -1074,6 +1068,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
             "integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.775.0",
@@ -1088,6 +1083,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
             "integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.775.0",
@@ -1103,6 +1099,7 @@
             "version": "3.787.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.787.0.tgz",
             "integrity": "sha512-Lnfj8SmPLYtrDFthNIaNj66zZsBCam+E4XiUDr55DIHTGstH6qZ/q6vg0GfbukxwSmUcGMwSR4Qbn8rb8yd77g==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/core": "3.775.0",
@@ -1121,6 +1118,7 @@
             "version": "3.787.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.787.0.tgz",
             "integrity": "sha512-xk03q1xpKNHgbuo+trEf1dFrI239kuMmjKKsqLEsHlAZbuFq4yRGMlHBrVMnKYOPBhVFDS/VineM991XI52fKg==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
@@ -1170,6 +1168,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
             "integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.775.0",
@@ -1187,6 +1186,7 @@
             "version": "3.775.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
             "integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "3.775.0",
@@ -1199,6 +1199,7 @@
             "version": "3.787.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.787.0.tgz",
             "integrity": "sha512-mG7Lz8ydfG4SF9e8WSXiPQ/Lsn3n8A5B5jtPROidafi06I3ckV2WxyMLdwG14m919NoS6IOfWHyRGSqWIwbVKA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/middleware-user-agent": "3.787.0",
@@ -1223,6 +1224,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
             "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.2.0",
@@ -1236,6 +1238,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
             "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/abort-controller": "^4.0.2",
@@ -3902,27 +3905,23 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.77",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.77.tgz",
-            "integrity": "sha512-i3I3dunGa88/e2ey36lfmKDljVONqT7XRG1/VxpKmzkqFKDValJ1rzAUI9TN7a42vsXbXpOYyIxr24adtFb0gg==",
+            "version": "0.2.78",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.78.tgz",
+            "integrity": "sha512-yUXCU6vnVUNQavevwENOKgW/R2lNZW39grXvOWYDPoyQnUS3ujzsTkokC+DQZykaMC4r58ij2q1JDfIFdbS4Yw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@apidevtools/json-schema-ref-parser": "^11.9.3",
-                "@aws-crypto/sha256-js": "^5.2.0",
-                "@aws-sdk/client-cognito-identity": "^3.758.0",
                 "@aws/language-server-runtimes-types": "^0.1.26",
                 "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/resources": "^1.30.1",
-                "@opentelemetry/sdk-metrics": "^1.30.1",
-                "@opentelemetry/sdk-node": "^0.57.2",
-                "@opentelemetry/sdk-trace-base": "^1.30.1",
-                "@opentelemetry/semantic-conventions": "^1.30.0",
+                "@opentelemetry/api-logs": "^0.200.0",
+                "@opentelemetry/exporter-logs-otlp-http": "^0.200.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "^0.200.0",
+                "@opentelemetry/resources": "^2.0.0",
+                "@opentelemetry/sdk-logs": "^0.200.0",
+                "@opentelemetry/sdk-metrics": "^2.0.0",
+                "@opentelemetry/sdk-node": "^0.200.0",
                 "@smithy/node-http-handler": "^4.0.2",
-                "@smithy/protocol-http": "^5.0.1",
-                "@smithy/signature-v4": "^5.0.1",
                 "ajv": "^8.17.1",
                 "aws-sdk": "^2.1692.0",
-                "axios": "^1.8.4",
                 "hpagent": "^1.2.0",
                 "jose": "^5.9.6",
                 "mac-ca": "^3.1.1",
@@ -6716,12 +6715,6 @@
                 "url": "https://opencollective.com/js-sdsl"
             }
         },
-        "node_modules/@jsdevtools/ono": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-            "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-            "license": "MIT"
-        },
         "node_modules/@jsonjoy.com/base64": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
@@ -7117,551 +7110,480 @@
             }
         },
         "node_modules/@opentelemetry/api-logs": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
+            "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api": "^1.3.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=8.0.0"
             }
         },
         "node_modules/@opentelemetry/context-async-hooks": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
-            "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.0.tgz",
+            "integrity": "sha512-IEkJGzK1A9v3/EHjXh3s2IiFc6L4jfK+lNgKVgUjeUJQRRhnVFMIO3TAvKwonm9O1HebCuoOt98v8bZW7oVQHA==",
             "license": "Apache-2.0",
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/core": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-            "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.57.2.tgz",
-            "integrity": "sha512-eovEy10n3umjKJl2Ey6TLzikPE+W4cUQ4gCwgGP1RqzTGtgDra0WjIqdy29ohiUKfvmbiL3MndZww58xfIvyFw==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.200.0.tgz",
+            "integrity": "sha512-+3MDfa5YQPGM3WXxW9kqGD85Q7s9wlEMVNhXXG7tYFLnIeaseUt9YtCeFhEDFzfEktacdFpOtXmJuNW8cHbU5A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.7.1",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2",
-                "@opentelemetry/sdk-logs": "0.57.2"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/otlp-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-transformer": "0.200.0",
+                "@opentelemetry/sdk-logs": "0.200.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.57.2.tgz",
-            "integrity": "sha512-0rygmvLcehBRp56NQVLSleJ5ITTduq/QfU7obOkyWgPpFHulwpw2LYTqNIz5TczKZuy5YY+5D3SDnXZL1tXImg==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.200.0.tgz",
+            "integrity": "sha512-KfWw49htbGGp9s8N4KI8EQ9XuqKJ0VG+yVYVYFiCYSjEV32qpQ5qZ9UZBzOZ6xRb+E16SXOSCT3RkqBVSABZ+g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2",
-                "@opentelemetry/sdk-logs": "0.57.2"
+                "@opentelemetry/api-logs": "0.200.0",
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/otlp-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-transformer": "0.200.0",
+                "@opentelemetry/sdk-logs": "0.200.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.57.2.tgz",
-            "integrity": "sha512-ta0ithCin0F8lu9eOf4lEz9YAScecezCHkMMyDkvd9S7AnZNX5ikUmC5EQOQADU+oCcgo/qkQIaKcZvQ0TYKDw==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.200.0.tgz",
+            "integrity": "sha512-GmahpUU/55hxfH4TP77ChOfftADsCq/nuri73I/AVLe2s4NIglvTsaACkFVZAVmnXXyPS00Fk3x27WS3yO07zA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-logs": "0.57.2",
-                "@opentelemetry/sdk-trace-base": "1.30.1"
+                "@opentelemetry/api-logs": "0.200.0",
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/otlp-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-transformer": "0.200.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-logs": "0.200.0",
+                "@opentelemetry/sdk-trace-base": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.57.2.tgz",
-            "integrity": "sha512-r70B8yKR41F0EC443b5CGB4rUaOMm99I5N75QQt6sHKxYDzSEc6gm48Diz1CI1biwa5tDPznpylTrywO/pT7qw==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.200.0.tgz",
+            "integrity": "sha512-uHawPRvKIrhqH09GloTuYeq2BjyieYHIpiklOvxm9zhrCL2eRsnI/6g9v2BZTVtGp8tEgIa7rCQ6Ltxw6NBgew==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.7.1",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-metrics": "1.30.1"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
+                "@opentelemetry/otlp-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-transformer": "0.200.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-metrics": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.57.2.tgz",
-            "integrity": "sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.200.0.tgz",
+            "integrity": "sha512-5BiR6i8yHc9+qW7F6LqkuUnIzVNA7lt0qRxIKcKT+gq3eGUPHZ3DY29sfxI3tkvnwMgtnHDMNze5DdxW39HsAw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-metrics": "1.30.1"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/otlp-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-transformer": "0.200.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-metrics": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.57.2.tgz",
-            "integrity": "sha512-HX068Q2eNs38uf7RIkNN9Hl4Ynl+3lP0++KELkXMCpsCbFO03+0XNNZ1SkwxPlP9jrhQahsMPMkzNXpq3fKsnw==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.200.0.tgz",
+            "integrity": "sha512-E+uPj0yyvz81U9pvLZp3oHtFrEzNSqKGVkIViTQY1rH3TOobeJPSpLnTVXACnCwkPR5XeTvPnK3pZ2Kni8AFMg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-metrics": "1.30.1"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
+                "@opentelemetry/otlp-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-transformer": "0.200.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-metrics": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-prometheus": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.57.2.tgz",
-            "integrity": "sha512-VqIqXnuxWMWE/1NatAGtB1PvsQipwxDcdG4RwA/umdBcW3/iOHp0uejvFHTRN2O78ZPged87ErJajyUBPUhlDQ==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.200.0.tgz",
+            "integrity": "sha512-ZYdlU9r0USuuYppiDyU2VFRA0kFl855ylnb3N/2aOlXrbA4PMCznen7gmPbetGQu7pz8Jbaf4fwvrDnVdQQXSw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-metrics": "1.30.1"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-metrics": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.57.2.tgz",
-            "integrity": "sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.200.0.tgz",
+            "integrity": "sha512-hmeZrUkFl1YMsgukSuHCFPYeF9df0hHoKeHUthRKFCxiURs+GwF1VuabuHmBMZnjTbsuvNjOB+JSs37Csem/5Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.7.1",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-grpc-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/otlp-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-transformer": "0.200.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-trace-base": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.57.2.tgz",
-            "integrity": "sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.200.0.tgz",
+            "integrity": "sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/otlp-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-transformer": "0.200.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-trace-base": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.57.2.tgz",
-            "integrity": "sha512-awDdNRMIwDvUtoRYxRhja5QYH6+McBLtoz1q9BeEsskhZcrGmH/V1fWpGx8n+Rc+542e8pJA6y+aullbIzQmlw==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.200.0.tgz",
+            "integrity": "sha512-V9TDSD3PjK1OREw2iT9TUTzNYEVWJk4Nhodzhp9eiz4onDMYmPy3LaGbPv81yIR6dUb/hNp/SIhpiCHwFUq2Vg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/otlp-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-transformer": "0.200.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-trace-base": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/exporter-zipkin": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.30.1.tgz",
-            "integrity": "sha512-6S2QIMJahIquvFaaxmcwpvQQRD/YFaMTNoIxrfPIPOeITN+a8lfEcPDxNxn8JDAaxkg+4EnXhz8upVDYenoQjA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.0.0.tgz",
+            "integrity": "sha512-icxaKZ+jZL/NHXX8Aru4HGsrdhK0MLcuRXkX5G5IRmCgoRLw+Br6I/nMVozX2xjGGwV7hw2g+4Slj8K7s4HbVg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-trace-base": "2.0.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.0.0"
             }
         },
-        "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@opentelemetry/instrumentation": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.200.0.tgz",
+            "integrity": "sha512-pmPlzfJd+vvgaZd/reMsC8RWgTXn2WY1OWT5RT42m3aOn5532TozwXNDhg1vzqJ+jnvmkREcdLr27ebJEQt0Jg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
+                "@opentelemetry/api-logs": "0.200.0",
                 "@types/shimmer": "^1.2.0",
                 "import-in-the-middle": "^1.8.1",
                 "require-in-the-middle": "^7.1.1",
-                "semver": "^7.5.2",
                 "shimmer": "^1.2.1"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
-        "node_modules/@opentelemetry/instrumentation/node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@opentelemetry/otlp-exporter-base": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.57.2.tgz",
-            "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.200.0.tgz",
+            "integrity": "sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-transformer": "0.57.2"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/otlp-transformer": "0.200.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.57.2.tgz",
-            "integrity": "sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.200.0.tgz",
+            "integrity": "sha512-CK2S+bFgOZ66Bsu5hlDeOX6cvW5FVtVjFFbWuaJP0ELxJKBB6HlbLZQ2phqz/uLj1cWap5xJr/PsR3iGoB7Vqw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.7.1",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/otlp-exporter-base": "0.57.2",
-                "@opentelemetry/otlp-transformer": "0.57.2"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/otlp-exporter-base": "0.200.0",
+                "@opentelemetry/otlp-transformer": "0.200.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/otlp-transformer": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
-            "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.200.0.tgz",
+            "integrity": "sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-logs": "0.57.2",
-                "@opentelemetry/sdk-metrics": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1",
+                "@opentelemetry/api-logs": "0.200.0",
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-logs": "0.200.0",
+                "@opentelemetry/sdk-metrics": "2.0.0",
+                "@opentelemetry/sdk-trace-base": "2.0.0",
                 "protobufjs": "^7.3.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@opentelemetry/propagator-b3": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
-            "integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.0.0.tgz",
+            "integrity": "sha512-blx9S2EI49Ycuw6VZq+bkpaIoiJFhsDuvFGhBIoH3vJ5oYjJ2U0s3fAM5jYft99xVIAv6HqoPtlP9gpVA2IZtA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1"
+                "@opentelemetry/core": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/propagator-jaeger": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
-            "integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.0.0.tgz",
+            "integrity": "sha512-Mbm/LSFyAtQKP0AQah4AfGgsD+vsZcyreZoQ5okFBk33hU7AquU4TltgyL9dvaO8/Zkoud8/0gEvwfOZ5d7EPA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1"
+                "@opentelemetry/core": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/resources": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+            "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/sdk-logs": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
-            "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
+            "integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1"
+                "@opentelemetry/api-logs": "0.200.0",
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/resources": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.4.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/sdk-metrics": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
-            "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
+            "integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/resources": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
-                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/sdk-node": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.57.2.tgz",
-            "integrity": "sha512-8BaeqZyN5sTuPBtAoY+UtKwXBdqyuRKmekN5bFzAO40CgbGzAxfTpiL3PBerT7rhZ7p2nBdq7FaMv/tBQgHE4A==",
+            "version": "0.200.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.200.0.tgz",
+            "integrity": "sha512-S/YSy9GIswnhYoDor1RusNkmRughipvTCOQrlF1dzI70yQaf68qgf5WMnzUxdlCl3/et/pvaO75xfPfuEmCK5A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/exporter-logs-otlp-grpc": "0.57.2",
-                "@opentelemetry/exporter-logs-otlp-http": "0.57.2",
-                "@opentelemetry/exporter-logs-otlp-proto": "0.57.2",
-                "@opentelemetry/exporter-metrics-otlp-grpc": "0.57.2",
-                "@opentelemetry/exporter-metrics-otlp-http": "0.57.2",
-                "@opentelemetry/exporter-metrics-otlp-proto": "0.57.2",
-                "@opentelemetry/exporter-prometheus": "0.57.2",
-                "@opentelemetry/exporter-trace-otlp-grpc": "0.57.2",
-                "@opentelemetry/exporter-trace-otlp-http": "0.57.2",
-                "@opentelemetry/exporter-trace-otlp-proto": "0.57.2",
-                "@opentelemetry/exporter-zipkin": "1.30.1",
-                "@opentelemetry/instrumentation": "0.57.2",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/sdk-logs": "0.57.2",
-                "@opentelemetry/sdk-metrics": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1",
-                "@opentelemetry/sdk-trace-node": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/api-logs": "0.200.0",
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/exporter-logs-otlp-grpc": "0.200.0",
+                "@opentelemetry/exporter-logs-otlp-http": "0.200.0",
+                "@opentelemetry/exporter-logs-otlp-proto": "0.200.0",
+                "@opentelemetry/exporter-metrics-otlp-grpc": "0.200.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
+                "@opentelemetry/exporter-metrics-otlp-proto": "0.200.0",
+                "@opentelemetry/exporter-prometheus": "0.200.0",
+                "@opentelemetry/exporter-trace-otlp-grpc": "0.200.0",
+                "@opentelemetry/exporter-trace-otlp-http": "0.200.0",
+                "@opentelemetry/exporter-trace-otlp-proto": "0.200.0",
+                "@opentelemetry/exporter-zipkin": "2.0.0",
+                "@opentelemetry/instrumentation": "0.200.0",
+                "@opentelemetry/propagator-b3": "2.0.0",
+                "@opentelemetry/propagator-jaeger": "2.0.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/sdk-logs": "0.200.0",
+                "@opentelemetry/sdk-metrics": "2.0.0",
+                "@opentelemetry/sdk-trace-base": "2.0.0",
+                "@opentelemetry/sdk-trace-node": "2.0.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@opentelemetry/sdk-trace-base": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
-            "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
+            "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/resources": "2.0.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
         "node_modules/@opentelemetry/sdk-trace-node": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
-            "integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.0.0.tgz",
+            "integrity": "sha512-omdilCZozUjQwY3uZRBwbaRMJ3p09l4t187Lsdf0dGMye9WKD4NGcpgZRvqhI1dwcH6og+YXQEtoO9Wx3ykilg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/context-async-hooks": "1.30.1",
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/propagator-b3": "1.30.1",
-                "@opentelemetry/propagator-jaeger": "1.30.1",
-                "@opentelemetry/sdk-trace-base": "1.30.1",
-                "semver": "^7.5.2"
+                "@opentelemetry/context-async-hooks": "2.0.0",
+                "@opentelemetry/core": "2.0.0",
+                "@opentelemetry/sdk-trace-base": "2.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^18.19.0 || >=20.6.0"
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/sdk-trace-node/node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@opentelemetry/semantic-conventions": {
@@ -11014,6 +10936,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
             "license": "Python-2.0"
         },
         "node_modules/args": {
@@ -11367,6 +11290,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/atomic-sleep": {
@@ -11428,17 +11352,6 @@
         "node_modules/awsdocuments-ls-client": {
             "resolved": "client/vscode",
             "link": true
-        },
-        "node_modules/axios": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-            "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
         },
         "node_modules/b4a": {
             "version": "1.6.7",
@@ -12685,6 +12598,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
@@ -13679,6 +13593,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -14356,6 +14271,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -15714,6 +15630,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
             "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -18988,6 +18905,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -20178,9 +20096,9 @@
             }
         },
         "node_modules/module-details-from-path": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-            "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
             "license": "MIT"
         },
         "node_modules/mri": {
@@ -21778,6 +21696,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/psl": {
@@ -26938,7 +26857,7 @@
             "version": "0.1.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-core": "^0.0.4"
             },
             "devDependencies": {
@@ -27012,7 +26931,7 @@
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.32",
-                "@aws/language-server-runtimes": "^0.2.75",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-core": "^0.0.4",
                 "@modelcontextprotocol/sdk": "^1.9.0",
                 "@smithy/node-http-handler": "^2.5.0",
@@ -27143,7 +27062,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-core": "^0.0.4",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -27189,7 +27108,7 @@
             "version": "0.1.4",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-core": "^0.0.4",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -27203,7 +27122,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-core": "0.0.4",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -27245,7 +27164,7 @@
             "version": "0.0.8",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -27278,7 +27197,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "@aws/lsp-core": "^0.0.4",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -27292,7 +27211,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -27303,7 +27222,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.77",
+                "@aws/language-server-runtimes": "^0.2.78",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-core": "^0.0.4"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.32",
-        "@aws/language-server-runtimes": "^0.2.75",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-core": "^0.0.4",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-core": "^0.0.4",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-core": "^0.0.4",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-core": "0.0.4",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "@aws/lsp-core": "^0.0.4",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.77",
+        "@aws/language-server-runtimes": "^0.2.78",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem
update runtimes version to 0.2.78 to be able to get awsServerCapabilities from aws/getConfigurationFromServer extension.
## Solution


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
