### PR TITLE
chore: bumping language server runtime versions

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -21,8 +21,8 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.1.33",
-        "@aws/language-server-runtimes-types": "^0.1.27",
+        "@aws/chat-client-ui-types": "^0.1.34",
+        "@aws/language-server-runtimes-types": "^0.1.28",
         "@aws/mynah-ui": "^4.34.1"
     },
     "devDependencies": {

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -346,8 +346,8 @@
     "devDependencies": {
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
-        "@aws/chat-client-ui-types": "^0.1.33",
-        "@aws/language-server-runtimes": "^0.2.80",
+        "@aws/chat-client-ui-types": "^0.1.34",
+        "@aws/language-server-runtimes": "^0.2.81",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,8 +245,8 @@
             "version": "0.1.10",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.1.33",
-                "@aws/language-server-runtimes-types": "^0.1.27",
+                "@aws/chat-client-ui-types": "^0.1.34",
+                "@aws/language-server-runtimes-types": "^0.1.28",
                 "@aws/mynah-ui": "^4.34.1"
             },
             "devDependencies": {
@@ -268,8 +268,8 @@
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
-                "@aws/chat-client-ui-types": "^0.1.33",
-                "@aws/language-server-runtimes": "^0.2.80",
+                "@aws/chat-client-ui-types": "^0.1.34",
+                "@aws/language-server-runtimes": "^0.2.81",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -3889,11 +3889,12 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.33",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.33.tgz",
-            "integrity": "sha512-o9VkQEkrNFvfi3lgU0vN3vm4AHAoicBe/F5UCDQj97CxvaRM5ovGLYsx3RTxHwaK6hQ2J+foZtlnI7QYltsWFg==",
+            "version": "0.1.34",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.34.tgz",
+            "integrity": "sha512-9IZvrGIJ9/VbiYg/HS+I19NuC/XCTTKrpd2dpeINIOou7j0NmP8w5nYfeVU8yLw4ko5bXETgayyYOWnrXmNe4A==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.27"
+                "@aws/language-server-runtimes-types": "^0.1.28"
             }
         },
         "node_modules/@aws/hello-world-lsp": {
@@ -3905,11 +3906,12 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.80",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.80.tgz",
-            "integrity": "sha512-RBO9E5QEidaD4sd39ROSkShkgVzHzR72HSGW3S6svlcdhya9g1G9uJhVD6OhXvvbHcydZ6fxEQTdixkWTTd1ww==",
+            "version": "0.2.81",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.81.tgz",
+            "integrity": "sha512-wnwa8ctVCAckIpfWSblHyLVzl6UKX5G7ft+yetH1pI0mZvseSNzHUhclxNl4WGaDgGnEbBjLD0XRNEy2yRrSYg==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.27",
+                "@aws/language-server-runtimes-types": "^0.1.28",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/api-logs": "^0.200.0",
                 "@opentelemetry/core": "^2.0.0",
@@ -3933,9 +3935,10 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.27",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.27.tgz",
-            "integrity": "sha512-nalsT6d4aUsAv9D+cP9XBsNfkzgdMSwnESEy0/eD3g9VGdSLuNlz6xlvqfeUf+DtPl8+1qHIdzf9ihDaaNtADQ==",
+            "version": "0.1.28",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.28.tgz",
+            "integrity": "sha512-eDNcEXGAyD4rzl+eVJ6Ngfbm4iaR8MkoMk1wVcnV+VGqu63TyvV1aVWnZdl9tR4pmC0rIH3tj8FSCjhSU6eJlA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"
@@ -26667,7 +26670,7 @@
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
                 "@aws/language-server-runtimes": "^0.2.80",
-                "@aws/lsp-core": "^0.0.7",
+                "@aws/lsp-core": "^0.0.8",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
                 "https-proxy-agent": "^7.0.5",
@@ -26727,7 +26730,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.80",
-                "@aws/lsp-core": "0.0.7",
+                "@aws/lsp-core": "0.0.8",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -26790,7 +26793,7 @@
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.623.0",
                 "@aws-sdk/types": "^3.734.0",
-                "@aws/lsp-core": "^0.0.7",
+                "@aws/lsp-core": "^0.0.8",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -135,6 +135,8 @@ type ChatHandlers = Omit<
     | 'onTabBarAction'
     | 'getSerializedChat'
     | 'chatOptionsUpdate'
+    | 'onListMcpServers'
+    | 'onMcpServerClick'
 >
 
 export class AgenticChatController implements ChatHandlers {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -67,6 +67,8 @@ type ChatHandlers = Omit<
     | 'getSerializedChat'
     | 'onTabBarAction'
     | 'chatOptionsUpdate'
+    | 'onListMcpServers'
+    | 'onMcpServerClick'
 >
 
 export class ChatController implements ChatHandlers {


### PR DESCRIPTION
- bump @aws/language-server-runtimes-types, @aws/chat-client-ui-types to latest npm versions

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
