### PR TITLE
Customizations profiles update

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -113,6 +113,7 @@
                 "ENABLE_CHAT": "true",
                 "ENABLE_CUSTOMIZATIONS": "true",
                 "ENABLE_AMAZON_Q_PROFILES": "false",
+                "ENABLE_CUSTOMIZATIONS_WITH_METADATA": "false",
                 "ENABLE_AWS_Q_SECTION": "true",
                 "ENABLE_AGENTIC_UI_MODE": "true"
                 // "HTTPS_PROXY": "http://127.0.0.1:8888",

--- a/client/vscode/src/activation.ts
+++ b/client/vscode/src/activation.ts
@@ -109,6 +109,7 @@ export async function activateDocumentsLanguageServer(extensionContext: Extensio
                 awsClientCapabilities: {
                     q: {
                         developerProfiles: process.env.ENABLE_AMAZON_Q_PROFILES === 'true',
+                        customizationsWithMetadata: process.env.ENABLE_CUSTOMIZATIONS_WITH_METADATA === 'true',
                     },
                     window: {
                         notifications: true,

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
@@ -387,15 +387,84 @@ describe('ServerConfigurationProvider', () => {
             assert.deepStrictEqual(result[0], {
                 arn: 'customization1',
                 name: 'Customization 1',
-                region: 'us-east-1',
-                profileArn: mockProfiles[0].arn,
+                isDefault: false,
+                profile: {
+                    arn: mockProfiles[0].arn,
+                    identityDetails: {
+                        region: 'us-east-1',
+                    },
+                    name: 'Profile 1',
+                },
             })
 
             assert.deepStrictEqual(result[2], {
                 arn: 'customization3',
                 name: 'Customization 3',
-                region: 'us-west-2',
-                profileArn: mockProfiles[1].arn,
+                isDefault: false,
+                profile: {
+                    arn: mockProfiles[1].arn,
+                    identityDetails: {
+                        region: 'us-west-2',
+                    },
+                    name: 'Profile 2',
+                },
+            })
+
+            // Verify the stubs were called correctly
+            sinon.assert.notCalled(listAllAvailableProfilesHandlerStub)
+            sinon.assert.calledTwice(listAvailableCustomizationsForProfileAndRegionStub)
+        })
+
+        it('add profile information and isDefault flag to true for a profile with 0 customizations', async () => {
+            // Setup stub for listAvailableCustomizationsForProfileAndRegion
+            const listAvailableCustomizationsForProfileAndRegionStub = sinon.stub(
+                serverConfigurationProvider,
+                'listAvailableCustomizationsForProfileAndRegion'
+            )
+
+            // Return different customizations for each profile
+            listAvailableCustomizationsForProfileAndRegionStub
+                .withArgs(mockProfiles[0].arn, mockProfiles[0].identityDetails!.region)
+                .resolves([])
+
+            listAvailableCustomizationsForProfileAndRegionStub
+                .withArgs(mockProfiles[1].arn, mockProfiles[1].identityDetails!.region)
+                .resolves([{ arn: 'customization3', name: 'Customization 3' }])
+
+            const result = await serverConfigurationProvider.listAllAvailableCustomizationsWithMetadata(
+                mockProfiles,
+                tokenSource.token
+            )
+
+            // Verify the results
+            assert.strictEqual(result.length, 2)
+
+            // Check that metadata was added correctly
+            assert.deepStrictEqual(result[0], {
+                arn: '',
+                name: 'Amazon Q foundation (Default)',
+                description: '',
+                isDefault: true,
+                profile: {
+                    arn: mockProfiles[0].arn,
+                    identityDetails: {
+                        region: 'us-east-1',
+                    },
+                    name: 'Profile 1',
+                },
+            })
+
+            assert.deepStrictEqual(result[1], {
+                arn: 'customization3',
+                name: 'Customization 3',
+                isDefault: false,
+                profile: {
+                    arn: mockProfiles[1].arn,
+                    identityDetails: {
+                        region: 'us-west-2',
+                    },
+                    name: 'Profile 2',
+                },
             })
 
             // Verify the stubs were called correctly
@@ -426,8 +495,14 @@ describe('ServerConfigurationProvider', () => {
             assert.deepStrictEqual(result[0], {
                 arn: 'customization1',
                 name: 'Customization 1',
-                region: 'us-east-1',
-                profileArn: mockProfiles[0].arn,
+                isDefault: false,
+                profile: {
+                    arn: mockProfiles[0].arn,
+                    identityDetails: {
+                        region: 'us-east-1',
+                    },
+                    name: 'Profile 1',
+                },
             })
 
             // Verify the profile handler was NOT called
@@ -463,8 +538,14 @@ describe('ServerConfigurationProvider', () => {
             assert.deepStrictEqual(result[0], {
                 arn: 'customization1',
                 name: 'Customization 1',
-                region: 'us-east-1',
-                profileArn: mockProfiles[0].arn,
+                isDefault: false,
+                profile: {
+                    arn: mockProfiles[0].arn,
+                    identityDetails: {
+                        region: 'us-east-1',
+                    },
+                    name: 'Profile 1',
+                },
             })
 
             // Verify error was logged

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
@@ -17,9 +17,10 @@ import {
 } from '@aws/language-server-runtimes/server-interface'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 import { setCredentialsForAmazonQTokenServiceManagerFactory } from '../../shared/testUtils'
-import { Q_CONFIGURATION_SECTION } from '../../shared/constants'
+import { Q_CONFIGURATION_SECTION, AWS_Q_ENDPOINTS } from '../../shared/constants'
+import { AmazonQDeveloperProfile } from '../../shared/amazonQServiceManager/qDeveloperProfiles'
 
-const getInitializeParams = (developerProfiles = true): InitializeParams => {
+const getInitializeParams = (customizationsWithMetadata = false, developerProfiles = true): InitializeParams => {
     return {
         processId: 0,
         rootUri: 'some-root-uri',
@@ -29,6 +30,7 @@ const getInitializeParams = (developerProfiles = true): InitializeParams => {
                 awsClientCapabilities: {
                     q: {
                         developerProfiles,
+                        customizationsWithMetadata,
                     },
                 },
             },
@@ -36,15 +38,48 @@ const getInitializeParams = (developerProfiles = true): InitializeParams => {
     }
 }
 
+// Mock data for tests
+const mockProfiles: AmazonQDeveloperProfile[] = [
+    {
+        arn: 'arn:aws:codewhisperer:us-east-1:123456789012:profile/profile1',
+        name: 'Profile 1',
+        identityDetails: {
+            region: 'us-east-1',
+        },
+    },
+    {
+        arn: 'arn:aws:codewhisperer:us-west-2:123456789012:profile/profile2',
+        name: 'Profile 2',
+        identityDetails: {
+            region: 'us-west-2',
+        },
+    },
+]
+
+const mockCustomizations = [
+    {
+        arn: 'arn:aws:codewhisperer:us-east-1:123456789012:customization/customization1',
+        name: 'Customization 1',
+        createdAt: new Date(),
+    },
+    {
+        arn: 'arn:aws:codewhisperer:us-east-1:123456789012:customization/customization2',
+        name: 'Customization 2',
+        createdAt: new Date(),
+    },
+]
+
 describe('QConfigurationServerToken', () => {
     let testFeatures: TestFeatures
     let amazonQServiceManager: AmazonQTokenServiceManager
     let listAvailableProfilesStub: sinon.SinonStub
     let listAvailableCustomizationsStub: sinon.SinonStub
+    let listAllAvailableCustomizationsWithMetadataStub: sinon.SinonStub
+    let getEnableDeveloperProfileSupportStub: sinon.SinonStub
 
-    beforeEach(async () => {
+    const setupTest = async (customizationsWithMetadata = false, developerProfiles = true) => {
         testFeatures = new TestFeatures()
-        testFeatures.setClientParams(getInitializeParams())
+        testFeatures.setClientParams(getInitializeParams(customizationsWithMetadata, developerProfiles))
 
         AmazonQTokenServiceManager.resetInstance()
         AmazonQTokenServiceManager.initInstance(testFeatures)
@@ -54,46 +89,118 @@ describe('QConfigurationServerToken', () => {
         const configurationServer: Server = QConfigurationServerToken()
 
         amazonQServiceManager.setServiceFactory(sinon.stub().returns(codeWhispererService))
+        getEnableDeveloperProfileSupportStub = sinon.stub(amazonQServiceManager, 'getEnableDeveloperProfileSupport')
+        getEnableDeveloperProfileSupportStub.returns(developerProfiles)
 
         listAvailableCustomizationsStub = sinon.stub(
             ServerConfigurationProvider.prototype,
             'listAvailableCustomizations'
         )
+        listAllAvailableCustomizationsWithMetadataStub = sinon.stub(
+            ServerConfigurationProvider.prototype,
+            'listAllAvailableCustomizationsWithMetadata'
+        )
         listAvailableProfilesStub = sinon.stub(ServerConfigurationProvider.prototype, 'listAvailableProfiles')
 
         await testFeatures.initialize(configurationServer)
-    })
+    }
 
     afterEach(() => {
         sinon.restore()
-        testFeatures.dispose()
+        if (testFeatures) {
+            testFeatures.dispose()
+        }
     })
 
-    it(`calls all list methods when ${Q_CONFIGURATION_SECTION} is requested`, () => {
-        testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg({
-            section: Q_CONFIGURATION_SECTION,
-        })
+    it(`calls all list methods when ${Q_CONFIGURATION_SECTION} is requested`, async () => {
+        await setupTest()
+
+        await testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg(
+            { section: Q_CONFIGURATION_SECTION },
+            new CancellationTokenSource().token
+        )
 
         sinon.assert.calledOnce(listAvailableCustomizationsStub)
         sinon.assert.calledOnce(listAvailableProfilesStub)
+        sinon.assert.notCalled(listAllAvailableCustomizationsWithMetadataStub)
     })
 
-    it(`only calls listAvailableCustomizations when ${Q_CUSTOMIZATIONS_CONFIGURATION_SECTION} is requested`, () => {
-        testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg({
-            section: Q_CUSTOMIZATIONS_CONFIGURATION_SECTION,
-        })
+    it(`only calls listAvailableCustomizations when ${Q_CUSTOMIZATIONS_CONFIGURATION_SECTION} is requested`, async () => {
+        await setupTest()
+
+        await testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg(
+            { section: Q_CUSTOMIZATIONS_CONFIGURATION_SECTION },
+            new CancellationTokenSource().token
+        )
 
         sinon.assert.calledOnce(listAvailableCustomizationsStub)
         sinon.assert.notCalled(listAvailableProfilesStub)
+        sinon.assert.notCalled(listAllAvailableCustomizationsWithMetadataStub)
     })
 
-    it(`only calls listAvailableProfiles when ${Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION} is requested`, () => {
-        testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg({
-            section: Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION,
-        })
+    it(`only calls listAvailableProfiles when ${Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION} is requested`, async () => {
+        await setupTest()
+
+        await testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg(
+            { section: Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION },
+            new CancellationTokenSource().token
+        )
 
         sinon.assert.notCalled(listAvailableCustomizationsStub)
         sinon.assert.calledOnce(listAvailableProfilesStub)
+        sinon.assert.notCalled(listAllAvailableCustomizationsWithMetadataStub)
+    })
+
+    it('uses listAllAvailableCustomizationsWithMetadata when feature flag is enabled', async () => {
+        await setupTest(true, true)
+
+        await testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg(
+            { section: Q_CONFIGURATION_SECTION },
+            new CancellationTokenSource().token
+        )
+
+        sinon.assert.notCalled(listAvailableCustomizationsStub)
+        sinon.assert.calledOnce(listAllAvailableCustomizationsWithMetadataStub)
+        sinon.assert.calledOnce(listAvailableProfilesStub)
+    })
+
+    it('uses listAvailableCustomizations when feature flag is disabled', async () => {
+        await setupTest(false, true)
+
+        await testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg(
+            { section: Q_CONFIGURATION_SECTION },
+            new CancellationTokenSource().token
+        )
+
+        sinon.assert.calledOnce(listAvailableCustomizationsStub)
+        sinon.assert.notCalled(listAllAvailableCustomizationsWithMetadataStub)
+        sinon.assert.calledOnce(listAvailableProfilesStub)
+    })
+
+    it('uses listAvailableCustomizations when developer profiles are disabled', async () => {
+        await setupTest(true, false)
+
+        await testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg(
+            { section: Q_CONFIGURATION_SECTION },
+            new CancellationTokenSource().token
+        )
+
+        sinon.assert.calledOnce(listAvailableCustomizationsStub)
+        sinon.assert.notCalled(listAllAvailableCustomizationsWithMetadataStub)
+        sinon.assert.calledOnce(listAvailableProfilesStub)
+    })
+
+    it('uses listAllAvailableCustomizationsWithMetadata for customizations section when feature flag is enabled', async () => {
+        await setupTest(true, true)
+
+        await testFeatures.lsp.extensions.onGetConfigurationFromServer.firstCall.firstArg(
+            { section: Q_CUSTOMIZATIONS_CONFIGURATION_SECTION },
+            new CancellationTokenSource().token
+        )
+
+        sinon.assert.notCalled(listAvailableCustomizationsStub)
+        sinon.assert.calledOnce(listAllAvailableCustomizationsWithMetadataStub)
+        sinon.assert.notCalled(listAvailableProfilesStub)
     })
 })
 
@@ -104,17 +211,20 @@ describe('ServerConfigurationProvider', () => {
     let testFeatures: TestFeatures
     let listAvailableProfilesHandlerSpy: sinon.SinonSpy
     let tokenSource: CancellationTokenSource
+    let serviceFactoryStub: sinon.SinonStub
 
     const setCredentials = setCredentialsForAmazonQTokenServiceManagerFactory(() => testFeatures)
 
     const setupServerConfigurationProvider = (developerProfiles = true) => {
-        testFeatures.setClientParams(getInitializeParams(developerProfiles))
+        testFeatures.setClientParams(getInitializeParams(false, developerProfiles))
 
         AmazonQTokenServiceManager.resetInstance()
         AmazonQTokenServiceManager.initInstance(testFeatures)
         amazonQServiceManager = AmazonQTokenServiceManager.getInstance()
 
-        amazonQServiceManager.setServiceFactory(sinon.stub().returns(codeWhispererService))
+        serviceFactoryStub = sinon.stub().returns(codeWhispererService)
+        amazonQServiceManager.setServiceFactory(serviceFactoryStub)
+
         serverConfigurationProvider = new ServerConfigurationProvider(
             amazonQServiceManager,
             testFeatures.credentialsProvider,
@@ -131,7 +241,7 @@ describe('ServerConfigurationProvider', () => {
         tokenSource = new CancellationTokenSource()
         codeWhispererService = stubInterface<CodeWhispererServiceToken>()
         codeWhispererService.listAvailableCustomizations.resolves({
-            customizations: [],
+            customizations: mockCustomizations,
             $response: {} as any,
         })
         codeWhispererService.listAvailableProfiles.resolves({
@@ -189,5 +299,148 @@ describe('ServerConfigurationProvider', () => {
             assert.strictEqual(responseError.data?.awsErrorCode, 'E_AMAZON_Q_PROFILE_THROTTLING')
             sinon.assert.calledOnce(listAvailableProfilesHandlerSpy)
         }
+    })
+
+    describe('listAvailableCustomizationsForProfileAndRegion', () => {
+        it('fetches customizations for specified region and profile', async () => {
+            const profileArn = 'arn:aws:codewhisperer:us-east-1:123456789012:profile/profile1'
+            const region = 'us-east-1'
+
+            await serverConfigurationProvider.listAvailableCustomizationsForProfileAndRegion(profileArn, region)
+
+            sinon.assert.calledWith(serviceFactoryStub, region, AWS_Q_ENDPOINTS.get(region))
+            sinon.assert.calledOnce(codeWhispererService.listAvailableCustomizations)
+            assert.strictEqual(codeWhispererService.profileArn, profileArn)
+        })
+
+        it('throws an error when the API call fails', async () => {
+            const profileArn = 'arn:aws:codewhisperer:us-east-1:123456789012:profile/profile1'
+            const region = 'us-east-1'
+
+            const error = new Error('API Error')
+            codeWhispererService.listAvailableCustomizations.rejects(error)
+
+            try {
+                await serverConfigurationProvider.listAvailableCustomizationsForProfileAndRegion(profileArn, region)
+                assert.fail('Expected method to throw')
+            } catch (err) {
+                const responseError = err as ResponseError<any>
+                assert.strictEqual(responseError.code, LSPErrorCodes.RequestFailed)
+            }
+        })
+    })
+
+    describe('listAllAvailableCustomizationsWithMetadata', () => {
+        let listAllAvailableProfilesHandlerStub: sinon.SinonStub
+
+        beforeEach(() => {
+            // We need to restore the spy before creating a stub on the same method
+            if (listAvailableProfilesHandlerSpy) {
+                listAvailableProfilesHandlerSpy.restore()
+            }
+
+            // Replace the listAllAvailableProfilesHandler with our stub
+            listAllAvailableProfilesHandlerStub = sinon.stub(
+                serverConfigurationProvider,
+                'listAllAvailableProfilesHandler' as keyof ServerConfigurationProvider
+            )
+            listAllAvailableProfilesHandlerStub.resolves(mockProfiles)
+        })
+
+        it('fetches customizations for each profile and adds metadata', async () => {
+            // Setup stub for listAvailableCustomizationsForProfileAndRegion
+            const listAvailableCustomizationsForProfileAndRegionStub = sinon.stub(
+                serverConfigurationProvider,
+                'listAvailableCustomizationsForProfileAndRegion'
+            )
+
+            // Return different customizations for each profile
+            listAvailableCustomizationsForProfileAndRegionStub
+                .withArgs(mockProfiles[0].arn, mockProfiles[0].identityDetails!.region)
+                .resolves([
+                    { arn: 'customization1', name: 'Customization 1' },
+                    { arn: 'customization2', name: 'Customization 2' },
+                ])
+
+            listAvailableCustomizationsForProfileAndRegionStub
+                .withArgs(mockProfiles[1].arn, mockProfiles[1].identityDetails!.region)
+                .resolves([{ arn: 'customization3', name: 'Customization 3' }])
+
+            const result = await serverConfigurationProvider.listAllAvailableCustomizationsWithMetadata(
+                tokenSource.token
+            )
+
+            // Verify the results
+            assert.strictEqual(result.length, 3)
+
+            // Check that metadata was added correctly
+            assert.deepStrictEqual(result[0], {
+                arn: 'customization1',
+                name: 'Customization 1',
+                region: 'us-east-1',
+                profileArn: mockProfiles[0].arn,
+            })
+
+            assert.deepStrictEqual(result[2], {
+                arn: 'customization3',
+                name: 'Customization 3',
+                region: 'us-west-2',
+                profileArn: mockProfiles[1].arn,
+            })
+
+            // Verify the stubs were called correctly
+            sinon.assert.calledOnce(listAllAvailableProfilesHandlerStub)
+            sinon.assert.calledTwice(listAvailableCustomizationsForProfileAndRegionStub)
+        })
+
+        it('continues processing if fetching customizations for one profile fails', async () => {
+            // Setup stub for listAvailableCustomizationsForProfileAndRegion
+            const listAvailableCustomizationsForProfileAndRegionStub = sinon.stub(
+                serverConfigurationProvider,
+                'listAvailableCustomizationsForProfileAndRegion'
+            )
+
+            // First profile succeeds
+            listAvailableCustomizationsForProfileAndRegionStub
+                .withArgs(mockProfiles[0].arn, mockProfiles[0].identityDetails!.region)
+                .resolves([{ arn: 'customization1', name: 'Customization 1' }])
+
+            // Second profile fails
+            listAvailableCustomizationsForProfileAndRegionStub
+                .withArgs(mockProfiles[1].arn, mockProfiles[1].identityDetails!.region)
+                .rejects(new Error('Failed to fetch customizations'))
+
+            const result = await serverConfigurationProvider.listAllAvailableCustomizationsWithMetadata(
+                tokenSource.token
+            )
+
+            // Should still have results from the first profile
+            assert.strictEqual(result.length, 1)
+            assert.deepStrictEqual(result[0], {
+                arn: 'customization1',
+                name: 'Customization 1',
+                region: 'us-east-1',
+                profileArn: mockProfiles[0].arn,
+            })
+
+            // Verify error was logged
+            sinon.assert.calledWith(
+                testFeatures.logging.error as sinon.SinonStub,
+                sinon.match(/Failed to fetch customizations for profile/)
+            )
+        })
+
+        it('handles cancellation token', async () => {
+            // Cancel the token
+            tokenSource.cancel()
+
+            try {
+                await serverConfigurationProvider.listAllAvailableCustomizationsWithMetadata(tokenSource.token)
+                assert.fail('Expected method to throw')
+            } catch (err) {
+                const responseError = err as ResponseError<any>
+                assert.strictEqual(responseError.code, LSPErrorCodes.RequestCancelled)
+            }
+        })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.test.ts
@@ -381,10 +381,24 @@ describe('ServerConfigurationProvider', () => {
             )
 
             // Verify the results
-            assert.strictEqual(result.length, 3)
+            assert.strictEqual(result.length, 5)
 
             // Check that metadata was added correctly
             assert.deepStrictEqual(result[0], {
+                arn: '',
+                name: 'Amazon Q foundation (Default)',
+                description: '',
+                isDefault: true,
+                profile: {
+                    arn: mockProfiles[0].arn,
+                    identityDetails: {
+                        region: 'us-east-1',
+                    },
+                    name: 'Profile 1',
+                },
+            })
+
+            assert.deepStrictEqual(result[1], {
                 arn: 'customization1',
                 name: 'Customization 1',
                 isDefault: false,
@@ -397,7 +411,7 @@ describe('ServerConfigurationProvider', () => {
                 },
             })
 
-            assert.deepStrictEqual(result[2], {
+            assert.deepStrictEqual(result[4], {
                 arn: 'customization3',
                 name: 'Customization 3',
                 isDefault: false,
@@ -415,7 +429,7 @@ describe('ServerConfigurationProvider', () => {
             sinon.assert.calledTwice(listAvailableCustomizationsForProfileAndRegionStub)
         })
 
-        it('add profile information and isDefault flag to true for a profile with 0 customizations', async () => {
+        it('add profile information and isDefault flag to true even for a profile with 0 customizations', async () => {
             // Setup stub for listAvailableCustomizationsForProfileAndRegion
             const listAvailableCustomizationsForProfileAndRegionStub = sinon.stub(
                 serverConfigurationProvider,
@@ -437,7 +451,7 @@ describe('ServerConfigurationProvider', () => {
             )
 
             // Verify the results
-            assert.strictEqual(result.length, 2)
+            assert.strictEqual(result.length, 3)
 
             // Check that metadata was added correctly
             assert.deepStrictEqual(result[0], {
@@ -455,6 +469,20 @@ describe('ServerConfigurationProvider', () => {
             })
 
             assert.deepStrictEqual(result[1], {
+                arn: '',
+                name: 'Amazon Q foundation (Default)',
+                description: '',
+                isDefault: true,
+                profile: {
+                    arn: mockProfiles[1].arn,
+                    identityDetails: {
+                        region: 'us-west-2',
+                    },
+                    name: 'Profile 2',
+                },
+            })
+
+            assert.deepStrictEqual(result[2], {
                 arn: 'customization3',
                 name: 'Customization 3',
                 isDefault: false,
@@ -491,8 +519,21 @@ describe('ServerConfigurationProvider', () => {
             )
 
             // Verify the results
-            assert.strictEqual(result.length, 1)
+            assert.strictEqual(result.length, 2)
             assert.deepStrictEqual(result[0], {
+                arn: '',
+                name: 'Amazon Q foundation (Default)',
+                description: '',
+                isDefault: true,
+                profile: {
+                    arn: mockProfiles[0].arn,
+                    identityDetails: {
+                        region: 'us-east-1',
+                    },
+                    name: 'Profile 1',
+                },
+            })
+            assert.deepStrictEqual(result[1], {
                 arn: 'customization1',
                 name: 'Customization 1',
                 isDefault: false,
@@ -511,7 +552,7 @@ describe('ServerConfigurationProvider', () => {
             sinon.assert.calledOnce(listAvailableCustomizationsForProfileAndRegionStub)
         })
 
-        it('continues processing if fetching customizations for one profile fails', async () => {
+        it('continues processing if fetching customizations for one profile fails - expected to return the default even for case where fetch fails', async () => {
             // Setup stub for listAvailableCustomizationsForProfileAndRegion
             const listAvailableCustomizationsForProfileAndRegionStub = sinon.stub(
                 serverConfigurationProvider,
@@ -534,8 +575,23 @@ describe('ServerConfigurationProvider', () => {
             )
 
             // Should still have results from the first profile
-            assert.strictEqual(result.length, 1)
+            assert.strictEqual(result.length, 3)
+
             assert.deepStrictEqual(result[0], {
+                arn: '',
+                name: 'Amazon Q foundation (Default)',
+                description: '',
+                isDefault: true,
+                profile: {
+                    arn: mockProfiles[0].arn,
+                    identityDetails: {
+                        region: 'us-east-1',
+                    },
+                    name: 'Profile 1',
+                },
+            })
+
+            assert.deepStrictEqual(result[1], {
                 arn: 'customization1',
                 name: 'Customization 1',
                 isDefault: false,
@@ -545,6 +601,20 @@ describe('ServerConfigurationProvider', () => {
                         region: 'us-east-1',
                     },
                     name: 'Profile 1',
+                },
+            })
+
+            assert.deepStrictEqual(result[2], {
+                arn: '',
+                name: 'Amazon Q foundation (Default)',
+                description: '',
+                isDefault: true,
+                profile: {
+                    arn: mockProfiles[1].arn,
+                    identityDetails: {
+                        region: 'us-west-2',
+                    },
+                    name: 'Profile 2',
                 },
             })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -276,23 +276,23 @@ export class ServerConfigurationProvider {
                             throw new ResponseError(LSPErrorCodes.RequestCancelled, 'Request cancelled')
                         }
 
-                        if (customizations.length === 0) {
-                            return [
-                                {
-                                    arn: '',
-                                    name: 'Amazon Q foundation (Default)',
-                                    description: '',
-                                    isDefault: true,
-                                    profile: profile,
-                                },
-                            ]
+                        // The default customization is added for each profile.
+                        const defaultCustomization = {
+                            arn: '',
+                            name: 'Amazon Q foundation (Default)',
+                            description: '',
+                            isDefault: true,
+                            profile: profile,
                         }
 
-                        return customizations.map(customization => ({
-                            ...customization,
-                            isDefault: false,
-                            profile: profile,
-                        }))
+                        return [
+                            defaultCustomization,
+                            ...customizations.map(customization => ({
+                                ...customization,
+                                isDefault: false,
+                                profile: profile,
+                            })),
+                        ]
                     })
                     .catch(error => {
                         if (error instanceof ResponseError) {
@@ -302,7 +302,15 @@ export class ServerConfigurationProvider {
                         this.logging.error(
                             `Failed to fetch customizations for profile ${profile.arn} in region ${region}: ${error}`
                         )
-                        return [] as CustomizationWithMetadata[]
+                        return [
+                            {
+                                arn: '',
+                                name: 'Amazon Q foundation (Default)',
+                                description: '',
+                                isDefault: true,
+                                profile: profile,
+                            },
+                        ] as CustomizationWithMetadata[]
                     })
             })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -25,8 +25,8 @@ export const Q_CUSTOMIZATIONS_CONFIGURATION_SECTION = `${Q_CONFIGURATION_SECTION
 export const Q_DEVELOPER_PROFILES_CONFIGURATION_SECTION = `${Q_CONFIGURATION_SECTION}.${Q_DEVELOPER_PROFILES}`
 
 interface CustomizationWithMetadata extends Customization {
-    region?: string
-    profileArn?: string
+    profile?: AmazonQDeveloperProfile
+    isDefault?: boolean
 }
 
 interface QConfigurationSections {
@@ -276,10 +276,22 @@ export class ServerConfigurationProvider {
                             throw new ResponseError(LSPErrorCodes.RequestCancelled, 'Request cancelled')
                         }
 
+                        if (customizations.length === 0) {
+                            return [
+                                {
+                                    arn: '',
+                                    name: 'Amazon Q foundation (Default)',
+                                    description: '',
+                                    isDefault: true,
+                                    profile: profile,
+                                },
+                            ]
+                        }
+
                         return customizations.map(customization => ({
                             ...customization,
-                            region,
-                            profileArn: profile.arn,
+                            isDefault: false,
+                            profile: profile,
                         }))
                     })
                     .catch(error => {

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
@@ -36,7 +36,7 @@ const MAX_Q_DEVELOPER_PROFILES_PER_PAGE = 10
 
 export const getListAllAvailableProfilesHandler =
     (service: (region: string, endpoint: string) => CodeWhispererServiceToken): ListAllAvailableProfilesHandler =>
-    async ({ connectionType, logging, endpoints, token }) => {
+    async ({ connectionType, logging, endpoints, token }): Promise<AmazonQDeveloperProfile[]> => {
         if (!connectionType || connectionType !== 'identityCenter') {
             logging.debug('Connection type is not set or not identityCenter - returning empty response.')
             return []


### PR DESCRIPTION
## Problem

## Solution

* Added `CustomizationWithMetadata` interface that extends `Customization` with `region` and `profileArn` fields.
* Added feature flag `customizationsWithMetadata` to client capabilities for opt-in functionality. Client extension must set `initializationOptions.aws.awsClientCapabilities.q.customizationsWithMetadata` flag to opt-in into new functionality.

If `customizationsWithMetadata` flag is set, when `aws.q.customizations` section is requested with `onGetConfigurationFromServer`, server will:
1. fetch all Profiles available to customer.
2. fetch all Customizations across all fetched Profiles.
3. Return list of `CustomizationWithMetadata` objects.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
