### PR TITLE
fix: don't add args or env to mcp.json file if args or env is empty

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -403,6 +403,29 @@ export class McpEventHandler {
             }
         }
 
+        // Environment variables must have both name and value, or neither
+        if (Array.isArray(values.env_variables)) {
+            const envVars = values.env_variables as Array<{ env_var_name: string; env_var_value: string }>
+            const hasEmptyNameWithValue = envVars.some(
+                env =>
+                    (!env.env_var_name || env.env_var_name.trim() === '') &&
+                    env.env_var_value &&
+                    env.env_var_value.trim() !== ''
+            )
+            const hasNameWithEmptyValue = envVars.some(
+                env =>
+                    env.env_var_name &&
+                    env.env_var_name.trim() !== '' &&
+                    (!env.env_var_value || env.env_var_value.trim() === '')
+            )
+            if (hasEmptyNameWithValue) {
+                errors.push('Environment variable name cannot be empty when value is provided')
+            }
+            if (hasNameWithEmptyValue) {
+                errors.push('Environment variable value cannot be empty when name is provided')
+            }
+        }
+
         return {
             isValid: errors.length === 0,
             errors,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -16,7 +16,7 @@ import {
     PersonaModel,
     MCPServerPermission,
 } from './mcpTypes'
-import { loadMcpServerConfigs, loadPersonaPermissions } from './mcpUtils'
+import { isEmptyEnv, loadMcpServerConfigs, loadPersonaPermissions } from './mcpUtils'
 import { AgenticChatError } from '../../errors'
 import { EventEmitter } from 'events'
 import { Mutex } from 'async-mutex'
@@ -356,13 +356,18 @@ export class McpManager {
             }
 
             await this.mutateConfigFile(configPath, json => {
-                json.mcpServers[serverName] = {
+                const serverConfig: MCPServerConfig = {
                     command: cfg.command,
-                    args: cfg.args,
-                    env: cfg.env,
                     initializationTimeout: cfg.initializationTimeout,
                     timeout: cfg.timeout,
                 }
+                if (cfg.args && cfg.args.length > 0) {
+                    serverConfig.args = cfg.args
+                }
+                if (cfg.env && !isEmptyEnv(cfg.env)) {
+                    serverConfig.env = cfg.env
+                }
+                json.mcpServers[serverName] = serverConfig
             })
 
             const newCfg: MCPServerConfig = { ...cfg, __configPath__: configPath }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -274,3 +274,16 @@ export function getWorkspaceMcpConfigPaths(wsUris: string[]): string[] {
 export function getGlobalMcpConfigPath(homeDir: string): string {
     return path.join(homeDir, '.aws', 'amazonq', 'mcp.json')
 }
+
+/** Returns true if env object is undefined, null, contains only empty keys or values */
+export function isEmptyEnv(env: Record<string, string>): boolean {
+    if (!env || typeof env !== 'object') {
+        return true
+    }
+    for (const [key, value] of Object.entries(env)) {
+        if (key.trim() !== '' && value.trim() !== '') {
+            return false
+        }
+    }
+    return true
+}


### PR DESCRIPTION
## Problem
- if a user does not include args or env fields when adding mcp server, it will be empty in the mcp.json
- user can input environment variable with a name but no value, and also a value but no name

## Solution
- do not add args or env fields in mcp.json if fields are empty
- field validation for env variables: must have both name and value, or neither


https://github.com/user-attachments/assets/e7bb48ca-53dd-4ecb-888f-585ff3e95a60



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
