### PR TITLE
fix: filter out .git folder from listDirectory

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/constants.ts
@@ -50,6 +50,7 @@ export const DEFAULT_EXCLUDE_DIRS = [
     'dist',
     'build',
     'out',
+    '.git',
 ]
 
 export const DEFAULT_EXCLUDE_FILES = [


### PR DESCRIPTION
## Problem
- Repos with large git history can bloom the result of listDirectory by 20x and causes listDirectory to error out

## Solution
- filter out .git folder from listDirectory

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
