### PR TITLE
feat: support mcp exec timeout, add tool state interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11338,6 +11338,15 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/async-mutex": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+            "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -26974,6 +26983,7 @@
                 "@smithy/node-http-handler": "^2.5.0",
                 "adm-zip": "^0.5.10",
                 "archiver": "^7.0.1",
+                "async-mutex": "^0.5.0",
                 "aws-sdk": "^2.1403.0",
                 "chokidar": "^4.0.3",
                 "deepmerge": "^4.3.1",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -38,6 +38,7 @@
         "@smithy/node-http-handler": "^2.5.0",
         "adm-zip": "^0.5.10",
         "archiver": "^7.0.1",
+        "async-mutex": "^0.5.0",
         "aws-sdk": "^2.1403.0",
         "chokidar": "^4.0.3",
         "deepmerge": "^4.3.1",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -9,6 +9,7 @@ type AgenticChatErrorCode =
     | 'PromptCharacterLimit' // customer prompt exceeds
     | 'ResponseProcessingTimeout' // response didn't finish streaming in the allowed time
     | 'MCPServerInitTimeout' // mcp server failed to start within allowed time
+    | 'MCPToolExecTimeout' // mcp tool call failed to complete within allowed time
 
 export const customerFacingErrorCodes: AgenticChatErrorCode[] = [
     'QModelResponse',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTypes.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTypes.ts
@@ -23,6 +23,7 @@ export interface MCPServerConfig {
     args?: string[]
     env?: Record<string, string>
     initializationTimeout?: number
+    timeout?: number
     disabled?: boolean
     autoApprove?: boolean
     toolOverrides?: Record<string, { autoApprove?: boolean; disabled?: boolean }>

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -98,6 +98,8 @@ export async function loadMcpServerConfigs(
                     typeof (entry as any).initializationTimeout === 'number'
                         ? (entry as any).initializationTimeout
                         : undefined,
+                timeout:
+                    typeof (entry as any).executionTimeout === 'number' ? (entry as any).executionTimeout : undefined,
                 __configPath__: fsPath,
             }
 


### PR DESCRIPTION
## Problem
More MCP logic changes
## Solution
* Support execution timeout for MCP tools
* Add mutex to guard local config file read/write operations and prevent concurrent access issues
* Add new interface for tools and their states to simplify UI integration
* Restructure unit tests into per-method test suites

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
