### PR TITLE
chore: generate a temporary workspaceIdentifier if not given

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -34,7 +34,8 @@ export const WorkspaceContextServer = (): Server => features => {
     lsp.addInitializer((params: InitializeParams) => {
         workspaceIdentifier = params.initializationOptions?.aws?.contextConfiguration?.workspaceIdentifier || ''
         if (!workspaceIdentifier) {
-            logging.warn(`No workspaceIdentifier set!`)
+            logging.warn(`No workspaceIdentifier set. Treating this workspace as a temporary session.`)
+            workspaceIdentifier = crypto.randomUUID()
         }
 
         const folders = workspace.getAllWorkspaceFolders()


### PR DESCRIPTION
## Problem

We want WorkspaceContextServer still being able to run even if extensions are running on old versions and not passing a workspaceIdentifier to WorkspaceContextServer.

## Solution

Generate a temporary workspaceIdentifier if not given

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
