### PR TITLE
fix: remove @ mention in placeholder q chat text if agentic mode not available

### DIFF
--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -91,11 +91,13 @@ import { TabFactory } from './tabs/tabFactory'
 import { ChatClientAdapter } from '../contracts/chatClientAdapter'
 import { toMynahContextCommand, toMynahIcon } from './utils'
 
-const DEFAULT_TAB_DATA = {
-    tabTitle: 'Chat',
-    promptInputInfo:
-        'Amazon Q Developer uses generative AI. You may need to verify responses. See the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
-    promptInputPlaceholder: 'Ask a question. Use @ to add context, / for quick actions',
+const DEFAULT_TAB_DATA = (agenticMode?: Boolean) => {
+    return {
+        tabTitle: 'Chat',
+        promptInputInfo:
+            'Amazon Q Developer uses generative AI. You may need to verify responses. See the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
+        promptInputPlaceholder: `Ask a question. Use${agenticMode ? ' @ to add context,' : ''} / for quick actions`,
+    }
 }
 
 type ChatClientConfig = Pick<MynahUIDataModel, 'quickActionCommands'> & {
@@ -374,7 +376,7 @@ export const createChat = (
     }
 
     const messager = new Messager(chatApi)
-    const tabFactory = new TabFactory(DEFAULT_TAB_DATA, [
+    const tabFactory = new TabFactory(DEFAULT_TAB_DATA(config?.agenticMode), [
         ...(config?.quickActionCommands ? config.quickActionCommands : []),
     ])
 

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -91,7 +91,7 @@ import { TabFactory } from './tabs/tabFactory'
 import { ChatClientAdapter } from '../contracts/chatClientAdapter'
 import { toMynahContextCommand, toMynahIcon } from './utils'
 
-const DEFAULT_TAB_DATA = (agenticMode?: Boolean) => {
+const getDefaultTabConfig = (agenticMode?: Boolean) => {
     return {
         tabTitle: 'Chat',
         promptInputInfo:
@@ -376,7 +376,7 @@ export const createChat = (
     }
 
     const messager = new Messager(chatApi)
-    const tabFactory = new TabFactory(DEFAULT_TAB_DATA(config?.agenticMode), [
+    const tabFactory = new TabFactory(getDefaultTabConfig(config?.agenticMode), [
         ...(config?.quickActionCommands ? config.quickActionCommands : []),
     ])
 


### PR DESCRIPTION
## Problem
remove @ mention in placeholder q chat text if agentic mode not available

## Solution
**With agentic mode:**
<img width="508" alt="Screenshot 2025-05-12 at 14 34 52" src="https://github.com/user-attachments/assets/883a6074-e5e9-4fb6-b084-b65d4770f2f9" />
**Without agentic mode:**
<img width="513" alt="Screenshot 2025-05-12 at 14 34 37" src="https://github.com/user-attachments/assets/2aacaf37-ad86-497f-8123-5c9204731956" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
