### PR TITLE
fix: adding error handling for config load errors to display them to ux

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.test.ts
@@ -1,0 +1,170 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved. SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+import { McpEventHandler } from './mcpEventHandler'
+import { McpManager } from './mcpManager'
+import * as mcpUtils from './mcpUtils'
+
+describe('McpEventHandler error handling', () => {
+    let eventHandler: McpEventHandler
+    let features: any
+    let loadStub: sinon.SinonStub
+
+    beforeEach(() => {
+        sinon.restore()
+
+        // Create fake features
+        features = {
+            logging: {
+                log: sinon.spy(),
+                info: sinon.spy(),
+                warn: sinon.spy(),
+                error: sinon.spy(),
+                debug: sinon.spy(),
+            },
+            workspace: {
+                fs: {
+                    exists: sinon.stub().resolves(false),
+                    readFile: sinon.stub().resolves(Buffer.from('{}')),
+                    writeFile: sinon.stub().resolves(undefined),
+                },
+                getUserHomeDir: sinon.stub().returns('/fake/home'),
+                getAllWorkspaceFolders: sinon.stub().returns([{ uri: '/fake/workspace' }]),
+            },
+            chat: {
+                sendChatUpdate: sinon.spy(),
+            },
+            agent: {
+                getTools: sinon.stub().returns([]),
+            },
+            lsp: {},
+        }
+
+        // Create the event handler
+        eventHandler = new McpEventHandler(features)
+
+        // Stub loadPersonaPermissions
+        sinon
+            .stub(mcpUtils, 'loadPersonaPermissions')
+            .resolves(new Map([['*', { enabled: true, toolPerms: {}, __configPath__: '/tmp/p.yaml' }]]))
+    })
+
+    afterEach(async () => {
+        sinon.restore()
+        try {
+            await McpManager.instance.close()
+        } catch {}
+    })
+
+    it('displays config load errors in the header status', async () => {
+        // Create mock errors
+        const mockErrors = new Map<string, string>([
+            ['file1.json', 'File not found error'],
+            ['serverA', 'Missing command error'],
+        ])
+
+        // Stub loadMcpServerConfigs to return errors
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({
+            servers: new Map(),
+            errors: mockErrors,
+        })
+
+        // Initialize McpManager with errors
+        await McpManager.init([], [], features)
+
+        // Stub getConfigLoadErrors to return formatted errors
+        sinon
+            .stub(McpManager.instance, 'getConfigLoadErrors')
+            .returns('File: file1.json, Error: File not found error\n\nFile: serverA, Error: Missing command error')
+
+        // Call onListMcpServers
+        const result = await eventHandler.onListMcpServers({})
+
+        // Verify error is displayed in header status
+        expect(result.header).to.not.be.undefined
+        expect(result.header.status).to.not.be.undefined
+        expect(result.header.status!.status).to.equal('error')
+        expect(result.header.status!.title).to.include('File: file1.json, Error: File not found error')
+        expect(result.header.status!.title).to.include('File: serverA, Error: Missing command error')
+    })
+
+    it('marks servers with validation errors as FAILED', async () => {
+        // Create a server config with an error
+        const serverConfig = new Map([
+            [
+                'errorServer',
+                {
+                    command: '', // Invalid - missing command
+                    args: [],
+                    env: {},
+                    __configPath__: 'config.json',
+                },
+            ],
+        ])
+
+        // Stub loadMcpServerConfigs to return a server with validation errors
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({
+            servers: serverConfig,
+            errors: new Map([['errorServer', 'Missing command error']]),
+        })
+
+        // Initialize McpManager with the problematic server
+        await McpManager.init([], [], features)
+
+        // Stub getAllServerConfigs to return our test server
+        sinon.stub(McpManager.instance, 'getAllServerConfigs').returns(serverConfig)
+
+        // Stub getConfigLoadErrors to return formatted errors
+        sinon
+            .stub(McpManager.instance, 'getConfigLoadErrors')
+            .returns('File: errorServer, Error: Missing command error')
+
+        // Call onListMcpServers
+        const result = await eventHandler.onListMcpServers({})
+
+        // Find the server in the result
+        const serverGroup = result.list.find(
+            group => group.children && group.children.some(item => item.title === 'errorServer')
+        )
+
+        expect(serverGroup).to.not.be.undefined
+        expect(serverGroup?.children).to.not.be.undefined
+
+        const serverItem = serverGroup?.children?.find(item => item.title === 'errorServer')
+        expect(serverItem).to.not.be.undefined
+        expect(serverItem?.children).to.not.be.undefined
+        expect(serverItem?.children?.[0]).to.not.be.undefined
+        expect(serverItem?.children?.[0].children).to.not.be.undefined
+
+        // Find the status in the server item's children
+        const statusItem = serverItem?.children?.[0].children?.find(item => item.title === 'status')
+        expect(statusItem).to.not.be.undefined
+        expect(statusItem?.description).to.equal('FAILED')
+    })
+
+    it('handles server click events for fixing failed servers', async () => {
+        // Stub loadMcpServerConfigs
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({
+            servers: new Map(),
+            errors: new Map(),
+        })
+
+        // Initialize McpManager
+        await McpManager.init([], [], features)
+
+        // Call onMcpServerClick with mcp-fix-server action
+        const result = await eventHandler.onMcpServerClick({
+            id: 'mcp-fix-server',
+            title: 'errorServer',
+        })
+
+        // Verify it redirects to edit server view
+        expect(result.id).to.equal('mcp-fix-server')
+        expect(result.header).to.not.be.undefined
+        expect(result.header.title).to.equal('Edit MCP Server')
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -62,7 +62,7 @@ describe('init()', () => {
     })
 
     it('returns the same instance', async () => {
-        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map())
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({ servers: new Map(), errors: new Map() })
         stubPersonaAllow()
 
         const m1 = await McpManager.init([], [], features)
@@ -82,7 +82,7 @@ describe('getAllTools()', () => {
     })
 
     it('returns empty array when no servers', async () => {
-        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map())
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({ servers: new Map(), errors: new Map() })
         stubPersonaAllow()
 
         const mgr = await McpManager.init([], [], features)
@@ -120,7 +120,7 @@ describe('callTool()', () => {
     })
 
     it('throws when server is unknown', async () => {
-        loadStub.resolves(new Map())
+        loadStub.resolves({ servers: new Map(), errors: new Map() })
         const mgr = await McpManager.init([], [], features)
 
         try {
@@ -132,7 +132,7 @@ describe('callTool()', () => {
     })
 
     it('invokes underlying client.callTool', async () => {
-        loadStub.resolves(new Map([['s1', enabledCfg]]))
+        loadStub.resolves({ servers: new Map([['s1', enabledCfg]]), errors: new Map() })
         const mgr = await McpManager.init(['p.json'], [], features)
         ;(mgr as any).clients.set('s1', new Client({ name: 'x', version: 'v' }))
 
@@ -143,7 +143,7 @@ describe('callTool()', () => {
 
     it('times out and logs error', async () => {
         const timeoutCfg = { ...enabledCfg, timeout: 1 }
-        loadStub.resolves(new Map([['s1', timeoutCfg]]))
+        loadStub.resolves({ servers: new Map([['s1', timeoutCfg]]), errors: new Map() })
         const mgr = await McpManager.init(['p.json'], [], features)
 
         callToolStub.resetBehavior()
@@ -181,7 +181,7 @@ describe('addServer()', () => {
     })
 
     it('persists config and initializes', async () => {
-        loadStub.resolves(new Map())
+        loadStub.resolves({ servers: new Map(), errors: new Map() })
         const mgr = await McpManager.init([], [], features)
         const newCfg: MCPServerConfig = {
             command: 'c2',
@@ -214,7 +214,7 @@ describe('removeServer()', () => {
     })
 
     it('shuts client and cleans state', async () => {
-        loadStub.resolves(new Map())
+        loadStub.resolves({ servers: new Map(), errors: new Map() })
         const mgr = await McpManager.init([], [], features)
         const dummy = new Client({ name: 'c', version: 'v' })
         ;(mgr as any).clients.set('x', dummy)
@@ -259,7 +259,7 @@ describe('updateServer()', () => {
             timeout: 1,
             __configPath__: 'u.json',
         }
-        loadStub.resolves(new Map([['u1', oldCfg]]))
+        loadStub.resolves({ servers: new Map([['u1', oldCfg]]), errors: new Map() })
         await McpManager.init([], [], features)
         const mgr = McpManager.instance
         const fakeClient = new Client({ name: 'c', version: 'v' })
@@ -287,7 +287,7 @@ describe('requiresApproval()', () => {
     })
 
     it('returns true for unknown server', async () => {
-        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map())
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({ servers: new Map(), errors: new Map() })
         stubPersonaAllow()
 
         const mgr = await McpManager.init([], [], features)
@@ -302,7 +302,9 @@ describe('requiresApproval()', () => {
             timeout: 0,
             __configPath__: 'p',
         }
-        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map([['s', cfg]]))
+        loadStub = sinon
+            .stub(mcpUtils, 'loadMcpServerConfigs')
+            .resolves({ servers: new Map([['s', cfg]]), errors: new Map() })
         stubPersonaAllow()
         await McpManager.init(['p'], [], features)
 
@@ -340,7 +342,9 @@ describe('getAllServerConfigs()', () => {
             timeout: 0,
             __configPath__: 'cfg.json',
         }
-        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map([['srv', cfg]]))
+        loadStub = sinon
+            .stub(mcpUtils, 'loadMcpServerConfigs')
+            .resolves({ servers: new Map([['srv', cfg]]), errors: new Map() })
         stubPersonaAllow()
         const mgr = await McpManager.init(['cfg.json'], [], features)
         const snap = mgr.getAllServerConfigs()
@@ -374,7 +378,7 @@ describe('getServerState()', () => {
             timeout: 0,
             __configPath__: 'state.json',
         }
-        loadStub.resolves(new Map([['srv', cfg]]))
+        loadStub.resolves({ servers: new Map([['srv', cfg]]), errors: new Map() })
         const mgr = await McpManager.init(['state.json'], [], features)
         expect(mgr.getServerState('srv')).to.deep.include({
             status: 'ENABLED',
@@ -400,7 +404,7 @@ describe('getAllServerStates()', () => {
             timeout: 0,
             __configPath__: 'state.json',
         }
-        loadStub.resolves(new Map([['srv', cfg]]))
+        loadStub.resolves({ servers: new Map([['srv', cfg]]), errors: new Map() })
         const mgr = await McpManager.init(['state.json'], [], features)
         const map = mgr.getAllServerStates()
         expect(map.get('srv')).to.deep.include({
@@ -435,7 +439,7 @@ describe('getEnabledTools()', () => {
             timeout: 0,
             __configPath__: 't.json',
         }
-        loadStub.resolves(new Map([['srv', cfg]]))
+        loadStub.resolves({ servers: new Map([['srv', cfg]]), errors: new Map() })
         const mgr = await McpManager.init(['t.json'], [], features)
 
         expect(mgr.getEnabledTools()).to.have.length(1)
@@ -472,7 +476,7 @@ describe('getAllToolsWithPermissions()', () => {
         loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs')
         stubPersonaAllow()
         initOneStub = stubInitOneServer()
-        loadStub.resolves(new Map([['s1', cfg]]))
+        loadStub.resolves({ servers: new Map([['s1', cfg]]), errors: new Map() })
         mgr = await McpManager.init(['p.json'], [], features)
     })
 
@@ -507,7 +511,7 @@ describe('close()', () => {
     afterEach(() => sinon.restore())
 
     it('shuts all clients and resets singleton', async () => {
-        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map())
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({ servers: new Map(), errors: new Map() })
         stubPersonaAllow()
         await McpManager.init([], [], features)
         const mgr = McpManager.instance
@@ -542,7 +546,7 @@ describe('isServerDisabled()', () => {
             timeout: 0,
             __configPath__: 's.json',
         }
-        sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map([['srv', cfg]]))
+        sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({ servers: new Map([['srv', cfg]]), errors: new Map() })
         const permMap1 = new Map<string, MCPServerPermission>([
             ['*', { enabled: true, toolPerms: {}, __configPath__: '/p' }],
         ])
@@ -578,7 +582,7 @@ describe('listServersAndTools()', () => {
     })
 
     it('lists names grouped by server', async () => {
-        sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map())
+        sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({ servers: new Map(), errors: new Map() })
         stubPersonaAllow()
         const initStub = stubInitOneServer()
         const mgr = await McpManager.init([], [], features)
@@ -610,7 +614,7 @@ describe('updateServerPermission()', () => {
             timeout: 0,
             __configPath__: 'x.json',
         }
-        sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map([['srv', cfg]]))
+        sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({ servers: new Map([['srv', cfg]]), errors: new Map() })
 
         const permEnabled = new Map<string, MCPServerPermission>([
             ['*', { enabled: true, toolPerms: {}, __configPath__: '/p' }],
@@ -679,9 +683,9 @@ describe('reinitializeMcpServers()', () => {
         const loadStub = sinon
             .stub(mcpUtils, 'loadMcpServerConfigs')
             .onFirstCall()
-            .resolves(new Map([['srvA', cfg1]]))
+            .resolves({ servers: new Map([['srvA', cfg1]]), errors: new Map() })
             .onSecondCall()
-            .resolves(new Map([['srvB', cfg2]]))
+            .resolves({ servers: new Map([['srvB', cfg2]]), errors: new Map() })
         stubPersonaAllow()
         stubInitOneServer()
 
@@ -704,7 +708,7 @@ describe('handleError()', () => {
     let toolsEvents: Array<{ server: string; tools: any[] }>
 
     beforeEach(async () => {
-        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves(new Map())
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({ servers: new Map(), errors: new Map() })
         stubPersonaAllow()
         mgr = await McpManager.init([], [], features)
         errorSpy = sinon.spy(fakeLogging, 'error')
@@ -741,5 +745,111 @@ describe('handleError()', () => {
         expect(toolsEvents).to.have.length(1)
         expect(toolsEvents[0].server).to.equal('srvX')
         expect(toolsEvents[0].tools).to.be.an('array').that.is.empty
+    })
+})
+
+describe('McpManager error handling', () => {
+    let loadStub: sinon.SinonStub
+
+    beforeEach(() => {
+        sinon.restore()
+        // Stub the loadPersonaPermissions to return a simple map
+        sinon
+            .stub(mcpUtils, 'loadPersonaPermissions')
+            .resolves(new Map([['*', { enabled: true, toolPerms: {}, __configPath__: '/tmp/p.yaml' }]]))
+    })
+
+    afterEach(async () => {
+        sinon.restore()
+        try {
+            await McpManager.instance.close()
+        } catch {}
+    })
+
+    it('stores and returns config load errors', async () => {
+        // Create a mock response with errors
+        const mockErrors = new Map<string, string>([
+            ['file1.json', 'File not found error'],
+            ['serverA', 'Missing command error'],
+        ])
+
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({
+            servers: new Map(),
+            errors: mockErrors,
+        })
+
+        const mgr = await McpManager.init([], [], features)
+
+        // Test that getConfigLoadErrors returns the expected error messages
+        const errors = mgr.getConfigLoadErrors()
+        expect(errors).to.not.be.undefined
+        expect(errors).to.include('File: file1.json, Error: File not found error')
+        expect(errors).to.include('File: serverA, Error: Missing command error')
+    })
+
+    it('returns undefined when no errors exist', async () => {
+        // Create a mock response with no errors
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({
+            servers: new Map(),
+            errors: new Map(),
+        })
+
+        const mgr = await McpManager.init([], [], features)
+
+        // Test that getConfigLoadErrors returns undefined when no errors
+        const errors = mgr.getConfigLoadErrors()
+        expect(errors).to.be.undefined
+    })
+
+    it('stores errors from handleError method', async () => {
+        // Create a mock response with no errors initially
+        loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({
+            servers: new Map(),
+            errors: new Map(),
+        })
+
+        const mgr = await McpManager.init([], [], features)
+
+        // Access the private handleError method using type assertion
+        const handleError = (mgr as any).handleError.bind(mgr)
+
+        // Call handleError with a server name and error
+        handleError('testServer', new Error('Test error message'))
+
+        // Test that the error was stored
+        const errors = mgr.getConfigLoadErrors()
+        expect(errors).to.not.be.undefined
+        expect(errors).to.include('File: testServer, Error: Test error message')
+    })
+
+    it('clears errors when reloading configurations', async () => {
+        // First load with errors
+        loadStub = sinon
+            .stub(mcpUtils, 'loadMcpServerConfigs')
+            .onFirstCall()
+            .resolves({
+                servers: new Map(),
+                errors: new Map([['file1.json', 'Initial error']]),
+            })
+            // Second load with no errors
+            .onSecondCall()
+            .resolves({
+                servers: new Map(),
+                errors: new Map(),
+            })
+
+        const mgr = await McpManager.init([], [], features)
+
+        // Verify initial errors exist
+        let errors = mgr.getConfigLoadErrors()
+        expect(errors).to.not.be.undefined
+        expect(errors).to.include('Initial error')
+
+        // Reinitialize to clear errors
+        await mgr.reinitializeMcpServers()
+
+        // Verify errors are cleared
+        errors = mgr.getConfigLoadErrors()
+        expect(errors).to.be.undefined
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -34,7 +34,7 @@ export class McpManager {
     private mcpTools: McpToolDefinition[]
     private mcpServers: Map<string, MCPServerConfig>
     private mcpServerStates: Map<string, McpServerRuntimeState>
-    private configLoadErrors: Map<string, string> = new Map<string, string>()
+    private configLoadErrors: Map<string, string>
     private mcpServerPermissions: Map<string, MCPServerPermission>
     public readonly events: EventEmitter
     private static readonly configMutex = new Mutex()
@@ -49,6 +49,7 @@ export class McpManager {
         this.clients = new Map<string, Client>()
         this.mcpServers = new Map<string, MCPServerConfig>()
         this.mcpServerStates = new Map<string, McpServerRuntimeState>()
+        this.configLoadErrors = new Map<string, string>()
         this.mcpServerPermissions = new Map<string, MCPServerPermission>()
         this.events = new EventEmitter()
         this.features.logging.info(`MCP manager: initialized with ${configPaths.length} configs`)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -34,6 +34,7 @@ export class McpManager {
     private mcpTools: McpToolDefinition[]
     private mcpServers: Map<string, MCPServerConfig>
     private mcpServerStates: Map<string, McpServerRuntimeState>
+    private configLoadErrors: Map<string, string> = new Map<string, string>()
     private mcpServerPermissions: Map<string, MCPServerPermission>
     public readonly events: EventEmitter
     private static readonly configMutex = new Mutex()
@@ -102,7 +103,19 @@ export class McpManager {
         )
         this.mcpServerPermissions = permissionMap
 
-        this.mcpServers = await loadMcpServerConfigs(this.features.workspace, this.features.logging, this.configPaths)
+        const { servers, errors } = await loadMcpServerConfigs(
+            this.features.workspace,
+            this.features.logging,
+            this.configPaths
+        )
+        this.mcpServers = servers
+        // Reset the configuration errors after every refresh.
+        this.configLoadErrors.clear()
+
+        // Store any config load errors
+        errors.forEach((errorMsg, key) => {
+            this.configLoadErrors.set(key, errorMsg)
+        })
 
         // Set all servers to UNINITIALIZED state initially
         for (const name of this.mcpServers.keys()) {
@@ -672,6 +685,24 @@ export class McpManager {
         if (server) {
             this.setState(server, McpServerStatus.FAILED, 0, msg)
             this.emitToolsChanged(server)
+
+            // Store the error in the configLoadErrors map
+            if (server !== undefined) {
+                this.configLoadErrors.set(server, msg)
+            }
         }
+    }
+
+    /**
+     * Returns any errors that occurred during loading of MCP configuration files
+     */
+    public getConfigLoadErrors(): string | undefined {
+        if (this.configLoadErrors.size === 0) {
+            return undefined
+        }
+
+        return Array.from(this.configLoadErrors.entries())
+            .map(([server, error]) => `File: ${server}, Error: ${error}`)
+            .join('\n\n')
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.test.ts
@@ -39,7 +39,7 @@ describe('McpTool', () => {
         } catch {
             // ignore if it wasn't initialized
         }
-        sinon.stub(require('./mcpUtils'), 'loadMcpServerConfigs').resolves(new Map())
+        sinon.stub(require('./mcpUtils'), 'loadMcpServerConfigs').resolves({ servers: new Map(), errors: new Map() })
         sinon
             .stub(require('./mcpUtils'), 'loadPersonaPermissions')
             .resolves(new Map([['*', { enabled: true, toolPerms: {}, __configPath__: '' }]]))

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -46,7 +46,6 @@ export async function loadMcpServerConfigs(
         } catch (e: any) {
             const errorMsg = `Could not stat MCP config at ${fsPath}: ${e.message}`
             logging.warn(errorMsg)
-            configErrors.set(`${fsPath}`, errorMsg)
             continue
         }
         if (!exists) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -51,7 +51,6 @@ export async function loadMcpServerConfigs(
         if (!exists) {
             const errorMsg = `MCP config not found at ${fsPath}, skipping.`
             logging.warn(errorMsg)
-            configErrors.set(`${fsPath}`, errorMsg)
             continue
         }
 
@@ -88,13 +87,11 @@ export async function loadMcpServerConfigs(
             if (!entry || typeof (entry as any).command !== 'string') {
                 const errorMsg = `MCP server '${name}' in ${fsPath} missing required 'command', skipping.`
                 logging.warn(errorMsg)
-                configErrors.set(name, errorMsg)
                 continue
             }
             if ((entry as any).timeout !== undefined && typeof (entry as any).timeout !== 'number') {
                 const errorMsg = `Invalid timeout value on '${name}', ignoring.`
                 logging.warn(errorMsg)
-                configErrors.set(`${name}_timeout`, errorMsg)
             }
             const cfg: MCPServerConfig = {
                 command: (entry as any).command,


### PR DESCRIPTION
## Problem
- If there is any syntax error like Invalid mcp.json error or any configuration error. This wont show up at the list of MCP servers UX.
- No proper error handling.
## Solution
- Fixed above issues
- Added valid test cases

https://github.com/user-attachments/assets/5a275a05-1cd5-411e-8d2b-7d82d4abd7bf


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
