### PR TITLE
fix: update fileSearch toolSpec and implementation

### DIFF
--- a/core/aws-lsp-core/src/util/workspaceUtils.test.ts
+++ b/core/aws-lsp-core/src/util/workspaceUtils.test.ts
@@ -184,7 +184,7 @@ describe('workspaceUtils', function () {
             const result = (
                 await readDirectoryRecursively(testFeatures, tempFolder.path, {
                     customFormatCallback: getEntryPath,
-                    excludeEntries: ['file4-bad', 'file2-bad'],
+                    excludeFiles: ['file4-bad', 'file2-bad'],
                 })
             ).sort()
             assert.deepStrictEqual(
@@ -209,7 +209,7 @@ describe('workspaceUtils', function () {
             const result = (
                 await readDirectoryRecursively(testFeatures, tempFolder.path, {
                     customFormatCallback: getEntryPath,
-                    excludeEntries: ['subdir12-bad'],
+                    excludeDirs: ['subdir12-bad'],
                 })
             ).sort()
             assert.deepStrictEqual(result, [subdir1.path, file1, subdir11.path, file3, subdir2.path, file2].sort())

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.test.ts
@@ -69,8 +69,8 @@ describe('FileSearch Tool', () => {
 
         assert.strictEqual(result.output.kind, 'text')
         const lines = result.output.content.split('\n')
-        const hasFileA = lines.some(line => line.includes('[F] ') && line.includes('fileA.txt'))
-        const hasFileB = lines.some(line => line.includes('[F] ') && line.includes('fileB.md'))
+        const hasFileA = lines.some(line => !line.includes('[F] ') && line.includes('fileA.txt'))
+        const hasFileB = lines.some(line => !line.includes('[F] ') && line.includes('fileB.md'))
 
         assert.ok(hasFileA, 'Should find fileA.txt matching the pattern')
         assert.ok(!hasFileB, 'Should not find fileB.md as it does not match the pattern')
@@ -90,9 +90,9 @@ describe('FileSearch Tool', () => {
 
         assert.strictEqual(result.output.kind, 'text')
         const lines = result.output.content.split('\n')
-        const hasFileA = lines.some(line => line.includes('[F] ') && line.includes('fileA.txt'))
-        const hasFileB = lines.some(line => line.includes('[F] ') && line.includes('fileB.txt'))
-        const hasFileC = lines.some(line => line.includes('[F] ') && line.includes('fileC.md'))
+        const hasFileA = lines.some(line => !line.includes('[F] ') && line.includes('fileA.txt'))
+        const hasFileB = lines.some(line => !line.includes('[F] ') && line.includes('fileB.txt'))
+        const hasFileC = lines.some(line => !line.includes('[F] ') && line.includes('fileC.md'))
 
         assert.ok(hasFileA, 'Should find fileA.txt in root directory')
         assert.ok(hasFileB, 'Should find fileB.txt in subfolder')
@@ -116,9 +116,9 @@ describe('FileSearch Tool', () => {
 
         assert.strictEqual(result.output.kind, 'text')
         const lines = result.output.content.split('\n')
-        const hasRootFile = lines.some(line => line.includes('[F] ') && line.includes('root.txt'))
-        const hasLevel1File = lines.some(line => line.includes('[F] ') && line.includes('level1.txt'))
-        const hasLevel2File = lines.some(line => line.includes('[F] ') && line.includes('level2.txt'))
+        const hasRootFile = lines.some(line => !line.includes('[F] ') && line.includes('root.txt'))
+        const hasLevel1File = lines.some(line => !line.includes('[F] ') && line.includes('level1.txt'))
+        const hasLevel2File = lines.some(line => !line.includes('[F] ') && line.includes('level2.txt'))
 
         assert.ok(hasRootFile, 'Should find root.txt in root directory')
         assert.ok(hasLevel1File, 'Should find level1.txt in subfolder1')
@@ -138,8 +138,8 @@ describe('FileSearch Tool', () => {
 
         assert.strictEqual(result.output.kind, 'text')
         const lines = result.output.content.split('\n')
-        const hasUpperFile = lines.some(line => line.includes('[F] ') && line.includes('FileUpper.txt'))
-        const hasLowerFile = lines.some(line => line.includes('[F] ') && line.includes('fileLower.txt'))
+        const hasUpperFile = lines.some(line => !line.includes('[F] ') && line.includes('FileUpper.txt'))
+        const hasLowerFile = lines.some(line => !line.includes('[F] ') && line.includes('fileLower.txt'))
 
         assert.ok(hasUpperFile, 'Should find FileUpper.txt with case-insensitive search')
         assert.ok(hasLowerFile, 'Should find fileLower.txt with case-insensitive search')
@@ -159,8 +159,8 @@ describe('FileSearch Tool', () => {
 
         assert.strictEqual(result.output.kind, 'text')
         const lines = result.output.content.split('\n')
-        const hasUpperFile = lines.some(line => line.includes('[F] ') && line.includes('FileUpper.txt'))
-        const hasLowerFile = lines.some(line => line.includes('[F] ') && line.includes('fileLower.txt'))
+        const hasUpperFile = lines.some(line => !line.includes('[F] ') && line.includes('FileUpper.txt'))
+        const hasLowerFile = lines.some(line => !line.includes('[F] ') && line.includes('fileLower.txt'))
 
         assert.ok(!hasUpperFile, 'Should not find FileUpper.txt with case-sensitive search')
         assert.ok(hasLowerFile, 'Should find fileLower.txt with case-sensitive search')
@@ -179,8 +179,8 @@ describe('FileSearch Tool', () => {
 
         assert.strictEqual(result.output.kind, 'text')
         const lines = result.output.content.split('\n')
-        const hasRegularFile = lines.some(line => line.includes('[F] ') && line.includes('regular.txt'))
-        const hasExcludedFile = lines.some(line => line.includes('[F] ') && line.includes('excluded.txt'))
+        const hasRegularFile = lines.some(line => !line.includes('[F] ') && line.includes('regular.txt'))
+        const hasExcludedFile = lines.some(line => !line.includes('[F] ') && line.includes('excluded.txt'))
 
         assert.ok(hasRegularFile, 'Should find regular.txt in root directory')
         assert.ok(!hasExcludedFile, 'Should not find excluded.txt in node_modules directory')

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/constants.ts
@@ -31,18 +31,6 @@ export const HELP_MESSAGE = `I'm Amazon Q, a generative AI assistant. Learn more
 
 export const DEFAULT_HELP_FOLLOW_UP_PROMPT = 'How can Amazon Q help me?'
 
-// TO BE DEPRECATED, use DEFAULT_EXCLUDE_DIRS and DEFAULT_EXCLUDE_FILES instead
-export const DEFAULT_EXCLUDE_ENTRIES = [
-    // Dependency directories
-    'node_modules',
-    // Build outputs
-    'dist',
-    'build',
-    'out',
-    // OS specific files
-    '.DS_Store',
-]
-
 export const DEFAULT_EXCLUDE_DIRS = [
     // Dependency directories
     'node_modules',


### PR DESCRIPTION
## Problem
- FileSearch is returning directories in the result
- FileSearch toolSpec is outdated

## Solution
- Update fileSearch toolSpec and implementation
- This PR is not enabling the tool, we will test offline first

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
