### PR TITLE
fix: pr for eye icon(do not merge)

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1248,6 +1248,8 @@ export class AgenticChatController implements ChatHandlers {
                 return 'This command may modify your code and/or files.'
             case CommandCategory.Destructive:
                 return 'This command may cause significant data loss or damage.'
+            case CommandCategory.ReadOnly:
+                return 'This command is read-only'
             default:
                 return undefined
         }
@@ -1484,7 +1486,7 @@ export class AgenticChatController implements ChatHandlers {
                                       ? 'warning'
                                       : commandCategory === CommandCategory.Mutate
                                         ? 'info'
-                                        : 'none',
+                                        : 'eye',
                               status:
                                   commandCategory === CommandCategory.Destructive
                                       ? 'warning'
@@ -1496,7 +1498,11 @@ export class AgenticChatController implements ChatHandlers {
                                   commandCategory ?? CommandCategory.ReadOnly
                               ),
                           }
-                        : {},
+                        : {
+                              icon: 'eye',
+                              position: 'left',
+                              description: this.#getCommandCategoryDescription(CommandCategory.ReadOnly),
+                          },
                     body: 'shell',
                     buttons,
                 }


### PR DESCRIPTION
## Problem
We want to show the description for auto executed command and show Run Automatically text. 
![image](https://github.com/user-attachments/assets/b346eb1d-ff7b-43e9-a7c6-5ad9a65f0d8f)

## Solution
This PR enhances the user experience by adding tooltips and changing icons for read-only commands before execution. The implementation adds visual indicators to help users distinguish between read-only operations and those that modify files.

The post-execution handling remains unchanged, as it's currently managed in the #getWritableStream function which doesn't differentiate between command types. Currently, tooltips are not displayed after commands have been executed - this behavior requires further discussion.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
