### PR TITLE
feat: bump logging level of critical messages

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
@@ -65,7 +65,7 @@ export const LocalProjectContextServer =
                 telemetryService = new TelemetryService(amazonQServiceManager, credentialsProvider, telemetry, logging)
 
                 await amazonQServiceManager.addDidChangeConfigurationListener(updateConfigurationHandler)
-                logging.log('Local context server has been initialized')
+                logging.info('Local context server has been initialized')
             } catch (error) {
                 logging.error(`Failed to initialize local context server: ${error}`)
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -140,7 +140,7 @@ export const WorkspaceContextServer = (): Server => features => {
                 result.featureEvaluations?.some(
                     feature => feature.feature === 'ServiceSideWorkspaceContext' && feature.variation === 'TREATMENT'
                 ) ?? false
-            logging.log(`A/B testing enabled: ${abTestingEnabled}`)
+            logging.info(`A/B testing enabled: ${abTestingEnabled}`)
             abTestingEvaluated = true
         } catch (error: any) {
             logging.error(`Error while checking A/B status: ${error.code}`)


### PR DESCRIPTION
## Problem
> When installing the latest VSCode version 1.68.0, from client side logs, server-side workspace context wasn't initialized correctly. 

These logs are critical to determine whether or not certain features are enabled. The log level updates are [sent as a notification](https://github.com/aws/aws-toolkit-vscode/blob/ea593e295bcdc30f29ac2c8960af1fa69c754daa/packages/amazonq/src/lsp/config.ts#L85-L89) so there is no guarantee they are set when the initialization of these servers starts. 

## Solution
- bump the log levels of these statements to info, which is the default sent to the language server in initialization. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
