### PR TITLE
fix: bump runtimes and fix broken test

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -14,7 +14,7 @@
         "test-bundles": "node scripts/test-bundles.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-partiql-runtimes/package.json
+++ b/app/aws-lsp-partiql-runtimes/package.json
@@ -11,7 +11,7 @@
         "package": "npm run compile && npm run compile:webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-partiql": "^0.0.5"
     },
     "devDependencies": {

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.78"
+        "@aws/language-server-runtimes": "^0.2.80"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -347,7 +347,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.32",
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -78,7 +78,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -111,7 +111,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -119,7 +119,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -139,7 +139,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -147,7 +147,7 @@
             "name": "@aws/lsp-partiql-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-partiql": "^0.0.5"
             },
             "devDependencies": {
@@ -183,7 +183,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -203,7 +203,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -225,7 +225,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.78"
+                "@aws/language-server-runtimes": "^0.2.80"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -269,7 +269,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.32",
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -278,31 +278,6 @@
             },
             "engines": {
                 "vscode": "^1.74.0"
-            }
-        },
-        "client/vscode/node_modules/@aws-sdk/types": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
-            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
-            "dev": true,
-            "dependencies": {
-                "@smithy/types": "^4.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "client/vscode/node_modules/@smithy/types": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "core/aws-lsp-core": {
@@ -3930,23 +3905,21 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.78",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.78.tgz",
-            "integrity": "sha512-yUXCU6vnVUNQavevwENOKgW/R2lNZW39grXvOWYDPoyQnUS3ujzsTkokC+DQZykaMC4r58ij2q1JDfIFdbS4Yw==",
-            "license": "Apache-2.0",
+            "version": "0.2.80",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.80.tgz",
+            "integrity": "sha512-RBO9E5QEidaD4sd39ROSkShkgVzHzR72HSGW3S6svlcdhya9g1G9uJhVD6OhXvvbHcydZ6fxEQTdixkWTTd1ww==",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.26",
+                "@aws/language-server-runtimes-types": "^0.1.27",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/api-logs": "^0.200.0",
+                "@opentelemetry/core": "^2.0.0",
                 "@opentelemetry/exporter-logs-otlp-http": "^0.200.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "^0.200.0",
                 "@opentelemetry/resources": "^2.0.0",
                 "@opentelemetry/sdk-logs": "^0.200.0",
                 "@opentelemetry/sdk-metrics": "^2.0.0",
-                "@opentelemetry/sdk-node": "^0.200.0",
-                "@smithy/node-http-handler": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
                 "ajv": "^8.17.1",
-                "aws-sdk": "^2.1692.0",
                 "hpagent": "^1.2.0",
                 "jose": "^5.9.6",
                 "mac-ca": "^3.1.1",
@@ -3960,10 +3933,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.26",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.26.tgz",
-            "integrity": "sha512-c63rpUbcrtLqaC33t6elRApQqLbQvFgKzIQ2z/VCavE5F7HSLBfzhHkhgUFd775fBpsF4MHrIzwNitYLhDGobw==",
-            "license": "Apache-2.0",
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.27.tgz",
+            "integrity": "sha512-nalsT6d4aUsAv9D+cP9XBsNfkzgdMSwnESEy0/eD3g9VGdSLuNlz6xlvqfeUf+DtPl8+1qHIdzf9ihDaaNtADQ==",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"
@@ -5609,37 +5581,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@grpc/grpc-js": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.3.tgz",
-            "integrity": "sha512-FTXHdOoPbZrBjlVLHuKbDZnsTxXv2BlHF57xw6LuThXacXvtkahEPED0CKMk6obZDf65Hv4k3z62eyPNpvinIg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@grpc/proto-loader": "^0.7.13",
-                "@js-sdsl/ordered-map": "^4.4.2"
-            },
-            "engines": {
-                "node": ">=12.10.0"
-            }
-        },
-        "node_modules/@grpc/proto-loader": {
-            "version": "0.7.15",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-            "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "lodash.camelcase": "^4.3.0",
-                "long": "^5.0.0",
-                "protobufjs": "^7.2.5",
-                "yargs": "^17.7.2"
-            },
-            "bin": {
-                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@hapi/bourne": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
@@ -6711,16 +6652,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@js-sdsl/ordered-map": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
-            "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/js-sdsl"
-            }
-        },
         "node_modules/@jsonjoy.com/base64": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
@@ -7151,7 +7082,6 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-            "license": "Apache-2.0",
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -7160,7 +7090,6 @@
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
             "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api": "^1.3.0"
             },
@@ -7168,23 +7097,10 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/@opentelemetry/context-async-hooks": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.0.0.tgz",
-            "integrity": "sha512-IEkJGzK1A9v3/EHjXh3s2IiFc6L4jfK+lNgKVgUjeUJQRRhnVFMIO3TAvKwonm9O1HebCuoOt98v8bZW7oVQHA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
         "node_modules/@opentelemetry/core": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
             "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -7195,80 +7111,16 @@
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.200.0.tgz",
-            "integrity": "sha512-+3MDfa5YQPGM3WXxW9kqGD85Q7s9wlEMVNhXXG7tYFLnIeaseUt9YtCeFhEDFzfEktacdFpOtXmJuNW8cHbU5A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@grpc/grpc-js": "^1.7.1",
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/otlp-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-transformer": "0.200.0",
-                "@opentelemetry/sdk-logs": "0.200.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
         "node_modules/@opentelemetry/exporter-logs-otlp-http": {
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.200.0.tgz",
             "integrity": "sha512-KfWw49htbGGp9s8N4KI8EQ9XuqKJ0VG+yVYVYFiCYSjEV32qpQ5qZ9UZBzOZ6xRb+E16SXOSCT3RkqBVSABZ+g==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api-logs": "0.200.0",
                 "@opentelemetry/core": "2.0.0",
                 "@opentelemetry/otlp-exporter-base": "0.200.0",
                 "@opentelemetry/otlp-transformer": "0.200.0",
                 "@opentelemetry/sdk-logs": "0.200.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.200.0.tgz",
-            "integrity": "sha512-GmahpUU/55hxfH4TP77ChOfftADsCq/nuri73I/AVLe2s4NIglvTsaACkFVZAVmnXXyPS00Fk3x27WS3yO07zA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.200.0",
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/otlp-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-transformer": "0.200.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-logs": "0.200.0",
-                "@opentelemetry/sdk-trace-base": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.200.0.tgz",
-            "integrity": "sha512-uHawPRvKIrhqH09GloTuYeq2BjyieYHIpiklOvxm9zhrCL2eRsnI/6g9v2BZTVtGp8tEgIa7rCQ6Ltxw6NBgew==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@grpc/grpc-js": "^1.7.1",
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
-                "@opentelemetry/otlp-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-transformer": "0.200.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-metrics": "2.0.0"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
@@ -7281,146 +7133,12 @@
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.200.0.tgz",
             "integrity": "sha512-5BiR6i8yHc9+qW7F6LqkuUnIzVNA7lt0qRxIKcKT+gq3eGUPHZ3DY29sfxI3tkvnwMgtnHDMNze5DdxW39HsAw==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "2.0.0",
                 "@opentelemetry/otlp-exporter-base": "0.200.0",
                 "@opentelemetry/otlp-transformer": "0.200.0",
                 "@opentelemetry/resources": "2.0.0",
                 "@opentelemetry/sdk-metrics": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.200.0.tgz",
-            "integrity": "sha512-E+uPj0yyvz81U9pvLZp3oHtFrEzNSqKGVkIViTQY1rH3TOobeJPSpLnTVXACnCwkPR5XeTvPnK3pZ2Kni8AFMg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
-                "@opentelemetry/otlp-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-transformer": "0.200.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-metrics": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-prometheus": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.200.0.tgz",
-            "integrity": "sha512-ZYdlU9r0USuuYppiDyU2VFRA0kFl855ylnb3N/2aOlXrbA4PMCznen7gmPbetGQu7pz8Jbaf4fwvrDnVdQQXSw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-metrics": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.200.0.tgz",
-            "integrity": "sha512-hmeZrUkFl1YMsgukSuHCFPYeF9df0hHoKeHUthRKFCxiURs+GwF1VuabuHmBMZnjTbsuvNjOB+JSs37Csem/5Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@grpc/grpc-js": "^1.7.1",
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/otlp-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-grpc-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-transformer": "0.200.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-trace-base": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.200.0.tgz",
-            "integrity": "sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/otlp-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-transformer": "0.200.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-trace-base": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.200.0.tgz",
-            "integrity": "sha512-V9TDSD3PjK1OREw2iT9TUTzNYEVWJk4Nhodzhp9eiz4onDMYmPy3LaGbPv81yIR6dUb/hNp/SIhpiCHwFUq2Vg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/otlp-exporter-base": "0.200.0",
-                "@opentelemetry/otlp-transformer": "0.200.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-trace-base": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/exporter-zipkin": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.0.0.tgz",
-            "integrity": "sha512-icxaKZ+jZL/NHXX8Aru4HGsrdhK0MLcuRXkX5G5IRmCgoRLw+Br6I/nMVozX2xjGGwV7hw2g+4Slj8K7s4HbVg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-trace-base": "2.0.0",
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.0.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.200.0.tgz",
-            "integrity": "sha512-pmPlzfJd+vvgaZd/reMsC8RWgTXn2WY1OWT5RT42m3aOn5532TozwXNDhg1vzqJ+jnvmkREcdLr27ebJEQt0Jg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.200.0",
-                "@types/shimmer": "^1.2.0",
-                "import-in-the-middle": "^1.8.1",
-                "require-in-the-middle": "^7.1.1",
-                "shimmer": "^1.2.1"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
@@ -7433,27 +7151,8 @@
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.200.0.tgz",
             "integrity": "sha512-IxJgA3FD7q4V6gGq4bnmQM5nTIyMDkoGFGrBrrDjB6onEiq1pafma55V+bHvGYLWvcqbBbRfezr1GED88lacEQ==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/otlp-transformer": "0.200.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.200.0.tgz",
-            "integrity": "sha512-CK2S+bFgOZ66Bsu5hlDeOX6cvW5FVtVjFFbWuaJP0ELxJKBB6HlbLZQ2phqz/uLj1cWap5xJr/PsR3iGoB7Vqw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@grpc/grpc-js": "^1.7.1",
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/otlp-exporter-base": "0.200.0",
                 "@opentelemetry/otlp-transformer": "0.200.0"
             },
             "engines": {
@@ -7467,7 +7166,6 @@
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.200.0.tgz",
             "integrity": "sha512-+9YDZbYybOnv7sWzebWOeK6gKyt2XE7iarSyBFkwwnP559pEevKOUD8NyDHhRjCSp13ybh9iVXlMfcj/DwF/yw==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api-logs": "0.200.0",
                 "@opentelemetry/core": "2.0.0",
@@ -7484,41 +7182,10 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
-        "node_modules/@opentelemetry/propagator-b3": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.0.0.tgz",
-            "integrity": "sha512-blx9S2EI49Ycuw6VZq+bkpaIoiJFhsDuvFGhBIoH3vJ5oYjJ2U0s3fAM5jYft99xVIAv6HqoPtlP9gpVA2IZtA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/propagator-jaeger": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.0.0.tgz",
-            "integrity": "sha512-Mbm/LSFyAtQKP0AQah4AfGgsD+vsZcyreZoQ5okFBk33hU7AquU4TltgyL9dvaO8/Zkoud8/0gEvwfOZ5d7EPA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
         "node_modules/@opentelemetry/resources": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
             "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "2.0.0",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -7534,7 +7201,6 @@
             "version": "0.200.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
             "integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api-logs": "0.200.0",
                 "@opentelemetry/core": "2.0.0",
@@ -7551,7 +7217,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.0.0.tgz",
             "integrity": "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "2.0.0",
                 "@opentelemetry/resources": "2.0.0"
@@ -7563,47 +7228,10 @@
                 "@opentelemetry/api": ">=1.9.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/sdk-node": {
-            "version": "0.200.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.200.0.tgz",
-            "integrity": "sha512-S/YSy9GIswnhYoDor1RusNkmRughipvTCOQrlF1dzI70yQaf68qgf5WMnzUxdlCl3/et/pvaO75xfPfuEmCK5A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.200.0",
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/exporter-logs-otlp-grpc": "0.200.0",
-                "@opentelemetry/exporter-logs-otlp-http": "0.200.0",
-                "@opentelemetry/exporter-logs-otlp-proto": "0.200.0",
-                "@opentelemetry/exporter-metrics-otlp-grpc": "0.200.0",
-                "@opentelemetry/exporter-metrics-otlp-http": "0.200.0",
-                "@opentelemetry/exporter-metrics-otlp-proto": "0.200.0",
-                "@opentelemetry/exporter-prometheus": "0.200.0",
-                "@opentelemetry/exporter-trace-otlp-grpc": "0.200.0",
-                "@opentelemetry/exporter-trace-otlp-http": "0.200.0",
-                "@opentelemetry/exporter-trace-otlp-proto": "0.200.0",
-                "@opentelemetry/exporter-zipkin": "2.0.0",
-                "@opentelemetry/instrumentation": "0.200.0",
-                "@opentelemetry/propagator-b3": "2.0.0",
-                "@opentelemetry/propagator-jaeger": "2.0.0",
-                "@opentelemetry/resources": "2.0.0",
-                "@opentelemetry/sdk-logs": "0.200.0",
-                "@opentelemetry/sdk-metrics": "2.0.0",
-                "@opentelemetry/sdk-trace-base": "2.0.0",
-                "@opentelemetry/sdk-trace-node": "2.0.0",
-                "@opentelemetry/semantic-conventions": "^1.29.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.3.0 <1.10.0"
-            }
-        },
         "node_modules/@opentelemetry/sdk-trace-base": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.0.0.tgz",
             "integrity": "sha512-qQnYdX+ZCkonM7tA5iU4fSRsVxbFGml8jbxOgipRGMFHKaXKHQ30js03rTobYjKjIfnOsZSbHKWF0/0v0OQGfw==",
-            "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "2.0.0",
                 "@opentelemetry/resources": "2.0.0",
@@ -7616,28 +7244,10 @@
                 "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/sdk-trace-node": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.0.0.tgz",
-            "integrity": "sha512-omdilCZozUjQwY3uZRBwbaRMJ3p09l4t187Lsdf0dGMye9WKD4NGcpgZRvqhI1dwcH6og+YXQEtoO9Wx3ykilg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/context-async-hooks": "2.0.0",
-                "@opentelemetry/core": "2.0.0",
-                "@opentelemetry/sdk-trace-base": "2.0.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
         "node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.32.0.tgz",
-            "integrity": "sha512-s0OpmpQFSfMrmedAn9Lhg4KWJELHCU6uU9dtIJ28N8UGhf9Y55im5X8fEzwhwDwiSqN+ZPSNrDJF7ivf/AuRPQ==",
-            "license": "Apache-2.0",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.33.0.tgz",
+            "integrity": "sha512-TIpZvE8fiEILFfTlfPnltpBaD3d9/+uQHVCyC3vfdh6WfCXKhNFzoP5RyDDIndfvZC5GrA4pyEDNyjPloJud+w==",
             "engines": {
                 "node": ">=14"
             }
@@ -7675,32 +7285,27 @@
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
         },
         "node_modules/@protobufjs/base64": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
         },
         "node_modules/@protobufjs/codegen": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
         },
         "node_modules/@protobufjs/eventemitter": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
         },
         "node_modules/@protobufjs/fetch": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
             "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.1",
                 "@protobufjs/inquire": "^1.1.0"
@@ -7709,32 +7314,27 @@
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
         },
         "node_modules/@protobufjs/inquire": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
         },
         "node_modules/@protobufjs/path": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
         },
         "node_modules/@protobufjs/pool": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
         },
         "node_modules/@protobufjs/utf8": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-            "license": "BSD-3-Clause"
+            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
         },
         "node_modules/@puppeteer/browsers": {
             "version": "2.10.1",
@@ -9206,12 +8806,6 @@
                 "@types/node": "*",
                 "@types/send": "*"
             }
-        },
-        "node_modules/@types/shimmer": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-            "license": "MIT"
         },
         "node_modules/@types/sinon": {
             "version": "17.0.4",
@@ -10725,21 +10319,13 @@
             "version": "8.14.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
             "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+            "devOptional": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-import-attributes": {
-            "version": "1.9.5",
-            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-            "license": "MIT",
-            "peerDependencies": {
-                "acorn": "^8"
             }
         },
         "node_modules/acorn-jsx": {
@@ -12473,6 +12059,7 @@
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
             "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/clean-css": {
@@ -12502,6 +12089,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
@@ -12516,6 +12104,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -12531,12 +12120,14 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/cliui/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -12551,6 +12142,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -16769,18 +16361,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/import-in-the-middle": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz",
-            "integrity": "sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "acorn": "^8.14.0",
-                "acorn-import-attributes": "^1.9.5",
-                "cjs-module-lexer": "^1.2.2",
-                "module-details-from-path": "^1.0.3"
-            }
-        },
         "node_modules/import-local": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -17044,6 +16624,7 @@
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
             "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
@@ -19342,6 +18923,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.clonedeep": {
@@ -19538,8 +19120,7 @@
         "node_modules/long": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-            "license": "Apache-2.0"
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
         },
         "node_modules/loupe": {
             "version": "2.3.7",
@@ -20113,12 +19694,6 @@
             "engines": {
                 "node": ">=12.0.0"
             }
-        },
-        "node_modules/module-details-from-path": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-            "license": "MIT"
         },
         "node_modules/mri": {
             "version": "1.2.0",
@@ -21039,6 +20614,7 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/path-scurry": {
@@ -21632,11 +21208,10 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.0.tgz",
-            "integrity": "sha512-Z2E/kOY1QjoMlCytmexzYfDm/w5fKAiRwpSzGtdnXW1zC88Z2yXazHHrOtwCzn+7wSxyE8PYM4rvVcMphF9sOA==",
+            "version": "7.5.1",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.1.tgz",
+            "integrity": "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==",
             "hasInstallScript": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -22354,20 +21929,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/require-in-the-middle": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-            "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.5",
-                "module-details-from-path": "^1.0.3",
-                "resolve": "^1.22.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
         "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -22378,6 +21939,7 @@
             "version": "1.22.10",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
             "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-core-module": "^2.16.0",
@@ -23283,12 +22845,6 @@
                 "node": "*"
             }
         },
-        "node_modules/shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-            "license": "BSD-2-Clause"
-        },
         "node_modules/shlex": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/shlex/-/shlex-2.1.2.tgz",
@@ -24013,6 +23569,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -26703,6 +26260,7 @@
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
             "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
@@ -26721,6 +26279,7 @@
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -26759,12 +26318,14 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/yargs/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -26894,7 +26455,7 @@
             "version": "0.1.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-core": "^0.0.7"
             },
             "devDependencies": {
@@ -26968,7 +26529,7 @@
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.32",
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-core": "^0.0.7",
                 "@modelcontextprotocol/sdk": "^1.9.0",
                 "@smithy/node-http-handler": "^2.5.0",
@@ -27105,7 +26666,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-core": "^0.0.7",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -27151,7 +26712,7 @@
             "version": "0.1.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-core": "^0.0.7",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -27165,7 +26726,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-core": "0.0.7",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -27207,7 +26768,7 @@
             "version": "0.0.8",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -27234,36 +26795,13 @@
                 "vscode-languageserver-textdocument": "^1.0.8"
             }
         },
-        "server/aws-lsp-s3/node_modules/@aws-sdk/types": {
-            "version": "3.734.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
-            "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
-            "dependencies": {
-                "@smithy/types": "^4.1.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "server/aws-lsp-s3/node_modules/@smithy/types": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-            "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
         "server/aws-lsp-yaml": {
             "name": "@aws/lsp-yaml",
             "version": "0.1.7",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-core": "^0.0.7",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -27277,7 +26815,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -27288,7 +26826,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.78",
+                "@aws/language-server-runtimes": "^0.2.80",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-core": "^0.0.7"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.32",
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-core": "^0.0.7",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -191,6 +191,7 @@ describe('AgenticChatController', () => {
                 }))
             ),
             addTool: sinon.stub().resolves(),
+            removeTool: sinon.stub().resolves(),
         }
 
         additionalContextProviderStub = sinon.stub(AdditionalContextProvider.prototype, 'getAdditionalContext')

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-core": "^0.0.7",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-core": "^0.0.7",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-core": "0.0.7",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-core": "^0.0.7",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.78",
+        "@aws/language-server-runtimes": "^0.2.80",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem
This PR bumps runtimes version to latest, and fix a broken test due to new changes in runtimes (removeTools in Agent): https://github.com/aws/language-server-runtimes/pull/501
## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
