### PR TITLE
fix: add robust validation logic to fixHistory

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -56,6 +56,9 @@ export const workspaceChunkMaxSize = 40_960
 // limit for the length of additionalContent
 export const additionalContextMaxLength = 100
 
+// maximum number of workspace folders allowed by the API
+export const maxWorkspaceFolders = 100
+
 export class AgenticChatTriggerContext {
     private static readonly DEFAULT_CURSOR_STATE: CursorState = { position: { line: 0, character: 0 } }
 
@@ -106,7 +109,8 @@ export class AgenticChatTriggerContext {
         additionalContent?: AdditionalContentEntryAddition[]
     ): Promise<GenerateAssistantResponseCommandInput> {
         const { prompt } = params
-        const defaultEditorState = { workspaceFolders: workspaceUtils.getWorkspaceFolderPaths(this.#lsp) }
+        const workspaceFolders = workspaceUtils.getWorkspaceFolderPaths(this.#lsp).slice(0, maxWorkspaceFolders)
+        const defaultEditorState = { workspaceFolders }
 
         const hasWorkspace = 'context' in params ? params.context?.some(c => c.command === '@workspace') : false
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
@@ -1,0 +1,355 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import sinon from 'ts-sinon'
+import { ChatDatabase } from './chatDb'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { Message } from './util'
+import { ChatMessage, ToolResultStatus } from '@amzn/codewhisperer-streaming'
+import * as fs from 'fs'
+
+describe('ChatDatabase', () => {
+    let mockFeatures: Features
+    let chatDb: ChatDatabase
+    let logDebugStub: sinon.SinonStub
+    let logWarnStub: sinon.SinonStub
+    let writeFileStub: sinon.SinonStub
+
+    beforeEach(() => {
+        logDebugStub = sinon.stub()
+        logWarnStub = sinon.stub()
+        writeFileStub = sinon.stub(fs, 'writeFile').callsArgWith(3, null)
+
+        mockFeatures = {
+            logging: {
+                debug: logDebugStub,
+                warn: logWarnStub,
+                log: sinon.stub(),
+                info: sinon.stub(),
+                error: sinon.stub(),
+            },
+            runtime: {
+                platform: 'node',
+            },
+            workspace: {
+                fs: {
+                    getServerDataDirPath: sinon.stub().returns('/tmp'),
+                    getFileSize: sinon.stub().resolves({ size: 0 }),
+                    mkdir: sinon.stub().resolves(undefined),
+                    writeFile: sinon.stub().resolves(undefined),
+                },
+            },
+            lsp: {
+                getClientInitializeParams: sinon.stub().returns({
+                    workspaceFolders: [{ uri: 'file:///workspace' }],
+                }),
+            },
+        } as unknown as Features
+
+        chatDb = new ChatDatabase(mockFeatures)
+    })
+
+    afterEach(() => {
+        chatDb.close()
+        sinon.restore()
+    })
+
+    describe('ensureValidMessageSequence', () => {
+        it('should preserve valid alternating sequence', () => {
+            const messages: Message[] = [
+                { type: 'prompt', body: 'User first message' },
+                { type: 'answer', body: 'Assistant first response' },
+                { type: 'prompt', body: 'User second message' },
+                { type: 'answer', body: 'Assistant second response' },
+            ]
+
+            const originalMessages = [...messages]
+
+            chatDb.ensureValidMessageSequence(messages, {
+                userInputMessage: { content: 'New message', userInputMessageContext: {} },
+            } as ChatMessage)
+
+            assert.strictEqual(messages.length, 4, 'Should not modify valid sequence')
+            assert.deepStrictEqual(messages, originalMessages, 'Messages should remain unchanged')
+        })
+
+        it('should remove assistant messages from the beginning and end', () => {
+            const messages: Message[] = [
+                { type: 'answer', body: 'Assistant first message' },
+                { type: 'answer', body: 'Assistant second message' },
+                { type: 'prompt', body: 'User message' },
+                { type: 'answer', body: 'Assistant response' },
+            ]
+
+            //  Should not be possible
+            chatDb.ensureValidMessageSequence(messages, {
+                assistantResponseMessage: { content: 'New assisstant message' },
+            } as ChatMessage)
+
+            assert.strictEqual(messages.length, 1, 'Should have removed assistant messages from the beginning and end')
+            assert.strictEqual(messages[0].type, 'prompt', 'First message should be from user')
+        })
+
+        it('should remove user message from the end', () => {
+            const messages: Message[] = [
+                { type: 'prompt', body: 'User first message' },
+                { type: 'answer', body: 'Assistant response' },
+                { type: 'prompt', body: 'User trailing message' },
+            ]
+
+            chatDb.ensureValidMessageSequence(messages, {
+                userInputMessage: { content: 'New message', userInputMessageContext: {} },
+            } as ChatMessage)
+
+            assert.strictEqual(messages.length, 2, 'Should have removed user message from the end')
+            assert.strictEqual(messages[0].type, 'prompt', 'First message should be from user')
+            assert.strictEqual(messages[1].type, 'answer', 'Last message should be from assistant')
+        })
+
+        it('should handle empty message array', () => {
+            const messages: Message[] = []
+
+            chatDb.ensureValidMessageSequence(messages, {
+                userInputMessage: { content: 'New message', userInputMessageContext: {} },
+            } as ChatMessage)
+
+            assert.strictEqual(messages.length, 0, 'Empty array should remain empty')
+        })
+    })
+
+    describe('validateNewMessageToolResults', () => {
+        it('should handle empty history message array', () => {
+            const messages: Message[] = []
+
+            const newUserMessage = {
+                userInputMessage: {
+                    content: '',
+                    userInputMessageContext: {
+                        toolResults: [
+                            {
+                                toolUseId: 'tool-1',
+                                status: ToolResultStatus.SUCCESS,
+                                content: [{ text: 'Valid result' }],
+                            },
+                        ],
+                    },
+                },
+            } as ChatMessage
+
+            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            assert.strictEqual(isValid, false)
+        })
+
+        it('should handle new user message with valid tool results', () => {
+            const messages: Message[] = [
+                {
+                    type: 'prompt',
+                    body: 'User first message',
+                },
+                {
+                    type: 'answer',
+                    body: 'Assistant message with tool use',
+                    toolUses: [{ toolUseId: 'tool-1', name: 'testTool', input: { key: 'value' } }],
+                },
+            ]
+
+            const newUserMessage = {
+                userInputMessage: {
+                    content: '',
+                    userInputMessageContext: {
+                        toolResults: [
+                            {
+                                toolUseId: 'tool-1',
+                                status: ToolResultStatus.SUCCESS,
+                                content: [{ text: 'Valid result' }],
+                            },
+                        ],
+                    },
+                },
+            } as ChatMessage
+
+            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            assert.strictEqual(isValid, true)
+
+            const toolResults = newUserMessage.userInputMessage!.userInputMessageContext?.toolResults || []
+            assert.strictEqual(toolResults.length, 1, 'Should keep valid tool results')
+            assert.strictEqual(toolResults[0].toolUseId, 'tool-1', 'Should have correct tool ID')
+            assert.strictEqual(toolResults[0].status, ToolResultStatus.SUCCESS, 'Should keep success status')
+            assert.strictEqual(toolResults[0].content?.[0]?.text, 'Valid result', 'Should keep original content')
+        })
+
+        it('should handle new user message with missing tool results', () => {
+            const messages: Message[] = [
+                {
+                    type: 'prompt',
+                    body: 'User first message',
+                },
+                {
+                    type: 'answer',
+                    body: 'Assistant message with tool use',
+                    toolUses: [{ toolUseId: 'tool-1', name: 'testTool', input: { key: 'value' } }],
+                },
+            ]
+
+            const newUserMessage = {
+                userInputMessage: {
+                    content: 'New message',
+                    userInputMessageContext: {},
+                },
+            } as ChatMessage
+
+            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            assert.strictEqual(isValid, true)
+
+            const toolResults = newUserMessage.userInputMessage!.userInputMessageContext?.toolResults || []
+            assert.strictEqual(toolResults.length, 1, 'Should have added tool results')
+
+            // Check missing tool result was added
+            assert.strictEqual(toolResults[0].toolUseId, 'tool-1', 'Should add missing tool ID')
+            assert.strictEqual(toolResults[0].status, ToolResultStatus.ERROR, 'Should mark as error')
+        })
+
+        it('should handle new user message with tool results after assistant message without tool uses', () => {
+            const messages: Message[] = [
+                {
+                    type: 'answer',
+                    body: 'Assistant message with tool use',
+                    toolUses: [],
+                },
+            ]
+
+            const newUserMessage = {
+                userInputMessage: {
+                    content: '',
+                    userInputMessageContext: {
+                        toolResults: [
+                            {
+                                toolUseId: 'tool-1',
+                                status: ToolResultStatus.SUCCESS,
+                                content: [{ text: 'Valid result' }],
+                            },
+                        ],
+                    },
+                },
+            } as ChatMessage
+
+            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            assert.strictEqual(isValid, false)
+        })
+
+        it('should handle new user message with invalid tool results ID', () => {
+            const messages: Message[] = [
+                {
+                    type: 'answer',
+                    body: 'Assistant message with tool use',
+                    toolUses: [{ toolUseId: 'tool-2', name: 'testTool', input: { key: 'value' } }],
+                },
+            ]
+
+            const newUserMessage = {
+                userInputMessage: {
+                    content: '',
+                    userInputMessageContext: {
+                        toolResults: [
+                            {
+                                toolUseId: 'tool-1',
+                                status: ToolResultStatus.SUCCESS,
+                                content: [{ text: 'Valid result' }],
+                            },
+                        ],
+                    },
+                },
+            } as ChatMessage
+
+            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            assert.strictEqual(isValid, true)
+
+            const toolResults = newUserMessage.userInputMessage!.userInputMessageContext?.toolResults || []
+            assert.strictEqual(toolResults.length, 1, 'Should have only one tool results')
+            assert.strictEqual(toolResults[0].toolUseId, 'tool-2', 'Tool ID should match previous message')
+        })
+
+        it('should handle multiple tool uses and results correctly', () => {
+            const messages: Message[] = [
+                {
+                    type: 'prompt',
+                    body: 'User first message',
+                },
+                {
+                    type: 'answer',
+                    body: 'Assistant first response',
+                    toolUses: [{ toolUseId: 'tool-1', name: 'testTool', input: { key: 'value1' } }],
+                },
+                {
+                    type: 'prompt',
+                    body: 'User second message',
+                    userInputMessageContext: {
+                        toolResults: [
+                            { toolUseId: 'tool-1', status: ToolResultStatus.SUCCESS, content: [{ text: 'Result 1' }] },
+                        ],
+                    },
+                },
+                {
+                    type: 'answer',
+                    body: 'Assistant second response',
+                    toolUses: [
+                        { toolUseId: 'tool-2', name: 'testTool', input: { key: 'value2' } },
+                        { toolUseId: 'tool-3', name: 'testTool', input: { key: 'value3' } },
+                    ],
+                },
+            ]
+
+            const newUserMessage = {
+                userInputMessage: {
+                    content: 'New message',
+                    userInputMessageContext: {
+                        toolResults: [
+                            { toolUseId: 'tool-2', status: ToolResultStatus.SUCCESS, content: [{ text: 'Result 2' }] },
+                        ],
+                    },
+                },
+            } as ChatMessage
+
+            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+
+            const toolResults = newUserMessage.userInputMessage!.userInputMessageContext?.toolResults || []
+            assert.strictEqual(toolResults.length, 2, 'Should have correct number of tool results')
+
+            // Check valid result is preserved
+            assert.strictEqual(toolResults[0].toolUseId, 'tool-2', 'Should preserve valid tool ID')
+            assert.strictEqual(toolResults[0].status, ToolResultStatus.SUCCESS, 'Should keep success status')
+
+            // Check missing tool result was added
+            assert.strictEqual(toolResults[1].toolUseId, 'tool-3', 'Should add missing tool ID')
+            assert.strictEqual(toolResults[1].status, ToolResultStatus.ERROR, 'Should mark as error')
+        })
+
+        it('should handle new user message with no tool results and blank content', () => {
+            const messages: Message[] = [
+                {
+                    type: 'prompt',
+                    body: 'User first message',
+                },
+                {
+                    type: 'answer',
+                    body: 'Assistant message with tool use',
+                },
+            ]
+
+            const newUserMessage = {
+                userInputMessage: {
+                    content: '',
+                    userInputMessageContext: {
+                        toolResults: [],
+                    },
+                },
+            } as ChatMessage
+
+            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            assert.strictEqual(isValid, false)
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -391,13 +391,13 @@ export class ChatDatabase {
     /**
      * Fixes the history to maintain the following invariants:
      * 1. The history contains at most MaxConversationHistoryMessages messages. Oldest messages are dropped.
-     * 2. The history character length is <= MaxConversationHistoryCharacters - newUserMessageCharacterCount. Oldest messages are dropped.
-     * 3. The first message is from the user. Oldest messages are dropped if needed.
-     * 4. The last message is from the assistant. The last message is dropped if it is from the user.
-     * 5. If the last message is from the assistant and it contains tool uses, and a next user
-     *    message is set without tool results, then the user message will have cancelled tool results.
+     * 2. The first message is from the user. Oldest messages are dropped if needed.
+     * 3. The last message is from the assistant. The last message is dropped if it is from the user.
+     * 4. The history contains alternating sequene of userMessage followed by assistantMessages
+     * 5. The toolUse and toolResult relationship is valid
+     * 6. The history character length is <= MaxConversationHistoryCharacters - newUserMessageCharacterCount. Oldest messages are dropped.
      */
-    fixHistory(tabId: string, newUserMessage: ChatMessage, conversationId: string): boolean {
+    fixAndValidateHistory(tabId: string, newUserMessage: ChatMessage, conversationId: string): boolean {
         if (!this.#initialized) {
             return true
         }
@@ -423,14 +423,15 @@ export class ChatDatabase {
         //  Drop empty assistant partial if it’s the last message
         this.handleEmptyAssistantMessage(allMessages)
 
+        //  Ensure messages in history a valid for server side checks
+        this.ensureValidMessageSequence(allMessages, newUserMessage)
+
+        // Ensure lastMessage in history toolUse and newMessage toolResult relationship is valid
+        const isValid = this.validateNewMessageToolResults(allMessages, newUserMessage)
+
         //  Make sure max characters ≤ MaxConversationHistoryCharacters - newUserMessageCharacterCount
         allMessages = this.trimMessagesToMaxLength(allMessages, newUserMessage)
 
-        //  Ensure messages in history a valid for server side checks
-        this.ensureValidMessageSequence(allMessages)
-
-        //  If the last message is from the assistant and it contains tool uses, and a next user message is set without tool results, then the user message will have cancelled tool results.
-        const isValid = this.validateToolUses(allMessages, newUserMessage)
         const clientType = this.#features.lsp.getClientInitializeParams()?.clientInfo?.name || 'unknown'
 
         tabData.conversations = [
@@ -627,7 +628,11 @@ export class ChatDatabase {
         return count
     }
 
-    private ensureValidMessageSequence(messages: Message[]): void {
+    ensureValidMessageSequence(messages: Message[], newUserMessage: ChatMessage): void {
+        if (messages.length === 0) {
+            return
+        }
+
         //  Make sure the first stored message is from the user (type === 'prompt'), else drop
         while (messages.length > 0 && messages[0].type === ('answer' as ChatItemType)) {
             messages.shift()
@@ -639,77 +644,59 @@ export class ChatDatabase {
             messages.pop()
             this.#features.logging.debug('Dropped trailing user message')
         }
+
+        //  Make sure there are alternating user and assistant messages
+        const currentMessageType = chatMessageToMessage(newUserMessage).type
+        const lastMessageType = messages[messages.length - 1].type
+
+        if (currentMessageType === lastMessageType) {
+            this.#features.logging.warn(
+                `Invalid alternation: last message is ${lastMessageType}, dropping it before inserting new ${currentMessageType}`
+            )
+            messages.splice(messages.length - 1, 1)
+        }
     }
 
-    private validateToolUses(messages: Message[], newUserMessage: ChatMessage): boolean {
-        if (messages.length === 0) {
-            if (newUserMessage.userInputMessage?.userInputMessageContext?.toolResults) {
-                this.#features.logging.debug('No history message found, but new user message has tool results.')
-                newUserMessage.userInputMessage.userInputMessageContext.toolResults = undefined
-                // tool results are empty, so content must not be empty
-                newUserMessage.userInputMessage.content = 'Conversation history was too large, so it was cleared.'
-            }
-            return true
-        }
+    validateNewMessageToolResults(messages: Message[], newUserMessage: ChatMessage): boolean {
+        if (newUserMessage?.userInputMessage?.userInputMessageContext) {
+            const newUserMessageContext = newUserMessage.userInputMessage.userInputMessageContext
+            const toolResults = newUserMessageContext.toolResults || []
+            const lastMsg = messages[messages.length - 1]
+            const lastMsgToolUses = lastMsg?.toolUses || []
 
-        const lastMsg = messages[messages.length - 1]
-        const toolResults = newUserMessage.userInputMessage?.userInputMessageContext?.toolResults
-
-        if (toolResults && toolResults.length > 0) {
             // If last message has no tool uses but new message has tool results, this is invalid
-            if (!lastMsg.toolUses || lastMsg.toolUses.length === 0) {
+            if (toolResults && toolResults.length > 0 && lastMsgToolUses.length === 0) {
                 this.#features.logging.warn('New message has tool results but last message has no tool uses')
                 return false
             }
 
-            const toolUseIds = new Set(lastMsg.toolUses.map(toolUse => toolUse.toolUseId))
+            const toolUseIds = new Set(lastMsgToolUses.map(toolUse => toolUse.toolUseId))
             const validToolResults = toolResults.filter(toolResult => toolUseIds.has(toolResult.toolUseId))
-            const invalidToolResults = toolResults.filter(toolResult => !toolUseIds.has(toolResult.toolUseId))
 
-            if (invalidToolResults.length > 0) {
-                this.#features.logging.warn(
-                    `Found ${invalidToolResults.length} tool results without matching tool uses, marking them as cancelled`
+            if (validToolResults.length < toolUseIds.size) {
+                // Add cancelled tool results for missing IDs
+                const missingToolUses = lastMsgToolUses.filter(
+                    toolUses => !validToolResults.some(toolResults => toolResults.toolUseId === toolUses.toolUseId)
                 )
 
-                // Mark invalid tool results as cancelled
-                for (const invalidResult of invalidToolResults) {
-                    invalidResult.status = ToolResultStatus.ERROR
-                    invalidResult.content = [
-                        {
-                            text: 'Tool use was cancelled by the user',
-                        },
-                    ]
-                }
-
-                // Update the tool results in the message
-                if (newUserMessage.userInputMessage?.userInputMessageContext) {
-                    newUserMessage.userInputMessage.userInputMessageContext.toolResults = [
-                        ...validToolResults,
-                        ...invalidToolResults,
-                    ]
+                for (const toolUse of missingToolUses) {
+                    this.#features.logging.warn(
+                        `newUserMessage missing ToolResult for ${toolUse.toolUseId}. Inserting cancelled.`
+                    )
+                    validToolResults.push({
+                        toolUseId: toolUse.toolUseId,
+                        status: ToolResultStatus.ERROR,
+                        content: [{ text: 'Tool use was cancelled by the user' }],
+                    })
                 }
             }
-        }
+            newUserMessageContext.toolResults = validToolResults
 
-        if (lastMsg.toolUses && lastMsg.toolUses.length > 0) {
-            if (!toolResults || toolResults.length === 0) {
-                this.#features.logging.debug(
-                    `No tools results in last user message following a tool use message from assisstant, marking as canceled`
-                )
-                if (newUserMessage.userInputMessage?.userInputMessageContext) {
-                    newUserMessage.userInputMessage.userInputMessageContext.toolResults = lastMsg.toolUses.map(
-                        toolUse => ({
-                            toolUseId: toolUse.toolUseId,
-                            content: [
-                                {
-                                    type: 'Text',
-                                    text: 'Tool use was cancelled by the user',
-                                },
-                            ],
-                            status: ToolResultStatus.ERROR,
-                        })
-                    )
-                }
+            if (
+                newUserMessageContext.toolResults.length === 0 &&
+                (!newUserMessage.userInputMessage.content || newUserMessage.userInputMessage.content?.trim() == '')
+            ) {
+                return false
             }
         }
         return true

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
@@ -225,6 +225,26 @@ describe('Chat Session Service', () => {
         assert.strictEqual(chatSessionServiceIAM.conversationId, undefined)
     })
 
+    describe('Prompt ID', () => {
+        let chatSessionService: ChatSessionService
+
+        beforeEach(() => {
+            chatSessionService = new ChatSessionService()
+        })
+
+        it('should initialize with undefined promptId', () => {
+            assert.strictEqual(chatSessionService.isCurrentPrompt('test-id'), false)
+        })
+
+        it('should set and check current prompt ID', () => {
+            const promptId = 'test-prompt-id'
+            chatSessionService.setCurrentPromptId(promptId)
+
+            assert.strictEqual(chatSessionService.isCurrentPrompt(promptId), true)
+            assert.strictEqual(chatSessionService.isCurrentPrompt('different-id'), false)
+        })
+    })
+
     describe('Approved Paths', () => {
         let chatSessionService: ChatSessionService
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -26,6 +26,7 @@ export class ChatSessionService {
     public pairProgrammingMode: boolean = true
     public contextListSent: boolean = false
     #abortController?: AbortController
+    #currentPromptId?: string
     #conversationId?: string
     #conversationType: string = 'AgenticChat'
     #deferredToolExecution: Record<string, DeferredHandler> = {}
@@ -180,6 +181,23 @@ export class ChatSessionService {
 
     public dispose(): void {
         this.#abortController?.abort()
+    }
+
+    /**
+     * Sets the current prompt ID
+     * @param promptId The unique ID of the current prompt
+     */
+    public setCurrentPromptId(promptId: string): void {
+        this.#currentPromptId = promptId
+    }
+
+    /**
+     * Checks if the given prompt ID matches the current one
+     * @param promptId The prompt ID to check
+     * @returns True if the given prompt ID matches the current one
+     */
+    public isCurrentPrompt(promptId: string): boolean {
+        return this.#currentPromptId === promptId
     }
 
     public abortRequest(): void {


### PR DESCRIPTION
## Problem
We are still seeing a high number of `Improperly formed request` errors caused by backend validation check failures on the history.


Main categories:
- UserInputMessage must be followed by AssistantResponseMessage
- UserInputMessage content cannot be blank if there are no ToolResults
- Got ValidationError: ToolResult with ID tooluse_ID has no corresponding ToolUse

We also see some `Improperly formed requests` caused by: `'conversationState.currentMessage.userInputMessage.userInputMessageContext.editorState.workspaceFolders' failed to satisfy constraint: Member must have length less than or equal to 100`


## Solution

Add robust validation checks on the history to match backend checks. Specifically:

- Only validate the last message in history and the incoming user message.
- Enforce user-assistant alternation by removing consecutive messages of the same type.
- Ensure tool results in the new message match tool uses in the previous assistant message.
- Prevents backend requests when validation fails by exiting the agent loop early.
- Applies validations only to new conversations, leaving existing histories unchanged.


In order to prevent race conditions, I:

- Added a unique prompt ID for each chat prompt entered by user to track which prompt is currently active
- Modified the agent loop to check both the prompt ID and cancellation token before modifying chat history. 
             - If cancellation token is true, then that means the user cancelled the request. 
             - If the prompt in the request does not match the current active prompt, means the user entered a new prompt   and we should not add the message.


- Limit workspace folders to 100 to satisfy API constraint

## Testing
- Manual Testing
- Unit Tests
      - Test cases cover backend validation checks:
     

| Test Case    | Backend Validation Check |
| -------- | ------- |
| should handle new user message with missing tool results    | AssistantResponseMessage with ToolUse must be followed by UserInputMessage with ToolResult   |
| should handle new user message with tool results after assistant message without tool uses    | Message with ToolResults must be preceded by AssistantResponseMessage with ToolUse   |
| should handle new user message with invalid tool results ID    | ToolResult with ID {tool_result.toolUseId} has no corresponding ToolUse   |
| should handle new user message with no tool results and blank content    | UserInputMessage content cannot be blank if there are no ToolResults   |


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
