### PR TITLE
fix: missing handle connection expired error for inline suggestions

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
@@ -623,7 +623,7 @@ describe('CodeWhisperer Server', () => {
             sinon.assert.calledOnceWithExactly(service.generateSuggestions, expectedGenerateSuggestionsRequest)
         })
 
-        it('throws connection error if connection is expired', async () => {
+        it('throws ResponseError with expected message if connection is expired', async () => {
             service.generateSuggestions.returns(Promise.reject(new Error(INVALID_TOKEN)))
 
             const promise = async () =>
@@ -636,7 +636,7 @@ describe('CodeWhisperer Server', () => {
                     CancellationToken.None
                 )
             // Throws expected error
-            assert.rejects(promise, AmazonQServiceConnectionExpiredError)
+            assert.rejects(promise, ResponseError, 'E_AMAZON_Q_CONNECTION_EXPIRED')
         })
 
         it('throws ResponseError if error is AmazonQError', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -592,6 +592,14 @@ export const CodewhispererServerFactory =
             logging.log('Recommendation failure: ' + error)
             emitServiceInvocationFailure(telemetry, session, error)
 
+            if (error instanceof AmazonQError) {
+                throw error
+            }
+
+            if (hasConnectionExpired(error)) {
+                throw new AmazonQServiceConnectionExpiredError(getErrorMessage(error))
+            }
+
             sessionManager.closeSession(session)
 
             return EMPTY_RESULT

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -592,15 +592,21 @@ export const CodewhispererServerFactory =
             logging.log('Recommendation failure: ' + error)
             emitServiceInvocationFailure(telemetry, session, error)
 
+            sessionManager.closeSession(session)
+
             if (error instanceof AmazonQError) {
-                throw error
+                throw new ResponseError(
+                    LSPErrorCodes.RequestFailed,
+                    error.message || 'Error processing suggestion requests',
+                    {
+                        awsErrorCode: error.code,
+                    }
+                )
             }
 
             if (hasConnectionExpired(error)) {
                 throw new AmazonQServiceConnectionExpiredError(getErrorMessage(error))
             }
-
-            sessionManager.closeSession(session)
 
             return EMPTY_RESULT
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -594,18 +594,20 @@ export const CodewhispererServerFactory =
 
             sessionManager.closeSession(session)
 
-            if (error instanceof AmazonQError) {
-                throw new ResponseError(
-                    LSPErrorCodes.RequestFailed,
-                    error.message || 'Error processing suggestion requests',
-                    {
-                        awsErrorCode: error.code,
-                    }
-                )
-            }
+            let translatedError = error
 
             if (hasConnectionExpired(error)) {
-                throw new AmazonQServiceConnectionExpiredError(getErrorMessage(error))
+                translatedError = new AmazonQServiceConnectionExpiredError(getErrorMessage(error))
+            }
+
+            if (translatedError instanceof AmazonQError) {
+                throw new ResponseError(
+                    LSPErrorCodes.RequestFailed,
+                    translatedError.message || 'Error processing suggestion requests',
+                    {
+                        awsErrorCode: translatedError.code,
+                    }
+                )
             }
 
             return EMPTY_RESULT


### PR DESCRIPTION
## Problem
https://github.com/aws/language-servers/pull/1001 (connection expired error handling) was negated by https://github.com/aws/language-servers/pull/1299
## Solution
add back changes in #1001 and add unit test
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
