### PR TITLE
fix(amazonq): export q chat in windows not working due to invalid path

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.test.ts
@@ -13,6 +13,7 @@ import { ConversationItemGroup, OpenTabParams, OpenTabResult } from '@aws/langua
 import { InitializeParams } from '@aws/language-server-runtimes/protocol'
 import { ChatHistoryActionType } from '../../shared/telemetry/types'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
+import { URI } from 'vscode-uri'
 
 describe('TabBarController', () => {
     let testFeatures: TestFeatures
@@ -348,7 +349,11 @@ describe('TabBarController', () => {
             )
 
             // Write serialized content to file
-            sinon.assert.calledWith(fsWriteFileStub, '/testworkspace/test.md', 'Test Serialized Content')
+            sinon.assert.calledWith(
+                fsWriteFileStub,
+                URI.file('/testworkspace/test.md').fsPath,
+                'Test Serialized Content'
+            )
 
             sinon.assert.calledWith(telemetryService.emitChatHistoryAction as sinon.SinonStub, {
                 action: ChatHistoryActionType.Export,
@@ -423,7 +428,11 @@ describe('TabBarController', () => {
             )
 
             // Write serialized content to file
-            sinon.assert.calledWith(fsWriteFileStub, '/testworkspace/test.md', 'Test Serialized Content')
+            sinon.assert.calledWith(
+                fsWriteFileStub,
+                URI.file('/testworkspace/test.md').fsPath,
+                'Test Serialized Content'
+            )
 
             sinon.assert.calledWith(telemetryService.emitExportTab as sinon.SinonStub, {
                 filenameExt: 'markdown',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
@@ -247,7 +247,7 @@ export class TabBarController {
             format,
         })
 
-        await this.#features.workspace.fs.writeFile(targetPath.path, content)
+        await this.#features.workspace.fs.writeFile(targetPath.fsPath, content)
 
         return format
     }


### PR DESCRIPTION
## Problem
Export Q chat in windows was not working

`Received response 'aws/chat/tabBarAction - (7)' in 2514ms. Request failed: Request aws/chat/tabBarAction failed with message: ENOENT: no such file or directory, open 'D:\d:\Users\ABC\CDE\q-dev-chat-2025-05-13.md' (-32603). `

## Solution
Use fsPath instead of path. Fix tested on Mac OS and Windows

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
