### PR TITLE
fix: closing mcp servers and each server should return to chat

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1503,9 +1503,7 @@ ${params.message}`,
                             // Handle action clicks (save, cancel, etc.)
                             messager.onMcpServerClick(action.id)
                         },
-                        onClose: () => {
-                            messager.onListMcpServers()
-                        },
+                        onClose: () => {},
                         onBackClick: () => {
                             messager.onListMcpServers()
                         },


### PR DESCRIPTION
## Problem
- If user click on close it return previous menu instead should return to chat menu.
## Solution
- Fixed this issue.

https://github.com/user-attachments/assets/cba29443-32a2-4796-88ac-92fd863c116e


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
