### PR TITLE
chore: update netTransform unsupportedViewComponents

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/resources/SupportedProjects.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/resources/SupportedProjects.ts
@@ -16,10 +16,4 @@ export const supportedProjects = [
     'Unknown',
 ]
 
-export const unsupportedViewComponents = [
-    '@Scripts',
-    '@Styles',
-    '@Session',
-    '@FormsAuthentication',
-    '@PagedListRenderOptions',
-]
+export const unsupportedViewComponents = ['@Session', '@PagedListRenderOptions', 'User.Identity.GetUserName']


### PR DESCRIPTION
## Problem
netTransform `unsupportedViewComponents` list is out-of-dated.
## Solution
Update `unsupportedViewComponents` to reflect the netTransform GA feature. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
