### PR TITLE
fix: use proper condition for trigger index enablement response

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -262,7 +262,7 @@ export class AgenticChatTriggerContext {
         chatResultStream?: AgenticChatResultStream
     ): Promise<RelevantTextDocumentAddition[]> {
         const localProjectContextController = await LocalProjectContextController.getInstance()
-        if (!localProjectContextController.isEnabled && chatResultStream) {
+        if (!localProjectContextController.isIndexingEnabled && chatResultStream) {
             await chatResultStream.writeResultBlock({
                 body: `To add your workspace as context, enable local indexing in your IDE settings. After enabling, add @workspace to your question, and I'll generate a response using your workspace as context.`,
                 buttons: [

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -355,6 +355,10 @@ export class LocalProjectContextController {
         }
     }
 
+    public isIndexingEnabled(): boolean {
+        return this._isIndexingEnabled
+    }
+
     private fileMeetsFileSizeConstraints(filePath: string, sizeConstraints: SizeConstraints): boolean {
         let fileSize
 


### PR DESCRIPTION
## Problem
We are conditionally reacting off `isEnabled` in the context controller for whether to send a chat response indicating the user should enable workspace indexing to complete their request. This is not working as expected since the context controller may be enabled while indexing is not.

## Solution
Moving the check to `isIndexingEnabled` which explicitly indicates that workspace indexing is enabled within the controller.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
