### PR TITLE
fix: move generateAssistant request log statement

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -599,7 +599,8 @@ export class AgenticChatController implements ChatHandlers {
             await chatResultStream.writeResultBlock({ ...loadingMessage, messageId: loadingMessageId })
 
             // Phase 3: Request Execution
-
+            // Note: these logs are very noisy, but contain information redacted on the backend.
+            this.#debug(`generateAssistantResponse Request: ${JSON.stringify(currentRequestInput, undefined, 2)}`)
             const response = await session.generateAssistantResponse(currentRequestInput)
 
             if (response.$metadata.requestId) {
@@ -779,8 +780,6 @@ export class AgenticChatController implements ChatHandlers {
      */
     truncateRequest(request: GenerateAssistantResponseCommandInput): number {
         let remainingCharacterBudget = generateAssistantResponseInputLimit
-        // Note: these logs are very noisy, but contain information redacted on the backend.
-        this.#debug(`generateAssistantResponse Request: ${JSON.stringify(request, undefined, 2)}`)
         if (!request?.conversationState?.currentMessage?.userInputMessage) {
             return remainingCharacterBudget
         }


### PR DESCRIPTION
## Problem

[In this change](https://github.com/aws/language-servers/pull/1372) we now retrieve the history after truncating the request. This causes the request to be logged without the history included. This will make debugging difficult

## Solution

Move generateAssistant request log statement to after we have retrieved the history

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
