### PR TITLE
fix(amazonq): normalize line endings to match local file endings in strReplace

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -1,10 +1,7 @@
-import { workspaceUtils } from '@aws/lsp-core'
 import { CommandValidation, ExplanatoryParams, InvokeOutput, requiresPathAcceptance } from './toolShared'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
-import { Change, diffLines } from 'diff'
-import { URI } from 'vscode-uri'
-import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
+import * as os from 'os'
 
 // Port of https://github.com/aws/aws-toolkit-vscode/blob/16aa8768834f41ae512522473a6a962bb96abe51/packages/core/src/codewhispererChat/tools/fsWrite.ts#L42
 
@@ -259,7 +256,15 @@ const getInsertContent = (params: InsertParams, oldContent: string) => {
 }
 
 const getStrReplaceContent = (params: StrReplaceParams, oldContent: string) => {
-    const matches = [...oldContent.matchAll(new RegExp(escapeRegExp(params.oldStr), 'g'))]
+    // Detect line ending from oldContent (CRLF, LF, or CR)
+    const match = oldContent.match(/\r\n|\r|\n/)
+    const lineEnding = match ? match[0] : os.EOL
+
+    // Normalize oldStr and newStr to match oldContent's line ending style
+    const normalizedOldStr = params.oldStr.split(/\r\n|\r|\n/).join(lineEnding)
+    const normalizedNewStr = params.newStr.split(/\r\n|\r|\n/).join(lineEnding)
+
+    const matches = [...oldContent.matchAll(new RegExp(escapeRegExp(normalizedOldStr), 'g'))]
 
     if (matches.length === 0) {
         throw new Error(`No occurrences of "${params.oldStr}" were found`)
@@ -268,7 +273,7 @@ const getStrReplaceContent = (params: StrReplaceParams, oldContent: string) => {
         throw new Error(`${matches.length} occurrences of oldStr were found when only 1 is expected`)
     }
 
-    return oldContent.replace(params.oldStr, params.newStr)
+    return oldContent.replace(normalizedOldStr, normalizedNewStr)
 }
 
 const escapeRegExp = (string: string) => {


### PR DESCRIPTION
## Problem

![image](https://github.com/user-attachments/assets/3e022edd-4fb6-4731-9042-67ea78d2d01c)

When using Amazon Q on Windows systems, the service responses contain LF (`\n`) line endings, but local files use CRLF (`\r\n`). This mismatch causes string comparison failures in fsWrite's strReplace command because:

1. Service returns: `oldStr` with `\n` endings
2. Local file has: `\r\n` endings
3. Direct string comparison fails even when content is semantically same
4. Results in "No occurrences found" errors requiring chat retries

## Solution

Added line ending normalization in getStrReplaceContent to handle the mismatch:

1. Detect line ending style from the target file
2. Normalize both oldStr and newStr to match file's line ending style before comparison
3. Ensures consistent comparison regardless of service response line endings

## Testing

1. Added unit tests for line ending scenarios
2. Verified Amazon Q responses now work correctly on Windows without requiring retries

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
