### PR TITLE
fix: add longer time out for stop text render

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -119,8 +119,8 @@ export const handleChatPrompt = async (
             promptInputDisabledState: false,
         })
 
-        // Add a slight delay to make sure the stop message would render before the new prompt
-        await new Promise(resolve => setTimeout(resolve, 50))
+        // Add a longer delay to ensure the stop message fully renders before the new prompt
+        await new Promise(resolve => setTimeout(resolve, 500))
     }
 
     if (prompt.command) {


### PR DESCRIPTION
## Problem
Before the stop message has very high possibility to be cut in half. 
## Solution
Add a longer timeout. 

https://github.com/user-attachments/assets/e366101e-f022-4cc8-95b4-398c92447d56


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
