### PR TITLE
feat: migrate inline completion telemetry to Flare

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codePercentage.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codePercentage.test.ts
@@ -47,11 +47,11 @@ describe('CodePercentage', () => {
                 totalCharacterCount: 20,
                 acceptedCharacterCount: 10,
                 customizationArn: undefined,
-                credentialStartUrl: undefined,
             },
             {
                 percentage: 50,
                 successCount: 1,
+                credentialStartUrl: undefined,
             }
         )
     })
@@ -87,11 +87,11 @@ describe('CodePercentage', () => {
                 totalCharacterCount: 20,
                 acceptedCharacterCount: 10,
                 customizationArn: undefined,
-                credentialStartUrl: undefined,
             },
             {
                 percentage: 50,
                 successCount: 1,
+                credentialStartUrl: undefined,
             }
         )
 
@@ -102,11 +102,11 @@ describe('CodePercentage', () => {
                 totalCharacterCount: 30,
                 acceptedCharacterCount: 10,
                 customizationArn: undefined,
-                credentialStartUrl: undefined,
             },
             {
                 percentage: 33.33,
                 successCount: 1,
+                credentialStartUrl: undefined,
             }
         )
     })
@@ -128,11 +128,11 @@ describe('CodePercentage', () => {
                 totalCharacterCount: 20,
                 acceptedCharacterCount: 10,
                 customizationArn: 'test-arn',
-                credentialStartUrl: undefined,
             },
             {
                 percentage: 50,
                 successCount: 1,
+                credentialStartUrl: undefined,
             }
         )
     })
@@ -152,11 +152,11 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 51,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
-                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
                     successCount: 0,
+                    credentialStartUrl: undefined,
                 }
             )
         })
@@ -174,11 +174,11 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 1,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
-                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
                     successCount: 0,
+                    credentialStartUrl: undefined,
                 }
             )
         })
@@ -196,11 +196,11 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 1,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
-                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
                     successCount: 0,
+                    credentialStartUrl: undefined,
                 }
             )
         })
@@ -218,11 +218,11 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 1,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
-                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
                     successCount: 0,
+                    credentialStartUrl: undefined,
                 }
             )
         })
@@ -244,11 +244,11 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 10,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
-                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
                     successCount: 0,
+                    credentialStartUrl: undefined,
                 }
             )
         })
@@ -277,11 +277,11 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 4,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
-                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
                     successCount: 0,
+                    credentialStartUrl: undefined,
                 }
             )
         })
@@ -299,11 +299,11 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 0,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
-                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
                     successCount: 0,
+                    credentialStartUrl: undefined,
                 }
             )
         })

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codePercentage.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codePercentage.test.ts
@@ -47,6 +47,7 @@ describe('CodePercentage', () => {
                 totalCharacterCount: 20,
                 acceptedCharacterCount: 10,
                 customizationArn: undefined,
+                credentialStartUrl: undefined,
             },
             {
                 percentage: 50,
@@ -86,6 +87,7 @@ describe('CodePercentage', () => {
                 totalCharacterCount: 20,
                 acceptedCharacterCount: 10,
                 customizationArn: undefined,
+                credentialStartUrl: undefined,
             },
             {
                 percentage: 50,
@@ -100,6 +102,7 @@ describe('CodePercentage', () => {
                 totalCharacterCount: 30,
                 acceptedCharacterCount: 10,
                 customizationArn: undefined,
+                credentialStartUrl: undefined,
             },
             {
                 percentage: 33.33,
@@ -125,6 +128,7 @@ describe('CodePercentage', () => {
                 totalCharacterCount: 20,
                 acceptedCharacterCount: 10,
                 customizationArn: 'test-arn',
+                credentialStartUrl: undefined,
             },
             {
                 percentage: 50,
@@ -148,6 +152,7 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 51,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
+                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
@@ -169,6 +174,7 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 1,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
+                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
@@ -190,6 +196,7 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 1,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
+                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
@@ -211,6 +218,7 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 1,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
+                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
@@ -236,6 +244,7 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 10,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
+                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
@@ -268,6 +277,7 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 4,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
+                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,
@@ -289,6 +299,7 @@ describe('CodePercentage', () => {
                     totalCharacterCount: 0,
                     acceptedCharacterCount: 0,
                     customizationArn: undefined,
+                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: 0,

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codePercentage.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codePercentage.ts
@@ -40,11 +40,11 @@ export class CodePercentageTracker {
                                 customizationArn: this.customizationArn,
                                 totalCharacterCount: event.codewhispererTotalTokens,
                                 acceptedCharacterCount: event.codewhispererSuggestedTokens,
-                                credentialStartUrl: event.credentialStartUrl,
                             },
                             {
                                 percentage: event.codewhispererPercentage,
                                 successCount: event.successCount,
+                                credentialStartUrl: event.credentialStartUrl,
                             }
                         )
                 )

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codePercentage.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codePercentage.ts
@@ -40,6 +40,7 @@ export class CodePercentageTracker {
                                 customizationArn: this.customizationArn,
                                 totalCharacterCount: event.codewhispererTotalTokens,
                                 acceptedCharacterCount: event.codewhispererSuggestedTokens,
+                                credentialStartUrl: event.credentialStartUrl,
                             },
                             {
                                 percentage: event.codewhispererPercentage,

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
@@ -1800,19 +1800,24 @@ describe('CodeWhisperer Server', () => {
 
                 await clock.tickAsync(5 * 60 * 1000 + 30)
 
-                sinon.assert.calledOnceWithExactly(telemetryServiceSpy, {
-                    sessionId: 'cwspr-session-id',
-                    requestId: 'cwspr-request-id',
-                    languageId: 'csharp',
-                    customizationArn: undefined,
-                    timestamp: new Date(startTime.getTime() + 5 * 60 * 1000),
-                    acceptedCharacterCount: 14,
-                    modificationPercentage: 0.9285714285714286,
-                    unmodifiedAcceptedCharacterCount: 1,
-                    completionType: 'Line',
-                    triggerType: 'OnDemand',
-                    credentialStartUrl: undefined,
-                })
+                sinon.assert.calledOnceWithExactly(
+                    telemetryServiceSpy,
+                    {
+                        sessionId: 'cwspr-session-id',
+                        requestId: 'cwspr-request-id',
+                        languageId: 'csharp',
+                        customizationArn: undefined,
+                        timestamp: new Date(startTime.getTime() + 5 * 60 * 1000),
+                        acceptedCharacterCount: 14,
+                        modificationPercentage: 0.9285714285714286,
+                        unmodifiedAcceptedCharacterCount: 1,
+                    },
+                    {
+                        completionType: 'Line',
+                        triggerType: 'OnDemand',
+                        credentialStartUrl: undefined,
+                    }
+                )
             })
         })
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
@@ -1392,6 +1392,13 @@ describe('CodeWhisperer Server', () => {
         })
 
         it('should emit Success ServiceInvocation telemetry on successful response', async () => {
+            await updateConfiguration(
+                features,
+                Promise.resolve({
+                    includeImportsWithSuggestions: true,
+                })
+            )
+
             await features.doInlineCompletionWithReferences(
                 {
                     textDocument: { uri: SOME_FILE.uri },
@@ -1421,6 +1428,8 @@ describe('CodeWhisperer Server', () => {
                     codewhispererSupplementalContextLatency: undefined,
                     codewhispererSupplementalContextLength: undefined,
                     codewhispererCustomizationArn: undefined,
+                    result: 'Succeeded',
+                    codewhispererImportRecommendationEnabled: true,
                 },
             }
             sinon.assert.calledOnceWithExactly(features.telemetry.emitMetric, expectedServiceInvocationMetric)
@@ -1469,6 +1478,8 @@ describe('CodeWhisperer Server', () => {
                     codewhispererSupplementalContextLatency: undefined,
                     codewhispererSupplementalContextLength: undefined,
                     codewhispererCustomizationArn: undefined,
+                    result: 'Succeeded',
+                    codewhispererImportRecommendationEnabled: false,
                 },
             }
             sinon.assert.calledOnceWithExactly(features.telemetry.emitMetric, expectedServiceInvocationMetric)
@@ -1508,6 +1519,9 @@ describe('CodeWhisperer Server', () => {
                     codewhispererSupplementalContextLatency: undefined,
                     codewhispererSupplementalContextLength: undefined,
                     codewhispererCustomizationArn: undefined,
+                    result: 'Failed',
+                    codewhispererImportRecommendationEnabled: undefined,
+                    traceId: 'notSet',
                 },
                 errorData: {
                     reason: 'TestError',
@@ -1550,6 +1564,9 @@ describe('CodeWhisperer Server', () => {
                     codewhispererSupplementalContextLatency: undefined,
                     codewhispererSupplementalContextLength: undefined,
                     codewhispererCustomizationArn: undefined,
+                    result: 'Failed',
+                    codewhispererImportRecommendationEnabled: undefined,
+                    traceId: 'notSet',
                 },
                 errorData: {
                     reason: 'UnknownError',
@@ -1604,6 +1621,9 @@ describe('CodeWhisperer Server', () => {
                     codewhispererSupplementalContextLatency: undefined,
                     codewhispererSupplementalContextLength: undefined,
                     codewhispererCustomizationArn: undefined,
+                    result: 'Failed',
+                    codewhispererImportRecommendationEnabled: undefined,
+                    traceId: 'notSet',
                 },
                 errorData: {
                     reason: 'TestAWSError',
@@ -1637,6 +1657,8 @@ describe('CodeWhisperer Server', () => {
                     codewhispererLanguage: 'csharp',
                     credentialStartUrl: undefined,
                     codewhispererCustomizationArn: undefined,
+                    result: 'Succeeded',
+                    passive: true,
                 },
             }
             sinon.assert.calledWithExactly(features.telemetry.emitMetric, expectedPerceivedLatencyMetric)
@@ -1745,6 +1767,9 @@ describe('CodeWhisperer Server', () => {
                     startPosition: { line: 0, character: 0 },
                     endPosition: { line: 0, character: 14 },
                     customizationArn: undefined,
+                    completionType: 'Line',
+                    triggerType: 'OnDemand',
+                    credentialStartUrl: undefined,
                 })
             })
 
@@ -1784,6 +1809,9 @@ describe('CodeWhisperer Server', () => {
                     acceptedCharacterCount: 14,
                     modificationPercentage: 0.9285714285714286,
                     unmodifiedAcceptedCharacterCount: 1,
+                    completionType: 'Line',
+                    triggerType: 'OnDemand',
+                    credentialStartUrl: undefined,
                 })
             })
         })

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -118,6 +118,8 @@ const emitServiceInvocationTelemetry = (telemetry: Telemetry, session: CodeWhisp
         codewhispererSupplementalContextLatency: session.supplementalMetadata?.latency,
         codewhispererSupplementalContextLength: session.supplementalMetadata?.contentsLength,
         codewhispererCustomizationArn: session.customizationArn,
+        result: 'Succeeded',
+        codewhispererImportRecommendationEnabled: session.includeImportsWithSuggestions,
     }
     telemetry.emitMetric({
         name: 'codewhisperer_serviceInvocation',
@@ -147,6 +149,9 @@ const emitServiceInvocationFailure = (telemetry: Telemetry, session: CodeWhisper
         codewhispererSupplementalContextLatency: session.supplementalMetadata?.latency,
         codewhispererSupplementalContextLength: session.supplementalMetadata?.contentsLength,
         codewhispererCustomizationArn: session.customizationArn,
+        codewhispererImportRecommendationEnabled: session.includeImportsWithSuggestions,
+        result: 'Failed',
+        traceId: 'notSet',
     }
 
     telemetry.emitMetric({
@@ -172,6 +177,8 @@ const emitPerceivedLatencyTelemetry = (telemetry: Telemetry, session: CodeWhispe
         codewhispererLanguage: session.language,
         credentialStartUrl: session.credentialStartUrl,
         codewhispererCustomizationArn: session.customizationArn,
+        result: 'Succeeded',
+        passive: true,
     }
 
     telemetry.emitMetric({
@@ -255,6 +262,9 @@ interface AcceptedInlineSuggestionEntry extends AcceptedSuggestionEntry {
     requestId: string
     languageId: CodewhispererLanguage
     customizationArn?: string
+    completionType: string
+    triggerType: string
+    credentialStartUrl?: string | undefined
 }
 
 export const CodewhispererServerFactory =
@@ -461,6 +471,8 @@ export const CodewhispererServerFactory =
             codePercentageTracker.countInvocation(session.language)
 
             userWrittenCodeTracker?.recordUsageCount(session.language)
+            session.includeImportsWithSuggestions =
+                amazonQServiceManager.getConfiguration().includeImportsWithSuggestions
 
             if (isNewSession) {
                 // Populate the session with information from codewhisperer response
@@ -546,6 +558,12 @@ export const CodewhispererServerFactory =
                 if (cachedSuggestion) cachedSuggestion.insertText = suggestion.insertText.toString()
             })
 
+            session.codewhispererSuggestionImportCount =
+                session.codewhispererSuggestionImportCount +
+                suggestionsWithRightContext.reduce((total, suggestion) => {
+                    return total + (suggestion.mostRelevantMissingImports?.length || 0)
+                }, 0)
+
             // If after all server-side filtering no suggestions can be displayed, and there is no nextToken
             // close session and return empty results
             if (suggestionsWithRightContext.length === 0 && !suggestionResponse.responseContext.nextToken) {
@@ -593,6 +611,9 @@ export const CodewhispererServerFactory =
                 startPosition: session.startPosition,
                 endPosition: endPosition,
                 customizationArn: session.customizationArn,
+                completionType: getCompletionType(acceptedSuggestion),
+                triggerType: session.triggerType,
+                credentialStartUrl: session.credentialStartUrl,
             })
         }
 
@@ -695,6 +716,9 @@ export const CodewhispererServerFactory =
                         acceptedCharacterCount: entry.originalString.length,
                         modificationPercentage: percentage,
                         unmodifiedAcceptedCharacterCount: unmodifiedAcceptedCharacterCount,
+                        completionType: entry.completionType,
+                        triggerType: entry.triggerType,
+                        credentialStartUrl: entry.credentialStartUrl,
                     })
                 }
             )

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -707,19 +707,23 @@ export const CodewhispererServerFactory =
                 workspace,
                 logging,
                 async (entry: AcceptedInlineSuggestionEntry, percentage, unmodifiedAcceptedCharacterCount) => {
-                    await telemetryService.emitUserModificationEvent({
-                        sessionId: entry.sessionId,
-                        requestId: entry.requestId,
-                        languageId: entry.languageId,
-                        customizationArn: entry.customizationArn,
-                        timestamp: new Date(),
-                        acceptedCharacterCount: entry.originalString.length,
-                        modificationPercentage: percentage,
-                        unmodifiedAcceptedCharacterCount: unmodifiedAcceptedCharacterCount,
-                        completionType: entry.completionType,
-                        triggerType: entry.triggerType,
-                        credentialStartUrl: entry.credentialStartUrl,
-                    })
+                    await telemetryService.emitUserModificationEvent(
+                        {
+                            sessionId: entry.sessionId,
+                            requestId: entry.requestId,
+                            languageId: entry.languageId,
+                            customizationArn: entry.customizationArn,
+                            timestamp: new Date(),
+                            acceptedCharacterCount: entry.originalString.length,
+                            modificationPercentage: percentage,
+                            unmodifiedAcceptedCharacterCount: unmodifiedAcceptedCharacterCount,
+                        },
+                        {
+                            completionType: entry.completionType,
+                            triggerType: entry.triggerType,
+                            credentialStartUrl: entry.credentialStartUrl,
+                        }
+                    )
                 }
             )
 

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
@@ -69,6 +69,8 @@ export class CodeWhispererSession {
     previousTriggerDecisionTime?: number
     reportedUserDecision: boolean = false
     customizationArn?: string
+    includeImportsWithSuggestions?: boolean
+    codewhispererSuggestionImportCount: number = 0
 
     constructor(data: SessionData) {
         this.id = this.generateSessionId()

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetry.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetry.test.ts
@@ -120,6 +120,7 @@ class HelloWorld
                     customizationArn: undefined,
                     totalCharacterCount: totalInsertCharacters,
                     acceptedCharacterCount: codeWhispererCharacters,
+                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: codePercentage,

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetry.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetry.test.ts
@@ -120,11 +120,11 @@ class HelloWorld
                     customizationArn: undefined,
                     totalCharacterCount: totalInsertCharacters,
                     acceptedCharacterCount: codeWhispererCharacters,
-                    credentialStartUrl: undefined,
                 },
                 {
                     percentage: codePercentage,
                     successCount: 1,
+                    credentialStartUrl: undefined,
                 }
             )
         })

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -106,6 +106,7 @@ describe('TelemetryService', () => {
             line: 12,
             character: 23,
         },
+        codewhispererSuggestionImportCount: 10,
     }
 
     beforeEach(() => {
@@ -315,6 +316,9 @@ describe('TelemetryService', () => {
                 codewhispererSupplementalContextIsUtg: undefined,
                 codewhispererSupplementalContextLength: undefined,
                 codewhispererCustomizationArn: 'test-arn',
+                codewhispererCharactersAccepted: 17,
+                codewhispererSuggestionImportCount: 10,
+                codewhispererSupplementalContextStrategyId: undefined,
             },
         })
     })
@@ -566,6 +570,8 @@ describe('TelemetryService', () => {
                 codewhispererSuggestedTokens: 123,
                 codewhispererPercentage: 50,
                 successCount: 1,
+                codewhispererCustomizationArn: 'test-arn',
+                credentialStartUrl: undefined,
             },
         })
     })
@@ -603,8 +609,9 @@ describe('TelemetryService', () => {
                 startUrl: 'idc-start-url',
             },
         })
-        telemetryService = new TelemetryService(serviceManagerStub, mockCredentialsProvider, {} as Telemetry, logging)
+        telemetryService = new TelemetryService(serviceManagerStub, mockCredentialsProvider, telemetry, logging)
         telemetryService.updateOptOutPreference('OPTIN')
+        telemetryService.updateEnableTelemetryEventsToDestination(true)
 
         telemetryService.emitUserModificationEvent({
             sessionId: 'test-session-id',
@@ -615,6 +622,9 @@ describe('TelemetryService', () => {
             modificationPercentage: 0.2,
             acceptedCharacterCount: 100,
             unmodifiedAcceptedCharacterCount: 80,
+            completionType: 'test-completion-type',
+            triggerType: 'test-trigger-type',
+            credentialStartUrl: 'test-url',
         })
 
         const expectedEvent = {
@@ -634,6 +644,20 @@ describe('TelemetryService', () => {
             },
             optOutPreference: 'OPTIN',
         }
+        sinon.assert.calledOnceWithExactly(telemetry.emitMetric as sinon.SinonStub, {
+            name: 'codewhisperer_userModification',
+            data: {
+                codewhispererRequestId: 'test-request-id',
+                codewhispererSessionId: 'test-session-id',
+                codewhispererCompletionType: 'test-completion-type',
+                codewhispererTriggerType: 'test-trigger-type',
+                codewhispererLanguage: 'typescript',
+                codewhispererModificationPercentage: 0.2,
+                credentialStartUrl: 'test-url',
+                codewhispererCharactersAccepted: 100,
+                codewhispererCharactersModified: 80,
+            },
+        })
         sinon.assert.calledOnceWithExactly(codeWhisperServiceStub.sendTelemetryEvent, expectedEvent)
     })
 

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -613,19 +613,23 @@ describe('TelemetryService', () => {
         telemetryService.updateOptOutPreference('OPTIN')
         telemetryService.updateEnableTelemetryEventsToDestination(true)
 
-        telemetryService.emitUserModificationEvent({
-            sessionId: 'test-session-id',
-            requestId: 'test-request-id',
-            languageId: 'typescript',
-            customizationArn: 'test-arn',
-            timestamp: new Date(),
-            modificationPercentage: 0.2,
-            acceptedCharacterCount: 100,
-            unmodifiedAcceptedCharacterCount: 80,
-            completionType: 'test-completion-type',
-            triggerType: 'test-trigger-type',
-            credentialStartUrl: 'test-url',
-        })
+        telemetryService.emitUserModificationEvent(
+            {
+                sessionId: 'test-session-id',
+                requestId: 'test-request-id',
+                languageId: 'typescript',
+                customizationArn: 'test-arn',
+                timestamp: new Date(),
+                modificationPercentage: 0.2,
+                acceptedCharacterCount: 100,
+                unmodifiedAcceptedCharacterCount: 80,
+            },
+            {
+                completionType: 'test-completion-type',
+                triggerType: 'test-trigger-type',
+                credentialStartUrl: 'test-url',
+            }
+        )
 
         const expectedEvent = {
             telemetryEvent: {

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -317,30 +317,34 @@ export class TelemetryService {
         })
     }
 
-    public emitUserModificationEvent(params: {
-        sessionId: string
-        requestId: string
-        languageId: CodewhispererLanguage
-        customizationArn?: string
-        timestamp: Date
-        modificationPercentage: number
-        acceptedCharacterCount: number
-        unmodifiedAcceptedCharacterCount: number
-        completionType: string
-        triggerType: string
-        credentialStartUrl: string | undefined
-    }) {
+    public emitUserModificationEvent(
+        params: {
+            sessionId: string
+            requestId: string
+            languageId: CodewhispererLanguage
+            customizationArn?: string
+            timestamp: Date
+            modificationPercentage: number
+            acceptedCharacterCount: number
+            unmodifiedAcceptedCharacterCount: number
+        },
+        additionalParams: {
+            completionType: string
+            triggerType: string
+            credentialStartUrl: string | undefined
+        }
+    ) {
         if (this.enableTelemetryEventsToDestination) {
             const data: CodeWhispererUserModificationEvent = {
                 codewhispererRequestId: params.requestId,
                 codewhispererSessionId: params.sessionId,
-                codewhispererCompletionType: params.completionType,
-                codewhispererTriggerType: params.triggerType,
+                codewhispererCompletionType: additionalParams.completionType,
+                codewhispererTriggerType: additionalParams.triggerType,
                 codewhispererLanguage: getRuntimeLanguage(params.languageId),
                 codewhispererModificationPercentage: params.modificationPercentage,
                 codewhispererCharactersAccepted: params.acceptedCharacterCount,
                 codewhispererCharactersModified: params.unmodifiedAcceptedCharacterCount,
-                credentialStartUrl: params.credentialStartUrl,
+                credentialStartUrl: additionalParams.credentialStartUrl,
             }
             this.telemetry.emitMetric({
                 name: 'codewhisperer_userModification',
@@ -373,11 +377,11 @@ export class TelemetryService {
             customizationArn?: string
             userWrittenCodeCharacterCount?: number
             userWrittenCodeLineCount?: number
-            credentialStartUrl?: string
         },
         additionalParams: Partial<{
             percentage: number
             successCount: number
+            credentialStartUrl?: string
         }>
     ) {
         if (this.enableTelemetryEventsToDestination) {
@@ -390,7 +394,7 @@ export class TelemetryService {
                     codewhispererPercentage: additionalParams.percentage,
                     successCount: additionalParams.successCount,
                     codewhispererCustomizationArn: params.customizationArn,
-                    credentialStartUrl: params.credentialStartUrl,
+                    credentialStartUrl: additionalParams.credentialStartUrl,
                 },
             })
         }

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -25,6 +25,9 @@ export interface CodeWhispererServiceInvocationEvent {
     codewhispererSupplementalContextIsUtg?: boolean
     codewhispererSupplementalContextLatency?: number
     codewhispererSupplementalContextLength?: number
+    codewhispererImportRecommendationEnabled?: boolean
+    result?: 'Succeeded' | 'Failed'
+    traceId?: string
 }
 
 export interface CodeWhispererPerceivedLatencyEvent {
@@ -36,6 +39,8 @@ export interface CodeWhispererPerceivedLatencyEvent {
     codewhispererLanguage: CodewhispererLanguage
     credentialStartUrl?: string
     codewhispererCustomizationArn?: string
+    passive?: boolean
+    result?: 'Succeeded' | 'Failed'
 }
 
 export interface CodeWhispererUserTriggerDecisionEvent {
@@ -64,8 +69,24 @@ export interface CodeWhispererUserTriggerDecisionEvent {
     codewhispererSupplementalContextTimeout?: boolean
     codewhispererSupplementalContextIsUtg?: boolean
     codewhispererSupplementalContextLength?: number
+    codewhispererCharactersAccepted?: number
+    codewhispererSuggestionImportCount?: number
+    codewhispererSupplementalContextStrategyId?: string
 }
 
+export interface CodeWhispererUserModificationEvent {
+    codewhispererRequestId?: string
+    codewhispererSessionId?: string
+    codewhispererCompletionType?: string
+    codewhispererTriggerType: string
+    codewhispererLanguage: string
+    codewhispererModificationPercentage: number
+    credentialStartUrl?: string
+    codewhispererCharactersAccepted?: number
+    codewhispererCharactersModified?: number
+}
+
+// 2tracker
 export interface CodeWhispererCodePercentageEvent {
     codewhispererTotalTokens: number
     codewhispererLanguage: string
@@ -73,6 +94,8 @@ export interface CodeWhispererCodePercentageEvent {
     codewhispererSuggestedTokens: number
     codewhispererPercentage: number
     successCount: number
+    codewhispererCustomizationArn?: string
+    credentialStartUrl?: string
 }
 
 export interface UserWrittenPercentageEvent {


### PR DESCRIPTION
## Problem

Comparing to the telemetry sent by VSC plugin, there are some attributes in the telemetries emitted from LS are missing. 

## Solution

Add missing attributes, testing by adding unit test
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
