### PR TITLE
 feat: add CRUD methods for MCP servers

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -212,9 +212,9 @@ export class AgenticChatController implements ChatHandlers {
             }
             params.buttonId === 'reject-shell-command'
                 ? (() => {
-                      handler.reject(new ToolApprovalException('Command was rejected.', true))
-                      this.#stoppedToolUses.add(messageId)
-                  })()
+                    handler.reject(new ToolApprovalException('Command was rejected.', true))
+                    this.#stoppedToolUses.add(messageId)
+                })()
                 : handler.resolve()
             return {
                 success: true,
@@ -288,7 +288,7 @@ export class AgenticChatController implements ChatHandlers {
             const updatedDetails = { ...fileList.details }
             for (const filePath of fileList.filePaths) {
                 if (updatedDetails[filePath]) {
-                    ;(updatedDetails[filePath] as any) = {
+                    ; (updatedDetails[filePath] as any) = {
                         ...updatedDetails[filePath],
                         clickable: false,
                     } as Partial<FileDetails>
@@ -616,7 +616,7 @@ export class AgenticChatController implements ChatHandlers {
                     codeReference: result.data.chatResult.codeReference,
                     relatedContent:
                         result.data.chatResult.relatedContent?.content &&
-                        result.data.chatResult.relatedContent.content.length > 0
+                            result.data.chatResult.relatedContent.content.length > 0
                             ? result.data?.chatResult.relatedContent
                             : undefined,
                     toolUses: Object.keys(result.data?.toolUses!)
@@ -1163,12 +1163,12 @@ export class AgenticChatController implements ChatHandlers {
                     ...(isAccept
                         ? {}
                         : {
-                              status: {
-                                  status: 'error',
-                                  icon: 'cancel',
-                                  text: 'Rejected',
-                              },
-                          }),
+                            status: {
+                                status: 'error',
+                                icon: 'cancel',
+                                text: 'Rejected',
+                            },
+                        }),
                     buttons: isAccept ? [{ id: 'stop-shell-command', text: 'Stop', icon: 'stop' }] : [],
                 },
             }
@@ -1304,26 +1304,26 @@ export class AgenticChatController implements ChatHandlers {
             case 'executeBash':
                 buttons = requiresAcceptance
                     ? [
-                          {
-                              id: 'run-shell-command',
-                              text: 'Run',
-                              icon: 'play',
-                          },
-                          {
-                              id: 'reject-shell-command',
-                              text: 'Reject',
-                              icon: 'cancel',
-                          },
-                      ]
+                        {
+                            id: 'run-shell-command',
+                            text: 'Run',
+                            icon: 'play',
+                        },
+                        {
+                            id: 'reject-shell-command',
+                            text: 'Reject',
+                            icon: 'cancel',
+                        },
+                    ]
                     : []
                 header = {
                     status: requiresAcceptance
                         ? {
-                              icon: 'warning',
-                              status: 'warning',
-                              position: 'left',
-                              // TODO: Add `description` if necessary to show a tooltip
-                          }
+                            icon: 'warning',
+                            status: 'warning',
+                            position: 'left',
+                            // TODO: Add `description` if necessary to show a tooltip
+                        }
                         : {},
                     body: 'shell',
                     buttons,
@@ -1476,8 +1476,8 @@ export class AgenticChatController implements ChatHandlers {
                 toolUse.name === 'fsRead'
                     ? `${itemCount} file${itemCount > 1 ? 's' : ''} read`
                     : toolUse.name === 'fileSearch'
-                      ? `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} searched`
-                      : `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} listed`
+                        ? `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} searched`
+                        : `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} listed`
         }
         const details: Record<string, FileDetails> = {}
         for (const item of filePathsPushed) {
@@ -1710,9 +1710,9 @@ export class AgenticChatController implements ChatHandlers {
 
             return result.success
                 ? {
-                      ...result.data.chatResult,
-                      requestId: response.$metadata.requestId,
-                  }
+                    ...result.data.chatResult,
+                    requestId: response.$metadata.requestId,
+                }
                 : new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, result.error)
         } catch (err) {
             this.#log(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -212,9 +212,9 @@ export class AgenticChatController implements ChatHandlers {
             }
             params.buttonId === 'reject-shell-command'
                 ? (() => {
-                    handler.reject(new ToolApprovalException('Command was rejected.', true))
-                    this.#stoppedToolUses.add(messageId)
-                })()
+                      handler.reject(new ToolApprovalException('Command was rejected.', true))
+                      this.#stoppedToolUses.add(messageId)
+                  })()
                 : handler.resolve()
             return {
                 success: true,
@@ -288,7 +288,7 @@ export class AgenticChatController implements ChatHandlers {
             const updatedDetails = { ...fileList.details }
             for (const filePath of fileList.filePaths) {
                 if (updatedDetails[filePath]) {
-                    ; (updatedDetails[filePath] as any) = {
+                    ;(updatedDetails[filePath] as any) = {
                         ...updatedDetails[filePath],
                         clickable: false,
                     } as Partial<FileDetails>
@@ -616,7 +616,7 @@ export class AgenticChatController implements ChatHandlers {
                     codeReference: result.data.chatResult.codeReference,
                     relatedContent:
                         result.data.chatResult.relatedContent?.content &&
-                            result.data.chatResult.relatedContent.content.length > 0
+                        result.data.chatResult.relatedContent.content.length > 0
                             ? result.data?.chatResult.relatedContent
                             : undefined,
                     toolUses: Object.keys(result.data?.toolUses!)
@@ -813,11 +813,15 @@ export class AgenticChatController implements ChatHandlers {
                     // — DEFAULT ⇒ MCP tools
                     default:
                         // toolUse.name is in format <server>_<tool>
-                        const toolName = toolUse.name.split('_').slice(1).join('_')
+                        const [serverName, ...toolParts] = toolUse.name.split('_')
+                        const toolName = toolParts.join('_')
                         const def = McpManager.instance.getAllTools().find(d => d.toolName === toolName)
                         if (def) {
                             const mcpTool = new McpTool(this.#features, def)
-                            const { requiresAcceptance, warning } = await mcpTool.requiresAcceptance(toolUse.input)
+                            const { requiresAcceptance, warning } = await mcpTool.requiresAcceptance(
+                                serverName,
+                                toolName
+                            )
                             if (requiresAcceptance) {
                                 const confirmation = this.#processToolConfirmation(toolUse, requiresAcceptance, warning)
                                 cachedButtonBlockId = await chatResultStream.writeResultBlock(confirmation)
@@ -1163,12 +1167,12 @@ export class AgenticChatController implements ChatHandlers {
                     ...(isAccept
                         ? {}
                         : {
-                            status: {
-                                status: 'error',
-                                icon: 'cancel',
-                                text: 'Rejected',
-                            },
-                        }),
+                              status: {
+                                  status: 'error',
+                                  icon: 'cancel',
+                                  text: 'Rejected',
+                              },
+                          }),
                     buttons: isAccept ? [{ id: 'stop-shell-command', text: 'Stop', icon: 'stop' }] : [],
                 },
             }
@@ -1304,26 +1308,26 @@ export class AgenticChatController implements ChatHandlers {
             case 'executeBash':
                 buttons = requiresAcceptance
                     ? [
-                        {
-                            id: 'run-shell-command',
-                            text: 'Run',
-                            icon: 'play',
-                        },
-                        {
-                            id: 'reject-shell-command',
-                            text: 'Reject',
-                            icon: 'cancel',
-                        },
-                    ]
+                          {
+                              id: 'run-shell-command',
+                              text: 'Run',
+                              icon: 'play',
+                          },
+                          {
+                              id: 'reject-shell-command',
+                              text: 'Reject',
+                              icon: 'cancel',
+                          },
+                      ]
                     : []
                 header = {
                     status: requiresAcceptance
                         ? {
-                            icon: 'warning',
-                            status: 'warning',
-                            position: 'left',
-                            // TODO: Add `description` if necessary to show a tooltip
-                        }
+                              icon: 'warning',
+                              status: 'warning',
+                              position: 'left',
+                              // TODO: Add `description` if necessary to show a tooltip
+                          }
                         : {},
                     body: 'shell',
                     buttons,
@@ -1476,8 +1480,8 @@ export class AgenticChatController implements ChatHandlers {
                 toolUse.name === 'fsRead'
                     ? `${itemCount} file${itemCount > 1 ? 's' : ''} read`
                     : toolUse.name === 'fileSearch'
-                        ? `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} searched`
-                        : `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} listed`
+                      ? `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} searched`
+                      : `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} listed`
         }
         const details: Record<string, FileDetails> = {}
         for (const item of filePathsPushed) {
@@ -1710,9 +1714,9 @@ export class AgenticChatController implements ChatHandlers {
 
             return result.success
                 ? {
-                    ...result.data.chatResult,
-                    requestId: response.$metadata.requestId,
-                }
+                      ...result.data.chatResult,
+                      requestId: response.$metadata.requestId,
+                  }
                 : new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, result.error)
         } catch (err) {
             this.#log(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -4,64 +4,388 @@
  */
 
 import { expect } from 'chai'
+import * as sinon from 'sinon'
 import { McpManager } from './mcpManager'
+import * as mcpUtils from './mcpUtils'
+import type { MCPServerConfig } from './mcpTypes'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 
-describe('McpManager (singleton & empty‑config)', () => {
-    const fakeLogging = {
-        log: (_: string) => {},
-        info: (_: string) => {},
-        warn: (_: string) => {},
-        error: (_: string) => {},
-        debug: (_: string) => {},
-    }
-
-    // Minimal stub for Features.workspace
+describe('McpManager (singleton & empty-config)', () => {
+    const fakeLogging = { log: () => {}, info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
     const fakeWorkspace = {
         fs: {
             exists: (_: string) => Promise.resolve(false),
             readFile: (_: string) => Promise.resolve(Buffer.from('')),
+            writeFile: (_path: string, _data: string) => Promise.resolve(),
         },
         getUserHomeDir: () => '',
     }
-
-    const fakeLsp = {}
-
-    const features = {
-        logging: fakeLogging,
-        workspace: fakeWorkspace,
-        lsp: fakeLsp,
-    } as unknown as Pick<
-        import('@aws/language-server-runtimes/server-interface/server').Features,
-        'logging' | 'workspace' | 'lsp'
-    >
+    const features = { logging: fakeLogging, workspace: fakeWorkspace, lsp: {} } as any
 
     afterEach(async () => {
+        sinon.restore()
         try {
             await McpManager.instance.close()
-        } catch {
-            /* ignore */
-        }
+        } catch {}
     })
 
     it('init() always returns the same instance', async () => {
+        sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map())
         const m1 = await McpManager.init([], features)
         const m2 = await McpManager.init([], features)
         expect(m1).to.equal(m2)
     })
 
     it('with no config paths it discovers zero tools', async () => {
+        sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map())
         const mgr = await McpManager.init([], features)
         expect(mgr.getAllTools()).to.be.an('array').that.is.empty
     })
 
-    it('callTool() on non‑existent server throws', async () => {
+    it('callTool() on non-existent server throws', async () => {
+        sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map())
         const mgr = await McpManager.init([], features)
         try {
             await mgr.callTool('nope', 'foo', {})
-            throw new Error('Expected callTool to throw, but it did not')
+            throw new Error('Expected callTool to throw for non-existent server')
         } catch (err: any) {
             expect(err).to.be.instanceOf(Error)
-            expect(err.message).to.equal(`MCP: server 'nope' not connected`)
+            expect(err.message).to.equal("MCP: server 'nope' is not configured")
         }
+    })
+})
+
+describe('McpManager additional methods', () => {
+    let loadStub: sinon.SinonStub
+    let initOneStub: sinon.SinonStub
+    let mutateStub: sinon.SinonStub
+    let callToolStub: sinon.SinonStub
+
+    const fakeLogging = { log: () => {}, info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+    const fakeWorkspace = {
+        fs: {
+            exists: (_: string) => Promise.resolve(true),
+            readFile: (_: string) => Promise.resolve(Buffer.from('{}')),
+            writeFile: (_path: string, _data: string) => Promise.resolve(),
+        },
+        getUserHomeDir: () => '',
+    }
+    const features = { logging: fakeLogging, workspace: fakeWorkspace, lsp: {} } as any
+
+    beforeEach(() => {
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs')
+        initOneStub = sinon.stub(McpManager.prototype as any, 'initOneServer' as any).callsFake(async function (
+            this: any,
+            ...args: any[]
+        ) {
+            const serverName = args[0] as string
+            this.clients.set(serverName, new Client({ name: 'stub', version: '0.0.0' }))
+            this.mcpTools.push({ serverName, toolName: 'tool1', description: 'desc', inputSchema: {} as any })
+        })
+        mutateStub = sinon.stub(McpManager.prototype as any, 'mutateConfigFile' as any).resolves()
+        callToolStub = sinon.stub(Client.prototype as any, 'callTool' as any).resolves('ok' as any)
+    })
+
+    afterEach(async () => {
+        sinon.restore()
+        try {
+            await McpManager.instance.close()
+        } catch {}
+    })
+
+    it('discovers and lists tools for enabled servers', async () => {
+        const cfg = {
+            command: 'c',
+            args: [],
+            env: {},
+            disabled: false,
+            autoApprove: false,
+            toolOverrides: {},
+            __configPath__: 'p.json',
+        } as MCPServerConfig
+        loadStub.resolves(new Map([['s1', cfg]]))
+
+        const mgr = await McpManager.init(['p.json'], features)
+        expect(initOneStub.calledOnceWith('s1', cfg)).to.be.true
+        expect(mgr.getAllTools()).to.deep.equal([
+            { serverName: 's1', toolName: 'tool1', description: 'desc', inputSchema: {} },
+        ])
+        expect(mgr.listServersAndTools()).to.deep.equal({ s1: ['tool1'] })
+    })
+
+    it('callTool invokes client.callTool correctly', async () => {
+        const cfg = {
+            command: 'c',
+            args: [],
+            env: {},
+            disabled: false,
+            autoApprove: false,
+            toolOverrides: {},
+            __configPath__: 'p.json',
+        } as MCPServerConfig
+        loadStub.resolves(new Map([['s1', cfg]]))
+
+        const mgr = await McpManager.init(['p.json'], features)
+        ;(mgr as any).clients.set('s1', new Client({ name: 'x', version: 'v' }))
+
+        const result = await mgr.callTool('s1', 'tool1', { foo: 1 })
+        expect(callToolStub.calledOnceWith({ name: 'tool1', arguments: { foo: 1 } })).to.be.true
+        expect(result).to.equal('ok')
+    })
+
+    it('addServer persists config and initializes new server', async () => {
+        loadStub.resolves(new Map())
+        const mgr = await McpManager.init([], features)
+        const newCfg = {
+            command: 'c2',
+            args: ['a'],
+            env: { X: '1' },
+            disabled: false,
+            autoApprove: true,
+            toolOverrides: {},
+            __configPath__: 'path.json',
+        } as MCPServerConfig
+
+        await mgr.addServer('newS', newCfg, 'path.json')
+        expect(mutateStub.calledOnce).to.be.true
+        expect(initOneStub.calledWith('newS', newCfg)).to.be.true
+        expect(mgr.listServersAndTools()).to.have.property('newS')
+    })
+
+    it('removeServer shuts down client and cleans state', async () => {
+        loadStub.resolves(new Map())
+        const mgr = await McpManager.init([], features)
+        const dummyClient = new Client({ name: 'c', version: 'v' })
+        const cfg = {
+            command: '',
+            args: [],
+            env: {},
+            disabled: false,
+            autoApprove: false,
+            toolOverrides: {},
+            __configPath__: 'cfg.json',
+        } as MCPServerConfig
+        ;(mgr as any).clients.set('s2', dummyClient)
+        ;(mgr as any).mcpServers.set('s2', cfg)
+        ;(mgr as any).mcpTools.push({ serverName: 's2', toolName: 't', description: '', inputSchema: {} })
+
+        await mgr.removeServer('s2')
+        expect(mutateStub.calledOnce).to.be.true
+        expect((mgr as any).clients.has('s2')).to.be.false
+        expect((mgr as any).mcpServers.has('s2')).to.be.false
+        expect(mgr.getAllTools()).to.be.empty
+    })
+
+    it('updateServer toggles autoApprove and re-initializes server', async () => {
+        const oldCfg = {
+            command: 'cmd',
+            args: [],
+            env: {},
+            disabled: false,
+            autoApprove: false,
+            toolOverrides: {},
+            __configPath__: 'u.json',
+        } as MCPServerConfig
+        loadStub.resolves(new Map([['u1', oldCfg]]))
+        await McpManager.init([], features)
+        const mgr = McpManager.instance
+
+        const fakeClient = new Client({ name: 'c', version: 'v' })
+        ;(mgr as any).clients.set('u1', fakeClient)
+        ;(mgr as any).mcpTools.push({ serverName: 'u1', toolName: 't1', description: 'd', inputSchema: {} })
+
+        initOneStub.resetHistory()
+        mutateStub.resetHistory()
+        const closeSpy = sinon.spy(fakeClient, 'close')
+
+        await mgr.updateServer('u1', { autoApprove: true })
+        expect(mutateStub.calledOnce).to.be.true
+        expect(closeSpy.calledOnce).to.be.true
+        expect(initOneStub.calledOnce).to.be.true
+
+        const updated = (mgr as any).mcpServers.get('u1')!
+        expect(updated.autoApprove).to.be.true
+    })
+
+    it('updateServer disables and re-enables server correctly', async () => {
+        const cfg = {
+            command: 'cmd2',
+            args: [],
+            env: {},
+            disabled: false,
+            autoApprove: false,
+            toolOverrides: {},
+            __configPath__: 'd.json',
+        } as MCPServerConfig
+        loadStub.resolves(new Map([['d1', cfg]]))
+        await McpManager.init([], features)
+        const mgr = McpManager.instance
+
+        const fakeClient2 = new Client({ name: 'c2', version: 'v2' })
+        ;(mgr as any).clients.set('d1', fakeClient2)
+        ;(mgr as any).mcpTools.push({ serverName: 'd1', toolName: 't2', description: 'd2', inputSchema: {} })
+
+        initOneStub.resetHistory()
+        mutateStub.resetHistory()
+        const closeSpy2 = sinon.spy(fakeClient2, 'close')
+
+        // Disable
+        await mgr.updateServer('d1', { disabled: true })
+        expect(mutateStub.calledOnce).to.be.true
+        expect(closeSpy2.calledOnce).to.be.true
+        expect(initOneStub.notCalled).to.be.true
+        expect((mgr as any).clients.has('d1')).to.be.false
+        expect(mgr.getAllTools().every(t => t.serverName !== 'd1')).to.be.true
+
+        // Re-enable
+        mutateStub.resetHistory()
+        initOneStub.resetHistory()
+        await mgr.updateServer('d1', { disabled: false })
+        expect(mutateStub.calledOnce).to.be.true
+        expect(initOneStub.calledOnceWith('d1', sinon.match.object)).to.be.true
+    })
+
+    it('updateServer merges toolOverrides in config correctly', async () => {
+        const initialOverrides = { toolA: { autoApprove: false } }
+        const cfg = {
+            command: 'cmd3',
+            args: [],
+            env: {},
+            disabled: false,
+            autoApprove: false,
+            toolOverrides: initialOverrides,
+            __configPath__: 'o.json',
+        } as MCPServerConfig
+        loadStub.resolves(new Map([['o1', cfg]]))
+        await McpManager.init([], features)
+        const mgr = McpManager.instance
+
+        initOneStub.resetHistory()
+        mutateStub.resetHistory()
+
+        const newOverrides = { toolA: { autoApprove: true } }
+        await mgr.updateServer('o1', { toolOverrides: newOverrides })
+        expect(mutateStub.calledOnce).to.be.true
+
+        const updated = (mgr as any).mcpServers.get('o1')!
+        expect(updated.toolOverrides.toolA.autoApprove).to.be.true
+    })
+
+    describe('requiresApproval()', () => {
+        it('requires approval when server not configured', async () => {
+            loadStub.resolves(new Map())
+            const mgr = await McpManager.init([], features)
+            expect(mgr.requiresApproval('unknown', 'anyTool')).to.be.true
+        })
+
+        it('uses server.autoApprove when no toolOverride', async () => {
+            const cfg = {
+                command: 'c',
+                args: [],
+                env: {},
+                disabled: false,
+                autoApprove: false,
+                toolOverrides: {},
+                __configPath__: 'p',
+            } as MCPServerConfig
+            loadStub.resolves(new Map([['s', cfg]]))
+            await McpManager.init(['p'], features)
+
+            // server default = false → require approval
+            expect(McpManager.instance.requiresApproval('s', 'foo')).to.be.true
+
+            // flip server autoApprove to true in-memory
+            ;(McpManager.instance as any).mcpServers.set('s', { ...cfg, autoApprove: true })
+            expect(McpManager.instance.requiresApproval('s', 'foo')).to.be.false
+        })
+
+        it('toolOverrides.autoApprove overrides server setting', async () => {
+            const cfg = {
+                command: 'c',
+                args: [],
+                env: {},
+                disabled: false,
+                autoApprove: true,
+                toolOverrides: { foo: { autoApprove: false } },
+                __configPath__: 'p',
+            } as MCPServerConfig
+            loadStub.resolves(new Map([['s', cfg]]))
+            await McpManager.init(['p'], features)
+
+            // override for 'foo' = false → require approval
+            expect(McpManager.instance.requiresApproval('s', 'foo')).to.be.true
+            // other tools fall back to server default true → no approval
+            expect(McpManager.instance.requiresApproval('s', 'bar')).to.be.false
+        })
+    })
+
+    it('getAllServerConfigs returns a snapshot of configs', async () => {
+        const cfg = {
+            command: 'cmd',
+            args: [],
+            env: {},
+            disabled: false,
+            autoApprove: true,
+            toolOverrides: {},
+            __configPath__: 'cfg.json',
+        } as MCPServerConfig
+        loadStub.resolves(new Map([['srv', cfg]]))
+        const mgr = await McpManager.init(['cfg.json'], features)
+
+        const snapshot = mgr.getAllServerConfigs()
+        expect(snapshot).to.be.instanceOf(Map)
+        expect(snapshot.get('srv')).to.deep.equal(cfg)
+
+        // Mutating the returned map should NOT affect the manager’s internal state
+        snapshot.delete('srv')
+        const again = mgr.getAllServerConfigs()
+        expect(again.has('srv')).to.be.true
+    })
+
+    it('listServersAndTools skips servers that have no tools', async () => {
+        const cfg = {
+            command: 'cmd',
+            args: [],
+            env: {},
+            disabled: true,
+            autoApprove: true,
+            toolOverrides: {},
+            __configPath__: 'p.json',
+        } as MCPServerConfig
+        loadStub.resolves(new Map([['emptySrv', cfg]]))
+
+        const mgr = await McpManager.init(['p.json'], features)
+        expect(mgr.listServersAndTools()).to.deep.equal({})
+    })
+})
+
+describe('McpManager close()', () => {
+    it('shuts all clients and resets singleton', async () => {
+        const fakeLogging = { log: () => {}, info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+        const fakeWorkspace = {
+            fs: {
+                exists: (_: string) => Promise.resolve(false),
+                readFile: (_: string) => Promise.resolve(Buffer.from('')),
+                writeFile: (_path: string, _data: string) => Promise.resolve(),
+            },
+            getUserHomeDir: () => '',
+        }
+        const features = { logging: fakeLogging, workspace: fakeWorkspace, lsp: {} } as any
+
+        sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map())
+        await McpManager.init([], features)
+        const mgr = McpManager.instance
+
+        const c1 = new Client({ name: 'c1', version: 'v' })
+        const c2 = new Client({ name: 'c2', version: 'v' })
+        const spy1 = sinon.spy(c1, 'close')
+        const spy2 = sinon.spy(c2, 'close')
+        ;(mgr as any).clients.set('a', c1)
+        ;(mgr as any).clients.set('b', c2)
+
+        await mgr.close()
+        expect(spy1.calledOnce).to.be.true
+        expect(spy2.calledOnce).to.be.true
+        expect(() => McpManager.instance).to.throw(Error, 'not initialized')
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -9,16 +9,28 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import type { MCPServerConfig, McpToolDefinition, ListToolsResponse } from './mcpTypes'
 import { loadMcpServerConfigs } from './mcpUtils'
 
+/**
+ * Manages MCP servers and their tools
+ */
 export class McpManager {
     static #instance?: McpManager
-    private clients = new Map<string, Client>()
-    private mcpTools: McpToolDefinition[] = []
+    private clients: Map<string, Client>
+    private mcpTools: McpToolDefinition[]
+    private mcpServers: Map<string, MCPServerConfig>
 
     private constructor(
         private configPaths: string[],
         private features: Pick<Features, 'logging' | 'workspace' | 'lsp'>
-    ) {}
+    ) {
+        this.mcpTools = []
+        this.clients = new Map<string, Client>()
+        this.mcpServers = new Map<string, MCPServerConfig>()
+        this.features.logging.info(`MCP manager: initialized with ${configPaths.length} configs`)
+    }
 
+    /**
+     * Initialize or return existing manager, then discover all servers.
+     */
     public static async init(
         configPaths: string[],
         features: Pick<Features, 'logging' | 'workspace' | 'lsp'>
@@ -39,25 +51,13 @@ export class McpManager {
         return McpManager.#instance
     }
 
-    public async close(): Promise<void> {
-        this.features.logging.info('MCP: closing all clients')
-        for (const [name, client] of this.clients.entries()) {
-            try {
-                await client.close()
-                this.features.logging.info(`MCP: closed client for ${name}`)
-            } catch (e: any) {
-                this.features.logging.error(`MCP: error closing client ${name}: ${e.message}`)
-            }
-        }
-        this.clients.clear()
-        this.mcpTools = []
-        McpManager.#instance = undefined
-    }
-
+    /**
+     * Load configurations and initialize each enabled server.
+     */
     private async discoverAllServers(): Promise<void> {
-        const configs = await loadMcpServerConfigs(this.features.workspace, this.features.logging, this.configPaths)
+        this.mcpServers = await loadMcpServerConfigs(this.features.workspace, this.features.logging, this.configPaths)
 
-        for (const [name, cfg] of configs.entries()) {
+        for (const [name, cfg] of this.mcpServers.entries()) {
             if (cfg.disabled) {
                 this.features.logging.info(`MCP: server '${name}' is disabled, skipping`)
                 continue
@@ -66,6 +66,10 @@ export class McpManager {
         }
     }
 
+    /**
+     * Start a server process, connect client, and register its tools.
+     * Errors are logged but do not stop discovery of other servers.
+     */
     private async initOneServer(serverName: string, cfg: MCPServerConfig): Promise<void> {
         try {
             this.features.logging.debug(`MCP: initializing server [${serverName}]`)
@@ -85,29 +89,223 @@ export class McpManager {
             await client.connect(transport)
             this.clients.set(serverName, client)
 
+            this.mcpTools = this.mcpTools.filter(t => t.serverName !== serverName)
             const resp = (await client.listTools()) as ListToolsResponse
             for (const t of resp.tools) {
-                const toolName = t.name!
+                if (!t.name) {
+                    this.features.logging.warn(`MCP: server [${serverName}] returned tool with no name, skipping`)
+                    continue
+                }
+                const toolName = t.name
                 this.features.logging.info(`MCP: discovered tool ${serverName}::${toolName}`)
-                this.mcpTools.push({
-                    serverName,
-                    toolName,
-                    description: t.description ?? '',
-                    inputSchema: t.inputSchema ?? {},
-                })
+                const disabled = cfg.toolOverrides?.[toolName]?.disabled
+                if (!disabled)
+                    this.mcpTools.push({
+                        serverName,
+                        toolName,
+                        description: t.description ?? '',
+                        inputSchema: t.inputSchema ?? {},
+                    })
             }
         } catch (e: any) {
+            const client = this.clients.get(serverName)
+            if (client) {
+                await client.close()
+                this.clients.delete(serverName)
+            }
+            this.mcpServers.delete(serverName)
+            this.mcpTools = this.mcpTools.filter(t => t.serverName !== serverName)
             this.features.logging.warn(`MCP: server [${serverName}] init failed: ${e.message}`)
         }
     }
 
+    /**
+     * Return a list of all discovered tools.
+     */
     public getAllTools(): McpToolDefinition[] {
         return [...this.mcpTools]
     }
 
+    /**
+     * Return a list of all server configurations.
+     */
+    public getAllServerConfigs(): Map<string, MCPServerConfig> {
+        return new Map(this.mcpServers)
+    }
+
+    /**
+     * Map server names to their available tool names.
+     */
+    public listServersAndTools(): Record<string, string[]> {
+        const result: Record<string, string[]> = {}
+        for (const { serverName, toolName } of this.mcpTools) {
+            result[serverName] ||= []
+            result[serverName].push(toolName)
+        }
+        return result
+    }
+
+    /**
+     * Invoke a tool on a server after validating server and tool.
+     * @throws if server or tool is missing, disabled, or disconnected(shouldn't happen).
+     */
     public async callTool(server: string, tool: string, args: any): Promise<any> {
-        const c = this.clients.get(server)
-        if (!c) throw new Error(`MCP: server '${server}' not connected`)
-        return c.callTool({ name: tool, arguments: args })
+        const cfg = this.mcpServers.get(server)
+        if (!cfg) throw new Error(`MCP: server '${server}' is not configured`)
+        if (cfg.disabled) throw new Error(`MCP: server '${server}' is disabled`)
+
+        const tools = this.mcpTools.filter(t => t.serverName === server).map(t => t.toolName)
+        if (!tools.includes(tool)) {
+            throw new Error(`MCP: tool '${tool}' not found on '${server}'. Available: ${tools.join(', ')}`)
+        }
+
+        const client = this.clients.get(server)
+        if (!client) throw new Error(`MCP: server '${server}' not connected`)
+        return client.callTool({ name: tool, arguments: args })
+    }
+
+    /**
+     * Add a new server: persist config, register in memory, and initialize.
+     */
+    public async addServer(serverName: string, cfg: MCPServerConfig, configPath: string): Promise<void> {
+        if (this.mcpServers.has(serverName)) {
+            throw new Error(`MCP: server '${serverName}' already exists`)
+        }
+
+        await this.mutateConfigFile(configPath, json => {
+            json.mcpServers[serverName] = {
+                command: cfg.command,
+                args: cfg.args,
+                env: cfg.env,
+                disabled: cfg.disabled,
+                autoApprove: cfg.autoApprove,
+                toolOverrides: cfg.toolOverrides,
+            }
+        })
+
+        const newCfg: MCPServerConfig = { ...cfg, __configPath__: configPath }
+        this.mcpServers.set(serverName, newCfg)
+
+        await this.initOneServer(serverName, newCfg)
+    }
+
+    /**
+     * Remove a server: shutdown client, remove tools, and delete disk entry.
+     */
+    public async removeServer(serverName: string): Promise<void> {
+        const cfg = this.mcpServers.get(serverName)
+        if (!cfg || !cfg.__configPath__) {
+            throw new Error(`MCP: server '${serverName}' not found`)
+        }
+
+        const client = this.clients.get(serverName)
+        if (client) {
+            await client.close()
+            this.clients.delete(serverName)
+        }
+        this.mcpTools = this.mcpTools.filter(t => t.serverName !== serverName)
+        this.mcpServers.delete(serverName)
+
+        await this.mutateConfigFile(cfg.__configPath__, json => {
+            delete json.mcpServers[serverName]
+        })
+    }
+
+    /**
+     * Update a server: persist changes, teardown old client/tools, and re-init if enabled.
+     */
+    public async updateServer(
+        serverName: string,
+        configUpdates: Partial<Omit<MCPServerConfig, '__configPath__'>>
+    ): Promise<void> {
+        const oldCfg = this.mcpServers.get(serverName)
+        if (!oldCfg || !oldCfg.__configPath__) {
+            throw new Error(`MCP: server '${serverName}' not found`)
+        }
+
+        await this.mutateConfigFile(oldCfg.__configPath__, json => {
+            json.mcpServers ||= {}
+            json.mcpServers[serverName] = {
+                ...json.mcpServers[serverName],
+                ...configUpdates,
+                toolOverrides: configUpdates.toolOverrides ?? oldCfg.toolOverrides ?? {},
+            }
+        })
+
+        const newCfg: MCPServerConfig = {
+            ...oldCfg,
+            ...configUpdates,
+            toolOverrides: configUpdates.toolOverrides ?? oldCfg.toolOverrides ?? {},
+            __configPath__: oldCfg.__configPath__,
+        }
+
+        const oldClient = this.clients.get(serverName)
+        if (oldClient) {
+            await oldClient.close()
+            this.clients.delete(serverName)
+        }
+        this.mcpTools = this.mcpTools.filter(t => t.serverName !== serverName)
+
+        if (!newCfg.disabled) {
+            this.mcpServers.set(serverName, newCfg)
+            await this.initOneServer(serverName, newCfg)
+        }
+    }
+
+    /**
+     * Close all clients, clear state, and reset singleton.
+     */
+    public async close(): Promise<void> {
+        this.features.logging.info('MCP: closing all clients')
+        for (const [name, client] of this.clients.entries()) {
+            try {
+                await client.close()
+                this.features.logging.info(`MCP: closed client for ${name}`)
+            } catch (e: any) {
+                this.features.logging.error(`MCP: error closing client ${name}: ${e.message}`)
+            }
+        }
+        this.clients.clear()
+        this.mcpTools = []
+        this.mcpServers.clear()
+        McpManager.#instance = undefined
+    }
+
+    /**
+     * Check if a tool requires approval.
+     */
+    public requiresApproval(server: string, tool: string): boolean {
+        const cfg = this.mcpServers.get(server)
+        if (!cfg) {
+            return true
+        }
+
+        // 1) server default (true = auto-approved)
+        const serverAuto = cfg.autoApprove ?? true
+
+        // 2) per-tool override, if any
+        const toolAuto = cfg.toolOverrides?.[tool]?.autoApprove
+
+        // 3) pick override if defined, else fall back to server
+        const finalAuto = toolAuto !== undefined ? toolAuto : serverAuto
+
+        return !finalAuto
+    }
+
+    /**
+     * Read, mutate, and write the JSON config at the given path.
+     * @private
+     */
+    private async mutateConfigFile(configPath: string, mutator: (json: any) => void): Promise<void> {
+        try {
+            const raw = await this.features.workspace.fs.readFile(configPath)
+            const json = JSON.parse(raw.toString())
+            json.mcpServers = json.mcpServers || {}
+            mutator(json)
+            await this.features.workspace.fs.writeFile(configPath, JSON.stringify(json, null, 2))
+        } catch (e: any) {
+            this.features.logging.error(`MCP: failed to update config at ${configPath}: ${e.message}`)
+            throw e
+        }
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.test.ts
@@ -57,4 +57,23 @@ describe('McpTool', () => {
             expect(err.message).to.equal(`Failed to invoke MCP tool: MCP: server 'nope' not connected`)
         }
     })
+
+    it('requiresAcceptance consults manager.requiresApproval flag', async () => {
+        await McpManager.init([], fakeFeatures)
+        const tool = new McpTool(fakeFeatures, definition)
+
+        // stub on the prototype → false
+        const stubFalse = sinon.stub(McpManager.prototype, 'requiresApproval').returns(false)
+        let result = tool.requiresAcceptance(definition.serverName, definition.toolName)
+        expect(result.requiresAcceptance).to.be.false
+        expect(result.warning).to.equal(`About to invoke MCP tool “${definition.toolName}”. Do you want to proceed?`)
+        stubFalse.restore()
+
+        // stub on the prototype → true
+        const stubTrue = sinon.stub(McpManager.prototype, 'requiresApproval').returns(true)
+        result = tool.requiresAcceptance(definition.serverName, definition.toolName)
+        expect(result.requiresAcceptance).to.be.true
+        expect(result.warning).to.equal(`About to invoke MCP tool “${definition.toolName}”. Do you want to proceed?`)
+        stubTrue.restore()
+    })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.ts
@@ -33,10 +33,10 @@ export class McpTool {
         writer.releaseLock()
     }
 
-    public requiresAcceptance(_input: any): CommandValidation {
-        // todo: read from config
+    public requiresAcceptance(serverName: string, toolName: string): CommandValidation {
+        const required = McpManager.instance.requiresApproval(serverName, toolName)
         return {
-            requiresAcceptance: true,
+            requiresAcceptance: required,
             warning: `About to invoke MCP tool “${this.def.toolName}”. Do you want to proceed?`,
         }
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTypes.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTypes.ts
@@ -7,9 +7,7 @@ export interface McpToolDefinition {
     serverName: string
     toolName: string
     description: string
-    inputSchema: any // schema from the server
-    disabled?: boolean
-    autoApprove?: boolean
+    inputSchema: any
 }
 
 export interface MCPServerConfig {
@@ -18,10 +16,8 @@ export interface MCPServerConfig {
     env?: Record<string, string>
     disabled?: boolean
     autoApprove?: boolean
-}
-
-export interface MCPConfig {
-    mcpServers: Record<string, MCPServerConfig>
+    toolOverrides?: Record<string, { autoApprove?: boolean; disabled?: boolean }>
+    __configPath__?: string
 }
 
 export interface ListToolsResponse {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.test.ts
@@ -10,6 +10,7 @@ import * as path from 'path'
 import { loadMcpServerConfigs } from './mcpUtils'
 import type { MCPServerConfig } from './mcpTypes'
 import { pathToFileURL } from 'url'
+import * as sinon from 'sinon'
 
 describe('loadMcpServerConfigs', () => {
     let tmpDir: string
@@ -17,6 +18,7 @@ describe('loadMcpServerConfigs', () => {
     let logger: any
 
     beforeEach(() => {
+        sinon.restore()
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpUtilsTest-'))
         // a minimal Workspace stub
         workspace = {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -7,14 +7,21 @@ import { Logger, Workspace } from '@aws/language-server-runtimes/server-interfac
 import { URI } from 'vscode-uri'
 import { MCPServerConfig } from './mcpTypes'
 
+/**
+ * Load, validate, and parse MCP server configurations from JSON files.
+ * - Deduplicates input paths.
+ * - Normalizes file and URI inputs.
+ * - Skips missing, unreadable, or invalid JSON files.
+ * - Validates required fields and logs warnings for issues.
+ */
 export async function loadMcpServerConfigs(
     workspace: Workspace,
     logging: Logger,
     rawPaths: string[]
 ): Promise<Map<string, MCPServerConfig>> {
     const servers = new Map<string, MCPServerConfig>()
-
-    for (const raw of rawPaths) {
+    const uniquePaths = Array.from(new Set(rawPaths))
+    for (const raw of uniquePaths) {
         // 1) normalize file:/ URIs → real fs paths
         let fsPath: string
         try {
@@ -23,6 +30,7 @@ export async function loadMcpServerConfigs(
         } catch {
             fsPath = raw
         }
+        fsPath = require('path').normalize(fsPath)
 
         // 2) skip missing
         let exists: boolean
@@ -71,11 +79,21 @@ export async function loadMcpServerConfigs(
             }
             const cfg: MCPServerConfig = {
                 command: (entry as any).command,
-                args: Array.isArray((entry as any).args) ? (entry as any).args : [],
-                env: typeof (entry as any).env === 'object' ? (entry as any).env : {},
+                args: Array.isArray((entry as any).args) ? (entry as any).args.map(String) : [],
+                env: typeof (entry as any).env === 'object' && (entry as any).env !== null ? (entry as any).env : {},
                 disabled: !!(entry as any).disabled,
-                autoApprove: Array.isArray((entry as any).autoApprove) ? (entry as any).autoApprove : [],
+                autoApprove: Boolean((entry as any).autoApprove),
+                toolOverrides: (() => {
+                    const o = (entry as any).toolOverrides
+                    if (o && typeof o === 'object' && !Array.isArray(o)) return o
+                    if (o != null) {
+                        logging.warn(`Invalid toolOverrides on '${name}', ignoring.`)
+                    }
+                    return {}
+                })(),
+                __configPath__: fsPath,
             }
+
             servers.set(name, cfg)
             logging.info(`Loaded MCP server '${name}' from ${fsPath}`)
         }


### PR DESCRIPTION
## Problem
Core logic is needed for managing MCP server configurations.
## Solution
* Implemented CRUD methods for MCP servers.
* Resolved merge conflicts with main.
## Notes
 * Methods were tested using unit tests and manual debugging ([code](https://paste.amazon.com/show/bywang/1746565989)); both file system and in-memory behavior were verified.
* Tool permission handling is not yet finalized—pending product input. Likely to require a separate configuration file.
* Error handling for configuration is still TODO and tracked separately; errors are currently thrown directly.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
