### PR TITLE
fix: the new prompt wont stop the process properly

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -427,11 +427,12 @@ export class AgenticChatController implements ChatHandlers {
                     session.pairProgrammingMode,
                     session.getConversationType()
                 )
-                await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric, 'Cancelled')
 
                 session.abortRequest()
                 void this.#invalidateAllShellCommands(params.tabId, session)
                 session.rejectAllDeferredToolExecutions(new CancellationError('user'))
+
+                await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric, 'Cancelled')
             })
             session.setConversationType('AgenticChat')
 


### PR DESCRIPTION
## Problem
When a new prompt was sent while the first was still processing, the telemetry emission for the cancelled prompt was happening before the request was aborted, which prevented the system from properly handling the second prompt.


## Solution
Moved the telemetry emission to occur after the request is aborted


https://github.com/user-attachments/assets/d60d4ed2-b31a-496d-8147-800bc864721b


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
