### PR TITLE
fix(amazonq): wrap sspc lsp handlers in try/catch so failures do not take down server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -179,290 +179,323 @@ export const WorkspaceContextServer = (): Server => features => {
     }
 
     lsp.onInitialized(async params => {
-        if (!isSupportedExtension) {
-            return {}
-        }
-        amazonQServiceManager = AmazonQTokenServiceManager.getInstance()
-
-        artifactManager = new ArtifactManager(workspace, logging, workspaceFolders)
-        dependencyDiscoverer = new DependencyDiscoverer(workspace, logging, workspaceFolders, artifactManager)
-        workspaceFolderManager = WorkspaceFolderManager.createInstance(
-            amazonQServiceManager,
-            logging,
-            artifactManager,
-            dependencyDiscoverer,
-            workspaceFolders,
-            credentialsProvider,
-            workspaceIdentifier
-        )
-        await updateConfiguration()
-
-        lsp.workspace.onDidChangeWorkspaceFolders(async params => {
-            const addedFolders = params.event.added
-
-            if (addedFolders.length > 0) {
-                workspaceFolders.push(...addedFolders)
+        try {
+            if (!isSupportedExtension) {
+                return {}
             }
+            amazonQServiceManager = AmazonQTokenServiceManager.getInstance()
 
-            const removedFolders = params.event.removed
-            if (removedFolders.length > 0) {
-                for (const folder of removedFolders) {
-                    const index = workspaceFolders.findIndex(f => f.uri === folder.uri)
-                    if (index !== -1) {
-                        workspaceFolders.splice(index, 1)
+            artifactManager = new ArtifactManager(workspace, logging, workspaceFolders)
+            dependencyDiscoverer = new DependencyDiscoverer(workspace, logging, workspaceFolders, artifactManager)
+            workspaceFolderManager = WorkspaceFolderManager.createInstance(
+                amazonQServiceManager,
+                logging,
+                artifactManager,
+                dependencyDiscoverer,
+                workspaceFolders,
+                credentialsProvider,
+                workspaceIdentifier
+            )
+            await updateConfiguration()
+
+            lsp.workspace.onDidChangeWorkspaceFolders(async params => {
+                const addedFolders = params.event.added
+
+                if (addedFolders.length > 0) {
+                    workspaceFolders.push(...addedFolders)
+                }
+
+                const removedFolders = params.event.removed
+                if (removedFolders.length > 0) {
+                    for (const folder of removedFolders) {
+                        const index = workspaceFolders.findIndex(f => f.uri === folder.uri)
+                        if (index !== -1) {
+                            workspaceFolders.splice(index, 1)
+                        }
                     }
                 }
-            }
 
-            workspaceFolderManager.updateWorkspaceFolders(workspaceFolders)
-
-            if (!isUserEligibleForWorkspaceContext()) {
-                return
-            }
-
-            if (addedFolders.length > 0) {
-                await workspaceFolderManager.processNewWorkspaceFolders(addedFolders)
-            }
-            if (removedFolders.length > 0) {
-                await workspaceFolderManager.processWorkspaceFoldersDeletion(removedFolders)
-            }
-        })
-        /**
-         * The below code checks the login state of the workspace and initializes the workspace
-         * folders. *isWorkflowInitialized* variable is used to keep track if the workflow has been initialized
-         * or not to prevent it from initializing again. However, there can be a case when user logs out, does some
-         * activity with removing or adding workspace folders, and logs back in. To handle this case- the new state
-         * of workspace folders is updated using *artifactManager.updateWorkspaceFolders(workspaceFolders)* before
-         * initializing again.
-         */
-        setInterval(async () => {
-            if (!isOptedIn) {
-                return
-            }
-            const isLoggedIn = isLoggedInUsingBearerToken(credentialsProvider)
-            if (isLoggedIn && !isWorkflowInitialized) {
-                try {
-                    // getCodewhispererService only returns the cwspr client if the service manager was initialized i.e. profile was selected otherwise it throws an error
-                    // we will not evaluate a/b status until profile is selected and service manager is fully initialized
-                    amazonQServiceManager.getCodewhispererService()
-                } catch (e) {
-                    return
-                }
-
-                await evaluateABTesting()
-                isWorkflowInitialized = true
+                workspaceFolderManager.updateWorkspaceFolders(workspaceFolders)
 
                 if (!isUserEligibleForWorkspaceContext()) {
                     return
                 }
 
-                workspaceFolderManager.initializeWorkspaceStatusMonitor().catch(error => {
-                    logging.error(`Error while initializing workspace status monitoring: ${error}`)
-                })
-                logging.log(`Workspace context workflow initialized`)
-                artifactManager.updateWorkspaceFolders(workspaceFolders)
-                workspaceFolderManager.processNewWorkspaceFolders(workspaceFolders).catch(error => {
-                    logging.error(`Error while processing new workspace folders: ${error}`)
-                })
-            } else if (!isLoggedIn) {
-                if (isWorkflowInitialized) {
-                    // If user is not logged in but the workflow is marked as initialized, it means user was logged in and is now logged out
-                    // In this case, clear the resources and stop the monitoring
-                    await workspaceFolderManager.clearAllWorkspaceResources()
+                if (addedFolders.length > 0) {
+                    await workspaceFolderManager.processNewWorkspaceFolders(addedFolders)
                 }
-                isWorkflowInitialized = false
-            }
-        }, 5000)
+                if (removedFolders.length > 0) {
+                    await workspaceFolderManager.processWorkspaceFoldersDeletion(removedFolders)
+                }
+            })
+            /**
+             * The below code checks the login state of the workspace and initializes the workspace
+             * folders. *isWorkflowInitialized* variable is used to keep track if the workflow has been initialized
+             * or not to prevent it from initializing again. However, there can be a case when user logs out, does some
+             * activity with removing or adding workspace folders, and logs back in. To handle this case- the new state
+             * of workspace folders is updated using *artifactManager.updateWorkspaceFolders(workspaceFolders)* before
+             * initializing again.
+             */
+            setInterval(async () => {
+                if (!isOptedIn) {
+                    return
+                }
+                const isLoggedIn = isLoggedInUsingBearerToken(credentialsProvider)
+                if (isLoggedIn && !isWorkflowInitialized) {
+                    try {
+                        // getCodewhispererService only returns the cwspr client if the service manager was initialized i.e. profile was selected otherwise it throws an error
+                        // we will not evaluate a/b status until profile is selected and service manager is fully initialized
+                        amazonQServiceManager.getCodewhispererService()
+                    } catch (e) {
+                        return
+                    }
+
+                    await evaluateABTesting()
+                    isWorkflowInitialized = true
+
+                    if (!isUserEligibleForWorkspaceContext()) {
+                        return
+                    }
+
+                    workspaceFolderManager.initializeWorkspaceStatusMonitor().catch(error => {
+                        logging.error(`Error while initializing workspace status monitoring: ${error}`)
+                    })
+                    logging.log(`Workspace context workflow initialized`)
+                    artifactManager.updateWorkspaceFolders(workspaceFolders)
+                    workspaceFolderManager.processNewWorkspaceFolders(workspaceFolders).catch(error => {
+                        logging.error(`Error while processing new workspace folders: ${error}`)
+                    })
+                } else if (!isLoggedIn) {
+                    if (isWorkflowInitialized) {
+                        // If user is not logged in but the workflow is marked as initialized, it means user was logged in and is now logged out
+                        // In this case, clear the resources and stop the monitoring
+                        await workspaceFolderManager.clearAllWorkspaceResources()
+                    }
+                    isWorkflowInitialized = false
+                }
+            }, 5000)
+        } catch (error) {
+            logging.error(`Failed to initialize workspace context server: ${error}`)
+        }
     })
 
     lsp.didChangeConfiguration(updateConfiguration)
 
     lsp.onDidSaveTextDocument(async event => {
-        if (!isUserEligibleForWorkspaceContext()) {
-            return
-        }
+        try {
+            if (!isUserEligibleForWorkspaceContext()) {
+                return
+            }
 
-        const programmingLanguage = getCodeWhispererLanguageIdFromPath(event.textDocument.uri)
-        if (!programmingLanguage || !SUPPORTED_WORKSPACE_CONTEXT_LANGUAGES.includes(programmingLanguage)) {
-            return
-        }
+            const programmingLanguage = getCodeWhispererLanguageIdFromPath(event.textDocument.uri)
+            if (!programmingLanguage || !SUPPORTED_WORKSPACE_CONTEXT_LANGUAGES.includes(programmingLanguage)) {
+                return
+            }
 
-        logging.log(`Received didSave event for ${event.textDocument.uri}`)
+            logging.log(`Received didSave event for ${event.textDocument.uri}`)
 
-        const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(event.textDocument.uri, workspaceFolders)
-        if (!workspaceFolder) {
-            logging.log(`No workspaceFolder found for ${event.textDocument.uri} discarding the save event`)
-            return
-        }
-        const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
+            const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(event.textDocument.uri, workspaceFolders)
+            if (!workspaceFolder) {
+                logging.log(`No workspaceFolder found for ${event.textDocument.uri} discarding the save event`)
+                return
+            }
+            const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
 
-        const fileMetadata = await artifactManager.processNewFile(workspaceFolder, event.textDocument.uri)
-        const s3Url = await workspaceFolderManager.uploadToS3(fileMetadata)
-        if (!s3Url) {
-            return
-        }
+            const fileMetadata = await artifactManager.processNewFile(workspaceFolder, event.textDocument.uri)
+            const s3Url = await workspaceFolderManager.uploadToS3(fileMetadata)
+            if (!s3Url) {
+                return
+            }
 
-        const message = JSON.stringify({
-            method: 'textDocument/didSave',
-            params: {
-                textDocument: {
-                    uri: event.textDocument.uri,
+            const message = JSON.stringify({
+                method: 'textDocument/didSave',
+                params: {
+                    textDocument: {
+                        uri: event.textDocument.uri,
+                    },
+                    workspaceChangeMetadata: {
+                        workspaceId: workspaceId,
+                        s3Path: cleanUrl(s3Url),
+                        programmingLanguage: programmingLanguage,
+                    },
                 },
-                workspaceChangeMetadata: {
-                    workspaceId: workspaceId,
-                    s3Path: cleanUrl(s3Url),
-                    programmingLanguage: programmingLanguage,
-                },
-            },
-        })
-        const workspaceState = workspaceFolderManager.getWorkspaceState()
-        workspaceState.messageQueue.push(message)
+            })
+            const workspaceState = workspaceFolderManager.getWorkspaceState()
+            workspaceState.messageQueue.push(message)
+        } catch (error) {
+            logging.error(`Error handling save event: ${error}`)
+        }
     })
 
     lsp.workspace.onDidCreateFiles(async event => {
-        if (!isUserEligibleForWorkspaceContext()) {
-            return
-        }
-        logging.log(`Received didCreateFiles event of length ${event.files.length}`)
-
-        const workspaceState = workspaceFolderManager.getWorkspaceState()
-        for (const file of event.files) {
-            const isDir = isDirectory(file.uri)
-            const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(file.uri, workspaceFolders)
-            if (!workspaceFolder) {
-                continue
+        try {
+            if (!isUserEligibleForWorkspaceContext()) {
+                return
             }
+            logging.log(`Received didCreateFiles event of length ${event.files.length}`)
 
-            let filesMetadata: FileMetadata[] = []
-            if (isDir && isEmptyDirectory(file.uri)) {
-                continue
-            } else if (isDir) {
-                filesMetadata = await artifactManager.addNewDirectories([URI.parse(file.uri)])
-            } else {
-                filesMetadata = [await artifactManager.processNewFile(workspaceFolder, file.uri)]
-            }
-
-            const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
-            for (const fileMetadata of filesMetadata) {
-                const s3Url = await workspaceFolderManager.uploadToS3(fileMetadata)
-                if (!s3Url) {
+            const workspaceState = workspaceFolderManager.getWorkspaceState()
+            for (const file of event.files) {
+                const isDir = isDirectory(file.uri)
+                const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(file.uri, workspaceFolders)
+                if (!workspaceFolder) {
                     continue
                 }
 
-                const message = JSON.stringify({
-                    method: 'workspace/didCreateFiles',
-                    params: {
-                        files: [
-                            {
-                                uri: file.uri,
+                const programmingLanguage = getCodeWhispererLanguageIdFromPath(file.uri)
+                if (!programmingLanguage || !SUPPORTED_WORKSPACE_CONTEXT_LANGUAGES.includes(programmingLanguage)) {
+                    continue
+                }
+
+                let filesMetadata: FileMetadata[] = []
+                if (isDir && isEmptyDirectory(file.uri)) {
+                    continue
+                } else if (isDir) {
+                    filesMetadata = await artifactManager.addNewDirectories([URI.parse(file.uri)])
+                } else {
+                    filesMetadata = [await artifactManager.processNewFile(workspaceFolder, file.uri)]
+                }
+
+                const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
+                for (const fileMetadata of filesMetadata) {
+                    const s3Url = await workspaceFolderManager.uploadToS3(fileMetadata)
+                    if (!s3Url) {
+                        continue
+                    }
+
+                    const message = JSON.stringify({
+                        method: 'workspace/didCreateFiles',
+                        params: {
+                            files: [
+                                {
+                                    uri: file.uri,
+                                },
+                            ],
+                            workspaceChangeMetadata: {
+                                workspaceId: workspaceId,
+                                s3Path: cleanUrl(s3Url),
+                                programmingLanguage: fileMetadata.language,
                             },
-                        ],
-                        workspaceChangeMetadata: {
-                            workspaceId: workspaceId,
-                            s3Path: cleanUrl(s3Url),
-                            programmingLanguage: fileMetadata.language,
                         },
-                    },
-                })
-                workspaceState.messageQueue.push(message)
+                    })
+                    workspaceState.messageQueue.push(message)
+                }
             }
+        } catch (error) {
+            logging.error(`Error handling create event: ${error}`)
         }
     })
 
     lsp.workspace.onDidDeleteFiles(async event => {
-        if (!isUserEligibleForWorkspaceContext()) {
-            return
-        }
-
-        logging.log(`Received didDeleteFiles event of length ${event.files.length}`)
-
-        const workspaceState = workspaceFolderManager.getWorkspaceState()
-        for (const file of event.files) {
-            const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(file.uri, workspaceFolders)
-            if (!workspaceFolder) {
-                logging.log(`Workspace details not found for deleted file: ${file.uri}`)
-                continue
+        try {
+            if (!isUserEligibleForWorkspaceContext()) {
+                return
             }
 
-            const programmingLanguages = artifactManager.handleDeletedPathAndGetLanguages(file.uri, workspaceFolder)
-            if (programmingLanguages.length === 0) {
-                logging.log(`No programming languages determined for: ${file.uri}`)
-                continue
-            }
+            logging.log(`Received didDeleteFiles event of length ${event.files.length}`)
 
-            const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
-            // Send notification for each programming language
-            for (const language of programmingLanguages) {
-                const message = JSON.stringify({
-                    method: 'workspace/didDeleteFiles',
-                    params: {
-                        files: [
-                            {
-                                uri: file.uri,
+            const workspaceState = workspaceFolderManager.getWorkspaceState()
+            for (const file of event.files) {
+                const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(file.uri, workspaceFolders)
+                if (!workspaceFolder) {
+                    logging.log(`Workspace details not found for deleted file: ${file.uri}`)
+                    continue
+                }
+
+                const programmingLanguages = artifactManager.handleDeletedPathAndGetLanguages(file.uri, workspaceFolder)
+                if (programmingLanguages.length === 0) {
+                    logging.log(`No programming languages determined for: ${file.uri}`)
+                    continue
+                }
+
+                const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
+                // Send notification for each programming language
+                for (const language of programmingLanguages) {
+                    const message = JSON.stringify({
+                        method: 'workspace/didDeleteFiles',
+                        params: {
+                            files: [
+                                {
+                                    uri: file.uri,
+                                },
+                            ],
+                            workspaceChangeMetadata: {
+                                workspaceId: workspaceId,
+                                programmingLanguage: language,
                             },
-                        ],
-                        workspaceChangeMetadata: {
-                            workspaceId: workspaceId,
-                            programmingLanguage: language,
                         },
-                    },
-                })
-                workspaceState.messageQueue.push(message)
+                    })
+                    workspaceState.messageQueue.push(message)
+                }
             }
+        } catch (error) {
+            logging.error(`Error handling delete event: ${error}`)
         }
     })
 
     lsp.workspace.onDidRenameFiles(async event => {
-        if (!isUserEligibleForWorkspaceContext()) {
-            return
-        }
-
-        logging.log(`Received didRenameFiles event of length ${event.files.length}`)
-
-        const workspaceState = workspaceFolderManager.getWorkspaceState()
-        for (const file of event.files) {
-            const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(file.newUri, workspaceFolders)
-            if (!workspaceFolder) {
-                continue
+        try {
+            if (!isUserEligibleForWorkspaceContext()) {
+                return
             }
 
-            const filesMetadata = await artifactManager.handleRename(workspaceFolder, file.oldUri, file.newUri)
+            logging.log(`Received didRenameFiles event of length ${event.files.length}`)
 
-            const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
-            for (const fileMetadata of filesMetadata) {
-                const s3Url = await workspaceFolderManager.uploadToS3(fileMetadata)
-                if (!s3Url) {
+            const workspaceState = workspaceFolderManager.getWorkspaceState()
+            for (const file of event.files) {
+                const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(file.newUri, workspaceFolders)
+                if (!workspaceFolder) {
                     continue
                 }
-                const message = JSON.stringify({
-                    method: 'workspace/didRenameFiles',
-                    params: {
-                        files: [
-                            {
-                                old_uri: file.oldUri,
-                                new_uri: file.newUri,
+
+                const filesMetadata = await artifactManager.handleRename(workspaceFolder, file.oldUri, file.newUri)
+
+                const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
+                for (const fileMetadata of filesMetadata) {
+                    const s3Url = await workspaceFolderManager.uploadToS3(fileMetadata)
+                    if (!s3Url) {
+                        continue
+                    }
+                    const message = JSON.stringify({
+                        method: 'workspace/didRenameFiles',
+                        params: {
+                            files: [
+                                {
+                                    old_uri: file.oldUri,
+                                    new_uri: file.newUri,
+                                },
+                            ],
+                            workspaceChangeMetadata: {
+                                workspaceId: workspaceId,
+                                s3Path: cleanUrl(s3Url),
+                                programmingLanguage: fileMetadata.language,
                             },
-                        ],
-                        workspaceChangeMetadata: {
-                            workspaceId: workspaceId,
-                            s3Path: cleanUrl(s3Url),
-                            programmingLanguage: fileMetadata.language,
                         },
-                    },
-                })
-                workspaceState.messageQueue.push(message)
+                    })
+                    workspaceState.messageQueue.push(message)
+                }
             }
+        } catch (error) {
+            logging.error(`Error handling rename event: ${error}`)
         }
     })
 
     lsp.extensions.onDidChangeDependencyPaths(async params => {
-        if (!isUserEligibleForWorkspaceContext()) {
-            return
-        }
-        logging.log(`Received onDidChangeDependencyPaths event for ${params.moduleName}`)
+        try {
+            if (!isUserEligibleForWorkspaceContext()) {
+                return
+            }
+            logging.log(`Received onDidChangeDependencyPaths event for ${params.moduleName}`)
 
-        const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(params.moduleName)
-        await dependencyDiscoverer.handleDependencyUpdateFromLSP(params.runtimeLanguage, params.paths, workspaceFolder)
+            const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(params.moduleName)
+            await dependencyDiscoverer.handleDependencyUpdateFromLSP(
+                params.runtimeLanguage,
+                params.paths,
+                workspaceFolder
+            )
+        } catch (error) {
+            logging.error(`Error handling didChangeDependencyPaths event: ${error}`)
+        }
     })
 
     logging.log('Workspace context server has been initialized')


### PR DESCRIPTION
## Problem
for example, if file is renamed from supported language to unsupported language, or upload itself fails, the server crashes.

## Solution
wrap everything in try/catch

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
