### PR TITLE
fix: add requestIds for each LLM call for amazonq_addMessage metric

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -578,6 +578,12 @@ export class AgenticChatController implements ChatHandlers {
             // Phase 3: Request Execution
             this.#truncateRequest(currentRequestInput)
             const response = await session.generateAssistantResponse(currentRequestInput)
+
+            if (response.$metadata.requestId) {
+                metric.mergeWith({
+                    requestIds: [response.$metadata.requestId],
+                })
+            }
             this.#features.logging.info(
                 `generateAssistantResponse ResponseMetadata: ${loggingUtils.formatObj(response.$metadata)}`
             )
@@ -665,6 +671,7 @@ export class AgenticChatController implements ChatHandlers {
                     shouldDisplayMessage = false
                 }
                 metric.setDimension('cwsprChatConversationType', 'AgenticChatWithToolUse')
+                metric.setDimension('requestIds', metric.metric.requestIds)
             } else {
                 // Send an error card to UI?
                 toolResults = pendingToolUses.map(toolUse => ({

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -242,6 +242,7 @@ export class ChatTelemetryController {
                 cwsprChatCodeContextCount: metric.cwsprChatCodeContextCount,
                 cwsprChatFocusFileContextLength: metric.cwsprChatFocusFileContextLength,
                 languageServerVersion: metric.languageServerVersion,
+                requestIds: metric.requestIds,
             }
         )
     }

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -801,6 +801,7 @@ describe('TelemetryService', () => {
                     codewhispererCustomizationArn: 'cust-123',
                     result: 'Succeeded',
                     languageServerVersion: undefined,
+                    requestIds: undefined,
                     cwsprChatHasContextList: true,
                     cwsprChatFolderContextCount: 0,
                     cwsprChatFileContextCount: 0,

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -457,12 +457,15 @@ export class TelemetryService {
             cwsprChatCodeContextLength: number
             cwsprChatFocusFileContextLength: number
             languageServerVersion?: string
+            requestIds?: string[]
         }>
     ) {
         if (!params.conversationId || !params.messageId) {
             return
         }
         const timeBetweenChunks = params.timeBetweenChunks?.slice(0, 100)
+        // truncate requestIds if longer than 875 so it does not go over field limit
+        const truncatedRequestIds = additionalParams.requestIds?.slice(0, 875)
 
         if (this.enableTelemetryEventsToDestination) {
             this.telemetry.emitMetric({
@@ -502,6 +505,7 @@ export class TelemetryService {
                     cwsprChatCodeContextLength: additionalParams.cwsprChatCodeContextLength,
                     result: 'Succeeded',
                     languageServerVersion: additionalParams.languageServerVersion,
+                    requestIds: truncatedRequestIds,
                 },
             })
         }

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -250,6 +250,7 @@ export type AddMessageEvent = {
     cwsprChatConversationType: ChatConversationType
     codewhispererCustomizationArn?: string
     languageServerVersion?: string
+    requestIds?: string[]
 
     // context related metrics
     cwsprChatHasContextList?: boolean


### PR DESCRIPTION
## Problem
- In the new agentic chat after a user types a message, it may trigger multiple LLM calls, but we only store the final LLM requestID (cwsprChatMessageId), which is the one that generates the response shown to the user. Earlier LLM calls in the sequence, which handle internal processing and aren't visible to users, are not currently emitted.


## Solution
- Emit all LLM RequestIDs in the order that these requests were made in amazonq_addMessage
    -  Will truncate any RequestIDs after 875 based on limit testing

## Verification
```
[debug] telemetry: amazonq_addMessage {
  Metadata: {
    metricId: '8d797efd-7c07-4256-baf0-d20e323a0f0c',
    traceId: '51be1d87-e728-4576-bdcb-a60575c780b2',
    parentId: '91f1f5fb-18f3-44d2-8617-6b97bd4f83d7',
    credentialStartUrl: 'https://amzn.awsapps.com/start',
    cwsprChatConversationId: '547a0b00-e946-4de7-9954-a455166e6e08',
    cwsprChatHasCodeSnippet: 'true',
    cwsprChatTriggerInteraction: 'click',
    cwsprChatMessageId: 'b26db8df-0da3-4b53-93f3-74261dab95c2',
    cwsprChatProgrammingLanguage: 'python',
    cwsprChatResponseCode: '200',
    cwsprChatSourceLinkCount: '0',
    cwsprChatReferencesCount: '0',
    cwsprChatFollowUpCount: '0',
    cwsprChatTimeToFirstChunk: '23727',
    cwsprChatFullResponseLatency: '79750',
    cwsprChatTimeBetweenChunks: '2,8,2,1,1,1,3,1,1747253186409,1,11,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1747253215430,2,7,2,1,1,5,2,1,1,1,1,1,1,2',
    cwsprChatRequestLength: '38',
    cwsprChatResponseLength: '611',
    cwsprChatConversationType: 'AgenticChatWithToolUse',
    cwsprChatActiveEditorTotalCharacters: '26448',
    cwsprChatHasContextList: 'false',
    cwsprChatFolderContextCount: '0',
    cwsprChatFileContextCount: '0',
    cwsprChatRuleContextCount: '0',
    cwsprChatPromptContextCount: '0',
    cwsprChatFileContextLength: '0',
    cwsprChatRuleContextLength: '0',
    cwsprChatPromptContextLength: '0',
    cwsprChatFocusFileContextLength: '9000',
    cwsprChatCodeContextCount: '0',
    cwsprChatCodeContextLength: '0',
    result: 'Succeeded',
    languageServerVersion: '0.1.0',
    requestIds: '64e985db-f780-4959-bf9a-c21a8644693f,74709c34-6913-4eeb-bd74-e522555ac256,b26db8df-0da3-4b53-93f3-74261dab95c2',
    awsAccount: 'not-set',
    awsRegion: 'us-east-1'
  },
  Value: 1,
  Unit: 'None',
  Passive: false
}
```

```
"history": [
      {
        "userInputMessage": {
          "content": "write a docstring for dict_to_sequence",
          "origin": "IDE",
          "userInputMessageContext": {
            "editorState": {
              "cursorState": {
                "range": {
                  "start": {
                    "line": 121,
                    "character": 24
                  },
                  "end": {
                    "line": 121,
                    "character": 24
                  }
                }
              },
              "document": {
                "text": "\"\"\"\nrequests.utils\n~~~~~~~~~~~~~~\n\nThis module provides utility functions that are used within Requests\nthat are also useful for external consumption.\n\"\"\"\n\nimport codecs\nimport contextlib\nimport io\nimport os\nimport re\nimport socket\nimport struct\nimport sys\nimport tempfile\nimport warnings\nimport zipfile\nfrom collections import OrderedDict\n\nfrom urllib3.util import make_headers, parse_url\n\nfrom . import certs\nfrom .__version__ import __version__\n\n# to_native_string is unused here, but imported here for backwards compatibility\nfrom ._internal_utils import (  # noqa: F401\n    _HEADER_VALIDATORS_BYTE,\n    _HEADER_VALIDATORS_STR,\n    HEADER_VALIDATORS,\n    to_native_string,\n)\nfrom .compat import (\n    Mapping,\n    basestring,\n    bytes,\n    getproxies,\n    getproxies_environment,\n    integer_types,\n    is_urllib3_1,\n)\nfrom .compat import parse_http_list as _parse_list_header\nfrom .compat import (\n    proxy_bypass,\n    proxy_bypass_environment,\n    quote,\n    str,\n    unquote,\n    urlparse,\n    urlunparse,\n)\nfrom .cookies import cookiejar_from_dict\nfrom .exceptions import (\n    FileModeWarning,\n    InvalidHeader,\n    InvalidURL,\n    UnrewindableBodyError,\n)\nfrom .structures import CaseInsensitiveDict\n\nNETRC_FILES = (\".netrc\", \"_netrc\")\n\nDEFAULT_CA_BUNDLE_PATH = certs.where()\n\nDEFAULT_PORTS = {\"http\": 80, \"https\": 443}\n\n# Ensure that ', ' is used to preserve previous delimiter behavior.\nDEFAULT_ACCEPT_ENCODING = \", \".join(\n    re.split(r\",\\s*\", make_headers(accept_encoding=True)[\"accept-encoding\"])\n)\n\n\nif sys.platform == \"win32\":\n    # provide a proxy_bypass version on Windows without DNS lookups\n\n    def proxy_bypass_registry(host):\n        try:\n            import winreg\n        except ImportError:\n            return False\n\n        try:\n            internetSettings = winreg.OpenKey(\n                winreg.HKEY_CURRENT_USER,\n                r\"Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\",\n            )\n            # ProxyEnable could be REG_SZ or REG_DWORD, normalizing it\n            proxyEnable = int(winreg.QueryValueEx(internetSettings, \"ProxyEnable\")[0])\n            # ProxyOverride is almost always a string\n            proxyOverride = winreg.QueryValueEx(internetSettings, \"ProxyOverride\")[0]\n        except (OSError, ValueError):\n            return False\n        if not proxyEnable or not proxyOverride:\n            return False\n\n        # make a check value list from the registry entry: replace the\n        # '<local>' string by the localhost entry and the corresponding\n        # canonical entry.\n        proxyOverride = proxyOverride.split(\";\")\n        # filter out empty strings to avoid re.match return true in the following code.\n        proxyOverride = filter(None, proxyOverride)\n        # now check if we match one of the registry values.\n        for test in proxyOverride:\n            if test == \"<local>\":\n                if \".\" not in host:\n                    return True\n            test = test.replace(\".\", r\"\\.\")  # mask dots\n            test = test.replace(\"*\", r\".*\")  # change glob sequence\n            test = test.replace(\"?\", r\".\")  # change glob char\n            if re.match(test, host, re.I):\n                return True\n        return False\n\n    def proxy_bypass(host):  # noqa\n        if getproxies_environment():\n            return proxy_bypass_environment(host)\n        else:\n            return proxy_bypass_registry(host)\n\n\ndef dict_to_sequence(d):\n    if hasattr(d, \"items\"):\n        d = d.items()\n\n    return d\n\n\ndef super_len(o):\n    total_length = None\n    current_position = 0\n\n    if not is_urllib3_1 and isinstance(o, str):\n        # urllib3 2.x+ treats all strings as utf-8 instead\n        # of latin-1 (iso-8859-1) like http.client.\n        o = o.encode(\"utf-8\")\n\n    if hasattr(o, \"__len__\"):\n        total_length = len(o)\n\n    elif hasattr(o, \"len\"):\n        total_length = o.len\n\n    elif hasattr(o, \"fileno\"):\n        try:\n            fileno = o.fileno()\n        except (io.UnsupportedOperation, AttributeError):\n            # AttributeError is a surprising exception, seeing as how we've just checked\n            # that `hasattr(o, 'fileno')`.  It happens for objects obtained via\n            # `Tarfile.extractfile()`, per issue 5229.\n            pass\n        else:\n            total_length = os.fstat(fileno).st_size\n\n            # Having used fstat to determine the file length, we need to\n            # confirm that this file was opened up in binary mode.\n            if \"b\" not in o.mode:\n                warnings.warn(\n                    (\n                        \"Requests has determined the content-length for this \"\n                        \"request using the binary size of the file: however, the \"\n                        \"file has been opened in text mode (i.e. without the 'b' \"\n                        \"flag in the mode). This may lead to an incorrect \"\n                        \"content-length. In Requests 3.0, support will be removed \"\n                        \"for files in text mode.\"\n                    ),\n                    FileModeWarning,\n                )\n\n    if hasattr(o, \"tell\"):\n        try:\n            current_position = o.tell()\n        except OSError:\n            # This can happen in some weird situations, such as when the file\n            # is actually a special file descriptor like stdin. In this\n            # instance, we don't know what the length is, so set it to zero and\n            # let requests chunk it instead.\n            if total_length is not None:\n                current_position = total_length\n        else:\n            if hasattr(o, \"seek\") and total_length is None:\n                # StringIO and BytesIO have seek but no usable fileno\n                try:\n                    # seek to end of file\n                    o.seek(0, 2)\n                    total_length = o.tell()\n\n                    # seek back to current position to support\n                    # partially read file-like objects\n                    o.seek(current_position or 0)\n                except OSError:\n                    total_length = 0\n\n    if total_length is None:\n        total_length = 0\n\n    return max(0, total_length - current_position)\n\n\ndef get_netrc_auth(url, raise_errors=False):\n\n    netrc_file = os.environ.get(\"NETRC\")\n    if netrc_file is not None:\n        netrc_locations = (netrc_file,)\n    else:\n        netrc_locations = (f\"~/{f}\" for f in NETRC_FILES)\n\n    try:\n        from netrc import NetrcParseError, netrc\n\n        netrc_path = None\n\n        for f in netrc_locations:\n            try:\n                loc = os.path.expanduser(f)\n            except KeyError:\n                # os.path.expanduser can fail when $HOME is undefined and\n                # getpwuid fails. See https://bugs.python.org/issue20164 &\n                # https://github.com/psf/requests/issues/1846\n                return\n\n            if os.path.exists(loc):\n                netrc_path = loc\n                break\n\n        # Abort early if there isn't one.\n        if netrc_path is None:\n            return\n\n        ri = urlparse(url)\n\n        # Strip port numbers from netloc. This weird `if...encode`` dance is\n        # used for Python 3.2, which doesn't support unicode literals.\n        splitstr = b\":\"\n        if isinstance(url, str):\n            splitstr = splitstr.decode(\"ascii\")\n        host = ri.netloc.split(splitstr)[0]\n\n        try:\n            _netrc = netrc(netrc_path).authenticators(host)\n            if _netrc:\n                # Return with login / password\n                login_i = 0 if _netrc[0] else 1\n                return (_netrc[login_i], _netrc[2])\n        except (NetrcParseError, OSError):\n            # If there was a parsing error or a permissions issue reading the file,\n            # we'll just skip netrc auth unless explicitly asked to raise errors.\n            if raise_errors:\n                raise\n\n    # App Engine hackiness.\n    except (ImportError, AttributeError):\n        pass\n\n\ndef guess_filename(obj):\n    name = getattr(obj, \"name\", None)\n    if name and isinstance(name, basestring) and name[0] != \"<\" and name[-1] != \">\":\n        return os.path.basename(name)\n\n\ndef extract_zipped_paths(path):\n    if os.path.exists(path):\n        # this is already a valid path, no need to do anything further\n        return path\n\n    # find the first valid part of the provided path and treat that as a zip archive\n    # assume the rest of the path is the name of a member in the archive\n    archive, member = os.path.split(path)\n    while archive and not os.path.exists(archive):\n        archive, prefix = os.path.split(archive)\n        if not prefix:\n            # If we don't check for an empty prefix after the split (in other words, archive remains unchanged after the split),\n            # we _can_ end up in an infinite loop on a rare corner case affecting a small number of users\n            break\n        member = \"/\".join([prefix, member])\n\n    if not zipfile.is_zipfile(archive):\n        return path\n\n    zip_file = zipfile.ZipFile(ar",
                "programmingLanguage": {
                  "languageName": "python"
                },
                "relativeFilePath": "src/requests/utils.py"
              },
              "useRelevantDocuments": false,
              "workspaceFolders": [
                "/Users/chungjac/repos/requests"
              ]
            }
          }
        }
      },
      {
        "assistantResponseMessage": {
          "content": "I'll write a docstring for the `dict_to_sequence` function in the requests.utils module. Let me first examine the function to understand what it does.",
          "toolUses": [
            {
              "toolUseId": "tooluse_KRn6MBLVTl--i5RvbNdQ0Q",
              "name": "fsRead",
              "input": {
                "paths": [
                  "/Users/chungjac/repos/requests/src/requests/utils.py"
                ]
              }
            }
          ]
        }
      },
      {
        "userInputMessage": {
          "content": "",
          "origin": "IDE",
          "userInputMessageContext": {
            "toolResults": [
              {
                "toolUseId": "tooluse_KRn6MBLVTl--i5RvbNdQ0Q",
                "status": "success",
                "content": [
                  {
                    "json": {
                      "output": {
                        "kind": "json",
                        "content": [
                          {
                            "path": "/Users/chungjac/repos/requests/src/requests/utils.py",
                            "content": "\"\"\"\nrequests.utils\n~~~~~~~~~~~~~~\n\nThis module provides utility functions that are used within Requests\nthat are also useful for external consumption.\n\"\"\"\n\nimport codecs\nimport contextlib\nimport io\nimport os\nimport re\nimport socket\nimport struct\nimport sys\nimport tempfile\nimport warnings\nimport zipfile\nfrom collections import OrderedDict\n\nfrom urllib3.util import make_headers, parse_url\n\nfrom . import certs\nfrom .__version__ import __version__\n\n# to_native_string is unused here, but imported here for backwards compatibility\nfrom ._internal_utils import (  # noqa: F401\n    _HEADER_VALIDATORS_BYTE,\n    _HEADER_VALIDATORS_STR,\n    HEADER_VALIDATORS,\n    to_native_string,\n)\nfrom .compat import (\n    Mapping,\n    basestring,\n    bytes,\n    getproxies,\n    getproxies_environment,\n    integer_types,\n    is_urllib3_1,\n)\nfrom .compat import parse_http_list as _parse_list_header\nfrom .compat import (\n    proxy_bypass,\n    proxy_bypass_environment,\n    quote,\n    str,\n    unquote,\n    urlparse,\n    urlunparse,\n)\nfrom .cookies import cookiejar_from_dict\nfrom .exceptions import (\n    FileModeWarning,\n    InvalidHeader,\n    InvalidURL,\n    UnrewindableBodyError,\n)\nfrom .structures import CaseInsensitiveDict\n\nNETRC_FILES = (\".netrc\", \"_netrc\")\n\nDEFAULT_CA_BUNDLE_PATH = certs.where()\n\nDEFAULT_PORTS = {\"http\": 80, \"https\": 443}\n\n# Ensure that ', ' is used to preserve previous delimiter behavior.\nDEFAULT_ACCEPT_ENCODING = \", \".join(\n    re.split(r\",\\s*\", make_headers(accept_encoding=True)[\"accept-encoding\"])\n)\n\n\nif sys.platform == \"win32\":\n    # provide a proxy_bypass version on Windows without DNS lookups\n\n    def proxy_bypass_registry(host):\n        try:\n            import winreg\n        except ImportError:\n            return False\n\n        try:\n            internetSettings = winreg.OpenKey(\n                winreg.HKEY_CURRENT_USER,\n                r\"Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\",\n            )\n            # ProxyEnable could be REG_SZ or REG_DWORD, normalizing it\n            proxyEnable = int(winreg.QueryValueEx(internetSettings, \"ProxyEnable\")[0])\n            # ProxyOverride is almost always a string\n            proxyOverride = winreg.QueryValueEx(internetSettings, \"ProxyOverride\")[0]\n        except (OSError, ValueError):\n            return False\n        if not proxyEnable or not proxyOverride:\n            return False\n\n        # make a check value list from the registry entry: replace the\n        # '<local>' string by the localhost entry and the corresponding\n        # canonical entry.\n        proxyOverride = proxyOverride.split(\";\")\n        # filter out empty strings to avoid re.match return true in the following code.\n        proxyOverride = filter(None, proxyOverride)\n        # now check if we match one of the registry values.\n        for test in proxyOverride:\n            if test == \"<local>\":\n                if \".\" not in host:\n                    return True\n            test = test.replace(\".\", r\"\\.\")  # mask dots\n            test = test.replace(\"*\", r\".*\")  # change glob sequence\n            test = test.replace(\"?\", r\".\")  # change glob char\n            if re.match(test, host, re.I):\n                return True\n        return False\n\n    def proxy_bypass(host):  # noqa\n        if getproxies_environment():\n            return proxy_bypass_environment(host)\n        else:\n            return proxy_bypass_registry(host)\n\n\ndef dict_to_sequence(d):\n    if hasattr(d, \"items\"):\n        d = d.items()\n\n    return d\n\n\ndef super_len(o):\n    total_length = None\n    current_position = 0\n\n    if not is_urllib3_1 and isinstance(o, str):\n        # urllib3 2.x+ treats all strings as utf-8 instead\n        # of latin-1 (iso-8859-1) like http.client.\n        o = o.encode(\"utf-8\")\n\n    if hasattr(o, \"__len__\"):\n        total_length = len(o)\n\n    elif hasattr(o, \"len\"):\n        total_length = o.len\n\n    elif hasattr(o, \"fileno\"):\n        try:\n            fileno = o.fileno()\n        except (io.UnsupportedOperation, AttributeError):\n            # AttributeError is a surprising exception, seeing as how we've just checked\n            # that `hasattr(o, 'fileno')`.  It happens for objects obtained via\n            # `Tarfile.extractfile()`, per issue 5229.\n            pass\n        else:\n            total_length = os.fstat(fileno).st_size\n\n            # Having used fstat to determine the file length, we need to\n            # confirm that this file was opened up in binary mode.\n            if \"b\" not in o.mode:\n                warnings.warn(\n                    (\n                        \"Requests has determined the content-length for this \"\n                        \"request using the binary size of the file: however, the \"\n                        \"file has been opened in text mode (i.e. without the 'b' \"\n                        \"flag in the mode). This may lead to an incorrect \"\n                        \"content-length. In Requests 3.0, support will be removed \"\n                        \"for files in text mode.\"\n                    ),\n                    FileModeWarning,\n                )\n\n    if hasattr(o, \"tell\"):\n        try:\n            current_position = o.tell()\n        except OSError:\n            # This can happen in some weird situations, such as when the file\n            # is actually a special file descriptor like stdin. In this\n            # instance, we don't know what the length is, so set it to zero and\n            # let requests chunk it instead.\n            if total_length is not None:\n                current_position = total_length\n        else:\n            if hasattr(o, \"seek\") and total_length is None:\n                # StringIO and BytesIO have seek but no usable fileno\n                try:\n                    # seek to end of file\n                    o.seek(0, 2)\n                    total_length = o.tell()\n\n                    # seek back to current position to support\n                    # partially read file-like objects\n                    o.seek(current_position or 0)\n                except OSError:\n                    total_length = 0\n\n    if total_length is None:\n        total_length = 0\n\n    return max(0, total_length - current_position)\n\n\ndef get_netrc_auth(url, raise_errors=False):\n\n    netrc_file = os.environ.get(\"NETRC\")\n    if netrc_file is not None:\n        netrc_locations = (netrc_file,)\n    else:\n        netrc_locations = (f\"~/{f}\" for f in NETRC_FILES)\n\n    try:\n        from netrc import NetrcParseError, netrc\n\n        netrc_path = None\n\n        for f in netrc_locations:\n            try:\n                loc = os.path.expanduser(f)\n            except KeyError:\n                # os.path.expanduser can fail when $HOME is undefined and\n                # getpwuid fails. See https://bugs.python.org/issue20164 &\n                # https://github.com/psf/requests/issues/1846\n                return\n\n            if os.path.exists(loc):\n                netrc_path = loc\n                break\n\n        # Abort early if there isn't one.\n        if netrc_path is None:\n            return\n\n        ri = urlparse(url)\n\n        # Strip port numbers from netloc. This weird `if...encode`` dance is\n        # used for Python 3.2, which doesn't support unicode literals.\n        splitstr = b\":\"\n        if isinstance(url, str):\n            splitstr = splitstr.decode(\"ascii\")\n        host = ri.netloc.split(splitstr)[0]\n\n        try:\n            _netrc = netrc(netrc_path).authenticators(host)\n            if _netrc:\n                # Return with login / password\n                login_i = 0 if _netrc[0] else 1\n                return (_netrc[login_i], _netrc[2])\n        except (NetrcParseError, OSError):\n            # If there was a parsing error or a permissions issue reading the file,\n            # we'll just skip netrc auth unless explicitly asked to raise errors.\n            if raise_errors:\n                raise\n\n    # App Engine hackiness.\n    except (ImportError, AttributeError):\n        pass\n\n\ndef guess_filename(obj):\n    name = getattr(obj, \"name\", None)\n    if name and isinstance(name, basestring) and name[0] != \"<\" and name[-1] != \">\":\n        return os.path.basename(name)\n\n\ndef extract_zipped_paths(path):\n    if os.path.exists(path):\n        # this is already a valid path, no need to do anything further\n        return path\n\n    # find the first valid part of the provided path and treat that as a zip archive\n    # assume the rest of the path is the name of a member in the archive\n    archive, member = os.path.split(path)\n    while archive and not os.path.exists(archive):\n        archive, prefix = os.path.split(archive)\n        if not prefix:\n            # If we don't check for an empty prefix after the split (in other words, archive remains unchanged after the split),\n            # we _can_ end up in an infinite loop on a rare corner case affecting a small number of users\n            break\n        member = \"/\".join([prefix, member])\n\n    if not zipfile.is_zipfile(archive):\n        return path\n\n    zip_file = zipfile.ZipFile(archive)\n    if member not in zip_file.namelist():\n        return path\n\n    # we have a valid zip archive and a valid member of that archive\n    tmp = tempfile.gettempdir()\n    extracted_path = os.path.join(tmp, member.split(\"/\")[-1])\n    if not os.path.exists(extracted_path):\n        # use read + write to avoid the creating nested folders, we only want the file, avoids mkdir racing condition\n        with atomic_open(extracted_path) as file_handler:\n            file_handler.write(zip_file.read(member))\n    return extracted_path\n\n\n@contextlib.contextmanager\ndef atomic_open(filename):\n    tmp_descriptor, tmp_name = tempfile.mkstemp(dir=os.path.dirname(filename))\n    try:\n        with os.fdopen(tmp_descriptor, \"wb\") as tmp_handler:\n            yield tmp_handler\n        os.replace(tmp_name, filename)\n    except BaseException:\n        os.remove(tmp_name)\n        raise\n\n\ndef from_key_val_list(value):\n    if value is None:\n        return None\n\n    if isinstance(value, (str, bytes, bool, int)):\n        raise ValueError(\"cannot encode objects that are not 2-tuples\")\n\n    return OrderedDict(value)\n\n\ndef to_key_val_list(value):\n    if value is None:\n        return None\n\n    if isinstance(value, (str, bytes, bool, int)):\n        raise ValueError(\"cannot encode objects that are not 2-tuples\")\n\n    if isinstance(value, Mapping):\n        value = value.items()\n\n    return list(value)\n\n\n# From mitsuhiko/werkzeug (used with permission).\ndef parse_list_header(value):\n    result = []\n    for item in _parse_list_header(value):\n        if item[:1] == item[-1:] == '\"':\n            item = unquote_header_value(item[1:-1])\n        result.append(item)\n    return result\n\n\n# From mitsuhiko/werkzeug (used with permission).\ndef parse_dict_header(value):\n    result = {}\n    for item in _parse_list_header(value):\n        if \"=\" not in item:\n            result[item] = None\n            continue\n        name, value = item.split(\"=\", 1)\n        if value[:1] == value[-1:] == '\"':\n            value = unquote_header_value(value[1:-1])\n        result[name] = value\n    return result\n\n\n# From mitsuhiko/werkzeug (used with permission).\ndef unquote_header_value(value, is_filename=False):\n    if value and value[0] == value[-1] == '\"':\n        # this is not the real unquoting, but fixing this so that the\n        # RFC is met will result in bugs with internet explorer and\n        # probably some other browsers as well.  IE for example is\n        # uploading files with \"C:\\foo\\bar.txt\" as filename\n        value = value[1:-1]\n\n        # if this is a filename and the starting characters look like\n        # a UNC path, then just return the value without quotes.  Using the\n        # replace sequence below on a UNC path has the effect of turning\n        # the leading double slash into a single slash and then\n        # _fix_ie_filename() doesn't work correctly.  See #458.\n        if not is_filename or value[:2] != \"\\\\\\\\\":\n            return value.replace(\"\\\\\\\\\", \"\\\\\").replace('\\\\\"', '\"')\n    return value\n\n\ndef dict_from_cookiejar(cj):\n\n    cookie_dict = {cookie.name: cookie.value for cookie in cj}\n    return cookie_dict\n\n\ndef add_dict_to_cookiejar(cj, cookie_dict):\n\n    return cookiejar_from_dict(cookie_dict, cj)\n\n\ndef get_encodings_from_content(content):\n    warnings.warn(\n        (\n            \"In requests 3.0, get_encodings_from_content will be removed. For \"\n            \"more information, please see the discussion on issue #2266. (This\"\n            \" warning should only appear once.)\"\n        ),\n        DeprecationWarning,\n    )\n\n    charset_re = re.compile(r'<meta.*?charset=[\"\\']*(.+?)[\"\\'>]', flags=re.I)\n    pragma_re = re.compile(r'<meta.*?content=[\"\\']*;?charset=(.+?)[\"\\'>]', flags=re.I)\n    xml_re = re.compile(r'^<\\?xml.*?encoding=[\"\\']*(.+?)[\"\\'>]')\n\n    return (\n        charset_re.findall(content)\n        + pragma_re.findall(content)\n        + xml_re.findall(content)\n    )\n\n\ndef _parse_content_type_header(header):\n\n    tokens = header.split(\";\")\n    content_type, params = tokens[0].strip(), tokens[1:]\n    params_dict = {}\n    items_to_strip = \"\\\"' \"\n\n    for param in params:\n        param = param.strip()\n        if param:\n            key, value = param, True\n            index_of_equals = param.find(\"=\")\n            if index_of_equals != -1:\n                key = param[:index_of_equals].strip(items_to_strip)\n                value = param[index_of_equals + 1 :].strip(items_to_strip)\n            params_dict[key.lower()] = value\n    return content_type, params_dict\n\n\ndef get_encoding_from_headers(headers):\n\n    content_type = headers.get(\"content-type\")\n\n    if not content_type:\n        return None\n\n    content_type, params = _parse_content_type_header(content_type)\n\n    if \"charset\" in params:\n        return params[\"charset\"].strip(\"'\\\"\")\n\n    if \"text\" in content_type:\n        return \"ISO-8859-1\"\n\n    if \"application/json\" in content_type:\n        # Assume UTF-8 based on RFC 4627: https://www.ietf.org/rfc/rfc4627.txt since the charset was unset\n        return \"utf-8\"\n\n\ndef stream_decode_response_unicode(iterator, r):\n\n    if r.encoding is None:\n        yield from iterator\n        return\n\n    decoder = codecs.getincrementaldecoder(r.encoding)(errors=\"replace\")\n    for chunk in iterator:\n        rv = decoder.decode(chunk)\n        if rv:\n            yield rv\n    rv = decoder.decode(b\"\", final=True)\n    if rv:\n        yield rv\n\n\ndef iter_slices(string, slice_length):\n    pos = 0\n    if slice_length is None or slice_length <= 0:\n        slice_length = len(string)\n    while pos < len(string):\n        yield string[pos : pos + slice_length]\n        pos += slice_length\n\n\ndef get_unicode_from_response(r):\n    warnings.warn(\n        (\n            \"In requests 3.0, get_unicode_from_response will be removed. For \"\n            \"more information, please see the discussion on issue #2266. (This\"\n            \" warning should only appear once.)\"\n        ),\n        DeprecationWarning,\n    )\n\n    tried_encodings = []\n\n    # Try charset from content-type\n    encoding = get_encoding_from_headers(r.headers)\n\n    if encoding:\n        try:\n            return str(r.content, encoding)\n        except UnicodeError:\n            tried_encodings.append(encoding)\n\n    # Fall back:\n    try:\n        return str(r.content, encoding, errors=\"replace\")\n    except TypeError:\n        return r.content\n\n\n# The unreserved URI characters (RFC 3986)\nUNRESERVED_SET = frozenset(\n    \"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\" + \"0123456789-._~\"\n)\n\n\ndef unquote_unreserved(uri):\n    parts = uri.split(\"%\")\n    for i in range(1, len(parts)):\n        h = parts[i][0:2]\n        if len(h) == 2 and h.isalnum():\n            try:\n                c = chr(int(h, 16))\n            except ValueError:\n                raise InvalidURL(f\"Invalid percent-escape sequence: '{h}'\")\n\n            if c in UNRESERVED_SET:\n                parts[i] = c + parts[i][2:]\n            else:\n                parts[i] = f\"%{parts[i]}\"\n        else:\n            parts[i] = f\"%{parts[i]}\"\n    return \"\".join(parts)\n\n\ndef requote_uri(uri):\n    safe_with_percent = \"!#$%&'()*+,/:;=?@[]~\"\n    safe_without_percent = \"!#$&'()*+,/:;=?@[]~\"\n    try:\n        # Unquote only the unreserved characters\n        # Then quote only illegal characters (do not quote reserved,\n        # unreserved, or '%')\n        return quote(unquote_unreserved(uri), safe=safe_with_percent)\n    except InvalidURL:\n        # We couldn't unquote the given URI, so let's try quoting it, but\n        # there may be unquoted '%'s in the URI. We need to make sure they're\n        # properly quoted so they do not cause issues elsewhere.\n        return quote(uri, safe=safe_without_percent)\n\n\ndef address_in_network(ip, net):\n    ipaddr = struct.unpack(\"=L\", socket.inet_aton(ip))[0]\n    netaddr, bits = net.split(\"/\")\n    netmask = struct.unpack(\"=L\", socket.inet_aton(dotted_netmask(int(bits))))[0]\n    network = struct.unpack(\"=L\", socket.inet_aton(netaddr))[0] & netmask\n    return (ipaddr & netmask) == (network & netmask)\n\n\ndef dotted_netmask(mask):\n    bits = 0xFFFFFFFF ^ (1 << 32 - mask) - 1\n    return socket.inet_ntoa(struct.pack(\">I\", bits))\n\n\ndef is_ipv4_address(string_ip):\n    try:\n        socket.inet_aton(string_ip)\n    except OSError:\n        return False\n    return True\n\n\ndef is_valid_cidr(string_network):\n    if string_network.count(\"/\") == 1:\n        try:\n            mask = int(string_network.split(\"/\")[1])\n        except ValueError:\n            return False\n\n        if mask < 1 or mask > 32:\n            return False\n\n        try:\n            socket.inet_aton(string_network.split(\"/\")[0])\n        except OSError:\n            return False\n    else:\n        return False\n    return True\n\n\n@contextlib.contextmanager\ndef set_environ(env_name, value):\n    value_changed = value is not None\n    if value_changed:\n        old_value = os.environ.get(env_name)\n        os.environ[env_name] = value\n    try:\n        yield\n    finally:\n        if value_changed:\n            if old_value is None:\n                del os.environ[env_name]\n            else:\n                os.environ[env_name] = old_value\n\n\ndef should_bypass_proxies(url, no_proxy):\n\n    # Prioritize lowercase environment variables over uppercase\n    # to keep a consistent behaviour with other http projects (curl, wget).\n    def get_proxy(key):\n        return os.environ.get(key) or os.environ.get(key.upper())\n\n    # First check whether no_proxy is defined. If it is, check that the URL\n    # we're getting isn't in the no_proxy list.\n    no_proxy_arg = no_proxy\n    if no_proxy is None:\n        no_proxy = get_proxy(\"no_proxy\")\n    parsed = urlparse(url)\n\n    if parsed.hostname is None:\n        # URLs don't always have hostnames, e.g. file:/// urls.\n        return True\n\n    if no_proxy:\n        # We need to check whether we match here. We need to see if we match\n        # the end of the hostname, both with and without the port.\n        no_proxy = (host for host in no_proxy.replace(\" \", \"\").split(\",\") if host)\n\n        if is_ipv4_address(parsed.hostname):\n            for proxy_ip in no_proxy:\n                if is_valid_cidr(proxy_ip):\n                    if address_in_network(parsed.hostname, proxy_ip):\n                        return True\n                elif parsed.hostname == proxy_ip:\n                    # If no_proxy ip was defined in plain IP notation instead of cidr notation &\n                    # matches the IP of the index\n                    return True\n        else:\n            host_with_port = parsed.hostname\n            if parsed.port:\n                host_with_port += f\":{parsed.port}\"\n\n            for host in no_proxy:\n                if parsed.hostname.endswith(host) or host_with_port.endswith(host):\n                    # The URL does match something in no_proxy, so we don't want\n                    # to apply the proxies on this URL.\n                    return True\n\n    with set_environ(\"no_proxy\", no_proxy_arg):\n        # parsed.hostname can be `None` in cases such as a file URI.\n        try:\n            bypass = proxy_bypass(parsed.hostname)\n        except (TypeError, socket.gaierror):\n            bypass = False\n\n    if bypass:\n        return True\n\n    return False\n\n\ndef get_environ_proxies(url, no_proxy=None):\n    if should_bypass_proxies(url, no_proxy=no_proxy):\n        return {}\n    else:\n        return getproxies()\n\n\ndef select_proxy(url, proxies):\n    proxies = proxies or {}\n    urlparts = urlparse(url)\n    if urlparts.hostname is None:\n        return proxies.get(urlparts.scheme, proxies.get(\"all\"))\n\n    proxy_keys = [\n        urlparts.scheme + \"://\" + urlparts.hostname,\n        urlparts.scheme,\n        \"all://\" + urlparts.hostname,\n        \"all\",\n    ]\n    proxy = None\n    for proxy_key in proxy_keys:\n        if proxy_key in proxies:\n            proxy = proxies[proxy_key]\n            break\n\n    return proxy\n\n\ndef resolve_proxies(request, proxies, trust_env=True):\n    proxies = proxies if proxies is not None else {}\n    url = request.url\n    scheme = urlparse(url).scheme\n    no_proxy = proxies.get(\"no_proxy\")\n    new_proxies = proxies.copy()\n\n    if trust_env and not should_bypass_proxies(url, no_proxy=no_proxy):\n        environ_proxies = get_environ_proxies(url, no_proxy=no_proxy)\n\n        proxy = environ_proxies.get(scheme, environ_proxies.get(\"all\"))\n\n        if proxy:\n            new_proxies.setdefault(scheme, proxy)\n    return new_proxies\n\n\ndef default_user_agent(name=\"python-requests\"):\n    return f\"{name}/{__version__}\"\n\n\ndef default_headers():\n    return CaseInsensitiveDict(\n        {\n            \"User-Agent\": default_user_agent(),\n            \"Accept-Encoding\": DEFAULT_ACCEPT_ENCODING,\n            \"Accept\": \"*/*\",\n            \"Connection\": \"keep-alive\",\n        }\n    )\n\n\ndef parse_header_links(value):\n\n    links = []\n\n    replace_chars = \" '\\\"\"\n\n    value = value.strip(replace_chars)\n    if not value:\n        return links\n\n    for val in re.split(\", *<\", value):\n        try:\n            url, params = val.split(\";\", 1)\n        except ValueError:\n            url, params = val, \"\"\n\n        link = {\"url\": url.strip(\"<> '\\\"\")}\n\n        for param in params.split(\";\"):\n            try:\n                key, value = param.split(\"=\")\n            except ValueError:\n                break\n\n            link[key.strip(replace_chars)] = value.strip(replace_chars)\n\n        links.append(link)\n\n    return links\n\n\n# Null bytes; no need to recreate these on each call to guess_json_utf\n_null = \"\\x00\".encode(\"ascii\")  # encoding to ASCII for Python 3\n_null2 = _null * 2\n_null3 = _null * 3\n\n\ndef guess_json_utf(data):\n    # JSON always starts with two ASCII characters, so detection is as\n    # easy as counting the nulls and from their location and count\n    # determine the encoding. Also detect a BOM, if present.\n    sample = data[:4]\n    if sample in (codecs.BOM_UTF32_LE, codecs.BOM_UTF32_BE):\n        return \"utf-32\"  # BOM included\n    if sample[:3] == codecs.BOM_UTF8:\n        return \"utf-8-sig\"  # BOM included, MS style (discouraged)\n    if sample[:2] in (codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE):\n        return \"utf-16\"  # BOM included\n    nullcount = sample.count(_null)\n    if nullcount == 0:\n        return \"utf-8\"\n    if nullcount == 2:\n        if sample[::2] == _null2:  # 1st and 3rd are null\n            return \"utf-16-be\"\n        if sample[1::2] == _null2:  # 2nd and 4th are null\n            return \"utf-16-le\"\n        # Did not detect 2 valid UTF-16 ascii-range characters\n    if nullcount == 3:\n        if sample[:3] == _null3:\n            return \"utf-32-be\"\n        if sample[1:] == _null3:\n            return \"utf-32-le\"\n        # Did not detect a valid UTF-32 ascii-range character\n    return None\n\n\ndef prepend_scheme_if_needed(url, new_scheme):\n    parsed = parse_url(url)\n    scheme, auth, host, port, path, query, fragment = parsed\n\n    # A defect in urlparse determines that there isn't a netloc present in some\n    # urls. We previously assumed parsing was overly cautious, and swapped the\n    # netloc and path. Due to a lack of tests on the original defect, this is\n    # maintained with parse_url for backwards compatibility.\n    netloc = parsed.netloc\n    if not netloc:\n        netloc, path = path, netloc\n\n    if auth:\n        # parse_url doesn't provide the netloc with auth\n        # so we'll add it ourselves.\n        netloc = \"@\".join([auth, netloc])\n    if scheme is None:\n        scheme = new_scheme\n    if path is None:\n        path = \"\"\n\n    return urlunparse((scheme, netloc, path, \"\", query, fragment))\n\n\ndef get_auth_from_url(url):\n    parsed = urlparse(url)\n\n    try:\n        auth = (unquote(parsed.username), unquote(parsed.password))\n    except (AttributeError, TypeError):\n        auth = (\"\", \"\")\n\n    return auth\n\n\ndef check_header_validity(header):\n    name, value = header\n    _validate_header_part(header, name, 0)\n    _validate_header_part(header, value, 1)\n\n\ndef _validate_header_part(header, header_part, header_validator_index):\n    if isinstance(header_part, str):\n        validator = _HEADER_VALIDATORS_STR[header_validator_index]\n    elif isinstance(header_part, bytes):\n        validator = _HEADER_VALIDATORS_BYTE[header_validator_index]\n    else:\n        raise InvalidHeader(\n            f\"Header part ({header_part!r}) from {header} \"\n            f\"must be of type str or bytes, not {type(header_part)}\"\n        )\n\n    if not validator.match(header_part):\n        header_kind = \"name\" if header_validator_index == 0 else \"value\"\n        raise InvalidHeader(\n            f\"Invalid leading whitespace, reserved character(s), or return \"\n            f\"character(s) in header {header_kind}: {header_part!r}\"\n        )\n\n\ndef urldefragauth(url):\n    scheme, netloc, path, params, query, fragment = urlparse(url)\n\n    # see func:`prepend_scheme_if_needed`\n    if not netloc:\n        netloc, path = path, netloc\n\n    netloc = netloc.rsplit(\"@\", 1)[-1]\n\n    return urlunparse((scheme, netloc, path, params, query, \"\"))\n\n\ndef rewind_body(prepared_request):\n    body_seek = getattr(prepared_request.body, \"seek\", None)\n    if body_seek is not None and isinstance(\n        prepared_request._body_position, integer_types\n    ):\n        try:\n            body_seek(prepared_request._body_position)\n        except OSError:\n            raise UnrewindableBodyError(\n                \"An error occurred when rewinding request body for redirect.\"\n            )\n    else:\n        raise UnrewindableBodyError(\"Unable to rewind request body for redirect.\")\n",
                            "truncated": false
                          }
                        ]
                      }
                    }
                  }
                ]
              }
            ]
          }
        }
      },
      {
        "assistantResponseMessage": {
          "content": "\n\nNow I'll write a docstring for the `dict_to_sequence` function based on its implementation:",
          "toolUses": [
            {
              "toolUseId": "tooluse_ox2y_rONQL6iL0L7ld14FA",
              "name": "fsWrite",
              "input": {
                "command": "strReplace",
                "path": "/Users/chungjac/repos/requests/src/requests/utils.py",
                "oldStr": "def dict_to_sequence(d):\n    if hasattr(d, \"items\"):\n        d = d.items()\n\n    return d",
                "newStr": "def dict_to_sequence(d):\n    \"\"\"Convert a dictionary-like object to a sequence of (key, value) tuples.\n    \n    If the provided object has an 'items' method, it calls that method to get the sequence.\n    Otherwise, it returns the object unchanged, assuming it's already a sequence.\n    \n    :param d: Dictionary-like object or sequence\n    :return: A sequence of (key, value) tuples or the unchanged input if already a sequence\n    \"\"\"\n    if hasattr(d, \"items\"):\n        d = d.items()\n\n    return d",
                "explanation": "Adding a docstring to the dict_to_sequence function that explains its purpose and parameters"
              }
            }
          ]
        }
      },
      {
        "userInputMessage": {
          "content": "",
          "origin": "IDE",
          "userInputMessageContext": {
            "toolResults": [
              {
                "toolUseId": "tooluse_ox2y_rONQL6iL0L7ld14FA",
                "status": "success",
                "content": [
                  {
                    "json": {
                      "output": {
                        "kind": "text",
                        "content": ""
                      }
                    }
                  }
                ]
              }
            ]
          }
        }
      },
      {
        "assistantResponseMessage": {
          "content": "\n\nI've added a docstring to the `dict_to_sequence` function that explains:\n\n1. What the function does - converts dictionary-like objects to sequences of (key, value) tuples\n2. How it works - checks for an `items` method and calls it if available\n3. The parameter and return value with their descriptions\n4. The behavior when the input is already a sequence\n\nThe docstring follows the standard format used in the requests library, with a clear description and parameter/return documentation using the `:param:` and `:return:` style.\n\nIs there anything else you'd like me to explain or modify about the docstring?",
          "toolUses": []
        }
      }
    ]
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
