### PR TITLE
feat: setup for MCP servers tools permission UX

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.35",
         "@aws/language-server-runtimes-types": "^0.1.29",
-        "@aws/mynah-ui": "^4.35.0-beta.4"
+        "@aws/mynah-ui": "^4.35.0-beta.6"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -34,6 +34,8 @@ import {
     InfoLinkClickParams,
     LinkClickParams,
     ListConversationsParams,
+    ListMcpServersParams,
+    McpServerClickParams,
     OpenTabResult,
     PromptInputOptionChangeParams,
     QuickActionParams,
@@ -89,8 +91,8 @@ export interface OutboundChatApi {
     fileClick(params: FileClickParams): void
     listConversations(params: ListConversationsParams): void
     conversationClick(params: ConversationClickParams): void
-    mcpServerClick(params: ConversationClickParams): void
-    listMcpServers(params: ListConversationsParams): void
+    mcpServerClick(params: McpServerClickParams): void
+    listMcpServers(params: ListMcpServersParams): void
     tabBarAction(params: TabBarActionParams): void
     onGetSerializedChat(requestId: string, result: GetSerializedChatResult | ErrorResult): void
     promptInputOptionChange(params: PromptInputOptionChangeParams): void
@@ -223,8 +225,8 @@ export class Messager {
         this.chatApi.listMcpServers({ filter })
     }
 
-    onMcpServerClick = (id: string, action?: ConversationAction): void => {
-        this.chatApi.mcpServerClick({ id: id, action })
+    onMcpServerClick = (id: string, title?: string, options?: Record<string, string>): void => {
+        this.chatApi.mcpServerClick({ id: id, title: title, optionsValues: options })
     }
 
     onTabBarAction = (params: TabBarActionParams): void => {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1115,41 +1115,42 @@ ${params.message}`,
                 children: group.children?.map(item => {
                     // Determine icon based on group name and status
                     let icon = 'ok-circled'
-                    const iconForegroundStatus = 'success'
+                    let iconForegroundStatus = 'success'
 
                     if (group.groupName === 'Disabled') {
                         icon = 'block'
+                        iconForegroundStatus = 'error'
                     }
 
                     // Create actions based on group name
                     const actions = []
                     if (group.groupName === 'Active') {
                         actions.push({
-                            id: 'open-mcp-xx',
+                            id: 'open-mcp-server',
                             icon: toMynahIcon('right-open'),
                         })
                     } else if (group.groupName === 'Disabled') {
                         actions.push({
-                            id: 'enable-mcp-' + item.title.toLowerCase(),
+                            id: 'enable-mcp-server',
                             icon: toMynahIcon('ok-circled'),
                             text: 'Enable',
                             description: 'Enable',
                         })
                         actions.push({
-                            id: 'delete-mcp-' + item.title.toLowerCase(),
+                            id: 'delete-mcp-server',
                             icon: toMynahIcon('trash'),
                             text: 'Delete',
                             description: 'Delete',
                         })
                         actions.push({
-                            id: 'open-mcp-xx',
+                            id: 'open-mcp-server',
                             icon: toMynahIcon('right-open'),
                             disabled: true,
                         })
                     }
 
                     return {
-                        id: 'mcp-server-' + item.title.toLowerCase(),
+                        id: 'mcp-server-click',
                         title: item.title,
                         description: item.description,
                         icon: toMynahIcon(icon),
@@ -1189,7 +1190,7 @@ ${params.message}`,
                     }
                 },
                 onActionClick: (action: ChatItemButton, item?: DetailedListItem) => {
-                    messager.onMcpServerClick(action.id)
+                    messager.onMcpServerClick(action.id, item?.title)
                 },
                 onClose: () => {
                     // No need to store reference
@@ -1202,7 +1203,105 @@ ${params.message}`,
     }
 
     const mcpServerClick = (params: McpServerClickResult) => {
-        // TODO: Add "add config" implementation here.
+        if (params.id === 'open-mcp-server') {
+            // Create a detailed list for the MCP server configuration
+
+            const detailedList: any = {
+                selectable: false,
+                textDirection: 'row',
+                header: params.header
+                    ? {
+                          title: params.header.title,
+                          description: params.header.description,
+                          status: params.header.status,
+                          actions: params.header.actions?.map(action => ({
+                              ...action,
+                              icon: action.icon ? toMynahIcon(action.icon) : undefined,
+                              ...(action.id === 'mcp-details-menu'
+                                  ? {
+                                        items: [
+                                            {
+                                                id: 'mcp-disable-tool',
+                                                text: `Disable ${params.header?.title}`,
+                                                icon: toMynahIcon('block'),
+                                            },
+                                            {
+                                                id: 'mcp-delete-tool',
+                                                confirmation: {
+                                                    cancelButtonText: 'Cancel',
+                                                    confirmButtonText: 'Delete',
+                                                    title: 'Delete Filesystem MCP server',
+                                                    description:
+                                                        'This configuration will be deleted and no longer available in Q. \n\n This cannot be undone.',
+                                                },
+                                                text: `Delete ${params.header?.title}`,
+                                                icon: toMynahIcon('trash'),
+                                            },
+                                        ],
+                                    }
+                                  : {}),
+                          })),
+                      }
+                    : undefined,
+                filterOptions: params.filterOptions?.map(filter => ({
+                    ...filter,
+                    icon: filter.icon ? toMynahIcon(filter.icon) : undefined,
+                })),
+                list: params.list?.map(group => ({
+                    groupName: group.groupName,
+                    children: group.children?.map(item => ({
+                        id: item.title,
+                        title: item.title,
+                        description: item.description,
+                        icon: toMynahIcon('tools'),
+                        groupActions: item.groupActions,
+                    })),
+                })),
+            }
+            // Add filter actions if present
+            if (params.filterActions && params.filterActions.length > 0) {
+                detailedList.filterActions = params.filterActions.map(action => ({
+                    ...action,
+                    icon: action.icon ? toMynahIcon(action.icon) : undefined,
+                }))
+            }
+
+            // Open the detailed list UI
+            const mcpServerSheet = mynahUi.openDetailedList(
+                {
+                    detailedList: detailedList,
+                    events: {
+                        onFilterValueChange: (filterValues: Record<string, string>) => {
+                            // Handle filter value changes for tool permissions
+                            messager.onMcpServerClick('mcp-permission-change', detailedList.header?.title, filterValues)
+                        },
+
+                        onFilterActionClick: (
+                            action: ChatItemButton,
+                            filterValues?: Record<string, any>,
+                            isValid?: boolean
+                        ) => {},
+                        onTitleActionClick: (action: ChatItemButton) => {},
+                        onKeyPress: (e: KeyboardEvent) => {
+                            if (e.key === 'Escape') {
+                                mcpServerSheet.close()
+                            }
+                        },
+                        onActionClick: (action: ChatItemButton) => {
+                            // Handle action clicks (save, cancel, etc.)
+                            messager.onMcpServerClick(action.id)
+                        },
+                        onClose: () => {
+                            messager.onListMcpServers()
+                        },
+                        onBackClick: () => {
+                            messager.onListMcpServers()
+                        },
+                    },
+                },
+                true
+            )
+        }
     }
 
     const getSerializedChat = (requestId: string, params: GetSerializedChatParams) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.35",
                 "@aws/language-server-runtimes-types": "^0.1.29",
-                "@aws/mynah-ui": "^4.35.0-beta.4"
+                "@aws/mynah-ui": "^4.35.0-beta.6"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4063,10 +4063,11 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.35.0-beta.4",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.35.0-beta.4.tgz",
-            "integrity": "sha512-xSHTVpPzLNXcvK3IUTzAjTLKn7jMRivvduzFhlOBpeWUDaikNVbTenm1gZdbveb156K9hzsFahWUDVZbZfTQPA==",
+            "version": "4.35.0-beta.6",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.35.0-beta.6.tgz",
+            "integrity": "sha512-dxzVJOrGGnSdlmJ2eXSw/2/tEvfDIZtndnqFq7YOycQjwkHrdqZMTP+DQm+O6F+yiK+ZbLzUDLwKDHHOtJnMoA==",
             "hasInstallScript": true,
+            "license": "Apache License 2.0",
             "dependencies": {
                 "escape-html": "^1.0.3",
                 "highlight.js": "^11.11.0",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -1,0 +1,251 @@
+/**
+ * Handles MCP server-related events
+ */
+
+import { Features } from '../../../types'
+import { McpManager } from './mcpManager'
+import {
+    DetailedListGroup,
+    DetailedListItem,
+    FilterOption,
+    ListMcpServersParams,
+    McpServerClickParams,
+} from '@aws/language-server-runtimes/protocol'
+
+export class McpEventHandler {
+    constructor(private features: Pick<Features, 'logging'>) {}
+
+    /**
+     * Handles the list MCP servers event
+     */
+    async onListMcpServers(params: ListMcpServersParams) {
+        const mcpManagerServerConfigs = McpManager.instance.getAllServerConfigs()
+
+        // Transform server configs into DetailedListItem objects
+        const activeItems: DetailedListItem[] = []
+        const disabledItems: DetailedListItem[] = []
+
+        Array.from(mcpManagerServerConfigs.entries()).forEach(([serverName, config]) => {
+            const toolsWithStates = McpManager.instance.getAllToolsWithStates(serverName)
+            const toolsCount = toolsWithStates.length
+
+            const item: DetailedListItem = {
+                title: serverName,
+                description: `Command: ${config.command}`,
+            }
+
+            if (config.disabled) {
+                disabledItems.push(item)
+            } else {
+                activeItems.push({
+                    ...item,
+                    description: `${toolsCount} tools - ${config.command}`,
+                })
+            }
+        })
+
+        // Create the groups
+        const groups: DetailedListGroup[] = []
+
+        if (activeItems.length > 0) {
+            groups.push({
+                groupName: 'Active',
+                children: activeItems,
+                actions: [
+                    {
+                        id: 'active-servers',
+                        text: `${activeItems.length} servers with tools`,
+                    },
+                ],
+            })
+        }
+
+        if (disabledItems.length > 0) {
+            groups.push({
+                groupName: 'Disabled',
+                children: disabledItems,
+            })
+        }
+
+        // Return the result in the expected format
+        return {
+            header: {
+                title: 'MCP Servers',
+                description:
+                    "Q automatically uses any MCP servers that have been added, so you don't have to add them as context.",
+            },
+            list: groups,
+        }
+    }
+
+    /**
+     * Handles MCP server click events
+     */
+    async onMcpServerClick(params: McpServerClickParams) {
+        this.features.logging.log(`[VSCode Server] onMcpServerClick event with params: ${JSON.stringify(params)}`)
+
+        if (params.id === 'open-mcp-server') {
+            const serverName = params.title
+            const toolsWithStates = McpManager.instance.getAllToolsWithStates(serverName)
+            if (!serverName) {
+                return {
+                    id: params.id,
+                }
+            }
+            const filterOptions: FilterOption[] = []
+
+            filterOptions.push({
+                type: 'radiogroup',
+                id: 'scope',
+                title: 'Scope',
+                options: [
+                    {
+                        label: `Global - Used globally. Edit config`,
+                        value: 'global',
+                    },
+                    {
+                        label: `This workspace - Only used in this workspace. Edit config`,
+                        value: 'workspace',
+                    },
+                ],
+            })
+
+            // Get server config to check existing permissions
+            const serverConfig = McpManager.instance.getAllServerConfigs().get(serverName)
+
+            // Define permission options interface for easy reference
+            interface PermissionOption {
+                label: string
+                value: string
+            }
+
+            // Add tool select options
+            toolsWithStates.forEach(item => {
+                const toolName = item.tool.toolName
+
+                // Get current permission for this tool if it exists
+                const toolOverrides = serverConfig?.toolOverrides?.[toolName]
+                let currentPermission = 'Ask to run'
+
+                if (toolOverrides?.autoApprove === true) {
+                    currentPermission = 'Always run'
+                } else if (toolOverrides?.disabled === true) {
+                    currentPermission = 'Deny'
+                } else {
+                    currentPermission = 'Ask to run'
+                }
+
+                // Create permission options excluding the current one
+                const permissionOptions: PermissionOption[] = []
+
+                if (currentPermission !== 'Always run') {
+                    permissionOptions.push({
+                        label: 'Always run',
+                        value: 'always',
+                    })
+                }
+
+                if (currentPermission !== 'Ask to run') {
+                    permissionOptions.push({
+                        label: 'Ask to run',
+                        value: 'ask',
+                    })
+                }
+
+                if (currentPermission !== 'Deny') {
+                    permissionOptions.push({
+                        label: 'Deny',
+                        value: 'deny',
+                    })
+                }
+
+                filterOptions.push({
+                    type: 'select',
+                    id: `${toolName}`,
+                    title: toolName,
+                    placeholder: currentPermission,
+                    options: permissionOptions,
+                })
+            })
+
+            return {
+                id: params.id,
+                header: {
+                    title: serverName,
+                    status: {},
+                    actions: [
+                        {
+                            id: 'edit-setup',
+                            icon: 'pencil',
+                            text: 'Edit setup',
+                        },
+                        {
+                            id: 'mcp-details-menu',
+                            icon: 'ellipsis-h',
+                            text: '',
+                        },
+                    ],
+                },
+                list: [],
+                filterActions: [],
+                filterOptions,
+            }
+        } else if (params.id === 'mcp-permission-change') {
+            const serverName = params.title
+            const updatedPermissionConfig = params.optionsValues
+            if (!serverName || !updatedPermissionConfig) {
+                return {
+                    id: params.id,
+                }
+            }
+            try {
+                const serverConfig = McpManager.instance.getAllServerConfigs().get(serverName)
+                if (!serverConfig) {
+                    throw new Error(`Server '${serverName}' not found`)
+                }
+                const toolOverrides: Record<string, { autoApprove?: boolean; disabled?: boolean }> = {}
+
+                // Process each tool permission setting
+                Object.entries(updatedPermissionConfig).forEach(([key, value]) => {
+                    // Skip the scope setting
+                    if (key === 'scope') return
+
+                    // Only process entries with actual values
+                    if (value) {
+                        const permValue = value as string
+
+                        if (permValue === 'always') {
+                            toolOverrides[key] = { autoApprove: true, disabled: false }
+                        } else if (permValue === 'ask') {
+                            toolOverrides[key] = { autoApprove: false, disabled: false }
+                        } else if (permValue === 'deny') {
+                            toolOverrides[key] = { disabled: true }
+                        }
+                    }
+                })
+
+                // Update the permissions directly in the config file
+                await McpManager.instance.updateServerPermission(serverName, { toolOverrides })
+                return {
+                    id: params.id,
+                }
+            } catch (error) {
+                this.features.logging.error(`Failed to update MCP permissions: ${error}`)
+                return {
+                    id: params.id,
+                }
+            }
+        }
+        return {
+            id: params.id,
+            header: {
+                title: 'MCP Servers',
+                status: {},
+                description:
+                    'Q automatically uses any MCP servers that have been added, so you don\'t have to add them as context. All MCPs are defaulted to "Ask before running".',
+                actions: [],
+            },
+            list: [],
+        }
+    }
+}


### PR DESCRIPTION
## Problem

We need to setup UX for adding, updating permission for MCP server tools.

## Solution
- Added events for onMCPServerClick to redirect and open MCP servers permission.
- Added events for mcp server permission changes.
- Added UI objects for disable, delete and enable(No events yet)



https://github.com/user-attachments/assets/ba8cf11f-30ae-418e-b897-2595463a5f98




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
