### PR TITLE
fix: Render timeout error, JSON parse error, cancellation to the in progress fs.write UI

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -217,19 +217,15 @@ export class AgenticChatResultStream {
         }
     }
 
-    async setProgressResultBlockStatusToError() {
+    async updateOngoingProgressResult(errorMessage: string) {
         for (const block of this.#state.chatResultBlocks) {
-            if (
-                block.messageId?.startsWith(progressPrefix) &&
-                block.header &&
-                block.header.status?.icon === 'progress'
-            ) {
+            if (block.messageId?.startsWith(progressPrefix) && block.header?.status?.icon === 'progress') {
+                await this.removeResultBlockAndUpdateUI(block.messageId)
                 block.header.status = {
                     status: 'error',
                     icon: 'error',
-                    text: 'Error',
+                    text: errorMessage,
                 }
-                await this.removeResultBlockAndUpdateUI(block.messageId)
                 block.messageId = block.messageId.substring(progressPrefix.length)
                 await this.writeResultBlock(block)
                 break

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -203,6 +203,10 @@ export class AgenticChatResultStream {
         this.#state.chatResultBlocks = this.#state.chatResultBlocks.filter(block => block.messageId !== messageId)
     }
 
+    /**
+     * Removes a specific messageId and renders the result on UI
+     * @param messageId
+     */
     async removeResultBlockAndUpdateUI(messageId: string) {
         if (this.hasMessage(messageId)) {
             const blockId = this.getMessageBlockId(messageId)
@@ -210,6 +214,26 @@ export class AgenticChatResultStream {
                 await this.overwriteResultBlock({ body: '', messageId: messageId }, blockId)
             }
             await this.removeResultBlock(messageId)
+        }
+    }
+
+    async setProgressResultBlockStatusToError() {
+        for (const block of this.#state.chatResultBlocks) {
+            if (
+                block.messageId?.startsWith(progressPrefix) &&
+                block.header &&
+                block.header.status?.icon === 'progress'
+            ) {
+                block.header.status = {
+                    status: 'error',
+                    icon: 'error',
+                    text: 'Error',
+                }
+                await this.removeResultBlockAndUpdateUI(block.messageId)
+                block.messageId = block.messageId.substring(progressPrefix.length)
+                await this.writeResultBlock(block)
+                break
+            }
         }
     }
 


### PR DESCRIPTION
## Problem
When there is a timeout error and/or JSON parse error, etc of the tool use and or a user cancel, the error status was not rendered in the progress fsWrite UI. that UI will remain in progress status.

## Solution
At those code path of timeout error and/or JSON parse error of the tool use and or a user cancel error, render the error in the fsWrite UI.


https://github.com/user-attachments/assets/c5958360-1712-462b-b9f1-82f728de9be1


This was tested by manually injecting errors including timeout error, JSON parse error, etc.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
