### PR TITLE
Fix bugs impacting indexing disabled functionality

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -1120,11 +1120,7 @@ describe('AgenticChatController', () => {
                 ]
 
                 sinon.stub(LocalProjectContextController, 'getInstance').resolves(localProjectContextController)
-
-                Object.defineProperty(localProjectContextController, 'isEnabled', {
-                    get: () => true,
-                })
-
+                sinon.stub(localProjectContextController, 'isIndexingEnabled').returns(true)
                 sinon.stub(localProjectContextController, 'queryVectorIndex').resolves(mockRelevantDocs)
 
                 await chatController.onChatPrompt(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -262,7 +262,7 @@ export class AgenticChatTriggerContext {
         chatResultStream?: AgenticChatResultStream
     ): Promise<RelevantTextDocumentAddition[]> {
         const localProjectContextController = await LocalProjectContextController.getInstance()
-        if (!localProjectContextController.isIndexingEnabled && chatResultStream) {
+        if (!localProjectContextController.isIndexingEnabled() && chatResultStream) {
             await chatResultStream.writeResultBlock({
                 body: `To add your workspace as context, enable local indexing in your IDE settings. After enabling, add @workspace to your question, and I'll generate a response using your workspace as context.`,
                 buttons: [

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.test.ts
@@ -6,6 +6,7 @@ import { Dirent } from 'fs'
 import * as path from 'path'
 import { URI } from 'vscode-uri'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import sinon from 'ts-sinon'
 
 class LoggingMock {
     public error: SinonStub
@@ -118,6 +119,19 @@ describe('LocalProjectContextController', () => {
         })
 
         it('should return empty array when vector library is not initialized', async () => {
+            sinon.stub(controller, 'isIndexingEnabled').returns(true)
+            const uninitializedController = new LocalProjectContextController(
+                'testClient',
+                mockWorkspaceFolders,
+                logging as any
+            )
+
+            const result = await uninitializedController.queryVectorIndex({ query: 'test' })
+            assert.deepStrictEqual(result, [])
+        })
+
+        it('should return empty array when indexing is disabled', async () => {
+            sinon.stub(controller, 'isIndexingEnabled').returns(false)
             const uninitializedController = new LocalProjectContextController(
                 'testClient',
                 mockWorkspaceFolders,
@@ -129,11 +143,13 @@ describe('LocalProjectContextController', () => {
         })
 
         it('should return chunks from vector library', async () => {
+            sinon.stub(controller, 'isIndexingEnabled').returns(true)
             const result = await controller.queryVectorIndex({ query: 'test' })
             assert.deepStrictEqual(result, ['mockChunk1', 'mockChunk2'])
         })
 
         it('should handle query errors', async () => {
+            sinon.stub(controller, 'isIndexingEnabled').returns(true)
             const vecLib = await vectorLibMock.start()
             vecLib.queryVectorIndex.rejects(new Error('Query failed'))
 
@@ -149,6 +165,23 @@ describe('LocalProjectContextController', () => {
         })
 
         it('should return empty array when vector library is not initialized', async () => {
+            sinon.stub(controller, 'isIndexingEnabled').returns(true)
+            const uninitializedController = new LocalProjectContextController(
+                'testClient',
+                mockWorkspaceFolders,
+                logging as any
+            )
+
+            const result = await uninitializedController.queryInlineProjectContext({
+                query: 'test',
+                filePath: 'test.java',
+                target: 'test',
+            })
+            assert.deepStrictEqual(result, [])
+        })
+
+        it('should return empty array when indexing is disabled', async () => {
+            sinon.stub(controller, 'isIndexingEnabled').returns(false)
             const uninitializedController = new LocalProjectContextController(
                 'testClient',
                 mockWorkspaceFolders,
@@ -164,6 +197,7 @@ describe('LocalProjectContextController', () => {
         })
 
         it('should return context from vector library', async () => {
+            sinon.stub(controller, 'isIndexingEnabled').returns(true)
             const result = await controller.queryInlineProjectContext({
                 query: 'test',
                 filePath: 'test.java',
@@ -173,6 +207,7 @@ describe('LocalProjectContextController', () => {
         })
 
         it('should handle query errors', async () => {
+            sinon.stub(controller, 'isIndexingEnabled').returns(true)
             const vecLib = await vectorLibMock.start()
             vecLib.queryInlineProjectContext.rejects(new Error('Query failed'))
 
@@ -188,6 +223,7 @@ describe('LocalProjectContextController', () => {
 
     describe('updateIndex', () => {
         beforeEach(async () => {
+            sinon.stub(controller, 'isIndexingEnabled').returns(true)
             await controller.init({ vectorLib: vectorLibMock })
         })
 

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -142,7 +142,7 @@ export class LocalProjectContextController {
                     void this.buildIndex()
                 }
                 if (!enableIndexing && this._isIndexingEnabled) {
-                    this._vecLib?.clear?.()
+                    void this._vecLib?.clear?.()
                 }
                 this._isIndexingEnabled = enableIndexing
                 return

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -141,6 +141,9 @@ export class LocalProjectContextController {
                 if (enableIndexing && !this._isIndexingEnabled) {
                     void this.buildIndex()
                 }
+                if (!enableIndexing && this._isIndexingEnabled) {
+                    this._vecLib?.clear?.()
+                }
                 this._isIndexingEnabled = enableIndexing
                 return
             }
@@ -184,7 +187,7 @@ export class LocalProjectContextController {
     }
 
     public async updateIndex(filePaths: string[], operation: UpdateMode): Promise<void> {
-        if (!this._vecLib) {
+        if (!this._vecLib || !this.isIndexingEnabled()) {
             return
         }
 
@@ -245,7 +248,7 @@ export class LocalProjectContextController {
     public async queryInlineProjectContext(
         request: QueryInlineProjectContextRequestV2
     ): Promise<InlineProjectContext[]> {
-        if (!this._vecLib) {
+        if (!this._vecLib || !this.isIndexingEnabled()) {
             return []
         }
 
@@ -259,7 +262,7 @@ export class LocalProjectContextController {
     }
 
     public async queryVectorIndex(request: QueryRequest): Promise<Chunk[]> {
-        if (!this._vecLib) {
+        if (!this._vecLib || !this.isIndexingEnabled()) {
             return []
         }
 

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -187,7 +187,7 @@ export class LocalProjectContextController {
     }
 
     public async updateIndex(filePaths: string[], operation: UpdateMode): Promise<void> {
-        if (!this._vecLib || !this.isIndexingEnabled()) {
+        if (!this.isIndexingEnabled()) {
             return
         }
 
@@ -248,7 +248,7 @@ export class LocalProjectContextController {
     public async queryInlineProjectContext(
         request: QueryInlineProjectContextRequestV2
     ): Promise<InlineProjectContext[]> {
-        if (!this._vecLib || !this.isIndexingEnabled()) {
+        if (!this.isIndexingEnabled()) {
             return []
         }
 
@@ -262,7 +262,7 @@ export class LocalProjectContextController {
     }
 
     public async queryVectorIndex(request: QueryRequest): Promise<Chunk[]> {
-        if (!this._vecLib || !this.isIndexingEnabled()) {
+        if (!this.isIndexingEnabled()) {
             return []
         }
 
@@ -354,7 +354,7 @@ export class LocalProjectContextController {
     }
 
     public isIndexingEnabled(): boolean {
-        return this._isIndexingEnabled
+        return this._vecLib !== undefined && this._isIndexingEnabled
     }
 
     private fileMeetsFileSizeConstraints(filePath: string, sizeConstraints: SizeConstraints): boolean {


### PR DESCRIPTION
## Problem
Disabling local indexing in IDE settings was not reflected in the chat results. The message prompting users to "enable workspace indexing" was never emitted, and query index was still being hit with setting disabled. Vector library instance in controller is always initialized, so checking for its existence is not sufficient for disabling indexing.
## Solution
Call correct method in trigger context conditional to check for indexing enabled and notify extension if disabled. Additionally, add checks in the local context controller to ensure setting is correctly considered during querying, and cache is cleared upon disable.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
