### PR TITLE
fix: disable the new tools to unblock release

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -33,15 +33,15 @@ export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
         return await listDirectoryTool.invoke(input, token)
     })
 
-    agent.addTool(fuzzySearchTool.getSpec(), async (input: FuzzySearchParams, token?: CancellationToken) => {
-        await fuzzySearchTool.validate(input)
-        return await fuzzySearchTool.invoke(input, token)
-    })
+    // agent.addTool(fuzzySearchTool.getSpec(), async (input: FuzzySearchParams, token?: CancellationToken) => {
+    //     await fuzzySearchTool.validate(input)
+    //     return await fuzzySearchTool.invoke(input, token)
+    // })
 
-    agent.addTool(grepSearchTool.getSpec(), async (input: GrepSearchParams, token?: CancellationToken) => {
-        await grepSearchTool.validate(input)
-        return await grepSearchTool.invoke(input, token)
-    })
+    // agent.addTool(grepSearchTool.getSpec(), async (input: GrepSearchParams, token?: CancellationToken) => {
+    //     await grepSearchTool.validate(input)
+    //     return await grepSearchTool.invoke(input, token)
+    // })
 
     return () => {}
 }


### PR DESCRIPTION
## Problem
- New tools requires bug bash and testing to verify it works

## Solution
- Do not have time to bug bash before next release, disabling them for now to unblock release
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
