### PR TITLE
fix: update reject button status

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1256,7 +1256,6 @@ export class AgenticChatController implements ChatHandlers {
                           },
                           {
                               id: 'reject-shell-command',
-                              status: 'dimmed-clear' as Status,
                               text: 'Reject',
                               icon: 'cancel',
                           },


### PR DESCRIPTION
## Problem
- fast follows - Reject Run (reject should be darker)
- related figma doc link: https://www.figma.com/design/DNKqLHITCpqAv9RGHKnWQQ/Agentic-Chat-Experience-2025?node-id=3378-28742&p=f&t=7wrhUKUKSPHc2XTS-0
## Solution
- update reject button status the same as run button
## Test
Before change
![Screenshot 2025-05-02 at 4 17 42 PM](https://github.com/user-attachments/assets/12005dc2-2928-4486-a95d-4de281ef0d09)

After change
![image](https://github.com/user-attachments/assets/b336f72b-f083-499c-92d4-6033ffc17f29)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
