### PR TITLE
fix: add visibleName property to fix empty directory name when the directory ends with a slash

### DIFF
--- a/chat-client/src/client/utils.ts
+++ b/chat-client/src/client/utils.ts
@@ -40,7 +40,8 @@ export function toMynahFileList(fileList: ChatMessage['fileList']): ChatItemCont
                             )
                             .join(', ') || '',
                     description: fileDetails.description,
-                    visibleName: filePath.split('/').filter(Boolean).pop() || filePath.split('/').slice(-2, -1)[0] || filePath,
+                    visibleName:
+                        filePath.split('/').filter(Boolean).pop() || filePath.split('/').slice(-2, -1)[0] || filePath,
                     clickable: true,
                     data: {
                         fullPath: fileDetails.fullPath || '',

--- a/chat-client/src/client/utils.ts
+++ b/chat-client/src/client/utils.ts
@@ -40,6 +40,7 @@ export function toMynahFileList(fileList: ChatMessage['fileList']): ChatItemCont
                             )
                             .join(', ') || '',
                     description: fileDetails.description,
+                    visibleName: filePath.split('/').filter(Boolean).pop() || filePath.split('/').slice(-2, -1)[0] || filePath,
                     clickable: true,
                     data: {
                         fullPath: fileDetails.fullPath || '',


### PR DESCRIPTION
## Problem
Utilize mynah `visibleName` property ([defined here](https://github.com/aws/mynah-ui/blob/516bc6d17f3461fe7d6f795e405409283103ebcd/src/static.ts#L315)) to make sure the name of the directory listed is displayed correctly. 

Previously if the directory ended with a `/` it would show an empty directory name, as it was trying to use the text after `/` namely an empty string.



## Solution
Old: directory `foo/bar/` rendered as ``
Fixed: directory `foo/bar/` rendered as `bar`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.


    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
