### PR TITLE
fix: remove limit on agentic loop

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -7,7 +7,6 @@ import * as crypto from 'crypto'
 import * as path from 'path'
 import {
     ChatTriggerType,
-    CodeWhispererStreamingServiceException,
     GenerateAssistantResponseCommandInput,
     GenerateAssistantResponseCommandOutput,
     SendMessageCommandInput,
@@ -114,7 +113,6 @@ import { loggingUtils } from '@aws/lsp-core'
 import { diffLines } from 'diff'
 import {
     genericErrorMsg,
-    maxAgentLoopIterations,
     loadingThresholdMs,
     generateAssistantResponseInputLimit,
     outputLimitExceedsPartialMsg,
@@ -558,7 +556,7 @@ export class AgenticChatController implements ChatHandlers {
         let shouldDisplayMessage = true
         metric.recordStart()
 
-        while (iterationCount < maxAgentLoopIterations) {
+        while (true) {
             iterationCount++
             this.#debug(`Agent loop iteration ${iterationCount} for conversation id:`, conversationIdentifier || '')
 
@@ -762,10 +760,6 @@ export class AgenticChatController implements ChatHandlers {
                 this.#toolUseLatencies = []
             }
             currentRequestInput = this.#updateRequestInputWithToolResults(currentRequestInput, toolResults, content)
-        }
-
-        if (iterationCount >= maxAgentLoopIterations) {
-            throw new AgenticChatError('Agent loop reached iteration limit', 'MaxAgentLoopIterations')
         }
 
         return (

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
@@ -1,5 +1,4 @@
 export const genericErrorMsg = 'An unexpected error occurred, check the logs for more information.'
-export const maxAgentLoopIterations = 100
 export const loadingThresholdMs = 2000
 export const generateAssistantResponseInputLimit = 500_000
 export const outputLimitExceedsPartialMsg = 'output exceeds maximum character limit of'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -4,14 +4,12 @@ type AgenticChatErrorCode =
     | 'QModelResponse' // generic backend error.
     | 'AmazonQServiceManager' // AmazonQServiceManager failed to initialize.
     | 'FailedResult' // general error when processing tool results
-    | 'MaxAgentLoopIterations'
     | 'InputTooLong' // too much context given to backend service.
     | 'PromptCharacterLimit' // customer prompt exceeds
     | 'ResponseProcessingTimeout' // response didn't finish streaming in the allowed time
 
 export const customerFacingErrorCodes: AgenticChatErrorCode[] = [
     'QModelResponse',
-    'MaxAgentLoopIterations',
     'InputTooLong',
     'PromptCharacterLimit',
 ]


### PR DESCRIPTION
## Problem
Some customers experience errors due to `Agent loop reached iteration limit`

## Solution
Remove limit on agentic loop entirely


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
