### PR TITLE
fix(amazonq): Lower max input limit in user input box. Align payload prompt with user typed prompt.

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -495,11 +495,12 @@ export const createMynahUi = (
                 stopGenerating: agenticMode ? uiComponentsTexts.stopGenerating : 'Stop generating',
                 spinnerText: agenticMode ? uiComponentsTexts.spinnerText : 'Generating your answer...',
             },
-            // RTS max user input is 600k, we need to leave around 500 chars to user to type the question
+            // Total model context window limit 600k.
+            // 500k for user input, 100k for context, history, system prompt.
             // beside, MynahUI will automatically crop it depending on the available chars left from the prompt field itself by using a 96 chars of threshold
-            // if we want to max user input as 599500, need to configure the maxUserInput as 599596
-            maxUserInput: 599596,
-            userInputLengthWarningThreshold: 550000,
+            // if we want to max user input as 500000, need to configure the maxUserInput as 500096
+            maxUserInput: 500096,
+            userInputLengthWarningThreshold: 450000,
         },
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
@@ -1,7 +1,7 @@
 export const genericErrorMsg = 'An unexpected error occurred, check the logs for more information.'
 export const maxAgentLoopIterations = 100
 export const loadingThresholdMs = 2000
-export const generateAssistantResponseInputLimit = 600_000
+export const generateAssistantResponseInputLimit = 500_000
 export const outputLimitExceedsPartialMsg = 'output exceeds maximum character limit of'
 export const responseTimeoutMs = 170_000
 export const responseTimeoutPartialMsg = 'Response processing timed out after'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -110,7 +110,9 @@ export class AgenticChatTriggerContext {
 
         const hasWorkspace = 'context' in params ? params.context?.some(c => c.command === '@workspace') : false
 
-        let promptContent = prompt.escapedPrompt ?? prompt.prompt
+        // prompt.prompt is what user typed in the input, should be sent to backend
+        // prompt.escapedPrompt is HTML serialized string, which should only be used for UI.
+        let promptContent = prompt.prompt ?? prompt.escapedPrompt
 
         // When the user adds @sage context, ** gets prepended and appended to the prompt because of markdown.
         // This intereferes with routing logic thus we need to remove it


### PR DESCRIPTION
## Problem

Currently, we allow user to input [599,596 characters in the chat input box](https://github.com/aws/language-servers/blob/c8a90443584e815350e3ca867e3bb35bc32f6db4/chat-client/src/client/mynahUi.ts#L498), which can cause ContextWindowOverflowException: The input is too long.

Claude 3.7 Sonnet support up to 200k tokens of entire prompt ( input prompt +  output). Note: this limitation applies to both input and output combines! This is roughly 600k characters, while taking the system prompt, output tokens and IDE side context into consideration, we decided that the user input should at most contain 500k characters.




## Solution

1. Make user facing input limit at 500k characters.
2. Fix a bug when escapePrompt is used in API payload https://github.com/aws/language-servers/pull/1190/files. escapedPrompt is an HTML encoded string which converts ' into &#39, etc. It should not be used in API payload. Without such fix, the input length validation and calculation will be wrong.  


Note that even with this fix, due to the nature of model tokenization, sub 500k prompt can still get input is too long but the chance of running into such issue will be reduced. 



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
