### PR TITLE
fix: ux fit and finish task and adding explanation to chat summary card

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1237,7 +1237,7 @@ ${params.message}`,
                     } else if (group.groupName === 'Disabled') {
                         actions.push({
                             id: 'mcp-enable-server',
-                            icon: toMynahIcon('ok-circled'),
+                            icon: toMynahIcon('ok'),
                             text: 'Enable',
                             description: 'Enable',
                         })
@@ -1246,6 +1246,13 @@ ${params.message}`,
                             icon: toMynahIcon('trash'),
                             text: 'Delete',
                             description: 'Delete',
+                            confirmation: {
+                                cancelButtonText: 'Cancel',
+                                confirmButtonText: 'Delete',
+                                title: 'Delete Filesystem MCP server',
+                                description:
+                                    'This configuration will be deleted and no longer available in Q. \n\n This cannot be undone.',
+                            },
                         })
                         actions.push({
                             id: 'open-mcp-server',
@@ -1441,7 +1448,6 @@ ${params.message}`,
                                   {
                                       id: 'mcp-disable-server',
                                       text: `Disable MCP server`,
-                                      icon: toMynahIcon('block'),
                                   },
                                   {
                                       id: 'mcp-delete-server',
@@ -1453,7 +1459,6 @@ ${params.message}`,
                                               'This configuration will be deleted and no longer available in Q. \n\n This cannot be undone.',
                                       },
                                       text: `Delete MCP server`,
-                                      icon: toMynahIcon('trash'),
                                   },
                               ],
                           }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -130,7 +130,6 @@ import { McpTool } from './tools/mcp/mcpTool'
 import { CommandCategory } from './tools/executeBash'
 import { UserWrittenCodeTracker } from '../../shared/userWrittenCodeTracker'
 import { McpEventHandler } from './tools/mcp/mcpEventHandler'
-import { isMCPSupported } from './tools/mcp/mcpUtils'
 import { createNamespacedToolName, getOriginalToolNames } from './tools/mcp/mcpUtils'
 import { enabledMCP } from './tools/mcp/mcpUtils'
 
@@ -2819,7 +2818,7 @@ export class AgenticChatController implements ChatHandlers {
                             },
                             {
                                 header: {
-                                    body: 'Results',
+                                    body: 'Result',
                                 },
                                 body: `\`\`\`json\n${toolResultContent}\n\`\`\``,
                             },

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -253,8 +253,7 @@ export class McpEventHandler {
             header: {
                 title: 'MCP Servers',
                 status: {},
-                description:
-                    'Q automatically uses any MCP servers that have been added, so you don\'t have to add them as context. All MCPs are defaulted to "Ask before running".',
+                description: `Add MCP servers to extend Q's capabilities.`,
                 actions: [],
             },
             list: [],

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -93,8 +93,22 @@ export const McpToolsServer: Server = ({ credentialsProvider, workspace, logging
             const namespaced = createNamespacedToolName(def.serverName, def.toolName, allNamespacedTools)
             const tool = new McpTool({ logging, workspace, lsp }, def)
 
-            agent.addTool({ name: namespaced, description: def.description, inputSchema: def.inputSchema }, input =>
-                tool.invoke(input)
+            // Add explanation field to input schema
+            const inputSchemaWithExplanation = {
+                ...def.inputSchema,
+                properties: {
+                    ...def.inputSchema.properties,
+                    explanation: {
+                        type: 'string',
+                        description:
+                            'One sentence explanation as to why this tool is being used, and how it contributes to the goal.',
+                    },
+                },
+            }
+
+            agent.addTool(
+                { name: namespaced, description: def.description, inputSchema: inputSchemaWithExplanation },
+                input => tool.invoke(input)
             )
             registered[server].push(namespaced)
             logging.info(`MCP: registered tool ${namespaced} (original: ${def.serverName}___${def.toolName})`)


### PR DESCRIPTION
## Problem

1. Update title description in MCP List of servers
2. In Chat summary card view the explanation is missing on top of chat summary card view.
3. Need to remove Icons of Disable and delete servers in Permissions page.
4. Enable servers icon is different from the UX in MCP Servers page.
5. “Delete option” will not show the modal view in the MCP Servers page.

## Solution
1,4
![image](https://github.com/user-attachments/assets/52ea6e28-0579-428e-ab58-8b3af507d908)
5
![image](https://github.com/user-attachments/assets/191aa00b-78ea-49c8-ad40-4415de68111a)
2
![image](https://github.com/user-attachments/assets/13771717-c147-4981-bb97-803a57cd02d0)
3
![image](https://github.com/user-attachments/assets/859076ac-854e-4c62-8af7-9cd8f1444bb2)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
