### PR TITLE
SSPC dependency upload and watcher fixes

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
@@ -177,8 +177,8 @@ export class ArtifactManager {
             })
 
             for (const relativePath of files) {
-                const fullPath = resolveSymlink(path.join(filePath, relativePath))
                 try {
+                    const fullPath = resolveSymlink(path.join(filePath, relativePath))
                     const fileMetadata = await this.createFileMetadata(
                         fullPath,
                         path.join(filePathInZipOverride !== undefined ? filePathInZipOverride : '', relativePath),
@@ -187,7 +187,7 @@ export class ArtifactManager {
                     )
                     fileMetadataList.push(fileMetadata)
                 } catch (error) {
-                    this.logging.warn(`Error processing file ${fullPath}: ${error}`)
+                    this.logging.warn(`Error processing file ${relativePath}: ${error}`)
                 }
             }
         } else {

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/DependencyWatcher.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/DependencyWatcher.ts
@@ -20,7 +20,7 @@ export class DependencyWatcher {
         try {
             const watcher = fs.watch(this.path, { recursive: false }, async (eventType, fileName) => {
                 if (!fileName) return
-                if (eventType === 'rename') {
+                if (eventType === 'rename' || eventType === 'change') {
                     this.eventQueue.add(fileName)
                     if (this.processingTimeout) {
                         clearTimeout(this.processingTimeout)

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/DependencyWatcher.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/DependencyWatcher.ts
@@ -1,0 +1,66 @@
+import { Logging } from '@aws/language-server-runtimes/server-interface'
+import * as fs from 'fs'
+
+export class DependencyWatcher {
+    private eventQueue = new Set<string>()
+    private processingTimeout: NodeJS.Timeout | null = null
+    private isProcessing = false
+    private watcher: fs.FSWatcher
+
+    constructor(
+        private readonly path: string,
+        private readonly callbackFunction: (events: string[]) => void,
+        private readonly logging: Logging,
+        private readonly interval: number = 1000
+    ) {
+        this.watcher = this.setupWatcher()
+    }
+
+    private setupWatcher(): fs.FSWatcher {
+        try {
+            const watcher = fs.watch(this.path, { recursive: false }, async (eventType, fileName) => {
+                if (!fileName) return
+                if (eventType === 'rename') {
+                    this.eventQueue.add(fileName)
+                    if (this.processingTimeout) {
+                        clearTimeout(this.processingTimeout)
+                    }
+                    this.processingTimeout = setTimeout(() => {
+                        this.processEvents().catch(error => {
+                            this.logging.warn(`Error processing events: ${error}`)
+                        })
+                    }, this.interval)
+                }
+            })
+            return watcher
+        } catch (error) {
+            this.logging.warn(`Error setting up watcher for ${this.path}: ${error}`)
+            throw error
+        }
+    }
+
+    private async processEvents(): Promise<void> {
+        if (this.isProcessing) return
+        this.isProcessing = true
+        const events = Array.from(this.eventQueue)
+        this.eventQueue.clear()
+        try {
+            this.callbackFunction(events)
+        } catch (error) {
+            this.logging.warn(`Error processing bundled events: ${error}`)
+        } finally {
+            this.isProcessing = false
+        }
+    }
+
+    getWatcher(): fs.FSWatcher {
+        return this.watcher
+    }
+
+    dispose(): void {
+        if (this.processingTimeout) {
+            clearTimeout(this.processingTimeout)
+        }
+        this.watcher.close()
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/DependencyWatcher.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/DependencyWatcher.ts
@@ -32,6 +32,9 @@ export class DependencyWatcher {
                     }, this.interval)
                 }
             })
+            watcher.on('error', error => {
+                this.logging.warn(`watcher error for ${this.path}: ${error}`)
+            })
             return watcher
         } catch (error) {
             this.logging.warn(`Error setting up watcher for ${this.path}: ${error}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/LanguageDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/LanguageDependencyHandler.ts
@@ -4,6 +4,8 @@ import { ArtifactManager, FileMetadata } from '../../artifactManager'
 import path = require('path')
 import { EventEmitter } from 'events'
 import { CodewhispererLanguage } from '../../../../shared/languageDetection'
+import { isDirectory } from '../../util'
+import { DependencyWatcher } from './DependencyWatcher'
 
 export interface Dependency {
     name: string
@@ -28,12 +30,13 @@ export abstract class LanguageDependencyHandler<T extends BaseDependencyInfo> {
     protected dependencyMap = new Map<WorkspaceFolder, Map<string, Dependency>>()
     protected dependencyUploadedSizeMap = new Map<WorkspaceFolder, number>()
     protected dependencyUploadedSizeSum: Uint32Array<SharedArrayBuffer>
-    protected dependencyWatchers: Map<string, fs.FSWatcher> = new Map<string, fs.FSWatcher>()
+    protected dependencyWatchers: Map<string, DependencyWatcher> = new Map<string, DependencyWatcher>()
     protected artifactManager: ArtifactManager
     protected dependenciesFolderName: string
     protected eventEmitter: EventEmitter
     protected readonly MAX_SINGLE_DEPENDENCY_SIZE: number = 500 * 1024 * 1024 // 500 MB
     protected readonly MAX_WORKSPACE_DEPENDENCY_SIZE: number = 8 * 1024 * 1024 * 1024 // 8 GB
+    protected readonly DEPENDENCY_WATCHER_EVENT_BATCH_INTERVAL: number = 1000
 
     constructor(
         language: CodewhispererLanguage,
@@ -339,6 +342,9 @@ export abstract class LanguageDependencyHandler<T extends BaseDependencyInfo> {
 
     // For synchronous version if needed:
     protected getDirectorySize(directoryPath: string): number {
+        if (!isDirectory(directoryPath)) {
+            return fs.statSync(directoryPath).size
+        }
         let totalSize = 0
         try {
             const files = fs.readdirSync(directoryPath)
@@ -346,12 +352,7 @@ export abstract class LanguageDependencyHandler<T extends BaseDependencyInfo> {
             for (const file of files) {
                 const filePath = path.join(directoryPath, file)
                 const stats = fs.statSync(filePath)
-
-                if (stats.isDirectory()) {
-                    totalSize += this.getDirectorySize(filePath)
-                } else {
-                    totalSize += stats.size
-                }
+                totalSize += this.getDirectorySize(filePath)
             }
 
             return totalSize

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/LanguageDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/LanguageDependencyHandler.ts
@@ -319,7 +319,7 @@ export abstract class LanguageDependencyHandler<T extends BaseDependencyInfo> {
     dispose(): void {
         this.dependencyMap.clear()
         this.dependencyUploadedSizeMap.clear()
-        this.dependencyWatchers.forEach(watcher => watcher.close())
+        this.dependencyWatchers.forEach(watcher => watcher.dispose())
         this.dependencyWatchers.clear()
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/PythonDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/PythonDependencyHandler.ts
@@ -138,7 +138,6 @@ export class PythonDependencyHandler extends LanguageDependencyHandler<PythonDep
                         this.DEPENDENCY_WATCHER_EVENT_BATCH_INTERVAL
                     )
                     this.dependencyWatchers.set(sitePackagesPath, watcher)
-                    this.logging.log(`Started watching Python site-packages: ${sitePackagesPath}`)
                 } catch (error) {
                     this.logging.warn(`Error setting up watcher for ${sitePackagesPath}: ${error}`)
                 }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/util.ts
@@ -57,6 +57,26 @@ export const isDirectory = (path: string): boolean => {
     return fs.statSync(URI.parse(path).path).isDirectory()
 }
 
+export const resolveSymlink = (dependencyPath: string): string => {
+    let truePath: string = dependencyPath
+    let symlinkTarget: string | null = null
+    try {
+        if (fs.lstatSync(dependencyPath).isSymbolicLink()) {
+            symlinkTarget = fs.readlinkSync(dependencyPath)
+
+            // If the symlink target is relative, resolve it relative to the symlink's directory
+            if (!path.isAbsolute(symlinkTarget)) {
+                symlinkTarget = path.resolve(path.dirname(dependencyPath), symlinkTarget)
+            }
+
+            // Get the real path (resolves all symlinks in the path)
+            truePath = fs.realpathSync(dependencyPath)
+        }
+    } catch (error) {}
+
+    return truePath
+}
+
 export const isEmptyDirectory = (path: string): boolean => {
     return fs.readdirSync(URI.parse(path).path).length === 0
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/util.ts
@@ -59,21 +59,10 @@ export const isDirectory = (path: string): boolean => {
 
 export const resolveSymlink = (dependencyPath: string): string => {
     let truePath: string = dependencyPath
-    let symlinkTarget: string | null = null
-    try {
-        if (fs.lstatSync(dependencyPath).isSymbolicLink()) {
-            symlinkTarget = fs.readlinkSync(dependencyPath)
-
-            // If the symlink target is relative, resolve it relative to the symlink's directory
-            if (!path.isAbsolute(symlinkTarget)) {
-                symlinkTarget = path.resolve(path.dirname(dependencyPath), symlinkTarget)
-            }
-
-            // Get the real path (resolves all symlinks in the path)
-            truePath = fs.realpathSync(dependencyPath)
-        }
-    } catch (error) {}
-
+    if (fs.lstatSync(dependencyPath).isSymbolicLink()) {
+        // Get the real path (resolves all symlinks in the path)
+        truePath = fs.realpathSync(dependencyPath)
+    }
     return truePath
 }
 


### PR DESCRIPTION
## Problem
1. Symlink inside dependency folder wasn't resolved and didn't get uploaded
2. Dependency watcher can crash Flare when there are lots of file events happening to file watcher.

## Solution

1. Resolve symlink
2. Bundle events for file watcher

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
