### PR TITLE
telemetry(amazonq): adding new telemetry metrics and addtional fields for existing metrics

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -674,7 +674,7 @@ export class AgenticChatController implements ChatHandlers {
                 this.#telemetryController.emitAgencticLoop_InvokeLLM(
                     response.$metadata.requestId!,
                     conversationId,
-                    session.getConversationType(),
+                    'AgenticChat',
                     undefined,
                     undefined,
                     'Succeeded',
@@ -705,9 +705,9 @@ export class AgenticChatController implements ChatHandlers {
                 this.#telemetryController.emitAgencticLoop_InvokeLLM(
                     response.$metadata.requestId!,
                     conversationId,
-                    session.getConversationType(),
-                    toolNames,
-                    toolUseIds,
+                    'AgenticChatWithToolUse',
+                    toolNames ?? undefined,
+                    toolUseIds ?? undefined,
                     'Succeeded',
                     this.#features.runtime.serverInfo.version ?? '',
                     latency,
@@ -723,7 +723,7 @@ export class AgenticChatController implements ChatHandlers {
                 this.#telemetryController.emitAgencticLoop_InvokeLLM(
                     response.$metadata.requestId!,
                     conversationId,
-                    session.getConversationType(),
+                    'AgenticChatWithToolUse',
                     undefined,
                     undefined,
                     'Failed',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -499,7 +499,7 @@ export class AgenticChatController implements ChatHandlers {
                     buttons: [],
                 }
             }
-            return this.#handleRequestError(err, errorMessageId, params.tabId, metric)
+            return this.#handleRequestError(err, errorMessageId, params.tabId, metric, session.pairProgrammingMode)
         }
     }
 
@@ -1713,7 +1713,8 @@ export class AgenticChatController implements ChatHandlers {
         err: any,
         errorMessageId: string,
         tabId: string,
-        metric: Metric<CombinedConversationEvent>
+        metric: Metric<CombinedConversationEvent>,
+        agenticCodingMode: boolean
     ): ChatResult | ResponseError<ChatResult> {
         const errorMessage = getErrorMessage(err)
         const requestID = getRequestID(err) ?? ''
@@ -1723,13 +1724,20 @@ export class AgenticChatController implements ChatHandlers {
         // use custom error message for unactionable errors (user-dependent errors like PromptCharacterLimit)
         if (err.code && err.code in unactionableErrorCodes) {
             const customErrMessage = unactionableErrorCodes[err.code as keyof typeof unactionableErrorCodes]
-            this.#telemetryController.emitMessageResponseError(tabId, metric.metric, requestID, customErrMessage)
+            this.#telemetryController.emitMessageResponseError(
+                tabId,
+                metric.metric,
+                requestID,
+                customErrMessage,
+                agenticCodingMode
+            )
         } else {
             this.#telemetryController.emitMessageResponseError(
                 tabId,
                 metric.metric,
                 requestID,
-                errorMessage ?? genericErrorMsg
+                errorMessage ?? genericErrorMsg,
+                agenticCodingMode
             )
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -27,6 +27,7 @@ export class ChatSessionService {
     public contextListSent: boolean = false
     #abortController?: AbortController
     #conversationId?: string
+    #conversationType: string = 'AgenticChat'
     #deferredToolExecution: Record<string, DeferredHandler> = {}
     #toolUseLookup: Map<
         string,
@@ -36,6 +37,14 @@ export class ChatSessionService {
     // Map to store approved paths to avoid repeated validation
     #approvedPaths: Set<string> = new Set<string>()
     #serviceManager?: AmazonQBaseServiceManager
+
+    public getConversationType(): string {
+        return this.#conversationType
+    }
+
+    public setConversationType(value: string) {
+        this.#conversationType = value
+    }
 
     public get conversationId(): string | undefined {
         return this.#conversationId

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -169,7 +169,41 @@ export class ChatTelemetryController {
         }
     }
 
-    public emitToolUseSuggested(toolUse: ToolUse, conversationId: string, languageServerVersion: string) {
+    public emitAgencticLoop_InvokeLLM(
+        requestId: string,
+        conversationId: string,
+        conversationType: string,
+        toolName: string[] | undefined,
+        toolUseId: string[] | undefined,
+        result: string,
+        languageServerVersion: string,
+        latency?: number[],
+        agenticCodingMode?: boolean
+    ) {
+        this.#telemetry.emitMetric({
+            name: ChatTelemetryEventName.AgencticLoop_InvokeLLM,
+            data: {
+                [CONVERSATION_ID_METRIC_KEY]: conversationId,
+                cwsprChatConversationType: conversationType,
+                credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
+                cwsprToolName: toolName,
+                cwsprToolUseId: toolUseId,
+                result,
+                languageServerVersion: languageServerVersion,
+                latency,
+                requestId,
+                enabled: agenticCodingMode,
+            },
+        })
+    }
+
+    public emitToolUseSuggested(
+        toolUse: ToolUse,
+        conversationId: string,
+        languageServerVersion: string,
+        latency?: number,
+        agenticCodingMode?: boolean
+    ) {
         this.#telemetry.emitMetric({
             name: ChatTelemetryEventName.ToolUseSuggested,
             data: {
@@ -178,21 +212,29 @@ export class ChatTelemetryController {
                 credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
                 cwsprToolName: toolUse.name ?? '',
                 cwsprToolUseId: toolUse.toolUseId ?? '',
+                perfE2ELatency: latency,
                 result: 'Succeeded',
                 languageServerVersion: languageServerVersion,
+                enabled: agenticCodingMode,
             },
         })
     }
 
-    public emitInteractWithAgenticChat(interactionType: AgenticChatInteractionType, tabId: string) {
+    public emitInteractWithAgenticChat(
+        interactionType: AgenticChatInteractionType,
+        tabId: string,
+        agenticCodingMode?: boolean,
+        conversationType?: string
+    ) {
         this.#telemetry.emitMetric({
             name: ChatTelemetryEventName.InteractWithAgenticChat,
             data: {
                 [CONVERSATION_ID_METRIC_KEY]: this.getConversationId(tabId) ?? '',
-                cwsprChatConversationType: 'AgenticChat',
+                cwsprChatConversationType: conversationType,
                 credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
                 cwsprAgenticChatInteractionType: interactionType,
                 result: 'Succeeded',
+                enabled: agenticCodingMode,
             },
         })
     }
@@ -221,6 +263,7 @@ export class ChatTelemetryController {
                 requestLength: metric.cwsprChatRequestLength,
                 responseLength: metric.cwsprChatResponseLength,
                 numberOfCodeBlocks: metric.cwsprChatResponseCodeSnippetCount,
+                agenticCodingMode: metric.enabled,
             },
             {
                 chatTriggerInteraction: metric.cwsprChatTriggerInteraction,

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -319,7 +319,8 @@ export class ChatTelemetryController {
         tabId: string,
         metric: Partial<CombinedConversationEvent>,
         requestId?: string,
-        errorReason?: string
+        errorReason?: string,
+        agenticCodingMode?: boolean
     ) {
         this.#telemetry.emitMetric({
             name: ChatTelemetryEventName.MessageResponseError,
@@ -337,6 +338,7 @@ export class ChatTelemetryController {
                 reasonDesc: getTelemetryReasonDesc(errorReason),
                 credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
                 result: 'Succeeded',
+                enabled: agenticCodingMode,
                 [CONVERSATION_ID_METRIC_KEY]: this.getConversationId(tabId),
                 languageServerVersion: metric.languageServerVersion,
             },

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -735,6 +735,7 @@ describe('TelemetryService', () => {
                     requestLength: 100,
                     responseLength: 3000,
                     numberOfCodeBlocks: 0,
+                    agenticCodingMode: true,
                 },
                 {
                     cwsprChatHasContextList: true,
@@ -800,6 +801,7 @@ describe('TelemetryService', () => {
                     cwsprChatActiveEditorImportCount: undefined,
                     codewhispererCustomizationArn: 'cust-123',
                     result: 'Succeeded',
+                    enabled: true,
                     languageServerVersion: undefined,
                     requestIds: undefined,
                     cwsprChatHasContextList: true,

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -436,6 +436,7 @@ export class TelemetryService {
             responseLength?: number
             numberOfCodeBlocks?: number
             hasProjectLevelContext?: number
+            agenticCodingMode?: boolean
         },
         additionalParams: Partial<{
             chatTriggerInteraction: string
@@ -504,6 +505,7 @@ export class TelemetryService {
                     cwsprChatCodeContextCount: additionalParams.cwsprChatCodeContextCount,
                     cwsprChatCodeContextLength: additionalParams.cwsprChatCodeContextLength,
                     result: 'Succeeded',
+                    enabled: params.agenticCodingMode,
                     languageServerVersion: additionalParams.languageServerVersion,
                     requestIds: truncatedRequestIds,
                 },

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -177,6 +177,7 @@ export enum ChatTelemetryEventName {
     MessageResponseError = 'amazonq_messageResponseError',
     ModifyCode = 'amazonq_modifyCode',
     ToolUseSuggested = 'amazonq_toolUseSuggested',
+    AgencticLoop_InvokeLLM = 'amazonq_invokeLLM',
     InteractWithAgenticChat = 'amazonq_interactWithAgenticChat',
     LoadHistory = 'amazonq_loadHistory',
     ChatHistoryAction = 'amazonq_performChatHistoryAction',
@@ -196,11 +197,23 @@ export interface ChatTelemetryEventMap {
     [ChatTelemetryEventName.MessageResponseError]: MessageResponseErrorEvent
     [ChatTelemetryEventName.ModifyCode]: ModifyCodeEvent
     [ChatTelemetryEventName.ToolUseSuggested]: ToolUseSuggestedEvent
+    [ChatTelemetryEventName.AgencticLoop_InvokeLLM]: AgencticLoop_InvokeLLMEvent
     [ChatTelemetryEventName.InteractWithAgenticChat]: InteractWithAgenticChatEvent
     [ChatTelemetryEventName.LoadHistory]: LoadHistoryEvent
     [ChatTelemetryEventName.ChatHistoryAction]: ChatHistoryActionEvent
     [ChatTelemetryEventName.ExportTab]: ExportTabEvent
     [ChatTelemetryEventName.UiClick]: UiClickEvent
+}
+
+export type AgencticLoop_InvokeLLMEvent = {
+    credentialStartUrl?: string
+    cwsprChatConversationId: string
+    cwsprChatConversationType: ChatConversationType
+    cwsprToolName: string
+    cwsprToolUseId: string
+    enabled?: boolean
+    languageServerVersion?: string
+    latency?: string
 }
 
 export type ToolUseSuggestedEvent = {
@@ -209,7 +222,9 @@ export type ToolUseSuggestedEvent = {
     cwsprChatConversationType: ChatConversationType
     cwsprToolName: string
     cwsprToolUseId: string
+    enabled?: boolean
     languageServerVersion?: string
+    perfE2ELatency?: string
 }
 
 export type InteractWithAgenticChatEvent = {
@@ -217,6 +232,7 @@ export type InteractWithAgenticChatEvent = {
     cwsprChatConversationId: string
     cwsprChatConversationType: ChatConversationType
     cwsprAgenticChatInteractionType: AgenticChatInteractionType
+    enabled?: boolean
 }
 
 export type ModifyCodeEvent = {
@@ -249,6 +265,7 @@ export type AddMessageEvent = {
     cwsprChatResponseLength?: number
     cwsprChatConversationType: ChatConversationType
     codewhispererCustomizationArn?: string
+    enabled?: boolean
     languageServerVersion?: string
     requestIds?: string[]
 
@@ -369,6 +386,7 @@ export type MessageResponseErrorEvent = {
     cwsprChatRepsonseCode: number
     cwsprChatRequestLength?: number
     cwsprChatConversationType: ChatConversationType
+    enabled?: boolean
     languageServerVersion?: string
 }
 


### PR DESCRIPTION
## Problem
- Existing metrics in agentic chat is missing some fields like agentic coding mode etc.
- Missing tool use latency.
## Solution
- Addressed the above issues.
- adding a new metric `amazonq_InvokeLLM`
- Implemented additional metrics from these two PR's 
  - https://github.com/aws/aws-toolkit-common/pull/1025
  - https://github.com/aws/aws-toolkit-common/pull/1027
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
