### PR TITLE
fix: stop chat response first when close tab

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -269,6 +269,7 @@ export const createMynahUi = (
             messager.onTabAdd(tabId)
         },
         onTabRemove: (tabId: string) => {
+            messager.onStopChatResponse(tabId)
             messager.onTabRemove(tabId)
         },
         onTabChange: (tabId: string) => {


### PR DESCRIPTION
## Problem
- We found bunch of `aborted` error  in Kibana dashboard. Found one root cause, we didn't handle stop chat response if customer closes/removes tab before the chat response completes.


```
[Trace - 8:48:45 AM] Received notification 'window/logMessage'.
Params: {
    "type": 4,
    "message": "[2025-05-08T15:48:45.239Z] Removing tab: aw1sgj"
}


[2025-05-08T15:48:45.239Z] Removing tab: aw1sgj
[Trace - 8:48:45 AM] Received notification 'window/logMessage'.
Params: {
    "type": 4,
    "message": "[2025-05-08T15:48:45.239Z] Updating tab open state: historyId=b359f1d7-d7d0-4388-8ad8-60616fd7859e, isOpen=false"
}


[2025-05-08T15:48:45.239Z] Updating tab open state: historyId=b359f1d7-d7d0-4388-8ad8-60616fd7859e, isOpen=false
[Trace - 8:48:45 AM] Received notification '$/progress'.
Params: {
    "token": "21b46f11-7a64-4a4b-8e66-7e3019a8f309",
    "value": "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..QLukVcnei22j7gyr.ykth55cwcXaJtYzS0HW8NVgvcvnG5grtTk-EQe_o9KClvcKjhrHkO6G8E0SYLbSR3jeLQ3gNkXdX5V3fm77tMImlWSuDlrLcp6nQyS_bDBzSMKaBYtOKDLQnwkv_XSjj_C8eawBwCStkTR0H.SV_2xeHnwvLpqePCdA8QWA"
}


[Trace - 8:48:45 AM] Received notification 'telemetry/event'.
Params: {
    "name": "amazonq_messageResponseError",
    "data": {
        "cwsprChatHasCodeSnippet": true,
        "cwsprChatTriggerInteraction": "click",
        "cwsprChatProgrammingLanguage": "typescript",
        "cwsprChatActiveEditorTotalCharacters": 762,
        "cwsprChatResponseCode": 0,
        "cwsprChatRequestLength": 11,
        "cwsprChatConversationType": "AgenticChat",
        "requestId": "",
        "reasonDesc": "aborted",
        "credentialStartUrl": "https://amzn.awsapps.com/start",
        "result": "Succeeded",
        "languageServerVersion": "0.1.0"
    }
}


[Trace - 8:48:45 AM] Received notification 'window/logMessage'.
Params: {
    "type": 1,
    "message": "[2025-05-08T15:48:45.242Z] Unknown Error: {\n  \"code\": \"ECONNRESET\",\n  \"name\": \"Error\",\n  \"message\": \"aborted\"\n}"
}


[Error - 8:48:45 AM] [2025-05-08T15:48:45.242Z] Unknown Error: {
  "code": "ECONNRESET",
  "name": "Error",
  "message": "aborted"
}

```



## Solution
- Add stop chat response handling before tab remove.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
