### PR TITLE
fix: set streamingClient timeout config

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
@@ -5,3 +5,4 @@ export const generateAssistantResponseInputLimit = 600_000
 export const outputLimitExceedsPartialMsg = 'output exceeds maximum character limit of'
 export const responseTimeoutMs = 170_000
 export const responseTimeoutPartialMsg = 'Response processing timed out after'
+export const clientTimeoutMs = 180_000

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -14,6 +14,7 @@ import { CredentialsProvider, SDKInitializator, Logging } from '@aws/language-se
 import { getBearerTokenFromProvider } from './utils'
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { CredentialProviderChain, Credentials } from 'aws-sdk'
+import { clientTimeoutMs } from '../language-server/agenticChat/constants'
 
 export type SendMessageCommandInput =
     | SendMessageCommandInputCodeWhispererStreaming
@@ -74,6 +75,10 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
             endpoint,
             token: tokenProvider,
             retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
+            requestHandler: {
+                keepAlive: true,
+                requestTimeout: clientTimeoutMs,
+            },
             customUserAgent: customUserAgent,
         })
     }


### PR DESCRIPTION
## Problem
- We are seeing errors like "socket hang up", "read ECONNRESET", "aborted", "read ETIMEDOUT" for long-lasting requests, this is caused by streaming client having a shorter timeout than the service timeout

## Solution
- set streamingClient timeout config to match service limit


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
