### PR TITLE
fix: hide non-user-generated messages when reloading history

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
@@ -218,7 +218,7 @@ export class TabBarController {
     async restoreTab(selectedTab?: Tab | null) {
         if (selectedTab) {
             const messages = selectedTab.conversations.flatMap((conv: Conversation) =>
-                conv.messages.flatMap(msg => messageToChatMessage(msg))
+                conv.messages.filter(msg => msg.shouldDisplayMessage != false).flatMap(msg => messageToChatMessage(msg))
             )
 
             const { tabId } = await this.#features.chat.openTab({ newTabOptions: { data: { messages } } })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -313,8 +313,9 @@ export class ChatDatabase {
 
             const tabData = historyId ? tabCollection.findOne({ historyId }) : undefined
             const tabTitle =
-                (message.type === 'prompt' && message.body.trim().length > 0 ? message.body : tabData?.title) ||
-                'Amazon Q Chat'
+                (message.type === 'prompt' && message.shouldDisplayMessage !== false && message.body.trim().length > 0
+                    ? message.body
+                    : tabData?.title) || 'Amazon Q Chat'
             message = this.formatChatHistoryMessage(message)
             if (tabData) {
                 this.#features.logging.log(`Updating existing tab with historyId=${historyId}`)


### PR DESCRIPTION
## Related PR on agentic chat branch

https://github.com/aws/aws-toolkit-vscode/pull/7059

## Problem

We show the system generated messages in the UI when reloading chat history. These should be hidden from users

![image](https://github.com/user-attachments/assets/f611e951-d19b-4272-90e7-8816aa0da9b9)


## Solution

Add a flag for determining whether we should display the messages when reloading from chat history



## Testing

See video:



https://github.com/user-attachments/assets/5ef114d7-29ae-40c9-8321-b20e0fd3ba41


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
