### PR TITLE
fix: update ignore pattern of glob for sspc

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
@@ -33,12 +33,8 @@ const IGNORE_PATTERNS = [
     '**/dist/**',
     '**/build/**',
     '**/out/**',
-    // Test directories
-    '**/test/**',
-    '**/tests/**',
     '**/coverage/**',
-    // Hidden directories and files
-    '**/.*/**',
+    // Hidden files
     '**/.*',
     // Logs and temporary files
     '**/logs/**',


### PR DESCRIPTION
## Problem
Source code which is created under /test/ or /tests/, they are ignored falsely, same as directory which might have hidden repository before the code package.

## Solution

Remove them from ignore patterns of glob


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
