### PR TITLE
fix(chat-client): fixes bug where pair-programmer option update was not stored properly

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -91,6 +91,18 @@ export const handlePromptInputChange = (mynahUi: MynahUI, tabId: string, options
 
     if (promptTypeValue != null) {
         mynahUi.addChatItem(tabId, promptTypeValue === 'true' ? pairProgrammingModeOn : pairProgrammingModeOff)
+        const options = [...(mynahUi.getTabData(tabId)?.getStore()?.promptInputOptions || [])]
+        const optionIndex = options.findIndex(opt => opt.id === 'pair-programmer-mode')
+
+        if (optionIndex >= 0) {
+            options[optionIndex].value = promptTypeValue
+        } else {
+            options.push({
+                id: 'pair-programmer-mode',
+                value: promptTypeValue,
+            } as any)
+        }
+        mynahUi.updateStore(tabId, { promptInputOptions: options as any })
     }
 }
 


### PR DESCRIPTION
## Problem
`OnPromptInputOptionChange` when the agentic mode button is toggled on and off, the mynahUI store was not updated properly to store the updated value. This resulted in "insert to cursor" option being disabled/hidden in a codeblock shown in an agentic mode OFF response.
## Solution
With this change, on prompt option change event, the MynahUi store is now updated to preserve the latest value of "pair-programmer-mode" option. I verified the insert to cursor option now appears on toggle
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
