### PR TITLE
fix: emit telemetry event to RTS when failed or cancelled

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
+++ b/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
@@ -829,6 +829,10 @@
             "max": 20,
             "min": 0
         },
+        "AgenticChatEventStatus": {
+            "type": "string",
+            "enum": ["SUCCEEDED", "CANCELLED", "FAILED"]
+        },
         "AppStudioState": {
             "type": "structure",
             "required": ["namespace", "propertyName", "propertyContext"],
@@ -1010,6 +1014,9 @@
                 },
                 "hasProjectLevelContext": {
                     "shape": "Boolean"
+                },
+                "result": {
+                    "shape": "AgenticChatEventStatus"
                 }
             }
         },

--- a/server/aws-lsp-codewhisperer/src/client/token/codewhispererbearertokenclient.d.ts
+++ b/server/aws-lsp-codewhisperer/src/client/token/codewhispererbearertokenclient.d.ts
@@ -246,6 +246,7 @@ declare namespace CodeWhispererBearerTokenClient {
   export type AdditionalContentEntryInnerContextString = string;
   export type AdditionalContentEntryNameString = string;
   export type AdditionalContentList = AdditionalContentEntry[];
+  export type AgenticChatEventStatus = "SUCCEEDED"|"CANCELLED"|"FAILED"|string;
   export interface AppStudioState {
     /**
      * The namespace of the context. Examples: 'ui.Button', 'ui.Table.DataSource', 'ui.Table.RowActions.Button', 'logic.invokeAWS', 'logic.JavaScript'
@@ -323,6 +324,7 @@ declare namespace CodeWhispererBearerTokenClient {
     responseLength?: Integer;
     numberOfCodeBlocks?: Integer;
     hasProjectLevelContext?: Boolean;
+    result?: AgenticChatEventStatus;
   }
   export type ChatHistory = ChatMessage[];
   export interface ChatInteractWithMessageEvent {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -425,6 +425,8 @@ export class AgenticChatController implements ChatHandlers {
                     session.pairProgrammingMode,
                     session.getConversationType()
                 )
+                await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric, 'Cancelled')
+
                 session.abortRequest()
                 void this.#invalidateAllShellCommands(params.tabId, session)
                 session.rejectAllDeferredToolExecutions(new CancellationError('user'))
@@ -491,7 +493,6 @@ export class AgenticChatController implements ChatHandlers {
                 },
                 params.partialResultToken
             )
-
             if (this.isUserAction(err, token)) {
                 /**
                  * when the session is aborted it generates an error.
@@ -505,7 +506,14 @@ export class AgenticChatController implements ChatHandlers {
                     buttons: [],
                 }
             }
-            return this.#handleRequestError(err, errorMessageId, params.tabId, metric, session.pairProgrammingMode)
+            return this.#handleRequestError(
+                session.conversationId,
+                err,
+                errorMessageId,
+                params.tabId,
+                metric,
+                session.pairProgrammingMode
+            )
         }
     }
 
@@ -1799,7 +1807,7 @@ export class AgenticChatController implements ChatHandlers {
                 cwsprChatFocusFileContextLength: triggerContext.text?.length,
             })
         }
-        await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric)
+        await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric, 'Succeeded')
 
         this.#telemetryController.updateTriggerInfo(params.tabId, {
             lastMessageTrigger: {
@@ -1819,18 +1827,23 @@ export class AgenticChatController implements ChatHandlers {
     /**
      * Handles errors that occur during the request
      */
-    #handleRequestError(
+    async #handleRequestError(
+        conversationId: string | undefined,
         err: any,
         errorMessageId: string,
         tabId: string,
         metric: Metric<CombinedConversationEvent>,
         agenticCodingMode: boolean
-    ): ChatResult | ResponseError<ChatResult> {
+    ): Promise<ChatResult | ResponseError<ChatResult>> {
         const errorMessage = getErrorMessage(err)
         const requestID = getRequestID(err) ?? ''
         metric.setDimension('cwsprChatResponseCode', getHttpStatusCode(err) ?? 0)
         metric.setDimension('languageServerVersion', this.#features.runtime.serverInfo.version)
 
+        metric.metric.requestIds = [requestID]
+        metric.metric.cwsprChatMessageId = errorMessageId
+        metric.metric.cwsprChatConversationId = conversationId
+        await this.#telemetryController.emitAddMessageMetric(tabId, metric.metric, 'Failed')
         // use custom error message for unactionable errors (user-dependent errors like PromptCharacterLimit)
         if (err.code && err.code in unactionableErrorCodes) {
             const customErrMessage = unactionableErrorCodes[err.code as keyof typeof unactionableErrorCodes]

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -23,6 +23,7 @@ import { AcceptedSuggestionEntry, CodeDiffTracker } from '../../inline-completio
 import { TelemetryService } from '../../../shared/telemetry/telemetryService'
 import { getEndPositionForAcceptedSuggestion, getTelemetryReasonDesc } from '../../../shared/utils'
 import { CodewhispererLanguage } from '../../../shared/languageDetection'
+import { AgenticChatEventStatus } from '../../../client/token/codewhispererbearertokenclient'
 
 export const CONVERSATION_ID_METRIC_KEY = 'cwsprChatConversationId'
 
@@ -239,7 +240,7 @@ export class ChatTelemetryController {
         })
     }
 
-    public emitAddMessageMetric(tabId: string, metric: Partial<CombinedConversationEvent>) {
+    public emitAddMessageMetric(tabId: string, metric: Partial<CombinedConversationEvent>, result?: string) {
         const conversationId = this.getConversationId(tabId)
         // Store the customization value associated with the message
         if (metric.cwsprChatMessageId && metric.codewhispererCustomizationArn) {
@@ -264,6 +265,7 @@ export class ChatTelemetryController {
                 responseLength: metric.cwsprChatResponseLength,
                 numberOfCodeBlocks: metric.cwsprChatResponseCodeSnippetCount,
                 agenticCodingMode: metric.enabled,
+                result: result,
             },
             {
                 chatTriggerInteraction: metric.cwsprChatTriggerInteraction,

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -799,6 +799,7 @@ describe('TelemetryService', () => {
                         responseLength: 3000,
                         numberOfCodeBlocks: 0,
                         hasProjectLevelContext: false,
+                        result: 'SUCCEEDED',
                     },
                 },
             }
@@ -881,28 +882,6 @@ describe('TelemetryService', () => {
             sinon.assert.neverCalledWithMatch(telemetry.emitMetric as sinon.SinonStub, {
                 name: 'amazonq_addMessage',
             })
-        })
-
-        it('should not send ChatAddMessage when conversationId is undefined', () => {
-            telemetryService.emitChatAddMessage(
-                {
-                    messageId: 'message123',
-                    customizationArn: 'cust-123',
-                },
-                {}
-            )
-            sinon.assert.notCalled(codeWhisperServiceStub.sendTelemetryEvent)
-        })
-
-        it('should not send ChatAddMessage when messageId is undefined', () => {
-            telemetryService.emitChatAddMessage(
-                {
-                    conversationId: 'conv123',
-                    customizationArn: 'cust-123',
-                },
-                {}
-            )
-            sinon.assert.notCalled(codeWhisperServiceStub.sendTelemetryEvent)
         })
 
         it('should not send ChatAddMessage when credentialsType is IAM', () => {


### PR DESCRIPTION
## Problem
- agentic chat didn't send failed and cancelled event to RTS
## Solution
- update RTS model, related cr: https://code.amazon.com/reviews/CR-195724096
- copy the model change from [codewhispererruntime-2022-11-11.api.json](https://prod.artifactbrowser.brazil.aws.dev/packages/AWSVectorConsolasRuntimeServiceModel/versions/1.1.4900.0/platforms/AL2_x86_64/flavors/DEV.STD.PTHREAD/smithyprojections/AWSVectorConsolasRuntimeServiceModel/aws-sdk-external-2022-11-11/c2j/codewhispererruntime-2022-11-11.api.json), run `npm run generateClients` and updated [codewhispererbearertokenclient.d.ts](https://github.com/aws/language-servers/compare/main...yueny2020:language-servers:rts-telemetry-event?expand=1#diff-78dca2db09279e2b8e1c808726c59f78ecc55ded0b6581b76f904ae6bf0a1006)
- emit events for failed and cancelled
## Test
Test example logs:
### Succeeded
IDE local log:
```
[Info  - 10:03:52 PM] [Telemetry] Emitting amazonq_addMessage telemetry: {"credentialStartUrl":"https://amzn.awsapps.com/start","cwsprChatConversationId":"74ad9f97-ae4b-4edc-bada-02e8a1e08580","cwsprChatHasCodeSnippet":false,"cwsprChatTriggerInteraction":"click","cwsprChatMessageId":"59ec1ef7-18ec-4518-9de3-b79172d24f6d","cwsprChatResponseCode":200,"cwsprChatSourceLinkCount":0,"cwsprChatReferencesCount":0,"cwsprChatFollowUpCount":0,"cwsprChatTimeToFirstChunk":2124,"cwsprChatFullResponseLatency":6322,"cwsprChatTimeBetweenChunks":[1,1,46,367,1,72,60,111,55,50,55,112,53,111,107,54,55,122,154,112,63,60,53,47,221,124,54,54,52,48,56,53,60,80,16,52,49,53,55,54,52,55,56,56,60,57,55,51,51,52,52,58,52,79,27,51,53,55,54,52,55],"cwsprChatRequestLength":12,"cwsprChatResponseLength":891,"cwsprChatConversationType":"AgenticChat","cwsprChatActiveEditorTotalCharacters":0,"cwsprChatHasContextList":false,"cwsprChatFolderContextCount":0,"cwsprChatFileContextCount":0,"cwsprChatRuleContextCount":0,"cwsprChatPromptContextCount":0,"cwsprChatFileContextLength":0,"cwsprChatRuleContextLength":0,"cwsprChatPromptContextLength":0,"cwsprChatCodeContextCount":0,"cwsprChatCodeContextLength":0,"result":"Succeeded","enabled":true,"languageServerVersion":"0.1.0","requestIds":["59ec1ef7-18ec-4518-9de3-b79172d24f6d"]}
```
Kibana log:
```
May 19, 2025 @ 22:03:52.037 | clientId:c342ab45-6aba-4118-b48c-44dcedb10a78 metadata.cwsprChatMessageId:59ec1ef7-18ec-4518-9de3-b79172d24f6d product:Amazon Q For VS Code productVersion:testPluginVersion sessionId:5979fad4-911a-4d45-9e4a-33da1dc8e7e9 computeEnv:local os:Mac OS X osVersion:24.4.0 parentProduct:Visual Studio Code - Insiders parentProductVersion:1.101.0-insider timestamp:May 19, 2025 @ 22:03:52.037 value:1 passive:false metadata.metricName:amazonq_addMessage metadata.unit:None metadata.metricId:cd517321-d0e9-4bab-b014-46b93a13a6ef metadata.traceId:05119c5b-af57-4757-bbf1-6539e27de5c9 metadata.parentId:daf9d13f-bb9b-4649-8c7e-9ac50229c8a2 metadata.credentialStartUrl:https://amzn.awsapps.com/start
-- | --

```
RTS log: https://tiny.amazon.com/rym2xj4q/IsenLink
```
AmznTlsEndpoint=codewhisperer.us-east-1.amazonaws.com

ConversationId=74ad9f97-ae4b-4edc-bada-02e8a1e08580

BearerTokenAuthType=IDENTITY_CENTER

RequestId=47aa86ef-8597-4bba-8674-4d699b941dc6

RemoteSocket=10.0.92.32:17630

AWSAccountId=011528293760

AmznTlsTraceId=Root=1-682c0d38-31530a246175872225ad21bc

AuthContext.ProfileArn=arn:aws:codewhisperer:us-east-1:011528293760:profile/VY74CUKQ7D7V

AmznTlsVersion=TLSv1.3

PID=387@ip-10-0-188-61.ec2.internal

AccountlessUserId=d-9067925563.34f8d478-d0c1-7077-aea9-2698ab06ced8

Operation=SendTelemetryEvent

OrganizationId=d-9067925563

RemoteIpAddress=52.94.133.132

Marketplace=prod:us-east-1

RemoteIpAddressSequence=52.94.133.132

CustomizationArn=

TelemetryEvent=ChatAddMessageEvent

UserAgent=aws-sdk-nodejs/2.1692.0 darwin/v23.10.0 AWS-Language-Servers AWS-CodeWhisperer/0.1.0 AmazonQ-For-VSCode/testPluginVersion Visual-Studio-Code---Insiders/1.101.0-insider ClientId/c342ab45-6aba-4118-b48c-44dcedb10a78 promise

HasCodeSnippet=false

MessageId=59ec1ef7-18ec-4518-9de3-b79172d24f6d
```

### Cancelled
IDE local log:
```
[Info  - 4:57:03 PM] [Telemetry] Emitting amazonq_addMessage telemetry: {"credentialStartUrl":"https://amzn.awsapps.com/start","cwsprChatConversationId":"e2dd94ba-0294-48b6-8ad7-ea1bf8fd0b31","cwsprChatHasCodeSnippet":false,"cwsprChatTriggerInteraction":"click","cwsprChatMessageId":"844713b1-a653-44b7-ac97-d76376b36aa8","cwsprChatResponseCode":200,"cwsprChatTimeToFirstChunk":3142,"cwsprChatTimeBetweenChunks":[196,202,273,202,311,178,593,227,368,396],"cwsprChatRequestLength":12,"cwsprChatConversationType":"AgenticChat","cwsprChatActiveEditorTotalCharacters":0,"result":"Cancelled","requestIds":["844713b1-a653-44b7-ac97-d76376b36aa8"]}

```
Kibana log:
```

May 19, 2025 @ 16:57:03.986 | clientId:c342ab45-6aba-4118-b48c-44dcedb10a78 metadata.cwsprChatMessageId:844713b1-a653-44b7-ac97-d76376b36aa8 product:Amazon Q For VS Code productVersion:testPluginVersion sessionId:dae3caf0-13ce-4c41-bf18-131c2083445f computeEnv:local os:Mac OS X osVersion:24.4.0 parentProduct:Visual Studio Code - Insiders parentProductVersion:1.100.0-insider timestamp:May 19, 2025 @ 16:57:03.986 value:1 passive:false metadata.metricName:amazonq_addMessage metadata.unit:None metadata.missingFields:cwsprChatFullResponseLatency metadata.metricId:9dd351bc-aeaf-45c9-987a-e7c5026efb1c metadata.traceId:0a425327-7d0c-4102-810d-ab1e28ed3076 metadata.parentId:af9e6ed2-efac-40fa-8e8c-dd3893919d99 metadata.credentialStartUrl:https://amzn.awsapps.com/start metadata.cwsprChatConversationId:e2dd94ba-0294-48b6-8ad7-ea1bf8fd0b31 metadata.cwsprChatHasCodeSnippet:false metadata.cwsprChatTriggerInteraction:click metadata.cwsprChatResponseCode:200 metadata.cwsprChatTimeToFirstChunk:3142 metadata.cwsprChatTimeBetweenChunks:196,202,273,202,311,178,593,227,368,396 metadata.cwsprChatRequestLength:12 metadata.cwsprChatConversationType:AgenticChat metadata.cwsprChatActiveEditorTotalCharacters:0 metadata.result:Cancelled metadata.requestIds:844713b1-a653-44b7-ac97-d76376b36aa8 metadata.awsAccount:not-set metadata.awsRegion:us-east-1 _id:49660863959751727544221396901133968469829294268694397106.893 _type:_doc _index:metrics-2025-05-19 _score: - buildZipFileBytes:-1 promptContextCharsTruncatedCount:-1 generatedCount:-1 subsystem:amazonq cwsprChatFileContextLength:-1 codewhispererTimeToFirstRecommendation: - duration:0.00 fileContextCharsTruncatedCount:-1 amazonqTimeToLoadHistory:-1 amazonqTimeToSearchHistory:-1 acceptedCount:-1 codewhispererCodeScanSrcZipFileBytes:0B ruleContextCharsTruncatedCount:-1 artifactsUploadDuration:-1 codewhispererCodeScanIssuesWithFixes:0 perfClientLatency:-1 amazonQHistoryFileSize:-1 codewhispererCodeScanTotalIssues:0
-- | --

```
RTS serviceMetric log: https://tiny.amazon.com/oskuls9r/IsenLink
```
AmznTlsEndpoint=codewhisperer.us-east-1.amazonaws.com

ConversationId=

BearerTokenAuthType=IDENTITY_CENTER

RequestId=844713b1-a653-44b7-ac97-d76376b36aa8

RemoteSocket=10.0.38.6:51876

AWSAccountId=011528293760

GenerateAssistantResponseTriggerType=MANUAL

AmznTlsTraceId=Root=1-682bc549-6b7578083eda8323615cf86f

AuthContext.ProfileArn=arn:aws:codewhisperer:us-east-1:011528293760:profile/VY74CUKQ7D7V

x-amz-user-agent=aws-sdk-js/1.0.6 AWS-Language-Servers-AWS-CodeWhisperer/0.1.0-AmazonQ-For-VSCode/testPluginVersion-Visual-Studio-Code---Insiders/1.100.0-insider-ClientId/c342ab45-6aba-4118-b48c-44dcedb10a78

AmznTlsVersion=TLSv1.3

PID=378@ip-10-0-103-237.ec2.internal

AccountlessUserId=d-9067925563.34f8d478-d0c1-7077-aea9-2698ab06ced8

Operation=GenerateAssistantResponse

OrganizationId=d-9067925563

RemoteIpAddress=52.94.133.132

Marketplace=prod:us-east-1

RemoteIpAddressSequence=52.94.133.132

UserAgent=aws-sdk-js/1.0.6 ua/2.1 os/darwin#24.4.0 lang/js md/nodejs#23.10.0 api/codewhispererstreaming#1.0.6 m/E AWS-Language-Servers-AWS-CodeWhisperer/0.1.0-AmazonQ-For-VSCode/testPluginVersion-Visual-Studio-Code---Insiders/1.100.0-insider-ClientId/c342ab45-6aba-4118-b48c-44dcedb10a78

amz-sdk-invocation-id=145635b1-f82c-45cb-a9a6-9eeacef176f8
```

### Failed
IDE local log:
```
[Info  - 9:36:38 PM] [Telemetry] Emitting amazonq_addMessage telemetry: {"credentialStartUrl":"https://amzn.awsapps.com/start","cwsprChatHasCodeSnippet":false,"cwsprChatTriggerInteraction":"click","cwsprChatMessageId":"error-message-id-d2f3aa64-eaf3-4749-a552-566cd93db8e5","cwsprChatResponseCode":400,"cwsprChatRequestLength":12,"cwsprChatConversationType":"AgenticChat","cwsprChatActiveEditorTotalCharacters":0,"result":"Failed","languageServerVersion":"0.1.0","requestIds":["64625b65-8ef8-4727-bebe-9a634cd0f601"]}

```
Kibana log:
```

May 19, 2025 @ 21:36:38.416 | clientId:c342ab45-6aba-4118-b48c-44dcedb10a78 metadata.cwsprChatMessageId:error-message-id-d2f3aa64-eaf3-4749-a552-566cd93db8e5 product:Amazon Q For VS Code productVersion:testPluginVersion sessionId:3c074cbe-bbea-49ab-8165-2f62be8e1d64 computeEnv:local os:Mac OS X osVersion:24.4.0 parentProduct:Visual Studio Code - Insiders parentProductVersion:1.101.0-insider timestamp:May 19, 2025 @ 21:36:38.416 value:1 passive:false metadata.metricName:amazonq_addMessage metadata.unit:None metadata.missingFields:cwsprChatConversationId,cwsprChatFullResponseLatency,cwsprChatTimeBetweenChunks,cwsprChatTimeToFirstChunk
-- | --

```

RTS serviceMetric log: https://tiny.amazon.com/ssguurql/IsenLink
```
AmznTlsEndpoint=codewhisperer.us-east-1.amazonaws.com

ConversationId=DummyConversationId

BearerTokenAuthType=IDENTITY_CENTER

RequestId=f353b825-f1f7-4d20-91f4-575f06fb81b1

RemoteSocket=10.0.27.8:2386

AWSAccountId=011528293760

AmznTlsTraceId=Root=1-682c06d6-45d954be4377f78572e8c9e7

AuthContext.ProfileArn=arn:aws:codewhisperer:us-east-1:011528293760:profile/VY74CUKQ7D7V

AmznTlsVersion=TLSv1.3

PID=386@ip-10-0-147-57.ec2.internal

AccountlessUserId=d-9067925563.34f8d478-d0c1-7077-aea9-2698ab06ced8

Operation=SendTelemetryEvent

OrganizationId=d-9067925563

RemoteIpAddress=72.21.196.64

Marketplace=prod:us-east-1

RemoteIpAddressSequence=72.21.196.64

CustomizationArn=

TelemetryEvent=ChatAddMessageEvent

UserAgent=aws-sdk-nodejs/2.1692.0 darwin/v23.10.0 AWS-Language-Servers AWS-CodeWhisperer/0.1.0 AmazonQ-For-VSCode/testPluginVersion Visual-Studio-Code---Insiders/1.101.0-insider ClientId/c342ab45-6aba-4118-b48c-44dcedb10a78 promise

HasCodeSnippet=false

MessageId=error-message-id-d2f3aa64-eaf3-4749-a552-566cd93db8e5

Size=2

Time=22.340085 ms

EndTime=Tue, 20 May 2025 04:36:38 UTC

StartTime=1747715798.737

Program=AmazonCodeWhispererService

... ...

```
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
