### PR TITLE
fix: don't force commit-lint locally

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,0 @@
-echo [pre-commit] linting commit message...
-npm run commitlint ${1}
-echo [pre-commit] done linting commit message


### PR DESCRIPTION
## Problem:

Forcing commit-lint locally is very disruptive. It adds friction to local development, and gains little because:

- commits will be checked in CI
- most PRs are squash-merged anyway

## Solution:

Drop the local hook.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
