### PR TITLE
fix: fix for removing duplicates of completed status for chat summary…

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -877,7 +877,7 @@ export const createMynahUi = (
     /**
      * Creates a properly formatted chat item for MCP tool summary with accordion view
      */
-    const createMcpToolSummaryItem = (message: ChatMessage): Partial<ChatItem> => {
+    const createMcpToolSummaryItem = (message: ChatMessage, isPartialResult?: boolean): Partial<ChatItem> => {
         const muted = message.summary?.content?.header?.status !== undefined
         return {
             type: ChatItemType.ANSWER,
@@ -893,7 +893,9 @@ export const createMynahUi = (
                                     icon: message.summary.content.header.icon as any,
                                     body: message.summary.content.header.body,
                                     buttons: message.summary.content?.header?.buttons as any,
-                                    status: message.summary.content?.header?.status as any,
+                                    status: isPartialResult
+                                        ? (message.summary.content?.header?.status as any)
+                                        : undefined,
                                     fileList: undefined,
                                 }
                               : undefined,
@@ -930,7 +932,7 @@ export const createMynahUi = (
         if (message.type === 'tool') {
             // Handle MCP tool summary with accordion view
             if (message.summary) {
-                return createMcpToolSummaryItem(message)
+                return createMcpToolSummaryItem(message, isPartialResult)
             }
             processedHeader = { ...header }
             if (header?.buttons) {


### PR DESCRIPTION
… item header for mcp tools

## Problem
- we are seeing duplicate statuses for chat item summary card for mcp server tool execution after loop completiong /full result.

## Solution
- Removed status for additional messages to avoid duplicates.

https://github.com/user-attachments/assets/9b9f20da-d98a-4088-9c6a-ef486c2bb681



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
