### PR TITLE
Set `source` parameter chat request context to 'IDE'

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
@@ -68,29 +68,29 @@ export class QChatTriggerContext {
                         userInputMessageContext:
                             triggerContext.cursorState && triggerContext.relativeFilePath
                                 ? {
-                                    editorState: {
-                                        cursorState: triggerContext.cursorState,
-                                        document: {
-                                            text: triggerContext.text,
-                                            programmingLanguage: triggerContext.programmingLanguage,
-                                            relativeFilePath: triggerContext.relativeFilePath,
-                                        },
-                                        ...(triggerContext.useRelevantDocuments && {
-                                            useRelevantDocuments: triggerContext.useRelevantDocuments,
-                                            relevantDocuments: triggerContext.relevantDocuments,
-                                        }),
-                                    },
-                                    tools,
-                                }
+                                      editorState: {
+                                          cursorState: triggerContext.cursorState,
+                                          document: {
+                                              text: triggerContext.text,
+                                              programmingLanguage: triggerContext.programmingLanguage,
+                                              relativeFilePath: triggerContext.relativeFilePath,
+                                          },
+                                          ...(triggerContext.useRelevantDocuments && {
+                                              useRelevantDocuments: triggerContext.useRelevantDocuments,
+                                              relevantDocuments: triggerContext.relevantDocuments,
+                                          }),
+                                      },
+                                      tools,
+                                  }
                                 : {
-                                    tools,
-                                    ...(triggerContext.useRelevantDocuments && {
-                                        editorState: {
-                                            useRelevantDocuments: triggerContext.useRelevantDocuments,
-                                            relevantDocuments: triggerContext.relevantDocuments,
-                                        },
-                                    }),
-                                },
+                                      tools,
+                                      ...(triggerContext.useRelevantDocuments && {
+                                          editorState: {
+                                              useRelevantDocuments: triggerContext.useRelevantDocuments,
+                                              relevantDocuments: triggerContext.relevantDocuments,
+                                          },
+                                      }),
+                                  },
                         userIntent: triggerContext.userIntent,
                         origin: 'IDE',
                     },
@@ -115,11 +115,11 @@ export class QChatTriggerContext {
 
         return textDocument
             ? this.#documentContextExtractor.extractDocumentContext(
-                textDocument,
-                // we want to include a default position if a text document is found so users can still ask questions about the opened file
-                // the range will be expanded up to the max characters downstream
-                cursorState?.[0] ?? QChatTriggerContext.DEFAULT_CURSOR_STATE
-            )
+                  textDocument,
+                  // we want to include a default position if a text document is found so users can still ask questions about the opened file
+                  // the range will be expanded up to the max characters downstream
+                  cursorState?.[0] ?? QChatTriggerContext.DEFAULT_CURSOR_STATE
+              )
             : undefined
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/triggerContext.ts
@@ -68,29 +68,29 @@ export class QChatTriggerContext {
                         userInputMessageContext:
                             triggerContext.cursorState && triggerContext.relativeFilePath
                                 ? {
-                                      editorState: {
-                                          cursorState: triggerContext.cursorState,
-                                          document: {
-                                              text: triggerContext.text,
-                                              programmingLanguage: triggerContext.programmingLanguage,
-                                              relativeFilePath: triggerContext.relativeFilePath,
-                                          },
-                                          ...(triggerContext.useRelevantDocuments && {
-                                              useRelevantDocuments: triggerContext.useRelevantDocuments,
-                                              relevantDocuments: triggerContext.relevantDocuments,
-                                          }),
-                                      },
-                                      tools,
-                                  }
+                                    editorState: {
+                                        cursorState: triggerContext.cursorState,
+                                        document: {
+                                            text: triggerContext.text,
+                                            programmingLanguage: triggerContext.programmingLanguage,
+                                            relativeFilePath: triggerContext.relativeFilePath,
+                                        },
+                                        ...(triggerContext.useRelevantDocuments && {
+                                            useRelevantDocuments: triggerContext.useRelevantDocuments,
+                                            relevantDocuments: triggerContext.relevantDocuments,
+                                        }),
+                                    },
+                                    tools,
+                                }
                                 : {
-                                      tools,
-                                      ...(triggerContext.useRelevantDocuments && {
-                                          editorState: {
-                                              useRelevantDocuments: triggerContext.useRelevantDocuments,
-                                              relevantDocuments: triggerContext.relevantDocuments,
-                                          },
-                                      }),
-                                  },
+                                    tools,
+                                    ...(triggerContext.useRelevantDocuments && {
+                                        editorState: {
+                                            useRelevantDocuments: triggerContext.useRelevantDocuments,
+                                            relevantDocuments: triggerContext.relevantDocuments,
+                                        },
+                                    }),
+                                },
                         userIntent: triggerContext.userIntent,
                         origin: 'IDE',
                     },
@@ -98,6 +98,7 @@ export class QChatTriggerContext {
                 customizationArn,
             },
             profileArn,
+            source: 'IDE',
         }
 
         return data
@@ -114,11 +115,11 @@ export class QChatTriggerContext {
 
         return textDocument
             ? this.#documentContextExtractor.extractDocumentContext(
-                  textDocument,
-                  // we want to include a default position if a text document is found so users can still ask questions about the opened file
-                  // the range will be expanded up to the max characters downstream
-                  cursorState?.[0] ?? QChatTriggerContext.DEFAULT_CURSOR_STATE
-              )
+                textDocument,
+                // we want to include a default position if a text document is found so users can still ask questions about the opened file
+                // the range will be expanded up to the max characters downstream
+                cursorState?.[0] ?? QChatTriggerContext.DEFAULT_CURSOR_STATE
+            )
             : undefined
     }
 


### PR DESCRIPTION
## Problem

The IAM `SendMessage` streaming client uses the `source` parameter to route the request, we currently don't set this parameter resulting in incorrect routing. For example, even when setting the `chatTriggerType` to `INLINE_CHAT` the IAM chat client still responds with natural language.

## Solution

We set it to `IDE` to route it to the right back-end.

## Testing

- Verified that the IAM chat client now responds with just code when passing the `INLINE_CHAT` trigger type.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
