### PR TITLE
fix: clear history for `inputTooLong` errors

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -1081,7 +1081,7 @@ describe('AgenticChatController', () => {
             const typedChatResult = chatResult as ResponseError<ChatResult>
             assert.strictEqual(
                 typedChatResult.data?.body,
-                'Too much context loaded. Please start a new conversation or ask about specific files.'
+                'Too much context loaded. I have cleared the conversation history. Please retry your request with smaller input.'
             )
         })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1591,6 +1591,10 @@ export class AgenticChatController implements ChatHandlers {
 
         if (customerFacingErrorCodes.includes(err.code)) {
             this.#features.logging.error(`${loggingUtils.formatErr(err)}`)
+            if (err.code === 'InputTooLong') {
+                // Clear the chat history in the database for this tab
+                this.#chatHistoryDb.clearTab(tabId)
+            }
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
                 type: 'answer',
                 body: err.message,

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -143,7 +143,7 @@ export class ChatSessionService {
                         requestId = e.$metadata?.requestId
                     }
                     throw new AgenticChatError(
-                        'Too much context loaded. Please start a new conversation or ask about specific files.',
+                        'Too much context loaded. I have cleared the conversation history. Please retry your request with smaller input.',
                         'InputTooLong',
                         e instanceof Error ? e : undefined,
                         requestId


### PR DESCRIPTION
## Problem
We currently try to estimate and trim the number of tokens in each request before sending to the server. However, this is an estimation and is not always accurate. As a result, we see a number of `Input too long` errors in our metrics.

We also force users to open a new conversation tab to continue.

## Solution
- Clear current tab history for `inputTooLong` errors to allow users to continue in current chat tab
- Rephrase customer-facing message

## Testing

Skip through the video if needed:

https://github.com/user-attachments/assets/7ac68c98-1169-4635-b6b1-a66da2549686




## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
