### PR TITLE
chore: bump runtimes-types and chat-client-ui-types version to latest

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -21,8 +21,8 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.1.32",
-        "@aws/language-server-runtimes-types": "^0.1.25",
+        "@aws/chat-client-ui-types": "^0.1.33",
+        "@aws/language-server-runtimes-types": "^0.1.27",
         "@aws/mynah-ui": "^4.34.1"
     },
     "devDependencies": {

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -346,7 +346,7 @@
     "devDependencies": {
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
-        "@aws/chat-client-ui-types": "^0.1.32",
+        "@aws/chat-client-ui-types": "^0.1.33",
         "@aws/language-server-runtimes": "^0.2.80",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,8 +245,8 @@
             "version": "0.1.9",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.1.32",
-                "@aws/language-server-runtimes-types": "^0.1.25",
+                "@aws/chat-client-ui-types": "^0.1.33",
+                "@aws/language-server-runtimes-types": "^0.1.27",
                 "@aws/mynah-ui": "^4.34.1"
             },
             "devDependencies": {
@@ -268,7 +268,7 @@
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
-                "@aws/chat-client-ui-types": "^0.1.32",
+                "@aws/chat-client-ui-types": "^0.1.33",
                 "@aws/language-server-runtimes": "^0.2.80",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
@@ -3889,11 +3889,11 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.32",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.32.tgz",
-            "integrity": "sha512-axJymxFQhXh8AOnhek61VL5va917TjIvfHF5sHpyQay+znILAs65osdIMeqHs6VTjZCKtzIEp5iCd6uZbvYRVw==",
+            "version": "0.1.33",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.33.tgz",
+            "integrity": "sha512-o9VkQEkrNFvfi3lgU0vN3vm4AHAoicBe/F5UCDQj97CxvaRM5ovGLYsx3RTxHwaK6hQ2J+foZtlnI7QYltsWFg==",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.26"
+                "@aws/language-server-runtimes-types": "^0.1.27"
             }
         },
         "node_modules/@aws/hello-world-lsp": {
@@ -26528,7 +26528,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.6.tgz",
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
-                "@aws/chat-client-ui-types": "^0.1.32",
+                "@aws/chat-client-ui-types": "^0.1.33",
                 "@aws/language-server-runtimes": "^0.2.80",
                 "@aws/lsp-core": "^0.0.7",
                 "@modelcontextprotocol/sdk": "^1.9.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -31,7 +31,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.6.tgz",
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
-        "@aws/chat-client-ui-types": "^0.1.32",
+        "@aws/chat-client-ui-types": "^0.1.33",
         "@aws/language-server-runtimes": "^0.2.80",
         "@aws/lsp-core": "^0.0.7",
         "@modelcontextprotocol/sdk": "^1.9.0",


### PR DESCRIPTION
## Problem
bump @aws/language-server-runtimes-types, @aws/chat-client-ui-types to latest npm versions

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
