### PR TITLE
fix: fix to remove approved paths for fsWrite

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -131,7 +131,7 @@ export class FsWrite {
     }
 
     public async requiresAcceptance(params: FsWriteParams, approvedPaths?: Set<string>): Promise<CommandValidation> {
-        return requiresPathAcceptance(params.path, this.lsp, this.logging, approvedPaths)
+        return requiresPathAcceptance(params.path, this.lsp, this.logging, approvedPaths, 'fsWrite')
     }
 
     private async handleCreate(params: CreateParams, sanitizedPath: string): Promise<void> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -114,9 +114,15 @@ export async function requiresPathAcceptance(
     path: string,
     lsp: Features['lsp'],
     logging: Features['logging'],
-    approvedPaths?: Set<string>
+    approvedPaths?: Set<string>,
+    toolName?: string
 ): Promise<CommandValidation> {
     try {
+        // Skip check for fsWrite tool
+        if (toolName === 'fsWrite') {
+            return { requiresAcceptance: false }
+        }
+
         // First check if the path is already approved
         if (isPathApproved(path, approvedPaths)) {
             return { requiresAcceptance: false }


### PR DESCRIPTION
## Problem
Security requirement to ask for permission for every file modification outisde of workpsace scope.

## Solution
- Skipping approvedPaths check for fsWrite tool.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
