### PR TITLE
feat(amazonq): add abap as supported language

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/languageDetection.ts
@@ -1,6 +1,7 @@
 import { TextDocument } from '@aws/language-server-runtimes/server-interface'
 
 export type CodewhispererLanguage =
+    | 'abap'
     | 'c'
     | 'cpp'
     | 'csharp'
@@ -34,6 +35,7 @@ export type CodewhispererLanguage =
 type RuntimeLanguage = Exclude<CodewhispererLanguage, 'jsx' | 'tsx' | 'systemVerilog'> | 'systemverilog'
 
 const runtimeLanguageSet: ReadonlySet<RuntimeLanguage> = new Set([
+    'abap',
     'c',
     'cpp',
     'csharp',
@@ -59,6 +61,7 @@ const runtimeLanguageSet: ReadonlySet<RuntimeLanguage> = new Set([
 // are integrated into the language server and clients.
 // See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocumentItem
 const supportedFileTypes: CodewhispererLanguage[] = [
+    'abap',
     'c',
     'cpp',
     'csharp',
@@ -98,6 +101,7 @@ export const supportedWorkspaceContextLanguages: CodewhispererLanguage[] = [
 ]
 
 export const languageByExtension: { [key: string]: CodewhispererLanguage } = {
+    '.abap': 'abap',
     '.c': 'c',
     '.cpp': 'cpp',
     '.cs': 'csharp',
@@ -141,6 +145,7 @@ export const languageByExtension: { [key: string]: CodewhispererLanguage } = {
 
 // some are exact match and some like javascriptreact and shellscript are not
 export const qLanguageIdByDocumentLanguageId: { [key: string]: CodewhispererLanguage } = {
+    abap: 'abap',
     c: 'c',
     cpp: 'cpp',
     csharp: 'csharp',


### PR DESCRIPTION
## Problem
Needed to add ABAP as a supported language, to be used by all IDEs plugins.

## Testing
Pointed the local VSC repo to Flare and was able to see ABAP as one of the recognized languages.

<img width="227" alt="Screenshot 2025-05-28 at 2 53 59 PM" src="https://github.com/user-attachments/assets/8983422c-656f-4ed6-b9ef-b3bff9d841c3" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
