### PR TITLE
feat: add userWrittenCodeTracker

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -52,6 +52,7 @@ import { getOrThrowBaseIAMServiceManager } from '../../shared/amazonQServiceMana
 // import { WorkspaceFolderManager } from '../workspaceContext/workspaceFolderManager'
 import path = require('path')
 import { getRelativePath } from '../workspaceContext/util'
+import { UserWrittenCodeTracker } from '../../shared/userWrittenCodeTracker'
 
 const EMPTY_RESULT = { sessionId: '', items: [] }
 export const CONTEXT_CHARACTERS_LIMIT = 10240
@@ -276,6 +277,7 @@ export const CodewhispererServerFactory =
 
         // CodePercentage and codeDiff tracker have a dependency on TelemetryService, so initialization is also delayed to `onInitialized` handler
         let codePercentageTracker: CodePercentageTracker
+        let userWrittenCodeTracker: UserWrittenCodeTracker | undefined
         let codeDiffTracker: CodeDiffTracker<AcceptedInlineSuggestionEntry>
 
         const onInlineCompletionHandler = async (
@@ -458,6 +460,8 @@ export const CodewhispererServerFactory =
         ): Promise<InlineCompletionListWithReferences> => {
             codePercentageTracker.countInvocation(session.language)
 
+            userWrittenCodeTracker?.recordUsageCount(session.language)
+
             if (isNewSession) {
                 // Populate the session with information from codewhisperer response
                 session.suggestions = suggestionResponse.suggestions
@@ -491,7 +495,7 @@ export const CodewhispererServerFactory =
             sessionManager.activateSession(session)
 
             // Process suggestions to apply Empty or Filter filters
-            const filteredSuggestions = suggestionResponse.suggestions
+            const filteredSuggestions = session.suggestions
                 // Empty suggestion filter
                 .filter(suggestion => {
                     if (suggestion.content === '') {
@@ -644,9 +648,15 @@ export const CodewhispererServerFactory =
         const updateConfiguration = (updatedConfig: AmazonQWorkspaceConfig) => {
             logging.debug('Updating configuration of inline complete server.')
 
-            const { customizationArn, optOutTelemetryPreference } = updatedConfig
+            const { customizationArn, optOutTelemetryPreference, sendUserWrittenCodeMetrics } = updatedConfig
 
             codePercentageTracker.customizationArn = customizationArn
+            if (sendUserWrittenCodeMetrics) {
+                userWrittenCodeTracker = UserWrittenCodeTracker.getInstance(telemetryService)
+            }
+            if (userWrittenCodeTracker) {
+                userWrittenCodeTracker.customizationArn = customizationArn
+            }
             logging.debug(`CodePercentageTracker customizationArn updated to ${customizationArn}`)
             /*
                             The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
@@ -706,6 +716,20 @@ export const CodewhispererServerFactory =
 
             p.contentChanges.forEach(change => {
                 codePercentageTracker.countTotalTokens(languageId, change.text, false)
+
+                const { sendUserWrittenCodeMetrics } = amazonQServiceManager.getConfiguration()
+                if (!sendUserWrittenCodeMetrics) {
+                    return
+                }
+                // exclude cases that the document change is from Q suggestions
+                const currentSession = sessionManager.getCurrentSession()
+                if (
+                    !currentSession?.suggestions.some(
+                        suggestion => suggestion?.insertText && suggestion.insertText === change.text
+                    )
+                ) {
+                    userWrittenCodeTracker?.countUserWrittenTokens(languageId, change.text)
+                }
             })
 
             // Record last user modification time for any document
@@ -719,6 +743,7 @@ export const CodewhispererServerFactory =
 
         return async () => {
             codePercentageTracker?.dispose()
+            userWrittenCodeTracker?.dispose()
             await codeDiffTracker?.shutdown()
         }
     }

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.test.ts
@@ -34,6 +34,7 @@ describe('getAmazonQRelatedWorkspaceConfigs', () => {
         includeSuggestionsWithCodeReferences: true,
         includeImportsWithSuggestions: true,
         shareCodeWhispererContentWithAWS: true,
+        sendUserWrittenCodeMetrics: false,
     }
 
     beforeEach(() => {
@@ -53,6 +54,7 @@ describe('getAmazonQRelatedWorkspaceConfigs', () => {
             includeSuggestionsWithCodeReferences: MOCKED_AWS_CODEWHISPERER_SECTION.includeSuggestionsWithCodeReferences,
             includeImportsWithSuggestions: MOCKED_AWS_CODEWHISPERER_SECTION.includeImportsWithSuggestions,
             shareCodeWhispererContentWithAWS: MOCKED_AWS_CODEWHISPERER_SECTION.shareCodeWhispererContentWithAWS,
+            sendUserWrittenCodeMetrics: MOCKED_AWS_CODEWHISPERER_SECTION.sendUserWrittenCodeMetrics,
             projectContext: {
                 enableLocalIndexing: MOCKED_AWS_Q_SECTION.projectContext.enableLocalIndexing,
                 enableGpuAcceleration: MOCKED_AWS_Q_SECTION.projectContext?.enableGpuAcceleration,
@@ -101,6 +103,7 @@ describe('AmazonQConfigurationCache', () => {
             includeSuggestionsWithCodeReferences: false,
             includeImportsWithSuggestions: false,
             shareCodeWhispererContentWithAWS: true,
+            sendUserWrittenCodeMetrics: false,
             projectContext: {
                 enableLocalIndexing: true,
                 enableGpuAcceleration: true,

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
@@ -92,6 +92,7 @@ interface CodeWhispererConfigSection {
     includeSuggestionsWithCodeReferences: boolean // aws.codeWhisperer.includeSuggestionsWithCodeReferences - return suggestions with code references
     includeImportsWithSuggestions: boolean // aws.codeWhisperer.includeImportsWithSuggestions - return imports with suggestions
     shareCodeWhispererContentWithAWS: boolean // aws.codeWhisperer.shareCodeWhispererContentWithAWS - share content with AWS
+    sendUserWrittenCodeMetrics: boolean
 }
 
 export type AmazonQWorkspaceConfig = QConfigSection & CodeWhispererConfigSection
@@ -150,6 +151,7 @@ export async function getAmazonQRelatedWorkspaceConfigs(
                     newCodeWhispererConfig['includeSuggestionsWithCodeReferences'] === true,
                 includeImportsWithSuggestions: newCodeWhispererConfig['includeImportsWithSuggestions'] === true,
                 shareCodeWhispererContentWithAWS: newCodeWhispererConfig['shareCodeWhispererContentWithAWS'] === true,
+                sendUserWrittenCodeMetrics: newCodeWhispererConfig['sendUserWrittenCodeMetrics'] === true,
             }
 
             logging.log(
@@ -179,6 +181,7 @@ export const defaultAmazonQWorkspaceConfigFactory = (): AmazonQWorkspaceConfig =
         includeSuggestionsWithCodeReferences: false,
         includeImportsWithSuggestions: false,
         shareCodeWhispererContentWithAWS: false,
+        sendUserWrittenCodeMetrics: false,
         projectContext: {
             enableLocalIndexing: false,
             enableGpuAcceleration: false,

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -529,6 +529,8 @@ describe('TelemetryService', () => {
                     acceptedCharacterCount: 123,
                     totalCharacterCount: 456,
                     timestamp: new Date(Date.now()),
+                    userWrittenCodeCharacterCount: undefined,
+                    userWrittenCodeLineCount: undefined,
                 },
             },
             optOutPreference: 'OPTIN',

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -341,6 +341,8 @@ export class TelemetryService {
             acceptedCharacterCount: number
             totalCharacterCount: number
             customizationArn?: string
+            userWrittenCodeCharacterCount?: number
+            userWrittenCodeLineCount?: number
         },
         additionalParams: Partial<{
             percentage: number
@@ -366,6 +368,8 @@ export class TelemetryService {
             acceptedCharacterCount: params.acceptedCharacterCount,
             totalCharacterCount: params.totalCharacterCount,
             timestamp: new Date(Date.now()),
+            userWrittenCodeCharacterCount: params.userWrittenCodeCharacterCount,
+            userWrittenCodeLineCount: params.userWrittenCodeLineCount,
         }
         if (params.customizationArn) event.customizationArn = params.customizationArn
 

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -75,6 +75,12 @@ export interface CodeWhispererCodePercentageEvent {
     successCount: number
 }
 
+export interface UserWrittenPercentageEvent {
+    codewhispererLanguage: string
+    userWrittenCodeCharacterCount: number
+    userWrittenCodeLineCount: number
+}
+
 export interface CodeWhispererUserDecisionEvent {
     codewhispererRequestId?: string
     codewhispererSessionId?: string

--- a/server/aws-lsp-codewhisperer/src/shared/userWrittenCodeTracker.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/userWrittenCodeTracker.test.ts
@@ -1,0 +1,114 @@
+import sinon, { StubbedInstance, stubInterface } from 'ts-sinon'
+import { TelemetryService } from './telemetry/telemetryService'
+import { UserWrittenCodeTracker } from './userWrittenCodeTracker'
+
+describe('UserWrittenCodeTracker', () => {
+    const LANGUAGE_ID = 'python'
+    const OTHER_LANGUAGE_ID = 'typescript'
+    const SOME_CONTENT = 'some text\n'
+
+    let tracker: UserWrittenCodeTracker
+    let telemetryService: StubbedInstance<TelemetryService> = stubInterface<TelemetryService>()
+    let clock: sinon.SinonFakeTimers
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers()
+        telemetryService = stubInterface<TelemetryService>()
+        tracker = UserWrittenCodeTracker.getInstance(telemetryService)
+    })
+
+    afterEach(() => {
+        tracker.dispose()
+        clock.reset()
+        clock.restore()
+    })
+
+    it('does not send telemetry without edits', () => {
+        clock.tick(5000 * 60)
+        sinon.assert.notCalled(telemetryService.emitCodeCoverageEvent)
+    })
+
+    it('emits metrics every 5 minutes while editing', () => {
+        tracker.countUserWrittenTokens(LANGUAGE_ID, SOME_CONTENT)
+        tracker.recordUsageCount(LANGUAGE_ID)
+
+        clock.tick(5000 * 60)
+
+        sinon.assert.calledWith(
+            telemetryService.emitCodeCoverageEvent,
+            {
+                languageId: LANGUAGE_ID,
+                totalCharacterCount: 0,
+                acceptedCharacterCount: 0,
+                customizationArn: undefined,
+                userWrittenCodeCharacterCount: 10,
+                userWrittenCodeLineCount: 1,
+            },
+            {}
+        )
+    })
+
+    it('emits no metrics without invocations', () => {
+        tracker.countUserWrittenTokens(LANGUAGE_ID, SOME_CONTENT)
+
+        clock.tick(5000 * 60 + 1)
+
+        sinon.assert.notCalled(telemetryService.emitCodeCoverageEvent)
+    })
+
+    it('emits separate metrics for different languages', () => {
+        tracker.recordUsageCount(LANGUAGE_ID)
+        tracker.countUserWrittenTokens(LANGUAGE_ID, SOME_CONTENT)
+        tracker.recordUsageCount(OTHER_LANGUAGE_ID)
+        tracker.countUserWrittenTokens(OTHER_LANGUAGE_ID, SOME_CONTENT)
+
+        clock.tick(5000 * 60)
+
+        sinon.assert.calledWith(
+            telemetryService.emitCodeCoverageEvent,
+            {
+                languageId: LANGUAGE_ID,
+                totalCharacterCount: 0,
+                acceptedCharacterCount: 0,
+                customizationArn: undefined,
+                userWrittenCodeCharacterCount: 10,
+                userWrittenCodeLineCount: 1,
+            },
+            {}
+        )
+
+        sinon.assert.calledWith(
+            telemetryService.emitCodeCoverageEvent,
+            {
+                languageId: OTHER_LANGUAGE_ID,
+                totalCharacterCount: 0,
+                acceptedCharacterCount: 0,
+                customizationArn: undefined,
+                userWrittenCodeCharacterCount: 10,
+                userWrittenCodeLineCount: 1,
+            },
+            {}
+        )
+    })
+
+    it('emits metrics with customizationArn value', () => {
+        tracker.recordUsageCount(LANGUAGE_ID)
+        tracker.customizationArn = 'test-arn'
+        tracker.countUserWrittenTokens(LANGUAGE_ID, SOME_CONTENT)
+
+        clock.tick(5000 * 60)
+
+        sinon.assert.calledWith(
+            telemetryService.emitCodeCoverageEvent,
+            {
+                languageId: LANGUAGE_ID,
+                totalCharacterCount: 0,
+                acceptedCharacterCount: 0,
+                customizationArn: 'test-arn',
+                userWrittenCodeCharacterCount: 10,
+                userWrittenCodeLineCount: 1,
+            },
+            {}
+        )
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/shared/userWrittenCodeTracker.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/userWrittenCodeTracker.ts
@@ -26,7 +26,7 @@ export class UserWrittenCodeTracker {
     private _lastQInvocationTime: number
     private telemetryService: TelemetryService
     private buckets: TelemetryBuckets
-    private intervalId: NodeJS.Timeout
+    private intervalId?: NodeJS.Timeout
     private static instance?: UserWrittenCodeTracker
 
     private constructor(telemetryService: TelemetryService) {
@@ -38,11 +38,10 @@ export class UserWrittenCodeTracker {
     }
 
     public static getInstance(telemetryService: TelemetryService) {
-        const instance = (this.instance ??= new this(telemetryService))
-        if (!this.instance.intervalId) {
-            this.instance.startListening()
+        if (!this.instance) {
+            this.instance = new this(telemetryService)
         }
-        return instance
+        return this.instance
     }
 
     private startListening() {
@@ -146,7 +145,9 @@ export class UserWrittenCodeTracker {
     dispose(): void {
         if (this.intervalId) {
             clearInterval(this.intervalId)
+            this.intervalId = undefined
         }
         this.reset()
+        UserWrittenCodeTracker.instance = undefined
     }
 }

--- a/server/aws-lsp-codewhisperer/src/shared/userWrittenCodeTracker.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/userWrittenCodeTracker.ts
@@ -1,0 +1,152 @@
+import { CodewhispererLanguage } from './languageDetection'
+import { TelemetryService } from './telemetry/telemetryService'
+import { UserWrittenPercentageEvent } from './telemetry/types'
+
+/**
+ * This is mostly ported over from VS Code: https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/codewhisperer/tracker/userWrittenCodeTracker.ts
+ * This class is mainly used for calculating the user written code
+ * for active Amazon Q users.
+ * It reports the user written code per 5 minutes when the user is coding and using Amazon Q features
+ */
+const USER_CODE_WRITTEN_INTERVAL = 5 * 60 * 1000
+const RESET_Q_EDITING_THRESHOLD = 2 * 60 * 1000
+const INSERT_CUTOFF_THRESHOLD = 50
+
+type TelemetryBuckets = {
+    [languageId: string]: {
+        userWrittenCodeCharacterCount: number
+        userWrittenCodeLineCount: number
+        invocationCount: number
+    }
+}
+
+export class UserWrittenCodeTracker {
+    public customizationArn?: string
+    private _qIsMakingEdits: boolean
+    private _lastQInvocationTime: number
+    private telemetryService: TelemetryService
+    private buckets: TelemetryBuckets
+    private intervalId: NodeJS.Timeout
+    private static instance?: UserWrittenCodeTracker
+
+    private constructor(telemetryService: TelemetryService) {
+        this._qIsMakingEdits = false
+        this._lastQInvocationTime = 0
+        this.telemetryService = telemetryService
+        this.buckets = {}
+        this.intervalId = this.startListening()
+    }
+
+    public static getInstance(telemetryService: TelemetryService) {
+        const instance = (this.instance ??= new this(telemetryService))
+        if (!this.instance.intervalId) {
+            this.instance.startListening()
+        }
+        return instance
+    }
+
+    private startListening() {
+        return setInterval(async () => {
+            const events = this.getEventDataAndRotate()
+            await Promise.all(
+                events.map(
+                    async event =>
+                        await this.telemetryService.emitCodeCoverageEvent(
+                            {
+                                customizationArn: this.customizationArn,
+                                languageId: event.codewhispererLanguage as CodewhispererLanguage,
+                                acceptedCharacterCount: 0,
+                                totalCharacterCount: 0,
+                                userWrittenCodeCharacterCount: event.userWrittenCodeCharacterCount,
+                                userWrittenCodeLineCount: event.userWrittenCodeLineCount,
+                            },
+                            {}
+                        )
+                )
+            )
+        }, USER_CODE_WRITTEN_INTERVAL)
+    }
+
+    private getEventDataAndRotate(): UserWrittenPercentageEvent[] {
+        const previousBuckets = this.rotate()
+        return Object.keys(previousBuckets)
+            .filter(languageId => previousBuckets[languageId]?.invocationCount > 0)
+            .map(languageId => {
+                const bucket = previousBuckets[languageId]
+                return {
+                    codewhispererLanguage: languageId,
+                    userWrittenCodeCharacterCount: bucket.userWrittenCodeCharacterCount,
+                    userWrittenCodeLineCount: bucket.userWrittenCodeLineCount,
+                }
+            })
+    }
+
+    private rotate() {
+        const previous = this.buckets
+        this.buckets = {}
+        return previous
+    }
+
+    public recordUsageCount(languageId: string) {
+        const languageBucket = this.getLanguageBucket(languageId)
+        languageBucket.invocationCount++
+        this._lastQInvocationTime = Date.now()
+    }
+
+    public onQStartsMakingEdits() {
+        this._qIsMakingEdits = true
+    }
+
+    public onQFinishesEdits() {
+        this._qIsMakingEdits = false
+    }
+
+    public reset() {
+        this._qIsMakingEdits = false
+        this._lastQInvocationTime = 0
+    }
+
+    private countNewLines(str: string) {
+        return str.split('\n').length - 1
+    }
+
+    public countUserWrittenTokens(languageId: string, tokens: string) {
+        if (this._qIsMakingEdits) {
+            // if the boolean of qIsMakingEdits was incorrectly set to true
+            // due to unhandled edge cases or early terminated code paths
+            // reset it back to false after a reasonable period of time
+            if (performance.now() - this._lastQInvocationTime > RESET_Q_EDITING_THRESHOLD) {
+                this._qIsMakingEdits = false
+            }
+        }
+        const languageBucket = this.getLanguageBucket(languageId)
+        // if user copies code into the editor for more than 50 characters
+        // do not count this as total new code, this will skew the data,
+        // reporting highly inflated user written code
+        if (tokens.length > INSERT_CUTOFF_THRESHOLD) {
+            return
+        }
+
+        languageBucket.userWrittenCodeCharacterCount += tokens.length
+        languageBucket.userWrittenCodeLineCount += this.countNewLines(tokens)
+    }
+
+    private getLanguageBucket(languageId: string): TelemetryBuckets[string] {
+        if (!this.buckets[languageId]) {
+            this.buckets[languageId] = {
+                userWrittenCodeCharacterCount: 0,
+                userWrittenCodeLineCount: 0,
+                invocationCount: 0,
+            }
+        }
+
+        return this.buckets[languageId]
+    }
+
+    dispose(): void {
+        if (this.intervalId) {
+            clearInterval(this.intervalId)
+        }
+        this.reset()
+    }
+}


### PR DESCRIPTION
## Problem
add userWrittenCodeTracker in flare
## Solution
this is behind a configuration `sendUserWrittenCodeMetrics` since this is currently only sent in VSC and JB

related VSC PR: https://github.com/aws/aws-toolkit-vscode/pull/7281
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
