### PR TITLE
fix: fix uncaught exception in workspaceFolderManager

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -133,7 +133,7 @@ export class AgenticChatTriggerContext {
         const remoteWsFolderManager = WorkspaceFolderManager.getInstance()
         const workspaceId =
             (remoteWsFolderManager &&
-                remoteWsFolderManager.getWorkspaceState().webSocketClient?.isConnected &&
+                remoteWsFolderManager.getWorkspaceState().webSocketClient?.isConnected() &&
                 remoteWsFolderManager.getWorkspaceState().workspaceId) ||
             undefined
         this.#logging.info(`remote workspaceId: ${workspaceId}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
@@ -135,7 +135,7 @@ describe('AgenticChatTriggerContext', () => {
         }
         sinon.stub(WorkspaceFolderManager, 'getInstance').returns(mockWorkspaceFolderManager)
         mockWorkspaceFolderManager.getWorkspaceState.returns({
-            webSocketClient: { isConnected: true },
+            webSocketClient: { isConnected: () => true },
             workspaceId: 'test-workspace-123',
         })
         const triggerContext = new AgenticChatTriggerContext(testFeatures)

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/util.ts
@@ -47,7 +47,7 @@ export const uploadArtifactToS3 = async (content: Buffer, resp: CreateUploadUrlR
             'x-amz-server-side-encryption-context': Buffer.from(encryptionContext, 'utf8').toString('base64'),
         })
     }
-    await axios.put(resp.uploadUrl, { body: content, headers: headersObj })
+    await axios.put(resp.uploadUrl, content, { headers: headersObj })
 }
 
 export const isDirectory = (path: string): boolean => {

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -37,7 +37,7 @@ export const WorkspaceContextServer = (): Server => features => {
     lsp.addInitializer((params: InitializeParams) => {
         let clientExtension = params.initializationOptions?.aws?.clientInfo?.extension.name || ''
         if (!allowedExtension.includes(clientExtension)) {
-            logging.warn(`Client extension ${clientExtension} is not in the allowed extensions list`)
+            logging.warn(`Server context is currently not supported in ${clientExtension}`)
             return {
                 capabilities: {},
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -86,7 +86,7 @@ export const WorkspaceContextServer = (): Server => features => {
             if (params.section === Q_CONTEXT_CONFIGURATION_SECTION) {
                 // Only append workspaceId to GenerateCompletions when WebSocket client is connected
                 if (
-                    !workspaceFolderManager.getWorkspaceState().webSocketClient?.isConnected ||
+                    !workspaceFolderManager.getWorkspaceState().webSocketClient?.isConnected() ||
                     !workspaceFolderManager.getWorkspaceState().workspaceId
                 ) {
                     return {


### PR DESCRIPTION
## Problem
There is uncaught exception thrown from a Promise. The Promise get replaced by new one and when rejection happened on the old promise, there is no try catch block to catch it. 
 
## Solution

Instead of rejection, we are using resolve to ensure the functionality of waiting snapshot set.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
