### PR TITLE
feat(amazonq): send relative file path for inline completion

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -13,6 +13,7 @@ import {
     TextDocument,
     ResponseError,
     LSPErrorCodes,
+    WorkspaceFolder,
 } from '@aws/language-server-runtimes/server-interface'
 import { AWSError } from 'aws-sdk'
 import { autoTrigger, triggerType } from './auto-trigger/autoTrigger'
@@ -56,6 +57,7 @@ import { UserWrittenCodeTracker } from '../../shared/userWrittenCodeTracker'
 
 const EMPTY_RESULT = { sessionId: '', items: [] }
 export const FILE_URI_CHARS_LIMIT = 1024
+export const FILENAME_CHARS_LIMIT = 1024
 export const CONTEXT_CHARACTERS_LIMIT = 10240
 
 // Both clients (token, sigv4) define their own types, this return value needs to match both of them.
@@ -63,6 +65,7 @@ const getFileContext = (params: {
     textDocument: TextDocument
     position: Position
     inferredLanguageId: CodewhispererLanguage
+    workspaceFolder: WorkspaceFolder | null | undefined
 }): {
     fileUri: string
     filename: string
@@ -81,18 +84,13 @@ const getFileContext = (params: {
         end: params.textDocument.positionAt(params.textDocument.getText().length),
     })
 
-    let relativeFileName = params.textDocument.uri
-    relativeFileName = path.basename(params.textDocument.uri)
-    // const workspaceFolder = WorkspaceFolderManager.getInstance()?.getWorkspaceFolder(params.textDocument.uri)
-    // if (workspaceFolder) {
-    // relativeFileName = getRelativePath(workspaceFolder, params.textDocument.uri)
-    // } else {
-    // relativeFileName = path.basename(params.textDocument.uri)
-    // }
+    const relativeFilePath = params.workspaceFolder
+        ? getRelativePath(params.workspaceFolder, params.textDocument.uri)
+        : path.basename(params.textDocument.uri)
 
     return {
         fileUri: params.textDocument.uri.substring(0, FILE_URI_CHARS_LIMIT),
-        filename: relativeFileName,
+        filename: relativeFilePath.substring(0, FILENAME_CHARS_LIMIT),
         programmingLanguage: {
             languageName: getRuntimeLanguage(params.inferredLanguageId),
         },
@@ -346,7 +344,12 @@ export const CodewhispererServerFactory =
                         params.context.triggerKind == InlineCompletionTriggerKind.Automatic
                     const maxResults = isAutomaticLspTriggerKind ? 1 : 5
                     const selectionRange = params.context.selectedCompletionInfo?.range
-                    const fileContext = getFileContext({ textDocument, inferredLanguageId, position: params.position })
+                    const fileContext = getFileContext({
+                        textDocument,
+                        inferredLanguageId,
+                        position: params.position,
+                        workspaceFolder: workspace.getWorkspaceFolder(textDocument.uri),
+                    })
                     const workspaceState = WorkspaceFolderManager.getInstance()?.getWorkspaceState()
                     const workspaceId = workspaceState?.webSocketClient?.isConnected()
                         ? workspaceState.workspaceId

--- a/server/aws-lsp-codewhisperer/src/shared/testUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/testUtils.ts
@@ -5,6 +5,7 @@ import { SsoConnectionType } from './utils'
 import { stubInterface } from 'ts-sinon'
 import { StreamingClientServiceBase } from './streamingClientService'
 import { SessionData } from '../language-server/inline-completion/session/sessionManager'
+import { WorkspaceFolder } from '@aws/language-server-runtimes/protocol'
 
 export const HELLO_WORLD_IN_CSHARP = `class HelloWorld
 {
@@ -34,6 +35,16 @@ export const SOME_UNSUPPORTED_FILE = TextDocument.create(
     'INPUT HELLO ; OUTPUT WORLD'
 )
 export const SOME_FILE_WITH_EXTENSION = TextDocument.create('file:///missing.hpp', '', 1, HELLO_WORLD_IN_CSHARP)
+export const SOME_WORKSPACE_FOLDER: WorkspaceFolder = {
+    uri: 'file:///tmp/workspaceFolderTest',
+    name: 'workspaceFolderTest',
+}
+export const SOME_FILE_UNDER_WORKSPACE_FOLDER = TextDocument.create(
+    `${SOME_WORKSPACE_FOLDER.uri}/relativePath/test.cs`,
+    'csharp',
+    1,
+    HELLO_WORLD_IN_CSHARP
+)
 
 export const SAMPLE_FILE_OF_60_LINES_IN_JAVA = `import java.util.List;
 // we need this comment on purpose because chunk will be trimed right, adding this to avoid trimRight and make assertion easier


### PR DESCRIPTION
## Problem

Inline completion request should send the `filename` field with the relative path of the file instead of just the base name, which would benefit model generation quality.

Related PR on VSCode side for more context: https://github.com/aws/aws-toolkit-vscode/pull/5543

## Solution

Send relative file path for the `filename` field for inline completion.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
