### PR TITLE
fix: refresh button should register tools in tool server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -678,18 +678,14 @@ describe('reinitializeMcpServers()', () => {
         const mgr = await McpManager.init(['cfg.json'], features)
 
         const closeStub = sinon.stub(mgr, 'close').resolves()
-        const initStub = sinon.stub(McpManager, 'init').resolves(mgr)
-
         loadStub.resetHistory()
 
         await mgr.reinitializeMcpServers()
 
-        expect(closeStub.calledOnce).to.be.true
-        expect(initStub.calledOnce).to.be.true
-        expect(initStub.firstCall.args[0]).to.deep.equal(['cfg.json'])
-        expect(initStub.firstCall.args[1]).to.equal(features)
+        expect(closeStub.calledOnceWith(true)).to.be.true
+        expect(loadStub.calledOnce).to.be.true
+        expect(loadStub.firstCall.args[2]).to.deep.equal(['cfg.json'])
 
         closeStub.restore()
-        initStub.restore()
     })
 })


### PR DESCRIPTION
## Problem
- When reinitializing McpServers, we were originally resetting the singleton instance. Then on refresh, the tools server would not register the server tools

## Solution
- Do not reset singleton instance so on refresh, it will register server tools

https://github.com/user-attachments/assets/73bfd6df-487e-417f-8cf6-71df4e54d83b

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
