### PR TITLE
fix: bug in skip edit for userWrittenCode

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/userWrittenCodeTracker.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/userWrittenCodeTracker.ts
@@ -89,7 +89,7 @@ export class UserWrittenCodeTracker {
     public recordUsageCount(languageId: string) {
         const languageBucket = this.getLanguageBucket(languageId)
         languageBucket.invocationCount++
-        this._lastQInvocationTime = Date.now()
+        this._lastQInvocationTime = performance.now()
     }
 
     public onQStartsMakingEdits() {
@@ -117,6 +117,7 @@ export class UserWrittenCodeTracker {
             if (performance.now() - this._lastQInvocationTime > RESET_Q_EDITING_THRESHOLD) {
                 this._qIsMakingEdits = false
             }
+            return
         }
         const languageBucket = this.getLanguageBucket(languageId)
         // if user copies code into the editor for more than 50 characters


### PR DESCRIPTION
## Problem
- use performance.now for both timestamp
- missing return
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
