### PR TITLE
feat: handle mcp config conflicts, support infinity timeout

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -136,6 +136,7 @@ describe('callTool()', () => {
 
         try {
             await mgr.callTool('s1', 'tool1', {})
+            throw new Error('Expected callTool to throw on timeout')
         } catch (e: any) {
             expect(e.code).to.equal('MCPToolExecTimeout')
         }
@@ -313,7 +314,6 @@ describe('updateServer()', () => {
 })
 
 // requiresApproval()
-
 describe('requiresApproval()', () => {
     let loadStub: sinon.SinonStub
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.test.ts
@@ -13,8 +13,11 @@ describe('McpTool', () => {
     const fakeFeatures = {
         logging: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {}, log: () => {} },
         workspace: {
-            fs: { exists: () => Promise.resolve(false), readFile: () => Promise.resolve(Buffer.from('')) },
-            getUserHomeDir: () => '',
+            fs: {
+                exists: () => Promise.resolve(false),
+                readFile: () => Promise.resolve(Buffer.from('')),
+                getUserHomeDir: () => '',
+            },
         },
         lsp: {},
     } as unknown as Pick<

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -9,6 +9,7 @@ import { LspApplyWorkspaceEdit, LspApplyWorkspaceEditParams } from './lspApplyWo
 import { AGENT_TOOLS_CHANGED, McpManager } from './mcp/mcpManager'
 import { McpTool } from './mcp/mcpTool'
 import { McpToolDefinition } from './mcp/mcpTypes'
+import { getGlobalMcpConfigPath, getWorkspaceMcpConfigPaths } from './mcp/mcpUtils'
 
 export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     const fsReadTool = new FsRead({ workspace, lsp, logging })
@@ -89,8 +90,8 @@ export const McpToolsServer: Server = ({ workspace, logging, lsp, agent }) => {
     lsp.onInitialized(async () => {
         // todo: move to constants
         const wsUris = lsp.getClientInitializeParams()?.workspaceFolders?.map(f => f.uri) ?? []
-        const wsConfigPaths = wsUris.map(uri => `${uri}/.amazonq/mcp.json`)
-        const globalConfigPath = `${workspace.fs.getUserHomeDir()}/.aws/amazonq/mcp.json`
+        const wsConfigPaths = getWorkspaceMcpConfigPaths(wsUris)
+        const globalConfigPath = getGlobalMcpConfigPath(workspace.fs.getUserHomeDir())
         const allPaths = [...wsConfigPaths, globalConfigPath]
 
         const mgr = await McpManager.init(allPaths, { logging, workspace, lsp })


### PR DESCRIPTION
## Problem
* Handle mcp config conflicts
* Support infinity timeout 
## Solution
* In case of server name conflicts, prefer workspace-level config over global config
* Setting timeout to 0 disables the default timeout

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
