### PR TITLE
fix: server side timeout causes ISE

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -224,6 +224,9 @@ export class AgenticChatResultStream {
                 return await this.#sendProgress(combinedResult)
             },
             close: async () => {
+                if (!this.#state.isLocked) {
+                    return
+                }
                 if (lastResult) {
                     this.#state.chatResultBlocks.push(lastResult)
                 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
@@ -3,3 +3,5 @@ export const maxAgentLoopIterations = 100
 export const loadingThresholdMs = 2000
 export const generateAssistantResponseInputLimit = 600_000
 export const outputLimitExceedsPartialMsg = 'output exceeds maximum character limit of'
+export const responseTimeoutMs = 170_000
+export const responseTimeoutPartialMsg = 'Response processing timed out after'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -7,6 +7,7 @@ type AgenticChatErrorCode =
     | 'MaxAgentLoopIterations'
     | 'InputTooLong' // too much context given to backend service.
     | 'PromptCharacterLimit' // customer prompt exceeds
+    | 'ResponseProcessingTimeout' // response didn't finish streaming in the allowed time
 
 export const customerFacingErrorCodes: AgenticChatErrorCode[] = [
     'QModelResponse',


### PR DESCRIPTION
## Problem

There is a service side timeout of 180 seconds. If the stream doesn't complete in that time it causes ISE.

## Solution

Handle this case by checking if the stream has exceeded 170 seconds on the client. If it has, abort the process and attempt to retry the request again by with smaller steps.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
