### PR TITLE
fix: bug fix for exportResultsArchive to call with profileArn as parameter

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -379,7 +379,7 @@ export class TransformHandler {
     async downloadExportResultArchive(exportId: string, saveToDir: string) {
         let result
         try {
-            result = await this.serviceManager.getStreamingClient().client.exportResultArchive({
+            result = await this.serviceManager.getStreamingClient().exportResultArchive({
                 exportId,
                 exportIntent: ExportIntent.TRANSFORMATION,
             })

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -131,7 +131,9 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
     ): Promise<ExportResultArchiveCommandOutputCodeWhispererStreaming> {
         const controller: AbortController = abortController ?? new AbortController()
         this.inflightRequests.add(controller)
-        const response = await this.client.exportResultArchive({ ...request, profileArn: this.profileArn })
+        const response = await this.client.exportResultArchive(
+            this.profileArn ? { ...request, profileArn: this.profileArn } : request
+        )
         this.inflightRequests.delete(controller)
         return response
     }

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -4,6 +4,8 @@ import {
     GenerateAssistantResponseCommandOutput as GenerateAssistantResponseCommandOutputCodeWhispererStreaming,
     SendMessageCommandInput as SendMessageCommandInputCodeWhispererStreaming,
     SendMessageCommandOutput as SendMessageCommandOutputCodeWhispererStreaming,
+    ExportResultArchiveCommandInput as ExportResultArchiveCommandInputCodeWhispererStreaming,
+    ExportResultArchiveCommandOutput as ExportResultArchiveCommandOutputCodeWhispererStreaming,
 } from '@amzn/codewhisperer-streaming'
 import {
     QDeveloperStreaming,
@@ -120,6 +122,17 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
 
         this.inflightRequests.delete(controller)
 
+        return response
+    }
+
+    public async exportResultArchive(
+        request: ExportResultArchiveCommandInputCodeWhispererStreaming,
+        abortController?: AbortController
+    ): Promise<ExportResultArchiveCommandOutputCodeWhispererStreaming> {
+        const controller: AbortController = abortController ?? new AbortController()
+        this.inflightRequests.add(controller)
+        const response = await this.client.exportResultArchive({ ...request, profileArn: this.profileArn })
+        this.inflightRequests.delete(controller)
         return response
     }
 }


### PR DESCRIPTION
## Problem

Export results archive is failing if profile arn was not passed with new tranform flow

## Solution

updated  flow.
Testing - verified with Q As well as transform flow, we can download results

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
