### PR TITLE
fix line number display in code context commands

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -195,7 +195,7 @@ export class ContextCommandsProvider implements Disposable {
                 codeCmds.push({
                     ...baseItem,
                     command: item.symbol.name,
-                    description: `${item.symbol.kind}, ${path.join(wsFolderName, item.relativePath)}, L${item.symbol.range.start.line}-${item.symbol.range.end.line}`,
+                    description: `${item.symbol.kind}, ${path.join(wsFolderName, item.relativePath)}, L${item.symbol.range.start.line + 1}-${item.symbol.range.end.line + 1}`,
                     label: 'code',
                     icon: 'code-block',
                 })


### PR DESCRIPTION
## Problem
Line numbers displayed in the webview were off by 1 when showing code symbol ranges. This is because the editor's internal line numbering starts at 0, but UI displays typically show line numbers starting at 1. This inconsistency affects all IDEs and creates confusion for users when they see line numbers that don't match what's shown in their editor. 
VS:
![image](https://github.com/user-attachments/assets/8f6d6d25-6a41-4836-8a04-9e5f7aa7b647)
VSC:
![image](https://github.com/user-attachments/assets/68266e99-e09a-41f9-b6f9-5af991a2a17f)
JB:
![image](https://github.com/user-attachments/assets/9a9f33f8-e407-440b-972f-14c1945feadb)


## Solution
Added +1 to both the start and end line numbers when displaying the line range in the code context command description. This ensures that the line numbers shown in the UI match what users see in their editor interface, providing a consistent experience across all IDEs.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
