### PR TITLE
fix: regex should match workspace text in bold style and startLine can be 0

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -412,7 +412,7 @@ export class AgenticChatController implements ChatHandlers {
 
             const additionalContext = await this.#additionalContextProvider.getAdditionalContext(
                 triggerContext,
-                (params.prompt as any).context
+                params.context
             )
             if (additionalContext.length) {
                 triggerContext.documentReference =

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -119,7 +119,7 @@ export class AgenticChatTriggerContext {
         }
 
         if (hasWorkspace) {
-            promptContent = promptContent?.replace(/^@workspace\/?/, '')
+            promptContent = promptContent?.replace(/\*\*@workspace\*\*/, '')
         }
 
         // Get workspace documents if @workspace is used
@@ -161,8 +161,8 @@ export class AgenticChatTriggerContext {
                     relativeFilePath: item.relativePath,
                     programmingLanguage: programmingLanguage,
                     type: filteredType,
-                    startLine: item.startLine || -1,
-                    endLine: item.endLine || -1,
+                    startLine: item.startLine ?? -1,
+                    endLine: item.endLine ?? -1,
                 }
                 relevantDocuments.push(relevantTextDocument)
             }

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -146,10 +146,16 @@ export class LocalProjectContextController {
             }
 
             // initialize vecLib and index if needed
-            const libraryPath = this.getVectorLibraryPath()
+            // const libraryPath = this.getVectorLibraryPath()
+            const libraryPath =
+                '/Users/yuxqiang/workspace/jetbrains/q-lsp-chat/plugins/amazonq/build/USER_HOME/Library/Caches/aws/toolkits/language-servers/1.0.0/indexing/dist/extension.js'
             const vecLib = vectorLib ?? (await eval(`import("${libraryPath}")`))
             if (vecLib) {
-                this._vecLib = await vecLib.start(LIBRARY_DIR, this.clientName, this.indexCacheDirPath)
+                this._vecLib = await vecLib.start(
+                    '/Users/yuxqiang/workspace/jetbrains/q-lsp-chat/plugins/amazonq/build/USER_HOME/Library/Caches/aws/toolkits/language-servers/1.0.0/indexing',
+                    this.clientName,
+                    this.indexCacheDirPath
+                )
                 if (enableIndexing) {
                     void this.buildIndex()
                 }

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -146,16 +146,10 @@ export class LocalProjectContextController {
             }
 
             // initialize vecLib and index if needed
-            // const libraryPath = this.getVectorLibraryPath()
-            const libraryPath =
-                '/Users/yuxqiang/workspace/jetbrains/q-lsp-chat/plugins/amazonq/build/USER_HOME/Library/Caches/aws/toolkits/language-servers/1.0.0/indexing/dist/extension.js'
+            const libraryPath = this.getVectorLibraryPath()
             const vecLib = vectorLib ?? (await eval(`import("${libraryPath}")`))
             if (vecLib) {
-                this._vecLib = await vecLib.start(
-                    '/Users/yuxqiang/workspace/jetbrains/q-lsp-chat/plugins/amazonq/build/USER_HOME/Library/Caches/aws/toolkits/language-servers/1.0.0/indexing',
-                    this.clientName,
-                    this.indexCacheDirPath
-                )
+                this._vecLib = await vecLib.start(LIBRARY_DIR, this.clientName, this.indexCacheDirPath)
                 if (enableIndexing) {
                     void this.buildIndex()
                 }


### PR DESCRIPTION
## Problem
1. @ workspace is in bold for which current regex can not capture and remove it
2. startLine || -1 will be -1 if startLine is 0, but we want 0 so use startLine ?? -1
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
