### PR TITLE
fix: add tests for PR#1479 that added support for updating context commands

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
@@ -2,6 +2,7 @@ import { ContextCommandsProvider } from './contextCommandsProvider'
 import * as sinon from 'sinon'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as chokidar from 'chokidar'
+import { ContextCommandItem } from 'local-indexing'
 
 describe('ContextCommandsProvider', () => {
     let provider: ContextCommandsProvider
@@ -54,6 +55,27 @@ describe('ContextCommandsProvider', () => {
             sinon.assert.match(result.length, 3) // 2 files + create button
             sinon.assert.match(result[0].command, 'test1')
             sinon.assert.match(result[1].command, 'test2')
+        })
+    })
+
+    describe('onContextItemsUpdated', () => {
+        it('should call processContextCommandUpdate when controller raises event', async () => {
+            const mockContextItems: ContextCommandItem[] = [
+                {
+                    workspaceFolder: '/workspace',
+                    type: 'file',
+                    relativePath: 'test/path',
+                    id: 'test-id',
+                },
+            ]
+
+            const processUpdateSpy = sinon.spy(provider, 'processContextCommandUpdate')
+
+            const callback = (provider as any).processContextCommandUpdate.bind(provider)
+            await callback(mockContextItems)
+
+            sinon.assert.calledOnce(processUpdateSpy)
+            sinon.assert.calledWith(processUpdateSpy, mockContextItems)
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -254,12 +254,12 @@ export class LocalProjectContextController {
             if (this._vecLib) {
                 if (actualRemovals.length > 0) {
                     const removedPaths = actualRemovals.map(folder => URI.parse(folder.uri).fsPath)
-                    void this.updateIndexAndContextCommand([], false, removedPaths)
+                    await this.updateIndexAndContextCommand([], false, removedPaths)
                 }
 
                 if (actualAdditions.length > 0) {
                     const addedPaths = actualAdditions.map(folder => URI.parse(folder.uri).fsPath)
-                    void this.updateIndexAndContextCommand([], true, addedPaths)
+                    await this.updateIndexAndContextCommand([], true, addedPaths)
                 }
             }
         } catch (error) {


### PR DESCRIPTION
## Changes
This change adds tests for changes introduced in PR #1479 to add support for updating context commands on `didWorkspaceFoldersChange` event.

This change also converts the void call of `updateIndexAndContextCommands` to await within the updateworkspacefolders call
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
