### PR TITLE
fix: add requestId to chat for QModelResponse errors

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1607,9 +1607,12 @@ export class AgenticChatController implements ChatHandlers {
                 // Clear the chat history in the database for this tab
                 this.#chatHistoryDb.clearTab(tabId)
             }
+
+            const errorBody =
+                err.code === 'QModelResponse' && requestID ? `${err.message}\n\nRequest ID: ${requestID}` : err.message
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
                 type: 'answer',
-                body: err.message,
+                body: errorBody,
                 messageId: errorMessageId,
                 buttons: [],
             })
@@ -1617,7 +1620,7 @@ export class AgenticChatController implements ChatHandlers {
         this.#features.logging.error(`Unknown Error: ${loggingUtils.formatErr(err)}`)
         return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
             type: 'answer',
-            body: requestID ? genericErrorMsg + `\n\nRequest ID: ${requestID}` : genericErrorMsg,
+            body: requestID ? `${genericErrorMsg}\n\nRequest ID: ${requestID}` : genericErrorMsg,
             messageId: errorMessageId,
             buttons: [],
         })


### PR DESCRIPTION
## Problem
We do not currently send the requestId to the chat window for errors thrown during sending the request. We log them but do not make them easily accessible for users to fetch. It was requested that we show this in the chat window

## Solution
- Add requestId to chat window for `QModelResponse` errors


## Testing

![Screenshot 2025-05-07 at 12 19 03 PM](https://github.com/user-attachments/assets/945c9a01-c229-45a6-b8b1-2554564487a4)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
