### PR TITLE
fix: removing edit config text from add mcp config 

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -284,11 +284,11 @@ export class McpEventHandler {
                     title: 'Scope',
                     options: [
                         {
-                            label: `Global - Used globally. Edit config`,
+                            label: `Global - Used globally.`,
                             value: 'global',
                         },
                         {
-                            label: `This workspace - Only used in this workspace. Edit config`,
+                            label: `This workspace - Only used in this workspace.`,
                             value: 'workspace',
                         },
                     ],


### PR DESCRIPTION
## Notes
- Removing `edit config` text from add mcp config.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
