### PR TITLE
fix: Stop text align

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -94,7 +94,7 @@ export const handlePromptInputChange = (mynahUi: MynahUI, tabId: string, options
     }
 }
 
-export const handleChatPrompt = (
+export const handleChatPrompt = async (
     mynahUi: MynahUI,
     tabId: string,
     prompt: ChatPrompt,
@@ -104,7 +104,24 @@ export const handleChatPrompt = (
     agenticMode?: boolean
 ) => {
     let userPrompt = prompt.escapedPrompt
-    messager.onStopChatResponse(tabId)
+
+    const tabStore = mynahUi.getTabData(tabId)?.getStore()
+    const isLoading = tabStore?.loadingChat === true
+    if (isLoading) {
+        messager.onStopChatResponse(tabId)
+        mynahUi.addChatItem(tabId, {
+            type: ChatItemType.DIRECTIVE,
+            messageId: `stopped-${Date.now()}`,
+        })
+        mynahUi.updateStore(tabId, {
+            loadingChat: false,
+            cancelButtonWhenLoading: true,
+            promptInputDisabledState: false,
+        })
+
+        await new Promise(resolve => setTimeout(resolve, 50))
+    }
+
     if (prompt.command) {
         // Temporary solution to handle clear quick actions on the client side
         if (prompt.command === '/clear') {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -119,6 +119,7 @@ export const handleChatPrompt = async (
             promptInputDisabledState: false,
         })
 
+        // Add a slight delay to make sure the stop message would render before the new prompt
         await new Promise(resolve => setTimeout(resolve, 50))
     }
 
@@ -912,8 +913,6 @@ export const createMynahUi = (
         const processedButtons: ChatItemButton[] | undefined = toMynahButtons(message.buttons)?.map(button =>
             button.id === 'undo-all-changes' ? { ...button, position: 'outside' } : button
         )
-        // Adding this conditional check to show the stop message in the center.
-        const contentHorizontalAlignment: ChatItem['contentHorizontalAlignment'] = undefined
 
         // If message.header?.status?.text is Stopped or Rejected or Ignored or Completed etc.. card should be in disabled state.
         const shouldMute = message.header?.status?.text !== undefined
@@ -926,7 +925,6 @@ export const createMynahUi = (
             // file diffs in the header need space
             fullWidth: message.type === 'tool' && message.header?.buttons ? true : undefined,
             padding,
-            contentHorizontalAlignment,
             wrapCodes: message.type === 'tool',
             codeBlockActions:
                 message.type === 'tool'

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -874,7 +874,7 @@ export const createMynahUi = (
                 }
             }
             if (!isPartialResult) {
-                if (processedHeader && processedHeader.status?.text !== 'error') {
+                if (processedHeader && processedHeader.status?.status !== 'error') {
                     processedHeader.status = undefined
                 }
             }

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -896,8 +896,7 @@ export const createMynahUi = (
             button.id === 'undo-all-changes' ? { ...button, position: 'outside' } : button
         )
         // Adding this conditional check to show the stop message in the center.
-        const contentHorizontalAlignment: ChatItem['contentHorizontalAlignment'] =
-            message.type === 'directive' && message.messageId?.startsWith('stopped') ? 'center' : undefined
+        const contentHorizontalAlignment: ChatItem['contentHorizontalAlignment'] = undefined
 
         // If message.header?.status?.text is Stopped or Rejected or Ignored or Completed etc.. card should be in disabled state.
         const shouldMute = message.header?.status?.text !== undefined


### PR DESCRIPTION
## Problem
Stop text was centered. 
![image](https://github.com/user-attachments/assets/6e60e8bf-8839-4bbc-9f1d-e653ab1803dd)

When user enter a prompt to stop the workflow, the stop message would show up after user's new prompt

## Solution
![image](https://github.com/user-attachments/assets/d58c029a-12d6-4194-ae70-46bd644bbef4)

https://github.com/user-attachments/assets/cc97f1b5-0789-44e0-84d7-996d736469f3


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
