### PR TITLE
fix: handle wilcar for enable/disable server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -399,7 +399,9 @@ export class McpManager {
         })
 
         if (permission && permission.__configPath__) {
-            await this.mutatePersonaFile(permission.__configPath__, p => p.removeServer(serverName))
+            await this.mutatePersonaFile(permission.__configPath__, p =>
+                p.removeServer(serverName, Array.from(this.mcpServers.keys()))
+            )
         }
         this.mcpServerPermissions = await loadPersonaPermissions(
             this.features.workspace,
@@ -509,7 +511,7 @@ export class McpManager {
 
             // disable whole server
             if (!perm.enabled) {
-                p.removeServer(serverName) // removes from list clears tool perms
+                p.removeServer(serverName, Array.from(this.mcpServers.keys())) // removes from list clears tool perms
                 return
             }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTypes.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTypes.ts
@@ -62,10 +62,16 @@ export class PersonaModel {
         }
     }
 
-    removeServer(name: string): void {
-        const idx = this.cfg['mcpServers'].indexOf(name)
-        if (idx >= 0) this.cfg['mcpServers'].splice(idx, 1)
-        if (this.cfg['toolPerms']) delete this.cfg['toolPerms'][name]
+    removeServer(name: string, knownServers: string[]): void {
+        const starIdx = this.cfg.mcpServers.indexOf('*')
+
+        if (starIdx >= 0) {
+            this.cfg.mcpServers = Array.from(new Set(knownServers))
+        }
+
+        const idx = this.cfg.mcpServers.indexOf(name)
+        if (idx >= 0) this.cfg.mcpServers.splice(idx, 1)
+        if (this.cfg.toolPerms) delete this.cfg.toolPerms[name]
     }
 
     replaceToolPerms(server: string, toolPerms: Record<string, McpPermissionType>): void {


### PR DESCRIPTION
## Problem
When '*' is used in persona enable/disable not properly handled
## Solution
If a server is disabled and '*' is used, add all the remaining severs in mcpServers list
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
