### PR TITLE
fix: show tooltip for warning message and remove the warning text 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27107,7 +27107,7 @@
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
                 "@aws/language-server-runtimes": "^0.2.78",
-                "@aws/lsp-core": "^0.0.5",
+                "@aws/lsp-core": "^0.0.6",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
                 "https-proxy-agent": "^7.0.5",
@@ -27167,7 +27167,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.78",
-                "@aws/lsp-core": "0.0.5",
+                "@aws/lsp-core": "0.0.6",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -27230,7 +27230,7 @@
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.623.0",
                 "@aws-sdk/types": "^3.734.0",
-                "@aws/lsp-core": "^0.0.5",
+                "@aws/lsp-core": "^0.0.6",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1068,10 +1068,10 @@ export class AgenticChatController implements ChatHandlers {
 
     /**
      * Get a description for the tooltip based on command category
-     * @param commandCategory The category of the command (0: normal, 1: mutation, 2: destructive)
+     * @param commandCategory The category of the command
      * @returns A descriptive message for the tooltip
      */
-    #getCommandCategoryDescription(category: number): string | undefined {
+    #getCommandCategoryDescription(category: CommandCategory): string | undefined {
         switch (category) {
             case CommandCategory.Mutate:
                 return 'This command may modify your code and/or files.'
@@ -1278,7 +1278,7 @@ export class AgenticChatController implements ChatHandlers {
         toolUse: ToolUse,
         requiresAcceptance: Boolean,
         warning?: string,
-        commandCategory?: number,
+        commandCategory?: CommandCategory,
         toolType?: string
     ): ChatResult {
         let buttons: Button[] = []
@@ -1319,7 +1319,9 @@ export class AgenticChatController implements ChatHandlers {
                               icon: 'warning',
                               status: 'warning',
                               position: 'left',
-                              description: this.#getCommandCategoryDescription(commandCategory ?? 0),
+                              description: this.#getCommandCategoryDescription(
+                                  commandCategory ?? CommandCategory.ReadOnly
+                              ),
                           }
                         : {},
                     body: 'shell',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1308,6 +1308,7 @@ export class AgenticChatController implements ChatHandlers {
                           },
                           {
                               id: 'reject-shell-command',
+                              status: 'dimmed-clear' as Status,
                               text: 'Reject',
                               icon: 'cancel',
                           },
@@ -1316,8 +1317,18 @@ export class AgenticChatController implements ChatHandlers {
                 header = {
                     status: requiresAcceptance
                         ? {
-                              icon: 'warning',
-                              status: 'warning',
+                              icon:
+                                  commandCategory === CommandCategory.Destructive
+                                      ? 'warning'
+                                      : commandCategory === CommandCategory.Mutate
+                                        ? 'info'
+                                        : 'none',
+                              status:
+                                  commandCategory === CommandCategory.Destructive
+                                      ? 'warning'
+                                      : commandCategory === CommandCategory.Mutate
+                                        ? 'info'
+                                        : undefined,
                               position: 'left',
                               description: this.#getCommandCategoryDescription(
                                   commandCategory ?? CommandCategory.ReadOnly

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1073,7 +1073,7 @@ export class AgenticChatController implements ChatHandlers {
     #getCommandCategoryDescription(category: number): string | undefined {
         switch (category) {
             case 1:
-                return 'This command is mutation.'
+                return 'This command may modify your code and/or files.'
             case 2:
                 return 'This command may cause significant data loss or damage.'
             default:

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -121,6 +121,7 @@ import {
 } from './constants'
 import { URI } from 'vscode-uri'
 import { AgenticChatError, customerFacingErrorCodes, unactionableErrorCodes } from './errors'
+import { CommandCategory } from './tools/executeBash'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -1072,9 +1073,9 @@ export class AgenticChatController implements ChatHandlers {
      */
     #getCommandCategoryDescription(category: number): string | undefined {
         switch (category) {
-            case 1:
+            case CommandCategory.Mutate:
                 return 'This command may modify your code and/or files.'
-            case 2:
+            case CommandCategory.Destructive:
                 return 'This command may cause significant data loss or damage.'
             default:
                 return undefined

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -16,6 +16,7 @@ export interface InvokeOutput {
 export interface CommandValidation {
     requiresAcceptance: boolean
     warning?: string
+    commandCategory?: number // 0 for normal, 1 more mutation, 2 for destructive
 }
 
 export async function validatePath(path: string, exists: (p: string) => Promise<boolean>) {
@@ -26,11 +27,6 @@ export async function validatePath(path: string, exists: (p: string) => Promise<
     if (!pathExists) {
         throw new Error(`Path "${path}" does not exist or cannot be accessed.`)
     }
-}
-
-export interface CommandValidation {
-    requiresAcceptance: boolean
-    warning?: string
 }
 
 export class ToolApprovalException extends Error {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -2,6 +2,7 @@ import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { workspaceUtils } from '@aws/lsp-core'
 import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
 import * as path from 'path'
+import { CommandCategory } from './executeBash'
 
 interface Output<Kind, Content> {
     kind: Kind
@@ -16,7 +17,7 @@ export interface InvokeOutput {
 export interface CommandValidation {
     requiresAcceptance: boolean
     warning?: string
-    commandCategory?: number // 0 for normal, 1 more mutation, 2 for destructive
+    commandCategory?: CommandCategory
 }
 
 export async function validatePath(path: string, exists: (p: string) => Promise<boolean>) {


### PR DESCRIPTION
## Problem

- Wrong icons for destructive and mutate command.
- Reject button should be more grey out.
- Tooltip for the different kinds of command.

## Solution
<img width="431" alt="Screenshot 2025-05-05 at 3 58 56 PM" src="https://github.com/user-attachments/assets/607c7cd1-3563-4274-be27-e3089027c244" />
<img width="427" alt="Screenshot 2025-05-05 at 3 59 11 PM" src="https://github.com/user-attachments/assets/38cde18a-658d-44eb-8b5e-b1f047d5a871" />

https://github.com/user-attachments/assets/c0b400ac-a032-49d9-bd23-a1f73ebe2168



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
