### PR TITLE
fix: truncate API payload for history, relevant documents and current editor

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -1300,6 +1300,242 @@ describe('AgenticChatController', () => {
             })
         })
     })
+    describe('truncateRequest', () => {
+        it('should truncate user input message if exceeds limit', () => {
+            const request: GenerateAssistantResponseCommandInput = {
+                conversationState: {
+                    currentMessage: {
+                        userInputMessage: {
+                            content: 'a'.repeat(590_000),
+                            userInputMessageContext: {
+                                editorState: {
+                                    relevantDocuments: [
+                                        {
+                                            relativeFilePath: '',
+                                            text: 'a'.repeat(490_000),
+                                        },
+                                    ],
+                                    document: {
+                                        relativeFilePath: '',
+                                        text: 'a'.repeat(490_000),
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    history: [
+                        {
+                            userInputMessage: {
+                                content: 'a'.repeat(490_000),
+                            },
+                        },
+                    ],
+                    chatTriggerType: undefined,
+                },
+            }
+            chatController.truncateRequest(request)
+            assert.strictEqual(request.conversationState?.currentMessage?.userInputMessage?.content?.length, 500_000)
+            assert.strictEqual(
+                request.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                    ?.document?.text?.length || 0,
+                0
+            )
+            assert.strictEqual(
+                request.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                    ?.relevantDocuments?.length || 0,
+                0
+            )
+            assert.strictEqual(request.conversationState?.history?.length || 0, 0)
+        })
+
+        it('should not modify user input message if within limit', () => {
+            const message = 'hello world'
+            const request: GenerateAssistantResponseCommandInput = {
+                conversationState: {
+                    currentMessage: {
+                        userInputMessage: {
+                            content: message,
+                        },
+                    },
+                    chatTriggerType: undefined,
+                },
+            }
+            chatController.truncateRequest(request)
+            assert.strictEqual(request.conversationState?.currentMessage?.userInputMessage?.content, message)
+        })
+
+        it('should truncate relevant documents if combined length exceeds remaining budget', () => {
+            const request: GenerateAssistantResponseCommandInput = {
+                conversationState: {
+                    currentMessage: {
+                        userInputMessage: {
+                            content: 'a'.repeat(400_000),
+                            userInputMessageContext: {
+                                editorState: {
+                                    relevantDocuments: [
+                                        {
+                                            relativeFilePath: 'a',
+                                            text: 'a'.repeat(100),
+                                        },
+                                        {
+                                            relativeFilePath: 'b',
+                                            text: 'a'.repeat(200),
+                                        },
+                                        {
+                                            relativeFilePath: 'c',
+                                            text: 'a'.repeat(100_000),
+                                        },
+                                    ],
+                                    document: {
+                                        relativeFilePath: '',
+                                        text: 'a'.repeat(490_000),
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    history: [
+                        {
+                            userInputMessage: {
+                                content: 'a'.repeat(490_000),
+                            },
+                        },
+                    ],
+                    chatTriggerType: undefined,
+                },
+            }
+            chatController.truncateRequest(request)
+            assert.strictEqual(request.conversationState?.currentMessage?.userInputMessage?.content?.length, 400_000)
+            assert.strictEqual(
+                request.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                    ?.document?.text?.length || 0,
+                0
+            )
+            assert.strictEqual(
+                request.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                    ?.relevantDocuments?.length || 0,
+                2
+            )
+            assert.strictEqual(request.conversationState?.history?.length || 0, 0)
+        })
+        it('should truncate current editor if combined length exceeds remaining budget', () => {
+            const request: GenerateAssistantResponseCommandInput = {
+                conversationState: {
+                    currentMessage: {
+                        userInputMessage: {
+                            content: 'a'.repeat(400_000),
+                            userInputMessageContext: {
+                                editorState: {
+                                    relevantDocuments: [
+                                        {
+                                            relativeFilePath: '',
+                                            text: 'a'.repeat(1000),
+                                        },
+                                        {
+                                            relativeFilePath: '',
+                                            text: 'a'.repeat(1000),
+                                        },
+                                    ],
+                                    document: {
+                                        relativeFilePath: '',
+                                        text: 'a'.repeat(100_000),
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    history: [
+                        {
+                            userInputMessage: {
+                                content: 'a'.repeat(100),
+                            },
+                        },
+                        {
+                            userInputMessage: {
+                                content: 'a'.repeat(100),
+                            },
+                        },
+                        {
+                            userInputMessage: {
+                                content: 'a'.repeat(100_000),
+                            },
+                        },
+                    ],
+                    chatTriggerType: undefined,
+                },
+            }
+            chatController.truncateRequest(request)
+            assert.strictEqual(request.conversationState?.currentMessage?.userInputMessage?.content?.length, 400_000)
+            assert.strictEqual(
+                request.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                    ?.document?.text?.length || 0,
+                0
+            )
+            assert.strictEqual(
+                request.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                    ?.relevantDocuments?.length || 0,
+                2
+            )
+            assert.strictEqual(request.conversationState?.history?.length || 0, 2)
+        })
+
+        it('should truncate chat history if combined length exceeds remaining budget', () => {
+            const request: GenerateAssistantResponseCommandInput = {
+                conversationState: {
+                    currentMessage: {
+                        userInputMessage: {
+                            content: 'a'.repeat(400_000),
+                            userInputMessageContext: {
+                                editorState: {
+                                    relevantDocuments: [
+                                        {
+                                            relativeFilePath: '',
+                                            text: 'a'.repeat(100),
+                                        },
+                                    ],
+                                    document: {
+                                        relativeFilePath: '',
+                                        text: 'a'.repeat(10_000),
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    history: [
+                        {
+                            userInputMessage: {
+                                content: 'a'.repeat(100),
+                            },
+                        },
+                        {
+                            userInputMessage: {
+                                content: 'a'.repeat(100),
+                            },
+                        },
+                        {
+                            userInputMessage: {
+                                content: 'a'.repeat(100_000),
+                            },
+                        },
+                    ],
+                    chatTriggerType: undefined,
+                },
+            }
+            chatController.truncateRequest(request)
+            assert.strictEqual(request.conversationState?.currentMessage?.userInputMessage?.content?.length, 400_000)
+            assert.strictEqual(
+                request.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                    ?.document?.text?.length || 0,
+                10_000
+            )
+            assert.strictEqual(
+                request.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                    ?.relevantDocuments?.length || 0,
+                1
+            )
+            assert.strictEqual(request.conversationState?.history?.length || 0, 2)
+        })
+    })
 
     describe('onCreatePrompt', () => {
         it('should create prompt file with given name', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -600,7 +600,7 @@ export class AgenticChatController implements ChatHandlers {
             await chatResultStream.writeResultBlock({ ...loadingMessage, messageId: loadingMessageId })
 
             // Phase 3: Request Execution
-            this.#truncateRequest(currentRequestInput)
+            this.truncateRequest(currentRequestInput)
             const response = await session.generateAssistantResponse(currentRequestInput)
 
             if (response.$metadata.requestId) {
@@ -781,19 +781,74 @@ export class AgenticChatController implements ChatHandlers {
      * performs truncation of request before sending to backend service.
      * @param request
      */
-    #truncateRequest(request: GenerateAssistantResponseCommandInput) {
+    truncateRequest(request: GenerateAssistantResponseCommandInput) {
         // Note: these logs are very noisy, but contain information redacted on the backend.
         this.#debug(`generateAssistantResponse Request: ${JSON.stringify(request, undefined, 2)}`)
         if (!request?.conversationState?.currentMessage?.userInputMessage) {
             return
         }
         const message = request.conversationState?.currentMessage?.userInputMessage?.content
-        if (message && message.length > generateAssistantResponseInputLimit) {
-            this.#debug(`Truncating userInputMessage to ${generateAssistantResponseInputLimit} characters}`)
-            request.conversationState.currentMessage.userInputMessage.content = message.substring(
-                0,
-                generateAssistantResponseInputLimit
-            )
+        let remainingCharacterBudget = generateAssistantResponseInputLimit
+
+        // 1. prioritize user input message
+        let truncatedUserInputMessage = ''
+        if (message) {
+            if (message.length > generateAssistantResponseInputLimit) {
+                this.#debug(`Truncating userInputMessage to ${generateAssistantResponseInputLimit} characters}`)
+                truncatedUserInputMessage = message.substring(0, generateAssistantResponseInputLimit)
+                remainingCharacterBudget = remainingCharacterBudget - truncatedUserInputMessage.length
+                request.conversationState.currentMessage.userInputMessage.content = truncatedUserInputMessage
+            } else {
+                remainingCharacterBudget = remainingCharacterBudget - message.length
+            }
+        }
+
+        // 2. try to fit @context into budget
+        let truncatedRelevantDocuments = []
+        if (
+            request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.editorState
+                ?.relevantDocuments
+        ) {
+            for (const relevantDoc of request.conversationState.currentMessage.userInputMessage.userInputMessageContext
+                ?.editorState?.relevantDocuments) {
+                const docLength = relevantDoc?.text?.length || 0
+                if (remainingCharacterBudget > docLength) {
+                    truncatedRelevantDocuments.push(relevantDoc)
+                    remainingCharacterBudget = remainingCharacterBudget - docLength
+                }
+            }
+            request.conversationState.currentMessage.userInputMessage.userInputMessageContext.editorState.relevantDocuments =
+                truncatedRelevantDocuments
+        }
+
+        // 3. try to fit current file context
+        let truncatedCurrentDocument = undefined
+        if (request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.editorState?.document) {
+            const docLength =
+                request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.editorState?.document
+                    .text?.length || 0
+            if (remainingCharacterBudget > docLength) {
+                truncatedCurrentDocument =
+                    request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.editorState
+                        ?.document
+                remainingCharacterBudget = remainingCharacterBudget - docLength
+            }
+            request.conversationState.currentMessage.userInputMessage.userInputMessageContext.editorState.document =
+                truncatedCurrentDocument
+        }
+
+        // 4. try to fit chat history
+        let truncatedChatHistory = []
+        if (request.conversationState.history) {
+            for (const history of request.conversationState.history) {
+                // use json strified string length to provide a conservative estimate
+                const historyLength = JSON.stringify(history).toString().length
+                if (remainingCharacterBudget > historyLength) {
+                    truncatedChatHistory.push(history)
+                    remainingCharacterBudget = remainingCharacterBudget - historyLength
+                }
+            }
+            request.conversationState.history = truncatedChatHistory
         }
     }
 


### PR DESCRIPTION
## Problem
The client side total character can exceed 600k when chat history is long or context is too long, which result in user seeing 4xx Input is too long. Previously we had a mechanism to drop chat history once input is too long is seen, but we should technically not surface such error to customer to begin with.

## Solution

Truncate API payload and prioritize them using user input > use selected context > current open editor > chat history. 
The limit is still at 500k characters to leave some room for server side prompts and future work.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
