### PR TITLE
feat: added built-in tools with proper permissions

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1422,6 +1422,8 @@ ${params.message}`,
         const typedParams = params as McpServerParams
 
         if (params.id === 'add-new-mcp') {
+            //turning off splash loader in case of being on when new server is added
+            mynahUi.toggleSplashLoader(false)
             const detailedList = createAddMcpServerDetailedList(typedParams)
 
             const events = {
@@ -1438,15 +1440,14 @@ ${params.message}`,
                     } else if (actionParams.id === 'save-mcp') {
                         mynahUi.toggleSplashLoader(true, '**Activating MCP Server**')
                         messager.onMcpServerClick(actionParams.id, 'Save configuration', filterValues)
-                        setTimeout(() => {
-                            mynahUi.toggleSplashLoader(false)
-                        }, 10000)
                     }
                 },
             }
 
             mynahUi.openDetailedList({ detailedList, events }, true)
         } else if (params.id === 'open-mcp-server') {
+            //turning off splash loader in case of being on when new server is added
+            mynahUi.toggleSplashLoader(false)
             const detailedList = createViewMcpServerDetailedList(typedParams)
 
             const mcpServerSheet = mynahUi.openDetailedList(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -961,22 +961,21 @@ export class AgenticChatController implements ChatHandlers {
                         const tool = new Tool(this.#features)
 
                         // For MCP tools, get the permission from McpManager
-                        const permission = McpManager.instance.getToolPerm('Built-in', toolUse.name)
+                        // const permission = McpManager.instance.getToolPerm('Built-in', toolUse.name)
                         // If permission is 'alwaysAllow', we don't need to ask for acceptance
-                        const builtInPermission = permission !== 'alwaysAllow'
+                        // const builtInPermission = permission !== 'alwaysAllow'
 
                         // Get the approved paths from the session
                         const approvedPaths = session.approvedPaths
 
                         // Pass the approved paths to the tool's requiresAcceptance method
-                        const {
-                            requiresAcceptance: toolRequiresAcceptance,
-                            warning,
-                            commandCategory,
-                        } = await tool.requiresAcceptance(toolUse.input as any, approvedPaths)
+                        const { requiresAcceptance, warning, commandCategory } = await tool.requiresAcceptance(
+                            toolUse.input as any,
+                            approvedPaths
+                        )
 
                         // Honor built-in permission if available, otherwise use tool's requiresAcceptance
-                        const requiresAcceptance = builtInPermission || toolRequiresAcceptance
+                        // const requiresAcceptance = builtInPermission || toolRequiresAcceptance
 
                         if (requiresAcceptance || toolUse.name === 'executeBash') {
                             // for executeBash, we till send the confirmation message without action buttons
@@ -984,9 +983,7 @@ export class AgenticChatController implements ChatHandlers {
                                 toolUse,
                                 requiresAcceptance,
                                 warning,
-                                commandCategory,
-                                undefined,
-                                builtInPermission
+                                commandCategory
                             )
                             cachedButtonBlockId = await chatResultStream.writeResultBlock(confirmationResult)
                             const isExecuteBash = toolUse.name === 'executeBash'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -37,8 +37,9 @@ export class McpEventHandler {
 
         // Get built-in tools programmatically
         const allTools = this.#features.agent.getTools({ format: 'bedrock' })
+        const mcpToolNames = new Set(mcpManager.getAllTools().map(tool => tool.toolName))
         const builtInTools = allTools
-            .filter(tool => !tool.toolSpecification.name.includes('_')) // Filter out MCP tools which have format serverName_toolName
+            .filter(tool => !mcpToolNames.has(tool.toolSpecification.name))
             .map(tool => ({
                 name: tool.toolSpecification.name,
                 description: tool.toolSpecification.description || `${tool.toolSpecification.name} tool`,
@@ -423,8 +424,9 @@ export class McpEventHandler {
         if (serverName === 'Built-in') {
             // Handle Built-in server specially
             const allTools = this.#features.agent.getTools({ format: 'bedrock' })
+            const mcpToolNames = new Set(McpManager.instance.getAllTools().map(tool => tool.toolName))
             const builtInTools = allTools
-                .filter(tool => !tool.toolSpecification.name.includes('_')) // Filter out MCP tools which have format serverName_toolName
+                .filter(tool => !mcpToolNames.has(tool.toolSpecification.name))
                 .map(tool => {
                     // Set default permission based on tool name
                     const permission = 'alwaysAllow'
@@ -743,8 +745,6 @@ export class McpEventHandler {
                     perm.toolPerms[key] = 'deny'
                     break
                 case 'ask':
-                    perm.toolPerms[key] = 'ask'
-                    break
                 default:
                     perm.toolPerms[key] = 'ask'
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -583,10 +583,7 @@ export class McpEventHandler {
             const toolName = item.tool.toolName
             const currentPermission = this.#getCurrentPermission(item.permission)
             // For Built-in server, use a special function that doesn't include the 'Disable' option
-            const permissionOptions =
-                serverName === 'Built-in'
-                    ? this.#buildBuiltInPermissionOptions(item.permission)
-                    : this.#buildPermissionOptions(item.permission)
+            const permissionOptions = this.#buildPermissionOptions(item.permission)
 
             filterOptions.push({
                 type: 'select',
@@ -646,25 +643,25 @@ export class McpEventHandler {
     /**
      * Builds permission options for Built-in tools (no 'Disable' option)
      */
-    #buildBuiltInPermissionOptions(currentPermission: string) {
-        const permissionOptions: PermissionOption[] = []
+    // #buildBuiltInPermissionOptions(currentPermission: string) {
+    //     const permissionOptions: PermissionOption[] = []
 
-        if (currentPermission !== 'alwaysAllow') {
-            permissionOptions.push({
-                label: 'Always run',
-                value: 'alwaysAllow',
-            })
-        }
+    //     if (currentPermission !== 'alwaysAllow') {
+    //         permissionOptions.push({
+    //             label: 'Always run',
+    //             value: 'alwaysAllow',
+    //         })
+    //     }
 
-        if (currentPermission !== 'ask') {
-            permissionOptions.push({
-                label: 'Ask to run',
-                value: 'ask',
-            })
-        }
+    //     if (currentPermission !== 'ask') {
+    //         permissionOptions.push({
+    //             label: 'Ask to run',
+    //             value: 'ask',
+    //         })
+    //     }
 
-        return permissionOptions
-    }
+    //     return permissionOptions
+    // }
 
     /**
      * Handles MCP permission change events
@@ -730,13 +727,13 @@ export class McpEventHandler {
         for (const [key, val] of Object.entries(updatedPermissionConfig)) {
             if (key === 'scope') continue
 
-            // Get the default permission for this tool from McpManager
-            let defaultPermission = McpManager.instance.getToolPerm(serverName, key)
+            // // Get the default permission for this tool from McpManager
+            // let defaultPermission = McpManager.instance.getToolPerm(serverName, key)
 
-            // If no default permission is found, use 'alwaysAllow' for Built-in and 'ask' for MCP servers
-            if (!defaultPermission) {
-                defaultPermission = serverName === 'Built-in' ? 'alwaysAllow' : 'ask'
-            }
+            // // If no default permission is found, use 'alwaysAllow' for Built-in and 'ask' for MCP servers
+            // if (!defaultPermission) {
+            //     defaultPermission = serverName === 'Built-in' ? 'alwaysAllow' : 'ask'
+            // }
 
             switch (val) {
                 case 'alwaysAllow':
@@ -749,7 +746,7 @@ export class McpEventHandler {
                     perm.toolPerms[key] = 'ask'
                     break
                 default:
-                    perm.toolPerms[key] = defaultPermission
+                    perm.toolPerms[key] = 'ask'
             }
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -45,25 +45,25 @@ export class McpEventHandler {
             }))
 
         // Add built-in tools as a server in the active items
-        activeItems.push({
-            title: 'Built-in',
-            description: `${builtInTools.length} tools`,
-            children: [
-                {
-                    groupName: 'serverInformation',
-                    children: [
-                        {
-                            title: 'status',
-                            description: 'ENABLED',
-                        },
-                        {
-                            title: 'toolcount',
-                            description: `${builtInTools.length}`,
-                        },
-                    ],
-                },
-            ],
-        })
+        // activeItems.push({
+        //     title: 'Built-in',
+        //     description: `${builtInTools.length} tools`,
+        //     children: [
+        //         {
+        //             groupName: 'serverInformation',
+        //             children: [
+        //                 {
+        //                     title: 'status',
+        //                     description: 'ENABLED',
+        //                 },
+        //                 {
+        //                     title: 'toolcount',
+        //                     description: `${builtInTools.length}`,
+        //                 },
+        //             ],
+        //         },
+        //     ],
+        // })
 
         Array.from(mcpManagerServerConfigs.entries()).forEach(([serverName, config]) => {
             const toolsWithPermissions = mcpManager.getAllToolsWithPermissions(serverName)


### PR DESCRIPTION
## Problem
We need to add Built-in tools in mcp server list to setup permissions. and there is an issue with splash loader closing once server initialization completes.

## Solution
- Fixed splash loader once server initialization completes.
- added built-in tools in UX for non-mcp tools
- added permission check for permissions from persona.
- fixed permission duplicates.
- fixed permission propogation.

## Todo
- bug with saving permission and it reverting when loading for both built-in and mcp tools.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
