### PR TITLE
feat: basic invoking and result message for MCP

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/src/agent-standalone.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/src/agent-standalone.ts
@@ -8,7 +8,11 @@ import {
     QNetTransformServerTokenProxy,
 } from '@aws/lsp-codewhisperer'
 import { IdentityServer } from '@aws/lsp-identity'
-import { BashToolsServer, FsToolsServer } from '@aws/lsp-codewhisperer/out/language-server/agenticChat/tools/toolServer'
+import {
+    BashToolsServer,
+    FsToolsServer,
+    McpToolsServer,
+} from '@aws/lsp-codewhisperer/out/language-server/agenticChat/tools/toolServer'
 import { createTokenRuntimeProps } from './standalone-common'
 
 const MAJOR = 0
@@ -26,7 +30,7 @@ const props = createTokenRuntimeProps(VERSION, [
     FsToolsServer,
     BashToolsServer,
     QLocalProjectContextServerTokenProxy,
-    // McpToolsServer,
+    McpToolsServer,
     // LspToolsServer,
 ])
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -54,8 +54,42 @@ import {
     AmazonQServicePendingProfileError,
     AmazonQServicePendingSigninError,
 } from '../../shared/amazonQServiceManager/errors'
+import { McpManager } from './tools/mcp/mcpManager'
+import { McpTool } from './tools/mcp/mcpTool'
 
 describe('AgenticChatController', () => {
+    let mcpInstanceStub: sinon.SinonStub
+
+    beforeEach(() => {
+        mcpInstanceStub = sinon.stub(McpManager, 'instance').get(() => ({
+            getAllTools: () => [
+                {
+                    serverName: 'server1',
+                    toolName: 'server1_tool1',
+                    description: 'Mock MCP tool 1',
+                    inputSchema: {},
+                },
+                {
+                    serverName: 'server2',
+                    toolName: 'server2_tool2',
+                    description: 'Mock MCP tool 2',
+                    inputSchema: {},
+                },
+                {
+                    serverName: 'server3',
+                    toolName: 'server3_tool3',
+                    description: 'Mock MCP tool 3',
+                    inputSchema: {},
+                },
+            ],
+            callTool: (_s: string, _t: string, _a: any) => Promise.resolve({}),
+        }))
+    })
+
+    afterEach(() => {
+        mcpInstanceStub.restore()
+        sinon.restore()
+    })
     const mockTabId = 'tab-1'
     const mockConversationId = 'mock-conversation-id'
     const mockMessageId = 'mock-message-id'
@@ -248,8 +282,8 @@ describe('AgenticChatController', () => {
     })
 
     afterEach(() => {
-        sinon.restore()
         chatController.dispose()
+        sinon.restore()
         ChatSessionManagementService.reset()
     })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.ts
@@ -34,7 +34,11 @@ export class McpTool {
     }
 
     public requiresAcceptance(_input: any): CommandValidation {
-        return { requiresAcceptance: false }
+        // todo: read from config
+        return {
+            requiresAcceptance: true,
+            warning: `About to invoke MCP tool “${this.def.toolName}”. Do you want to proceed?`,
+        }
     }
 
     public async invoke(input: any): Promise<InvokeOutput> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTypes.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTypes.ts
@@ -8,6 +8,8 @@ export interface McpToolDefinition {
     toolName: string
     description: string
     inputSchema: any // schema from the server
+    disabled?: boolean
+    autoApprove?: boolean
 }
 
 export interface MCPServerConfig {
@@ -15,7 +17,7 @@ export interface MCPServerConfig {
     args?: string[]
     env?: Record<string, string>
     disabled?: boolean
-    autoApprove?: string[]
+    autoApprove?: boolean
 }
 
 export interface MCPConfig {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -83,3 +83,28 @@ export async function loadMcpServerConfigs(
 
     return servers
 }
+
+// todo: pending final UX
+export function processMcpToolUseMessage(message: string) {
+    const allLines = message.split(/\r?\n/)
+    // show only first line for long output and collaps the rest
+    const summaryLine = allLines[0].trim()
+    let detail = allLines.slice(1).join('\n').trim()
+    detail = detail.replace(/^[ \t]*```+[\w-]*[ \t]*\r?\n?/, '')
+    detail = detail.replace(/\r?\n?```+[\s`]*$/, '')
+    const isJson = detail.trim().startsWith('{') || detail.trim().startsWith('[')
+    const fence = '```' + (isJson ? 'json' : '')
+
+    const collapsed = [
+        '<details>',
+        `  <summary>▶ ${summaryLine}</summary>`,
+        '',
+        fence,
+        detail,
+        '```',
+        '',
+        '</details>',
+    ].join('\n')
+
+    return collapsed
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -72,6 +72,7 @@ export const McpToolsServer: Server = ({ workspace, logging, lsp, agent }) => {
             const namespaced = `${def.serverName}_${def.toolName}`
             const tool = new McpTool({ logging, workspace, lsp }, def)
 
+            //todo: handle enable/disable here
             agent.addTool(
                 { name: namespaced, description: baseSpec.description, inputSchema: baseSpec.inputSchema },
                 (input: any) => tool.invoke(input)


### PR DESCRIPTION
## Problem
Have basic MCP function working
## Solution
* Add basic invoking and result messages for MCP (Final message format is still TBD)
* Require acceptance for MCP tool invocation
* Minor fixes for regression
## Note
Enabled the MCP LSP servers so product can start testing the basic function(without UI). and it won't be customer facing.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
