### PR TITLE
fix(amazonq): fix for honouring the index cache dir path value

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
@@ -132,6 +132,7 @@ export const LocalProjectContextServer =
                     maxFileSizeMB: updatedConfig.projectContext?.localIndexing?.maxFileSizeMB,
                     maxIndexSizeMB: updatedConfig.projectContext?.localIndexing?.maxIndexSizeMB,
                     enableIndexing: localProjectContextEnabled,
+                    indexCacheDirPath: updatedConfig.projectContext?.localIndexing?.indexCacheDirPath,
                 })
             } catch (error) {
                 logging.error(`Error handling configuration change: ${error}`)


### PR DESCRIPTION
## Problem
The Workspace Indexing settings in Amazon Q are not functioning as expected. Specifically, when changing the cache location for indexing, the indexing files are not being stored in the newly specified location.

## Solution
This PR has a fix to ensure that Amazon Q honors the index cache directory path value set by the user. This change ensures that indexing files are correctly stored in the newly specified location when the cache location is modified.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
