### PR TITLE
fix: permission check ux changes

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -898,10 +898,8 @@ export const createMynahUi = (
         const contentHorizontalAlignment: ChatItem['contentHorizontalAlignment'] =
             message.type === 'directive' && message.messageId?.startsWith('stopped') ? 'center' : undefined
 
-        const shouldMute =
-            message.header?.status?.text === 'Stopped' ||
-            message.header?.status?.text === 'Rejected' ||
-            message.header?.status?.text === 'Allowed'
+        // If message.header?.status?.text is Stopped or Rejected or Ignored or Completed etc.. card should be in disabled state.
+        const shouldMute = message.header?.status?.text !== undefined
 
         return {
             body: message.body,

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -898,7 +898,10 @@ export const createMynahUi = (
         const contentHorizontalAlignment: ChatItem['contentHorizontalAlignment'] =
             message.type === 'directive' && message.messageId?.startsWith('stopped') ? 'center' : undefined
 
-        const shouldMute = message.header?.status?.text === 'Stopped' || message.header?.status?.text === 'Rejected'
+        const shouldMute =
+            message.header?.status?.text === 'Stopped' ||
+            message.header?.status?.text === 'Rejected' ||
+            message.header?.status?.text === 'Allowed'
 
         return {
             body: message.body,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1154,43 +1154,34 @@ export class AgenticChatController implements ChatHandlers {
 
         // For file operations and other tools, create appropriate confirmation UI
         let header: {
-            body: string
+            body: string | undefined
             status: { status: 'info' | 'success' | 'warning' | 'error'; icon: string; text: string }
         }
-        let body: string
+        let body: string | undefined
 
         switch (toolName) {
             case 'fsWrite':
-                const writeFilePath = (toolUse.input as unknown as FsWriteParams).path
                 header = {
-                    body: 'File Write',
+                    body: undefined,
                     status: {
-                        status: isAccept ? 'success' : 'error',
-                        icon: isAccept ? 'ok' : 'cancel',
-                        text: isAccept ? 'Allowed' : 'Rejected',
+                        status: 'success',
+                        icon: 'ok',
+                        text: 'Allowed',
                     },
                 }
-                body = isAccept
-                    ? `File modification allowed: \`${writeFilePath}\``
-                    : `File modification rejected: \`${writeFilePath}\``
                 break
 
             case 'fsRead':
             case 'listDirectory':
                 // Common handling for read operations
-                const path = (toolUse.input as unknown as FsReadParams | ListDirectoryParams).path
-                const isDirectory = toolName === 'listDirectory'
                 header = {
-                    body: isDirectory ? 'Directory Listing' : 'File Read',
+                    body: undefined,
                     status: {
-                        status: isAccept ? 'success' : 'error',
-                        icon: isAccept ? 'ok' : 'cancel',
-                        text: isAccept ? 'Allowed' : 'Rejected',
+                        status: 'success',
+                        icon: 'ok',
+                        text: 'Allowed',
                     },
                 }
-                body = isAccept
-                    ? `${isDirectory ? 'Directory listing' : 'File read'} allowed: \`${path}\``
-                    : `${isDirectory ? 'Directory listing' : 'File read'} rejected: \`${path}\``
                 break
 
             case 'fileSearch':
@@ -1341,8 +1332,8 @@ export class AgenticChatController implements ChatHandlers {
                     },
                 ]
                 header = {
-                    icon: 'warning',
-                    iconForegroundStatus: 'warning',
+                    icon: 'tools',
+                    iconForegroundStatus: 'tools',
                     body: '#### Allow read-only tools outside your workspace',
                     buttons,
                 }


### PR DESCRIPTION
## Problem
- Use the tool icon for read only permission, and use warning icon for file modification in permission check for outside of workspace.
- String should not change after “Allow” is clicked
-  Ignored, Rejected, Failed, and Complete commands should have a disabled grey state for all the text and border (except the status)
## Solution
- Fixed above issues


https://github.com/user-attachments/assets/dd6fe591-bf47-4aec-a1dc-22f4df6d1e24




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
