### PR TITLE
fix: wrap load chats on ready in try-catch

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1806,7 +1806,7 @@ export class AgenticChatController implements ChatHandlers {
     onLinkClick() {}
 
     async onReady() {
-        await this.#tabBarController.loadChats()
+        await this.restorePreviousChats()
         try {
             const localProjectContextController = await LocalProjectContextController.getInstance()
             const contextItems = await localProjectContextController.getContextCommandItems()
@@ -2192,6 +2192,14 @@ export class AgenticChatController implements ChatHandlers {
             return tools.filter(tool => !['fsWrite', 'executeBash'].includes(tool.toolSpecification?.name || ''))
         }
         return tools
+    }
+
+    async restorePreviousChats() {
+        try {
+            await this.#tabBarController.loadChats()
+        } catch (error) {
+            this.#log('Error restoring previous chats: ' + error)
+        }
     }
 
     #createDeferred() {


### PR DESCRIPTION
## Problem
Currently when the chat loads up a UI ready event is sent to the lsp, to load up previous chats and start indexing. If loading of previous chats fail, the LSP process crashes. This is particularly evident when openTab event has not been handled by the client.
An error in that flow should not crash the LSP process or block the rest of the indexing from continuing.
## Solution
This change surrounds the load chat logic within a try catch of its own to allow the rest of the indexing logic to proceed and not crash the server process
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
