### PR TITLE
fix: ensure local index server updates with workspaceChangeEvent and bump runtimes

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -15,7 +15,7 @@
         "local-build": "node scripts/local-build.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.85"
+        "@aws/language-server-runtimes": "^0.2.86"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -347,7 +347,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.37",
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "server/**"
             ],
             "dependencies": {
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@smithy/types": "4.2.0",
                 "typescript": "^5.8.2"
             },
@@ -41,7 +42,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -78,7 +79,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -111,7 +112,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -119,7 +120,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -139,7 +140,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -183,7 +184,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -203,7 +204,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -225,7 +226,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.85"
+                "@aws/language-server-runtimes": "^0.2.86"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -269,7 +270,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.37",
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -3911,9 +3912,9 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.85",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.85.tgz",
-            "integrity": "sha512-rj2kr4REUKeTXGgx7alu07lXJl/yk6A0/GqiPwW7tSZ5G8dvmJTtXYzmlaAwRg7nJoGR47MUEZeByYglezQaNg==",
+            "version": "0.2.86",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.86.tgz",
+            "integrity": "sha512-7Nk+NoozmZhk3S5MZHIwoOWfh4NXYMQotbH7odlnzwCCKITJn7qkJ13l7dyEBU13LkPOgdv92Bn4afIpEODcGw==",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.1.31",
                 "@opentelemetry/api": "^1.9.0",
@@ -26486,7 +26487,7 @@
             "version": "0.1.9",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-core": "^0.0.9"
             },
             "devDependencies": {
@@ -26560,7 +26561,7 @@
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.37",
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-core": "^0.0.9",
                 "@modelcontextprotocol/sdk": "^1.9.0",
                 "@smithy/node-http-handler": "^2.5.0",
@@ -26698,7 +26699,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-core": "^0.0.9",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -26744,7 +26745,7 @@
             "version": "0.1.9",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-core": "^0.0.9",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -26758,7 +26759,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-core": "0.0.9",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -26800,7 +26801,7 @@
             "version": "0.0.10",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -26833,7 +26834,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "@aws/lsp-core": "^0.0.9",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -26847,7 +26848,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -26858,7 +26859,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.85",
+                "@aws/language-server-runtimes": "^0.2.86",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "package": "npm run compile && npm run package --workspaces --if-present"
     },
     "dependencies": {
+        "@aws/language-server-runtimes": "^0.2.86",
         "@smithy/types": "4.2.0",
         "typescript": "^5.8.2"
     },

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-core": "^0.0.9"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.37",
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-core": "^0.0.9",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -237,6 +237,7 @@ export class LocalProjectContextController {
                     merged.push(addition)
                 }
             }
+            this.workspaceFolders = merged
             if (this._vecLib && this._isIndexingEnabled) {
                 void this.buildIndex()
             }

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-core": "^0.0.9",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -24,7 +24,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-core": "^0.0.9",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -19,7 +19,7 @@
         "test-unit": "mocha \"./out/**/*.test.js\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-core": "0.0.9",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "@aws/lsp-core": "^0.0.9",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -11,7 +11,7 @@
         "test": "ts-mocha -b \"./src/**/*.test.ts\""
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.85",
+        "@aws/language-server-runtimes": "^0.2.86",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Changes
This change bumps runtimes to include fix related to didWorkspaceChangeFolders handling in https://github.com/aws/language-server-runtimes/pull/522
In addition this change makes a fix in the `localProjectContextServer` where `onDidChangeWorkpaceFolders` event didn't update the workspaceFolders list used for indexing. It now updates to reflect the change.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
