### PR TITLE
fix: remove gradient from create prompt button

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -432,7 +432,7 @@ export const createMynahUi = (
                         {
                             id: ContextPrompt.SubmitButtonId,
                             text: 'Create',
-                            status: 'main',
+                            status: 'primary',
                             waitMandatoryFormItems: true,
                         },
                     ],


### PR DESCRIPTION
## Problem

The "create a prompt" dialog's "create" button has a q branded gradient instead of a standard button color.

## Solution

Change the button's style.

![image](https://github.com/user-attachments/assets/3b7edae5-bbf9-4967-8d86-360d9d57a156)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
