### PR TITLE
fix: abandon requests with invalid toolResults

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -546,7 +546,15 @@ export class AgenticChatController implements ChatHandlers {
 
             //  Fix the history to maintain invariants
             if (currentMessage) {
-                this.#chatHistoryDb.fixHistory(tabId, currentMessage, conversationIdentifier ?? '')
+                const isHistoryValid = this.#chatHistoryDb.fixHistory(
+                    tabId,
+                    currentMessage,
+                    conversationIdentifier ?? ''
+                )
+                if (!isHistoryValid) {
+                    this.#features.logging.warn('Skipping request due to invalid tool result/tool use relationship')
+                    break
+                }
             }
 
             //  Retrieve the history from DB; Do not include chatHistory for requests going to Mynah Backend


### PR DESCRIPTION
## Problem

We occasionally have a race condition caused by the stop button, where toolResults for cancelled tool executions get processed after the conversation has continued, resulting in erros: 

`Got ValidationError: ToolResult with ID tooluse_ has no corresponding ToolUse`

## Solution
- Added validation to check when a message has tool results but the last message has no tool uses
- Added logic to filter valid and invalid tool results, keeping valid ones and marking invalid ones as cancelled.
- Added logic to terminate agent loop when history is invalid

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
