### PR TITLE
feat: add fileUri to FileContext

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperersigv4client.d.ts
+++ b/server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperersigv4client.d.ts
@@ -4,12 +4,12 @@
  * DO NOT EDIT BY HAND.
  */
 
-import {Request} from 'aws-sdk/lib/request';
-import {Response} from 'aws-sdk/lib/response';
-import {AWSError} from 'aws-sdk/lib/error';
-import {Service} from 'aws-sdk/lib/service';
-import {ServiceConfigurationOptions} from 'aws-sdk/lib/service';
-import {ConfigBase as Config} from 'aws-sdk/lib/config-base';
+import { Request } from 'aws-sdk/lib/request';
+import { Response } from 'aws-sdk/lib/response';
+import { AWSError } from 'aws-sdk/lib/error';
+import { Service } from 'aws-sdk/lib/service';
+import { ServiceConfigurationOptions } from 'aws-sdk/lib/service';
+import { ConfigBase as Config } from 'aws-sdk/lib/config-base';
 interface Blob {}
 declare class CodeWhispererSigV4Client extends Service {
   /**
@@ -131,11 +131,11 @@ declare class CodeWhispererSigV4Client extends Service {
   updateProfile(callback?: (err: AWSError, data: CodeWhispererSigV4Client.Types.UpdateProfileResponse) => void): Request<CodeWhispererSigV4Client.Types.UpdateProfileResponse, AWSError>;
 }
 declare namespace CodeWhispererSigV4Client {
-  export type ArtifactMap = {[key: string]: UploadId};
-  export type ArtifactType = "SourceCode"|"BuiltJars"|string;
+  export type ArtifactMap = { [key: string]: UploadId };
+  export type ArtifactType = "SourceCode" | "BuiltJars" | string;
   export type Base64EncodedPaginationToken = string;
-  export type CodeScanFindingsSchema = "codescan/findings/1.0"|string;
-  export type CodeScanStatus = "Completed"|"Pending"|"Failed"|string;
+  export type CodeScanFindingsSchema = "codescan/findings/1.0" | string;
+  export type CodeScanStatus = "Completed" | "Pending" | "Failed" | string;
   export interface CreateCodeScanRequest {
     artifacts: ArtifactMap;
     programmingLanguage: ProgrammingLanguage;
@@ -178,8 +178,10 @@ declare namespace CodeWhispererSigV4Client {
     leftFileContent: FileContextLeftFileContentString;
     rightFileContent: FileContextRightFileContentString;
     filename: FileContextFilenameString;
+    fileUri?: FileContextFileUriString;
     programmingLanguage: ProgrammingLanguage;
   }
+  export type FileContextFileUriString = string;
   export type FileContextFilenameString = string;
   export type FileContextLeftFileContentString = string;
   export type FileContextRightFileContentString = string;
@@ -290,7 +292,7 @@ declare namespace CodeWhispererSigV4Client {
   }
   export type RecommendationContentString = string;
   export type RecommendationsList = Recommendation[];
-  export type RecommendationsWithReferencesPreference = "BLOCK"|"ALLOW"|string;
+  export type RecommendationsWithReferencesPreference = "BLOCK" | "ALLOW" | string;
   export interface Reference {
     licenseName?: ReferenceLicenseNameString;
     repository?: ReferenceRepositoryString;
@@ -353,7 +355,7 @@ declare namespace CodeWhispererSigV4Client {
   /**
    * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
    */
-  export type apiVersion = "2022-06-15"|"latest"|string;
+  export type apiVersion = "2022-06-15" | "latest" | string;
   export interface ClientApiVersions {
     /**
      * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
@@ -368,4 +370,3 @@ declare namespace CodeWhispererSigV4Client {
 }
 export = CodeWhispererSigV4Client;
 
-    

--- a/server/aws-lsp-codewhisperer/src/client/sigv4/service.json
+++ b/server/aws-lsp-codewhisperer/src/client/sigv4/service.json
@@ -612,10 +612,18 @@
                 "filename": {
                     "shape": "FileContextFilenameString"
                 },
+                "fileUri": {
+                    "shape": "FileContextFileUriString"
+                },
                 "programmingLanguage": {
                     "shape": "ProgrammingLanguage"
                 }
             }
+        },
+        "FileContextFileUriString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1
         },
         "FileContextFilenameString": {
             "type": "string",

--- a/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
+++ b/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
@@ -2223,10 +2223,19 @@
                 "filename": {
                     "shape": "FileContextFilenameString"
                 },
+                "fileUri": {
+                    "shape": "FileContextFileUriString"
+                },
                 "programmingLanguage": {
                     "shape": "ProgrammingLanguage"
                 }
             }
+        },
+        "FileContextFileUriString": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "sensitive": true
         },
         "FileContextFilenameString": {
             "type": "string",

--- a/server/aws-lsp-codewhisperer/src/client/token/codewhispererbearertokenclient.d.ts
+++ b/server/aws-lsp-codewhisperer/src/client/token/codewhispererbearertokenclient.d.ts
@@ -4,12 +4,12 @@
  * DO NOT EDIT BY HAND.
  */
 
-import {Request} from 'aws-sdk/lib/request';
-import {Response} from 'aws-sdk/lib/response';
-import {AWSError} from 'aws-sdk/lib/error';
-import {Service} from 'aws-sdk/lib/service';
-import {ServiceConfigurationOptions} from 'aws-sdk/lib/service';
-import {ConfigBase as Config} from 'aws-sdk/lib/config-base';
+import { Request } from 'aws-sdk/lib/request';
+import { Response } from 'aws-sdk/lib/response';
+import { AWSError } from 'aws-sdk/lib/error';
+import { Service } from 'aws-sdk/lib/service';
+import { ServiceConfigurationOptions } from 'aws-sdk/lib/service';
+import { ConfigBase as Config } from 'aws-sdk/lib/config-base';
 interface Blob {}
 declare class CodeWhispererBearerTokenClient extends Service {
   /**
@@ -246,7 +246,7 @@ declare namespace CodeWhispererBearerTokenClient {
   export type AdditionalContentEntryInnerContextString = string;
   export type AdditionalContentEntryNameString = string;
   export type AdditionalContentList = AdditionalContentEntry[];
-  export type AgenticChatEventStatus = "SUCCEEDED"|"CANCELLED"|"FAILED"|string;
+  export type AgenticChatEventStatus = "SUCCEEDED" | "CANCELLED" | "FAILED" | string;
   export interface AppStudioState {
     /**
      * The namespace of the context. Examples: 'ui.Button', 'ui.Table.DataSource', 'ui.Table.RowActions.Button', 'logic.invokeAWS', 'logic.JavaScript'
@@ -277,8 +277,8 @@ declare namespace CodeWhispererBearerTokenClient {
   }
   export type ApplicationPropertiesList = ApplicationProperties[];
   export type ArtifactId = string;
-  export type ArtifactMap = {[key: string]: UploadId};
-  export type ArtifactType = "SourceCode"|"BuiltJars"|string;
+  export type ArtifactMap = { [key: string]: UploadId };
+  export type ArtifactType = "SourceCode" | "BuiltJars" | string;
   export interface AssistantResponseMessage {
     messageId?: MessageId;
     /**
@@ -344,8 +344,8 @@ declare namespace CodeWhispererBearerTokenClient {
     userInputMessage?: UserInputMessage;
     assistantResponseMessage?: AssistantResponseMessage;
   }
-  export type ChatMessageInteractionType = "INSERT_AT_CURSOR"|"COPY_SNIPPET"|"COPY"|"CLICK_LINK"|"CLICK_BODY_LINK"|"CLICK_FOLLOW_UP"|"HOVER_REFERENCE"|"UPVOTE"|"DOWNVOTE"|string;
-  export type ChatTriggerType = "MANUAL"|"DIAGNOSTIC"|"INLINE_CHAT"|string;
+  export type ChatMessageInteractionType = "INSERT_AT_CURSOR" | "COPY_SNIPPET" | "COPY" | "CLICK_LINK" | "CLICK_BODY_LINK" | "CLICK_FOLLOW_UP" | "HOVER_REFERENCE" | "UPVOTE" | "DOWNVOTE" | string;
+  export type ChatTriggerType = "MANUAL" | "DIAGNOSTIC" | "INLINE_CHAT" | string;
   export interface ChatUserModificationEvent {
     conversationId: ConversationId;
     customizationArn?: CustomizationArn;
@@ -354,9 +354,9 @@ declare namespace CodeWhispererBearerTokenClient {
     modificationPercentage: Double;
     hasProjectLevelContext?: Boolean;
   }
-  export type CodeAnalysisFindingsSchema = "codeanalysis/findings/1.0"|string;
-  export type CodeAnalysisScope = "FILE"|"PROJECT"|string;
-  export type CodeAnalysisStatus = "Completed"|"Pending"|"Failed"|string;
+  export type CodeAnalysisFindingsSchema = "codeanalysis/findings/1.0" | string;
+  export type CodeAnalysisScope = "FILE" | "PROJECT" | string;
+  export type CodeAnalysisStatus = "Completed" | "Pending" | "Failed" | string;
   export interface CodeAnalysisUploadContext {
     codeScanName: CodeScanName;
   }
@@ -392,7 +392,7 @@ declare namespace CodeWhispererBearerTokenClient {
     linesOfCodeGenerated?: Integer;
     charsOfCodeGenerated?: Integer;
   }
-  export type CodeFixJobStatus = "Succeeded"|"InProgress"|"Failed"|string;
+  export type CodeFixJobStatus = "Succeeded" | "InProgress" | "Failed" | string;
   export type CodeFixName = string;
   export interface CodeFixUploadContext {
     codeFixName: CodeFixName;
@@ -403,8 +403,8 @@ declare namespace CodeWhispererBearerTokenClient {
     currentStage: CodeGenerationWorkflowStage;
   }
   export type CodeGenerationStatusDetail = string;
-  export type CodeGenerationWorkflowStage = "InitialCodeGeneration"|"CodeRefinement"|string;
-  export type CodeGenerationWorkflowStatus = "InProgress"|"Complete"|"Failed"|string;
+  export type CodeGenerationWorkflowStage = "InitialCodeGeneration" | "CodeRefinement" | string;
+  export type CodeGenerationWorkflowStatus = "InProgress" | "Complete" | "Failed" | string;
   export interface CodeScanEvent {
     programmingLanguage: ProgrammingLanguage;
     codeScanJobId: CodeScanJobId;
@@ -431,7 +431,7 @@ declare namespace CodeWhispererBearerTokenClient {
     result?: String;
     includesFix?: Boolean;
   }
-  export type CodeScanRemediationsEventType = "CODESCAN_ISSUE_HOVER"|"CODESCAN_ISSUE_APPLY_FIX"|"CODESCAN_ISSUE_VIEW_DETAILS"|string;
+  export type CodeScanRemediationsEventType = "CODESCAN_ISSUE_HOVER" | "CODESCAN_ISSUE_APPLY_FIX" | "CODESCAN_ISSUE_VIEW_DETAILS" | string;
   export interface CodeScanSucceededEvent {
     programmingLanguage: ProgrammingLanguage;
     codeScanJobId: CodeScanJobId;
@@ -445,7 +445,7 @@ declare namespace CodeWhispererBearerTokenClient {
     mostRelevantMissingImports?: Imports;
   }
   export type CompletionContentString = string;
-  export type CompletionType = "BLOCK"|"LINE"|string;
+  export type CompletionType = "BLOCK" | "LINE" | string;
   export type Completions = Completion[];
   export interface ConsoleState {
     region?: String;
@@ -455,8 +455,8 @@ declare namespace CodeWhispererBearerTokenClient {
     serviceSubconsolePage?: String;
     taskName?: SensitiveString;
   }
-  export type ContentChecksumType = "SHA_256"|string;
-  export type ContextTruncationScheme = "ANALYSIS"|"GUMBY"|string;
+  export type ContentChecksumType = "SHA_256" | string;
+  export type ContextTruncationScheme = "ANALYSIS" | "GUMBY" | string;
   export type ConversationId = string;
   export interface ConversationState {
     /**
@@ -556,7 +556,7 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     runtimeDiagnostic?: RuntimeDiagnostic;
   }
-  export type DiagnosticSeverity = "ERROR"|"WARNING"|"INFORMATION"|"HINT"|string;
+  export type DiagnosticSeverity = "ERROR" | "WARNING" | "INFORMATION" | "HINT" | string;
   export interface Dimension {
     name?: DimensionNameString;
     value?: DimensionValueString;
@@ -564,7 +564,7 @@ declare namespace CodeWhispererBearerTokenClient {
   export type DimensionList = Dimension[];
   export type DimensionNameString = string;
   export type DimensionValueString = string;
-  export type DocFolderLevel = "SUB_FOLDER"|"ENTIRE_WORKSPACE"|string;
+  export type DocFolderLevel = "SUB_FOLDER" | "ENTIRE_WORKSPACE" | string;
   export interface DocGenerationEvent {
     conversationId: ConversationId;
     numberOfAddChars?: PrimitiveInteger;
@@ -576,8 +576,8 @@ declare namespace CodeWhispererBearerTokenClient {
     numberOfNavigation?: PrimitiveInteger;
     folderLevel?: DocFolderLevel;
   }
-  export type DocInteractionType = "GENERATE_README"|"UPDATE_README"|"EDIT_README"|string;
-  export type DocUserDecision = "ACCEPT"|"REJECT"|string;
+  export type DocInteractionType = "GENERATE_README" | "UPDATE_README" | "EDIT_README" | string;
+  export type DocUserDecision = "ACCEPT" | "REJECT" | string;
   export interface DocV2AcceptanceEvent {
     conversationId: ConversationId;
     numberOfAddedChars: DocV2AcceptanceEventNumberOfAddedCharsInteger;
@@ -627,7 +627,7 @@ declare namespace CodeWhispererBearerTokenClient {
     type: DocumentationType;
   }
   export type DocumentationIntentContextScopeString = string;
-  export type DocumentationType = "README"|string;
+  export type DocumentationType = "README" | string;
   export type Double = number;
   export interface EditorState {
     /**
@@ -720,8 +720,10 @@ declare namespace CodeWhispererBearerTokenClient {
     leftFileContent: FileContextLeftFileContentString;
     rightFileContent: FileContextRightFileContentString;
     filename: FileContextFilenameString;
+    fileUri?: FileContextFileUriString;
     programmingLanguage: ProgrammingLanguage;
   }
+  export type FileContextFileUriString = string;
   export type FileContextFilenameString = string;
   export type FileContextLeftFileContentString = string;
   export type FileContextRightFileContentString = string;
@@ -736,7 +738,7 @@ declare namespace CodeWhispererBearerTokenClient {
     userIntent?: UserIntent;
   }
   export type FollowupPromptContentString = string;
-  export type FunctionalityName = "COMPLETIONS"|"ANALYSIS"|"CONVERSATIONS"|"TASK_ASSIST"|"TRANSFORMATIONS"|"CHAT_CUSTOMIZATION"|"TRANSFORMATIONS_WEBAPP"|string;
+  export type FunctionalityName = "COMPLETIONS" | "ANALYSIS" | "CONVERSATIONS" | "TASK_ASSIST" | "TRANSFORMATIONS" | "CHAT_CUSTOMIZATION" | "TRANSFORMATIONS_WEBAPP" | string;
   export interface GenerateCompletionsRequest {
     fileContext: FileContext;
     maxResults?: GenerateCompletionsRequestMaxResultsInteger;
@@ -814,7 +816,7 @@ declare namespace CodeWhispererBearerTokenClient {
     status?: GitStateStatusString;
   }
   export type GitStateStatusString = string;
-  export type IdeCategory = "JETBRAINS"|"VSCODE"|"CLI"|"JUPYTER_MD"|"JUPYTER_SM"|"ECLIPSE"|"VISUAL_STUDIO"|string;
+  export type IdeCategory = "JETBRAINS" | "VSCODE" | "CLI" | "JUPYTER_MD" | "JUPYTER_SM" | "ECLIPSE" | "VISUAL_STUDIO" | string;
   export type IdempotencyToken = string;
   export interface IdentityDetails {
     ssoIdentityDetails?: SSOIdentityDetails;
@@ -839,9 +841,9 @@ declare namespace CodeWhispererBearerTokenClient {
     responseEndLatency?: Double;
     programmingLanguage?: ProgrammingLanguage;
   }
-  export type InlineChatUserDecision = "ACCEPT"|"REJECT"|"DISMISS"|string;
+  export type InlineChatUserDecision = "ACCEPT" | "REJECT" | "DISMISS" | string;
   export type Integer = number;
-  export type Intent = "DEV"|"DOC"|string;
+  export type Intent = "DEV" | "DOC" | string;
   export interface IntentContext {
     documentation?: DocumentationIntentContext;
   }
@@ -910,8 +912,8 @@ declare namespace CodeWhispererBearerTokenClient {
     feature: FeatureName;
     toggle: OptInFeatureToggle;
   }
-  export type OperatingSystem = "MAC"|"WINDOWS"|"LINUX"|string;
-  export type OptInFeatureToggle = "ON"|"OFF"|string;
+  export type OperatingSystem = "MAC" | "WINDOWS" | "LINUX" | string;
+  export type OptInFeatureToggle = "ON" | "OFF" | string;
   export interface OptInFeatures {
     promptLogging?: PromptLogging;
     byUserAnalytics?: ByUserAnalytics;
@@ -919,8 +921,8 @@ declare namespace CodeWhispererBearerTokenClient {
     notifications?: Notifications;
     workspaceContext?: WorkspaceContext;
   }
-  export type OptOutPreference = "OPTIN"|"OPTOUT"|string;
-  export type Origin = "CHATBOT"|"CONSOLE"|"DOCUMENTATION"|"MARKETING"|"MOBILE"|"SERVICE_INTERNAL"|"UNIFIED_SEARCH"|"UNKNOWN"|"MD"|"IDE"|"SAGE_MAKER"|"CLI"|"AI_EDITOR"|"OPENSEARCH_DASHBOARD"|"GITLAB"|string;
+  export type OptOutPreference = "OPTIN" | "OPTOUT" | string;
+  export type Origin = "CHATBOT" | "CONSOLE" | "DOCUMENTATION" | "MARKETING" | "MOBILE" | "SERVICE_INTERNAL" | "UNIFIED_SEARCH" | "UNKNOWN" | "MD" | "IDE" | "SAGE_MAKER" | "CLI" | "AI_EDITOR" | "OPENSEARCH_DASHBOARD" | "GITLAB" | string;
   export interface PackageInfo {
     executionCommand?: SensitiveString;
     buildCommand?: SensitiveString;
@@ -965,8 +967,8 @@ declare namespace CodeWhispererBearerTokenClient {
   export type ProfileArn = string;
   export type ProfileList = Profile[];
   export type ProfileName = string;
-  export type ProfileStatus = "ACTIVE"|"CREATING"|"CREATE_FAILED"|"UPDATING"|"UPDATE_FAILED"|"DELETING"|"DELETE_FAILED"|string;
-  export type ProfileType = "Q_DEVELOPER"|"CODEWHISPERER"|string;
+  export type ProfileStatus = "ACTIVE" | "CREATING" | "CREATE_FAILED" | "UPDATING" | "UPDATE_FAILED" | "DELETING" | "DELETE_FAILED" | string;
+  export type ProfileType = "Q_DEVELOPER" | "CODEWHISPERER" | string;
   export interface ProgrammingLanguage {
     languageName: ProgrammingLanguageLanguageNameString;
   }
@@ -986,7 +988,7 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     end: Position;
   }
-  export type RecommendationsWithReferencesPreference = "BLOCK"|"ALLOW"|string;
+  export type RecommendationsWithReferencesPreference = "BLOCK" | "ALLOW" | string;
   export interface Reference {
     /**
      * License name
@@ -1035,12 +1037,12 @@ declare namespace CodeWhispererBearerTokenClient {
   export type RelevantTextDocumentTextString = string;
   export type RequestHeaderKey = string;
   export type RequestHeaderValue = string;
-  export type RequestHeaders = {[key: string]: RequestHeaderValue};
+  export type RequestHeaders = { [key: string]: RequestHeaderValue };
   export type ResourceArn = string;
   export interface ResourcePolicy {
     effect: ResourcePolicyEffect;
   }
-  export type ResourcePolicyEffect = "ALLOW"|"DENY"|string;
+  export type ResourcePolicyEffect = "ALLOW" | "DENY" | string;
   export interface ResumeTransformationRequest {
     transformationJobId: TransformationJobId;
     userActionStatus?: TransformationUserActionStatus;
@@ -1213,7 +1215,7 @@ declare namespace CodeWhispererBearerTokenClient {
   }
   export type SuggestedFixCodeDiffString = string;
   export type SuggestedFixDescriptionString = string;
-  export type SuggestionState = "ACCEPT"|"REJECT"|"DISCARD"|"EMPTY"|"MERGE"|string;
+  export type SuggestionState = "ACCEPT" | "REJECT" | "DISCARD" | "EMPTY" | "MERGE" | string;
   export interface SupplementalContext {
     filePath: SupplementalContextFilePathString;
     content: SupplementalContextContentString;
@@ -1239,7 +1241,7 @@ declare namespace CodeWhispererBearerTokenClient {
   export type SupplementaryWebLinkTitleString = string;
   export type SupplementaryWebLinkUrlString = string;
   export type SupplementaryWebLinks = SupplementaryWebLink[];
-  export type SymbolType = "DECLARATION"|"USAGE"|string;
+  export type SymbolType = "DECLARATION" | "USAGE" | string;
   export interface TargetCode {
     /**
      * The file path relative to the root of the workspace, could be a single file or a folder.
@@ -1286,7 +1288,7 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     action?: TaskAssistPlanStepAction;
   }
-  export type TaskAssistPlanStepAction = "MODIFY"|"CREATE"|"DELETE"|"UNKNOWN"|string;
+  export type TaskAssistPlanStepAction = "MODIFY" | "CREATE" | "DELETE" | "UNKNOWN" | string;
   export type TaskAssistPlanStepDescriptionString = string;
   export type TaskAssistPlanStepEndLineInteger = number;
   export type TaskAssistPlanStepFilePathString = string;
@@ -1331,7 +1333,7 @@ declare namespace CodeWhispererBearerTokenClient {
     isCompletionAccepted?: Boolean;
     cliToolCommand?: String;
   }
-  export type TerminalUserInteractionEventType = "CODEWHISPERER_TERMINAL_TRANSLATION_ACTION"|"CODEWHISPERER_TERMINAL_COMPLETION_INSERTED"|string;
+  export type TerminalUserInteractionEventType = "CODEWHISPERER_TERMINAL_TRANSLATION_ACTION" | "CODEWHISPERER_TERMINAL_COMPLETION_INSERTED" | string;
   export interface TestGenerationEvent {
     jobId: UUID;
     groupName: TestGenerationJobGroupName;
@@ -1361,7 +1363,7 @@ declare namespace CodeWhispererBearerTokenClient {
   export type TestGenerationJobJobPlanString = string;
   export type TestGenerationJobJobSummaryString = string;
   export type TestGenerationJobProgressRateInteger = number;
-  export type TestGenerationJobStatus = "IN_PROGRESS"|"FAILED"|"COMPLETED"|string;
+  export type TestGenerationJobStatus = "IN_PROGRESS" | "FAILED" | "COMPLETED" | string;
   export interface TextDocument {
     /**
      * Filepath relative to the root of the workspace
@@ -1434,7 +1436,7 @@ declare namespace CodeWhispererBearerTokenClient {
     json?: SensitiveDocument;
   }
   export type ToolResultContentBlockTextString = string;
-  export type ToolResultStatus = "success"|"error"|string;
+  export type ToolResultStatus = "success" | "error" | string;
   export type ToolResults = ToolResult[];
   export interface ToolSpecification {
     inputSchema: ToolInputSchema;
@@ -1461,14 +1463,14 @@ declare namespace CodeWhispererBearerTokenClient {
     charsOfCodeChanged?: Integer;
     linesOfCodeSubmitted?: Integer;
   }
-  export type TransformationDotNetRuntimeEnv = "NET_5_0"|"NET_6_0"|"NET_7_0"|"NET_8_0"|"NET_9_0"|"NET_STANDARD_2_0"|string;
+  export type TransformationDotNetRuntimeEnv = "NET_5_0" | "NET_6_0" | "NET_7_0" | "NET_8_0" | "NET_9_0" | "NET_STANDARD_2_0" | string;
   export interface TransformationDownloadArtifact {
     downloadArtifactType?: TransformationDownloadArtifactType;
     downloadArtifactId?: ArtifactId;
   }
-  export type TransformationDownloadArtifactType = "ClientInstructions"|"Logs"|"GeneratedCode"|string;
+  export type TransformationDownloadArtifactType = "ClientInstructions" | "Logs" | "GeneratedCode" | string;
   export type TransformationDownloadArtifacts = TransformationDownloadArtifact[];
-  export type TransformationJavaRuntimeEnv = "JVM_8"|"JVM_11"|"JVM_17"|"JVM_21"|string;
+  export type TransformationJavaRuntimeEnv = "JVM_8" | "JVM_11" | "JVM_17" | "JVM_21" | string;
   export interface TransformationJob {
     jobId?: TransformationJobId;
     transformationSpec?: TransformationSpec;
@@ -1479,10 +1481,10 @@ declare namespace CodeWhispererBearerTokenClient {
     endExecutionTime?: Timestamp;
   }
   export type TransformationJobId = string;
-  export type TransformationLanguage = "JAVA_8"|"JAVA_11"|"JAVA_17"|"JAVA_21"|"C_SHARP"|"COBOL"|"PL_I"|"JCL"|string;
+  export type TransformationLanguage = "JAVA_8" | "JAVA_11" | "JAVA_17" | "JAVA_21" | "C_SHARP" | "COBOL" | "PL_I" | "JCL" | string;
   export type TransformationLanguages = TransformationLanguage[];
-  export type TransformationMainframeRuntimeEnv = "MAINFRAME"|string;
-  export type TransformationOperatingSystemFamily = "WINDOWS"|"LINUX"|string;
+  export type TransformationMainframeRuntimeEnv = "MAINFRAME" | string;
+  export type TransformationOperatingSystemFamily = "WINDOWS" | "LINUX" | string;
   export interface TransformationPlan {
     transformationSteps: TransformationSteps;
   }
@@ -1497,7 +1499,7 @@ declare namespace CodeWhispererBearerTokenClient {
     endTime?: Timestamp;
     downloadArtifacts?: TransformationDownloadArtifacts;
   }
-  export type TransformationProgressUpdateStatus = "IN_PROGRESS"|"COMPLETED"|"FAILED"|"PAUSED"|"AWAITING_CLIENT_ACTION"|"SKIPPED"|string;
+  export type TransformationProgressUpdateStatus = "IN_PROGRESS" | "COMPLETED" | "FAILED" | "PAUSED" | "AWAITING_CLIENT_ACTION" | "SKIPPED" | string;
   export interface TransformationProjectArtifactDescriptor {
     sourceCodeArtifact?: TransformationSourceCodeArtifactDescriptor;
   }
@@ -1521,7 +1523,7 @@ declare namespace CodeWhispererBearerTokenClient {
     source?: TransformationProjectState;
     target?: TransformationProjectState;
   }
-  export type TransformationStatus = "CREATED"|"ACCEPTED"|"REJECTED"|"STARTED"|"PREPARING"|"PREPARED"|"PLANNING"|"PLANNED"|"TRANSFORMING"|"TRANSFORMED"|"FAILED"|"COMPLETED"|"PARTIALLY_COMPLETED"|"STOPPING"|"STOPPED"|"PAUSED"|"RESUMED"|string;
+  export type TransformationStatus = "CREATED" | "ACCEPTED" | "REJECTED" | "STARTED" | "PREPARING" | "PREPARED" | "PLANNING" | "PLANNED" | "TRANSFORMING" | "TRANSFORMED" | "FAILED" | "COMPLETED" | "PARTIALLY_COMPLETED" | "STOPPING" | "STOPPED" | "PAUSED" | "RESUMED" | string;
   export interface TransformationStep {
     id: StepId;
     name: String;
@@ -1531,15 +1533,15 @@ declare namespace CodeWhispererBearerTokenClient {
     startTime?: Timestamp;
     endTime?: Timestamp;
   }
-  export type TransformationStepStatus = "CREATED"|"COMPLETED"|"PARTIALLY_COMPLETED"|"STOPPED"|"FAILED"|"PAUSED"|"SKIPPED"|string;
+  export type TransformationStepStatus = "CREATED" | "COMPLETED" | "PARTIALLY_COMPLETED" | "STOPPED" | "FAILED" | "PAUSED" | "SKIPPED" | string;
   export type TransformationSteps = TransformationStep[];
-  export type TransformationType = "LANGUAGE_UPGRADE"|"DOCUMENT_GENERATION"|string;
-  export type TransformationUploadArtifactType = "Dependencies"|"ClientBuildResult"|string;
+  export type TransformationType = "LANGUAGE_UPGRADE" | "DOCUMENT_GENERATION" | string;
+  export type TransformationUploadArtifactType = "Dependencies" | "ClientBuildResult" | string;
   export interface TransformationUploadContext {
     jobId: TransformationJobId;
     uploadArtifactType: TransformationUploadArtifactType;
   }
-  export type TransformationUserActionStatus = "COMPLETED"|"REJECTED"|string;
+  export type TransformationUserActionStatus = "COMPLETED" | "REJECTED" | string;
   export type UUID = string;
   export interface UploadContext {
     taskAssistPlanningUploadContext?: TaskAssistPlanningUploadContext;
@@ -1549,7 +1551,7 @@ declare namespace CodeWhispererBearerTokenClient {
     workspaceContextUploadContext?: WorkspaceContextUploadContext;
   }
   export type UploadId = string;
-  export type UploadIntent = "TRANSFORMATION"|"TASK_ASSIST_PLANNING"|"AUTOMATIC_FILE_SECURITY_SCAN"|"FULL_PROJECT_SECURITY_SCAN"|"UNIT_TESTS_GENERATION"|"CODE_FIX_GENERATION"|"WORKSPACE_CONTEXT"|string;
+  export type UploadIntent = "TRANSFORMATION" | "TASK_ASSIST_PLANNING" | "AUTOMATIC_FILE_SECURITY_SCAN" | "FULL_PROJECT_SECURITY_SCAN" | "UNIT_TESTS_GENERATION" | "CODE_FIX_GENERATION" | "WORKSPACE_CONTEXT" | string;
   export type Url = string;
   export interface UserContext {
     ideCategory: IdeCategory;
@@ -1624,7 +1626,7 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     tools?: Tools;
   }
-  export type UserIntent = "SUGGEST_ALTERNATE_IMPLEMENTATION"|"APPLY_COMMON_BEST_PRACTICES"|"IMPROVE_CODE"|"SHOW_EXAMPLES"|"CITE_SOURCES"|"EXPLAIN_LINE_BY_LINE"|"EXPLAIN_CODE_SELECTION"|"GENERATE_CLOUDFORMATION_TEMPLATE"|"GENERATE_UNIT_TESTS"|"CODE_GENERATION"|string;
+  export type UserIntent = "SUGGEST_ALTERNATE_IMPLEMENTATION" | "APPLY_COMMON_BEST_PRACTICES" | "IMPROVE_CODE" | "SHOW_EXAMPLES" | "CITE_SOURCES" | "EXPLAIN_LINE_BY_LINE" | "EXPLAIN_CODE_SELECTION" | "GENERATE_CLOUDFORMATION_TEMPLATE" | "GENERATE_UNIT_TESTS" | "CODE_GENERATION" | string;
   export interface UserModificationEvent {
     sessionId: UUID;
     requestId: UUID;
@@ -1683,12 +1685,12 @@ declare namespace CodeWhispererBearerTokenClient {
      */
     contextTruncationScheme?: ContextTruncationScheme;
   }
-  export type WorkspaceStatus = "CREATED"|"PENDING"|"READY"|"CONNECTED"|"DELETING"|string;
+  export type WorkspaceStatus = "CREATED" | "PENDING" | "READY" | "CONNECTED" | "DELETING" | string;
   export type timeBetweenChunks = Double[];
   /**
    * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.
    */
-  export type apiVersion = "2022-11-11"|"latest"|string;
+  export type apiVersion = "2022-11-11" | "latest" | string;
   export interface ClientApiVersions {
     /**
      * A string in YYYY-MM-DD format that represents the latest possible API version that can be used in this service. Specify 'latest' to use the latest possible version.

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
@@ -170,6 +170,7 @@ describe('CodeWhisperer Server', () => {
 
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
+                    fileUri: SOME_FILE.uri,
                     filename: URI.parse(SOME_FILE.uri).path.substring(1),
                     programmingLanguage: { languageName: 'csharp' },
                     leftFileContent: '',
@@ -202,6 +203,7 @@ describe('CodeWhisperer Server', () => {
 
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
+                    fileUri: SOME_FILE.uri,
                     filename: URI.parse(SOME_FILE.uri).path.substring(1),
                     programmingLanguage: { languageName: 'csharp' },
                     leftFileContent: firstTwoLines,
@@ -258,6 +260,7 @@ describe('CodeWhisperer Server', () => {
 
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
+                    fileUri: SOME_FILE_WITH_ALT_CASED_LANGUAGE_ID.uri,
                     filename: URI.parse(SOME_FILE_WITH_ALT_CASED_LANGUAGE_ID.uri).path.substring(1),
                     programmingLanguage: { languageName: 'csharp' },
                     leftFileContent: '',
@@ -312,6 +315,7 @@ describe('CodeWhisperer Server', () => {
 
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
+                    fileUri: SOME_FILE.uri,
                     filename: URI.parse(SOME_FILE.uri).path.substring(1),
                     programmingLanguage: { languageName: 'csharp' },
                     leftFileContent: extraContext + '\n',
@@ -355,6 +359,7 @@ describe('CodeWhisperer Server', () => {
 
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
+                    fileUri: SOME_FILE_WITH_EXTENSION.uri,
                     filename: URI.parse(SOME_FILE_WITH_EXTENSION.uri).path.substring(1),
                     programmingLanguage: { languageName: 'cpp' },
                     leftFileContent: '',
@@ -442,6 +447,7 @@ describe('CodeWhisperer Server', () => {
             const rightContext = lines.slice(cutOffLine).join('\n')
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
+                    fileUri: MY_FILE.uri,
                     filename: URI.parse(MY_FILE.uri).path.substring(1),
                     programmingLanguage: { languageName: 'csharp' },
                     leftFileContent: leftContext,
@@ -479,6 +485,7 @@ describe('CodeWhisperer Server', () => {
             const modifiedRightContext = lines.slice(cutOffLine).join('\n')
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
+                    fileUri: MY_WINDOWS_FILE.uri,
                     filename: URI.parse(MY_WINDOWS_FILE.uri).path.substring(1),
                     programmingLanguage: { languageName: 'csharp' },
                     leftFileContent: modifiedLeftContext,
@@ -704,6 +711,7 @@ describe('CodeWhisperer Server', () => {
 
                 const expectedGenerateSuggestionsRequest = {
                     fileContext: {
+                        fileUri: 'file:///TargetFile.java',
                         filename: 'TargetFile.java',
                         programmingLanguage: { languageName: 'java' },
                         leftFileContent: '',
@@ -1193,6 +1201,7 @@ describe('CodeWhisperer Server', () => {
 
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
+                    fileUri: SOME_FILE.uri,
                     filename: URI.parse(SOME_FILE.uri).path.substring(1),
                     programmingLanguage: { languageName: 'csharp' },
                     leftFileContent: SPECIAL_CHARACTER_HELLO_WORLD.substring(0, 1),
@@ -1227,6 +1236,7 @@ describe('CodeWhisperer Server', () => {
 
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
+                    fileUri: SOME_FILE.uri,
                     filename: URI.parse(SOME_FILE.uri).path.substring(1),
                     programmingLanguage: { languageName: 'csharp' },
                     leftFileContent: LEFT_FILE_CONTEXT,

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -55,6 +55,7 @@ import { getRelativePath } from '../workspaceContext/util'
 import { UserWrittenCodeTracker } from '../../shared/userWrittenCodeTracker'
 
 const EMPTY_RESULT = { sessionId: '', items: [] }
+export const FILE_URI_CHARS_LIMIT = 1024
 export const CONTEXT_CHARACTERS_LIMIT = 10240
 
 // Both clients (token, sigv4) define their own types, this return value needs to match both of them.
@@ -63,6 +64,7 @@ const getFileContext = (params: {
     position: Position
     inferredLanguageId: CodewhispererLanguage
 }): {
+    fileUri: string
     filename: string
     programmingLanguage: {
         languageName: CodewhispererLanguage
@@ -89,6 +91,7 @@ const getFileContext = (params: {
     // }
 
     return {
+        fileUri: params.textDocument.uri.substring(0, FILE_URI_CHARS_LIMIT),
         filename: relativeFileName,
         programmingLanguage: {
             languageName: getRuntimeLanguage(params.inferredLanguageId),


### PR DESCRIPTION
## Problem

In order to coordinate the new [aws/language-servers](https://github.com/aws/language-servers/pull/1348) change, GenerateCompletions requests would start expecting the `fileUri` field to be set.

We implemented this in both VSCode and JetBrains extensions, but as we are migrating GenerateCompletions away from them to `aws/language-servers`, we also need to ensure they are added in the relevant code paths here.
- https://github.com/aws/aws-toolkit-vscode/pull/7294
- https://github.com/aws/aws-toolkit-jetbrains/pull/5732

## Solution

Add `fileUri` to FileContext

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
