### PR TITLE
Improve the executeBash tool spec

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -649,10 +649,7 @@ export class ExecuteBash {
                 '- When you need to perform file operations (use dedicated file tools instead).\n' +
                 '- When you need to search through files (use dedicated search tools instead).\n\n' +
                 '## Notes\n' +
-                '- Commands are categorized as ReadOnly, Mutate, or Destructive based on their potential impact.\n' +
-                '- Commands that operate outside the workspace require explicit user approval.\n' +
-                '- Output is limited to prevent overwhelming responses.\n' +
-                '- Command execution can be cancelled by the user.',
+                '- Output is limited to prevent overwhelming responses.\n',
             inputSchema: {
                 type: 'object',
                 properties: {


### PR DESCRIPTION
## Problem
- `executeBash` tool sometimes doesn't use a proper Windows command.

## Solution
- Improve the `executeBash` tool spec.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
