### PR TITLE
fix: success and error case for adding mcp server

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1407,7 +1407,7 @@ ${params.message}`,
     const mcpServerClick = (params: McpServerClickResult) => {
         const typedParams = params as McpServerParams
 
-        if (params.id === 'add-new-mcp' || (params.id === 'save-mcp' && params.header?.status)) {
+        if (params.id === 'add-new-mcp') {
             const detailedList = createAddMcpServerDetailedList(typedParams)
 
             const events = {
@@ -1427,7 +1427,6 @@ ${params.message}`,
                         setTimeout(() => {
                             mynahUi.toggleSplashLoader(false)
                         }, 10000)
-                        messager.onMcpServerClick('open-mcp-server', filterValues?.['name'])
                     }
                 },
             }

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1319,6 +1319,7 @@ ${params.message}`,
             header: {
                 title: params.header?.title || 'Add MCP Server',
                 description: params.header?.description || '',
+                status: params.header?.status ?? {},
             },
             filterOptions: processFilterOptions(params.filterOptions),
             filterActions: params.filterActions,
@@ -1393,7 +1394,7 @@ ${params.message}`,
     const mcpServerClick = (params: McpServerClickResult) => {
         const typedParams = params as McpServerParams
 
-        if (params.id === 'add-new-mcp') {
+        if (params.id === 'add-new-mcp' || (params.id === 'save-mcp' && params.header?.status)) {
             const detailedList = createAddMcpServerDetailedList(typedParams)
 
             const events = {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1332,7 +1332,7 @@ ${params.message}`,
             header: {
                 title: params.header?.title || 'Add MCP Server',
                 description: params.header?.description || '',
-                status: params.header?.status ?? {},
+                status: params.header?.status || {},
             },
             filterOptions: processFilterOptions(params.filterOptions),
             filterActions: params.filterActions,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -227,6 +227,7 @@ export class McpEventHandler {
                             value: 'workspace',
                         },
                     ],
+                    value: existingValues.scope || 'global',
                 },
                 {
                     type: 'textinput',
@@ -314,6 +315,8 @@ export class McpEventHandler {
             const formattedFields = missingFields.map(f => f.charAt(0).toUpperCase() + f.slice(1)).join(', ')
             // adds errorTitle mapping to optionsValues which is not normally there. chose this option over adding new parameter to #handleAddNewMcp
             params.optionsValues['errorTitle'] = `Required Fields: ${formattedFields}`
+            // goes back to add-new-mcp page but will now show an error card
+            params.id = 'add-new-mcp'
             return this.#handleAddNewMcp(params)
         }
 
@@ -372,7 +375,7 @@ export class McpEventHandler {
         // TODO: According to workspace specific scope and persona and pass configPath to addServer
         await McpManager.instance.addServer(serverName, config, configPath, personaPath)
 
-        return this.#getDefaultMcpResponse(params.id)
+        return this.#handleOpenMcpServer({ id: 'open-mcp-server', title: serverName })
     }
 
     /**

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -131,12 +131,18 @@ export class McpEventHandler {
     /**
      * Handles the add new MCP server action
      */
-    async #handleAddNewMcp(params: McpServerClickParams) {
+    async #handleAddNewMcp(params: McpServerClickParams, errorTitle: string = '') {
         return {
             id: params.id,
             header: {
                 title: 'Add MCP Server',
-                status: {},
+                status: errorTitle
+                    ? {
+                          title: errorTitle,
+                          icon: 'cancel-circle',
+                          status: 'error',
+                      }
+                    : {},
                 actions: [],
             },
             list: [],
@@ -244,6 +250,15 @@ export class McpEventHandler {
     async #handleSaveMcp(params: McpServerClickParams) {
         if (!params.optionsValues) {
             return this.#getDefaultMcpResponse(params.id)
+        }
+
+        const requiredFields = ['name', 'command', 'timeout']
+        const missingFields = requiredFields.filter(
+            field => !params.optionsValues?.[field] || params.optionsValues[field].trim() === ''
+        )
+        if (missingFields.length > 0) {
+            const formattedFields = missingFields.map(f => f.charAt(0).toUpperCase() + f.slice(1)).join(', ')
+            return this.#handleAddNewMcp(params, `Required Fields: ${formattedFields}`)
         }
 
         // Process args to string[]

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -151,7 +151,7 @@ export class McpEventHandler {
     /**
      * Handles the add new MCP server action
      */
-    async #handleAddNewMcp(params: McpServerClickParams, errorTitle: string = '') {
+    async #handleAddNewMcp(params: McpServerClickParams) {
         const existingValues = params.optionsValues || {}
         let argsValue = [
             {


### PR DESCRIPTION
## Problem
- after successfully adding mcp server, it stays on the same page. it should go to permissions page
- after failing to add mcp server, it does not show error card to user. it should stay on the page while showing error card to user

## Solution
- after successfully adding mcp server, goes to permissions page
- after failing to add mcp server, shows error card to user
    - currently only validation is checking that name, command, and timeout have been inputted. more validations are needed in a followup
    - data will persist so user will not have to retype everything

### TODO
- persist scope (global or workspace) on success case 

### Verification
- manually tested:
    - happy case for adding mcp server --> goes to permissions page
    - with missing name, command, timeout -->  stays on same page, error card shown at top, and data persists

https://github.com/user-attachments/assets/6520a678-746a-4714-b3aa-5717000c032e



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
