### PR TITLE
fix: prevent timeout messages from displaying

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -611,6 +611,7 @@ export class AgenticChatController implements ChatHandlers {
                     shouldDisplayMessage: false,
                 })
                 currentRequestInput = this.#updateRequestInputWithToolResults(currentRequestInput, [], content)
+                shouldDisplayMessage = false
                 continue
             }
 


### PR DESCRIPTION
## Problem

System generated message `You took too long to respond - try to split up the work into smaller steps. Do not apologize.`sent to the model is still being displayed to users when chat history is reloaded
![Screenshot 2025-05-06 at 7 31 11 PM](https://github.com/user-attachments/assets/8340af4c-8a4d-4834-9935-7df20cfc25b0)

## Solution

- Set the `shouldDisplayMessage` to false for this case

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
