### PR TITLE
fix: handle requestAborted errors silently

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -57,6 +57,7 @@ import {
     AmazonQServicePendingSigninError,
 } from '../../shared/amazonQServiceManager/errors'
 import { AgenticChatResultStream } from './agenticChatResultStream'
+import { AgenticChatError } from './errors'
 
 describe('AgenticChatController', () => {
     const mockTabId = 'tab-1'
@@ -2224,10 +2225,12 @@ ${' '.repeat(8)}}
         const cancellationError = new CancellationError('user')
         const rejectionError = new ToolApprovalException()
         const tokenSource = new CancellationTokenSource()
+        const requestAbortedError = new AgenticChatError('Request aborted', 'RequestAborted')
 
         assert.ok(!chatController.isUserAction(nonUserAction))
         assert.ok(chatController.isUserAction(cancellationError))
         assert.ok(chatController.isUserAction(rejectionError))
+        assert.ok(chatController.isUserAction(requestAbortedError))
 
         assert.ok(!chatController.isUserAction(nonUserAction, tokenSource.token))
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -121,7 +121,7 @@ import {
     responseTimeoutPartialMsg,
 } from './constants'
 import { URI } from 'vscode-uri'
-import { AgenticChatError, customerFacingErrorCodes, unactionableErrorCodes } from './errors'
+import { AgenticChatError, customerFacingErrorCodes, isRequestAbortedError, unactionableErrorCodes } from './errors'
 import { CommandCategory } from './tools/executeBash'
 import { UserWrittenCodeTracker } from '../../shared/userWrittenCodeTracker'
 
@@ -1261,6 +1261,7 @@ export class AgenticChatController implements ChatHandlers {
         return (
             CancellationError.isUserCancelled(err) ||
             err instanceof ToolApprovalException ||
+            isRequestAbortedError(err) ||
             (token?.isCancellationRequested ?? false)
         )
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -7,6 +7,7 @@ type AgenticChatErrorCode =
     | 'InputTooLong' // too much context given to backend service.
     | 'PromptCharacterLimit' // customer prompt exceeds
     | 'ResponseProcessingTimeout' // response didn't finish streaming in the allowed time
+    | 'RequestAborted' // request was aborted by the user
 
 export const customerFacingErrorCodes: AgenticChatErrorCode[] = [
     'QModelResponse',
@@ -48,6 +49,19 @@ export function isInputTooLongError(error: unknown): boolean {
     if (error instanceof Error) {
         //  This is fragile (breaks if the backend changes their error message wording)
         return error.message.includes('Input is too long')
+    }
+
+    return false
+}
+
+export function isRequestAbortedError(error: unknown): boolean {
+    if (error instanceof AgenticChatError && error.code === 'RequestAborted') {
+        return true
+    }
+
+    if (error instanceof Error) {
+        //  This is fragile (breaks if the backend changes their error message wording)
+        return error.message.includes('Request aborted')
     }
 
     return false


### PR DESCRIPTION
## Problem
If a user stops the agentic chat mid-execution while the request to Q is in-flight, we abort the request. However, we are currently surfacing that request to customers

## Solution
Swallow exception and handle it in `isUserAction`


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
