### PR TITLE
fix: use the correct command name for testing bundles

### DIFF
--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -41,7 +41,7 @@ jobs:
                   npm run package
             - name: Test bundles
               run: |
-                  npm run test:bundles --workspaces --if-present
+                  npm run test-bundles --workspaces --if-present
             - name: Attach bundles
               uses: actions/upload-artifact@v4
               with:
@@ -82,7 +82,7 @@ jobs:
                   npm run package
             - name: Test bundles
               run: |
-                  npm run test:bundles --workspaces --if-present
+                  npm run test-bundles --workspaces --if-present
             - name: Attach bundles
               uses: actions/upload-artifact@v4
               with:

--- a/app/aws-lsp-codewhisperer-runtimes/scripts/test-bundles.js
+++ b/app/aws-lsp-codewhisperer-runtimes/scripts/test-bundles.js
@@ -8,7 +8,7 @@ function testBundle(bundlePath) {
         let startupTimeout
 
         const serverProcess = spawn('node', [bundlePath, '--stdio'], {
-            stdio: 'inherit',
+            stdio: 'pipe',
             shell: true,
         })
 


### PR DESCRIPTION
## Problem
The command introduced in the [PR](https://github.com/aws/language-servers/pull/1228) to test the generated bundle is `test-bundles`. With new PRs post merge of the PR mentioned, I could not see the logs for testing bundles in the packaging step ([Test bundles](https://github.com/aws/language-servers/actions/runs/14876033430/job/41773390164?pr=1276) step has no logs) executed as part of Github workflow action. 

## Solution
Incorrect command was being used in the lsp-ci.yaml file `test:bundles` instead of `test-bundles`. The PR contains the fix for the same. Also, tested the github actions workflow on my local for Ubuntu setup using [act](https://github.com/nektos/act) utility: `act -W .github/workflows/lsp-ci.yaml` 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
