### PR TITLE
fix(amazonq): welcome card shows everytime after ide restart

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -488,8 +488,8 @@ export const createMynahUi = (
             [tabFactory.initialTabId]: {
                 isSelected: true,
                 store: {
-                    ...tabFactory.createTab(true),
-                    chatItems: tabFactory.getChatItems(true, true),
+                    ...tabFactory.createTab(disclaimerCardActive),
+                    chatItems: tabFactory.getChatItems(true, programmingModeCardActive),
                 },
             },
         },


### PR DESCRIPTION
## Problem
- Welcome card and Disclaimer card is shown every time if user installs a new plugin or refresh the existing plugin.
## Solution
- Fixed this issue.
![image](https://github.com/user-attachments/assets/be7c76c2-c7ce-46a7-a806-004865c4634a)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
