### PR TITLE
chore: bump up language server version

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -14,7 +14,7 @@
         "test-bundles": "node scripts/test-bundles.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.81"
+        "@aws/language-server-runtimes": "^0.2.83"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.33",
-        "@aws/language-server-runtimes-types": "^0.1.28",
+        "@aws/language-server-runtimes-types": "^0.1.29",
         "@aws/mynah-ui": "^4.35.0-beta.4"
     },
     "devDependencies": {

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -21,7 +21,7 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.1.33",
+        "@aws/chat-client-ui-types": "^0.1.35",
         "@aws/language-server-runtimes-types": "^0.1.29",
         "@aws/mynah-ui": "^4.35.0-beta.4"
     },

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1192,12 +1192,7 @@ ${params.message}`,
     }
 
     const mcpServerClick = (params: McpServerClickResult) => {
-        if (!params.success) {
-            mynahUi.notify({
-                content: `Failed to open the MCP server`,
-                type: NotificationType.ERROR,
-            })
-        }
+        // TODO: Add "add config" implementation here.
     }
 
     const getSerializedChat = (requestId: string, params: GetSerializedChatParams) => {

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -346,7 +346,7 @@
     "devDependencies": {
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
-        "@aws/chat-client-ui-types": "^0.1.32",
+        "@aws/chat-client-ui-types": "^0.1.35",
         "@aws/language-server-runtimes": "^0.2.83",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -347,7 +347,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.32",
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -78,7 +78,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -111,7 +111,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -119,7 +119,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -139,7 +139,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -183,7 +183,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -203,7 +203,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -225,7 +225,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.81"
+                "@aws/language-server-runtimes": "^0.2.83"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -246,7 +246,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.33",
-                "@aws/language-server-runtimes-types": "^0.1.28",
+                "@aws/language-server-runtimes-types": "^0.1.29",
                 "@aws/mynah-ui": "^4.35.0-beta.4"
             },
             "devDependencies": {
@@ -269,7 +269,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.32",
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -3931,12 +3931,12 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.81",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.81.tgz",
-            "integrity": "sha512-wnwa8ctVCAckIpfWSblHyLVzl6UKX5G7ft+yetH1pI0mZvseSNzHUhclxNl4WGaDgGnEbBjLD0XRNEy2yRrSYg==",
+            "version": "0.2.83",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.83.tgz",
+            "integrity": "sha512-S/sVimOICn16Lnp/ZU9TJQSJKKQlSdPJGGC/5rsTgvLDrlF+dXVPzZsJ+p0hpvdWfjTOZFBEGgMtHASSfIC+lQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.28",
+                "@aws/language-server-runtimes-types": "^0.1.29",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/api-logs": "^0.200.0",
                 "@opentelemetry/core": "^2.0.0",
@@ -3953,6 +3953,7 @@
                 "rxjs": "^7.8.2",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-protocol": "^3.17.5",
+                "vscode-uri": "^3.1.0",
                 "win-ca": "^3.5.1"
             },
             "engines": {
@@ -3960,9 +3961,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.28",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.28.tgz",
-            "integrity": "sha512-eDNcEXGAyD4rzl+eVJ6Ngfbm4iaR8MkoMk1wVcnV+VGqu63TyvV1aVWnZdl9tR4pmC0rIH3tj8FSCjhSU6eJlA==",
+            "version": "0.1.29",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.29.tgz",
+            "integrity": "sha512-/9cv2HXxFBYceynJKVcWgl5Eg3aBMVuIll6sPei+X6m8GhKZ8aMps3ru0MlFcfQrtU6iyKW+Jhpvm0lRDP+a+Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -26517,7 +26518,7 @@
             "version": "0.1.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-core": "^0.0.7"
             },
             "devDependencies": {
@@ -26591,7 +26592,7 @@
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.32",
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-core": "^0.0.7",
                 "@modelcontextprotocol/sdk": "^1.9.0",
                 "@smithy/node-http-handler": "^2.5.0",
@@ -26729,7 +26730,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-core": "^0.0.7",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -26775,7 +26776,7 @@
             "version": "0.1.7",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-core": "^0.0.7",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -26789,7 +26790,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-core": "0.0.7",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -26831,7 +26832,7 @@
             "version": "0.0.8",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -26887,7 +26888,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-core": "^0.0.7",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -26901,7 +26902,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -26912,7 +26913,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.81",
+                "@aws/language-server-runtimes": "^0.2.83",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,7 +245,7 @@
             "version": "0.1.9",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.1.33",
+                "@aws/chat-client-ui-types": "^0.1.35",
                 "@aws/language-server-runtimes-types": "^0.1.29",
                 "@aws/mynah-ui": "^4.35.0-beta.4"
             },
@@ -268,7 +268,7 @@
             "devDependencies": {
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
-                "@aws/chat-client-ui-types": "^0.1.32",
+                "@aws/chat-client-ui-types": "^0.1.35",
                 "@aws/language-server-runtimes": "^0.2.83",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
@@ -3914,12 +3914,12 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.34",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.34.tgz",
-            "integrity": "sha512-9IZvrGIJ9/VbiYg/HS+I19NuC/XCTTKrpd2dpeINIOou7j0NmP8w5nYfeVU8yLw4ko5bXETgayyYOWnrXmNe4A==",
+            "version": "0.1.35",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.35.tgz",
+            "integrity": "sha512-aqFX0pTr89CiJA5VFqJEKveD9pfinuNJeYJ5qRp7c6M9rgUDj5/CJg+CkbFWiQDxgzoeF3C/aZBY4DuShd9rEA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.28"
+                "@aws/language-server-runtimes-types": "^0.1.29"
             }
         },
         "node_modules/@aws/hello-world-lsp": {
@@ -26591,7 +26591,7 @@
                 "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.6.tgz",
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
-                "@aws/chat-client-ui-types": "^0.1.32",
+                "@aws/chat-client-ui-types": "^0.1.35",
                 "@aws/language-server-runtimes": "^0.2.83",
                 "@aws/lsp-core": "^0.0.7",
                 "@modelcontextprotocol/sdk": "^1.9.0",

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-core": "^0.0.7"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.32",
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-core": "^0.0.7",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -31,7 +31,7 @@
         "@amzn/codewhisperer-streaming": "file:../../core/codewhisperer-streaming/amzn-codewhisperer-streaming-1.0.6.tgz",
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
-        "@aws/chat-client-ui-types": "^0.1.32",
+        "@aws/chat-client-ui-types": "^0.1.35",
         "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-core": "^0.0.7",
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-core": "^0.0.7",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-core": "^0.0.7",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-core": "0.0.7",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "@aws/lsp-core": "^0.0.7",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.81",
+        "@aws/language-server-runtimes": "^0.2.83",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
- Bump up language server version to
```
language-server-runtimes: 0.2.83
language-server-runtimes-types: 0.1.29
```
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
