### PR TITLE
fix: Reduce perceived latency of fsWrite. Show fsWrite errors in the UX 

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2270,7 +2270,10 @@ export class AgenticChatController implements ChatHandlers {
                         },
                     })
                 }
-                // render the tool use explanatory as soon as this is received.
+            }
+
+            // render the tool use explanatory as soon as this is received for all tool uses.
+            if (typeof toolUse.input === 'string') {
                 const explanation = extractKey(toolUse.input, 'explanation')
                 const messageId = progressPrefix + toolUse.toolUseId + '_explanation'
                 if (explanation && !chatResultStream.hasMessage(messageId)) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -836,8 +836,7 @@ export class AgenticChatController implements ChatHandlers {
                 }
 
                 // remove progress UI
-                const progressMessageId = progressPrefix + toolUse.toolUseId
-                await chatResultStream.removeResultBlockAndUpdateUI(progressMessageId)
+                await chatResultStream.removeResultBlockAndUpdateUI(progressPrefix + toolUse.toolUseId)
 
                 // fsRead and listDirectory write to an existing card and could show nothing in the current position
                 if (!['fsWrite', 'fsRead', 'listDirectory'].includes(toolUse.name)) {
@@ -2236,6 +2235,7 @@ export class AgenticChatController implements ChatHandlers {
         chatResultStream: AgenticChatResultStream,
         streamWriter: ResultStreamWriter
     ) {
+        // extract the key value from incomplete JSON response stream
         function extractKey(incompleteJson: string, key: string): string | undefined {
             const pattern = new RegExp(`"${key}":\\s*"([^"]*)"`, 'g')
             const match = pattern.exec(incompleteJson)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -736,6 +736,31 @@ export class AgenticChatController implements ChatHandlers {
                         'Your toolUse input is incomplete, try again. If the error happens consistently, break this task down into multiple tool uses with smaller input. Do not apologize.'
                     shouldDisplayMessage = false
                 }
+                // send error state to UI
+                for (const toolUse of pendingToolUses) {
+                    if (toolUse.toolUseId) {
+                        await this.#features.chat.sendChatUpdate({
+                            tabId,
+                            state: { inProgress: false },
+                            data: {
+                                messages: [
+                                    {
+                                        messageId: toolUse.toolUseId,
+                                        type: 'tool',
+                                        header: {
+                                            status: {
+                                                status: 'error',
+                                                icon: 'error',
+                                                text: 'Error',
+                                            },
+                                            buttons: [],
+                                        },
+                                    },
+                                ],
+                            },
+                        })
+                    }
+                }
             }
             if (result.success && this.#toolUseLatencies.length > 0) {
                 // Clear latencies for the next LLM call

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2230,7 +2230,7 @@ export class AgenticChatController implements ChatHandlers {
         }
     }
 
-    async #showToolUseIntemediateResult(
+    async #showToolUseIntermediateResult(
         data: AgenticChatResultWithMetadata,
         chatResultStream: AgenticChatResultStream,
         streamWriter: ResultStreamWriter
@@ -2336,7 +2336,7 @@ export class AgenticChatController implements ChatHandlers {
                     toolUseStartTimes,
                     toolUseLoadingTimeouts
                 )
-                await this.#showToolUseIntemediateResult(result.data, chatResultStream, streamWriter)
+                await this.#showToolUseIntermediateResult(result.data, chatResultStream, streamWriter)
             }
         }
         await streamWriter.close()

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -44,6 +44,8 @@ interface FileDetailsWithPath extends FileDetails {
 
 type OperationType = 'read' | 'write' | 'listDir'
 
+export const progressPrefix = 'progress_'
+
 interface FileOperation {
     type: OperationType
     filePaths: FileDetailsWithPath[]
@@ -199,6 +201,15 @@ export class AgenticChatResultStream {
      */
     async removeResultBlock(messageId: string) {
         this.#state.chatResultBlocks = this.#state.chatResultBlocks.filter(block => block.messageId !== messageId)
+    }
+
+    getMessageBlockId(messageId: string): number | undefined {
+        for (const [i, block] of this.#state.chatResultBlocks.entries()) {
+            if (block.messageId === messageId) {
+                return i
+            }
+        }
+        return undefined
     }
 
     getResultStreamWriter(): ResultStreamWriter {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -203,6 +203,16 @@ export class AgenticChatResultStream {
         this.#state.chatResultBlocks = this.#state.chatResultBlocks.filter(block => block.messageId !== messageId)
     }
 
+    async removeResultBlockAndUpdateUI(messageId: string) {
+        if (this.hasMessage(messageId)) {
+            const blockId = this.getMessageBlockId(messageId)
+            if (blockId !== undefined) {
+                await this.overwriteResultBlock({ body: '', messageId: messageId }, blockId)
+            }
+            await this.removeResultBlock(messageId)
+        }
+    }
+
     hasMessage(messageId: string): boolean {
         return this.#state.chatResultBlocks.some(block => block.messageId === messageId)
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -203,6 +203,10 @@ export class AgenticChatResultStream {
         this.#state.chatResultBlocks = this.#state.chatResultBlocks.filter(block => block.messageId !== messageId)
     }
 
+    hasMessage(messageId: string): boolean {
+        return this.#state.chatResultBlocks.some(block => block.messageId === messageId)
+    }
+
     getMessageBlockId(messageId: string): number | undefined {
         for (const [i, block] of this.#state.chatResultBlocks.entries()) {
             if (block.messageId === messageId) {


### PR DESCRIPTION
## Problem

1. Need to show fsWrite errors in the UX , not just in the messages.
2. Need to show fsWrite is starting before the entire file write is done.

## Solution


1. Display fsWrite errors in the UX according to the design

https://github.com/user-attachments/assets/19ca5464-8481-417c-a2d2-08da299b1fa4


3. Render fsWrite progress


https://github.com/user-attachments/assets/0b03604e-fc9a-47a9-b00b-5937c1fd9056



https://github.com/user-attachments/assets/c6b911f1-10a2-4473-b0db-3a2ca97d2c15

https://github.com/user-attachments/assets/a3fd3a76-9ed1-4ac5-87e1-de2234753bfc



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
