### PR TITLE
chore: revert local indexing stub

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -83,8 +83,8 @@ export class LocalProjectContextController {
     public static async getInstance(): Promise<LocalProjectContextController> {
         try {
             await waitUntil(async () => this.instance, {
-                interval: 100,
-                timeout: 600,
+                interval: 1000,
+                timeout: 60_000,
                 truthy: true,
             })
 
@@ -94,12 +94,7 @@ export class LocalProjectContextController {
 
             return this.instance
         } catch (error) {
-            // throw new Error(`Failed to get LocalProjectContextController instance: ${error}`)
-            return {
-                isEnabled: true,
-                getContextCommandItems: () => [],
-                shouldUpdateContextCommandSymbolsOnce: () => false,
-            } as unknown as LocalProjectContextController
+            throw new Error(`Failed to get LocalProjectContextController instance: ${error}`)
         }
     }
 


### PR DESCRIPTION
## Problem

Local project indexing stub was accidentally merged.

## Solution

Revert the stub.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
