### PR TITLE
feat: adding correct icons for MCP servers state

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1134,9 +1134,23 @@ ${params.message}`,
                     let icon = 'ok-circled'
                     let iconForegroundStatus = 'success'
 
-                    if (group.groupName === 'Disabled') {
-                        icon = 'block'
+                    // Extract status from serverInformation if available
+                    const serverInfoGroup = item.children?.find(child => child.groupName === 'serverInformation')
+                    const statusChild = serverInfoGroup?.children?.find(child => child.title === 'status')
+                    const status = statusChild?.description || 'DISABLED'
+
+                    if (status === 'ENABLED') {
+                        icon = 'ok-circled'
+                        iconForegroundStatus = 'success'
+                    } else if (status === 'FAILED') {
+                        icon = 'cancel-circle'
                         iconForegroundStatus = 'error'
+                    } else if (status === 'INITIALIZING') {
+                        icon = 'progress'
+                        iconForegroundStatus = 'info'
+                    } else if (group.groupName === 'Disabled') {
+                        icon = 'block'
+                        iconForegroundStatus = 'info'
                     }
 
                     // Create actions based on group name

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -1,5 +1,5 @@
 import { Features } from '../../../types'
-import { McpManager } from './mcpManager'
+import { MCP_SERVER_STATUS_CHANGED, McpManager } from './mcpManager'
 import {
     DetailedListGroup,
     DetailedListItem,
@@ -48,7 +48,7 @@ export class McpEventHandler {
                         children: [
                             {
                                 title: 'status',
-                                description: serverState?.status || 'Unknown',
+                                description: serverState?.status || 'DISABLED',
                             },
                             {
                                 title: 'toolcount',


### PR DESCRIPTION
## Problem
We need correct icons displayed for server state

## Solution
- Adds icons according to server state.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
