### PR TITLE
feat: added mcp tool count to MCP server list

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1126,6 +1126,12 @@ ${params.message}`,
                     const actions = []
                     if (group.groupName === 'Active') {
                         actions.push({
+                            id: 'tools-count',
+                            icon: toMynahIcon('tools'),
+                            text: `${item.description}`,
+                            disabled: true,
+                        })
+                        actions.push({
                             id: 'open-mcp-server',
                             icon: toMynahIcon('right-open'),
                         })
@@ -1152,7 +1158,6 @@ ${params.message}`,
                     return {
                         id: 'mcp-server-click',
                         title: item.title,
-                        description: item.description,
                         icon: toMynahIcon(icon),
                         iconForegroundStatus: iconForegroundStatus,
                         groupActions: false,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -39,7 +39,7 @@ export class McpEventHandler {
             } else {
                 activeItems.push({
                     ...item,
-                    description: `${toolsCount} tools - ${config.command}`,
+                    description: `${toolsCount}`,
                 })
             }
         })
@@ -200,6 +200,7 @@ export class McpEventHandler {
             }
             try {
                 const serverConfig = McpManager.instance.getAllServerConfigs().get(serverName)
+
                 if (!serverConfig) {
                     throw new Error(`Server '${serverName}' not found`)
                 }


### PR DESCRIPTION
## Problem
We need to display number of tools for each MCP server.

## Solution
- Added tool count to the List MCP server UX.

https://github.com/user-attachments/assets/f1555808-5af9-44c2-81fd-cd231d671bcf



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
