### PR TITLE
chore: bump mynah-ui version to 4.35.1 in chat-client

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.37",
         "@aws/language-server-runtimes-types": "^0.1.31",
-        "@aws/mynah-ui": "^4.34.1"
+        "@aws/mynah-ui": "^4.35.1"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -15,10 +15,9 @@ import {
 import { afterEach } from 'mocha'
 import { assert } from 'sinon'
 import { createChat } from './chat'
-import sinon = require('sinon')
+import * as sinon from 'sinon'
 import { TELEMETRY } from '../contracts/serverContracts'
 import {
-    ENTER_FOCUS,
     ERROR_MESSAGE_TELEMETRY_EVENT,
     SEND_TO_PROMPT_TELEMETRY_EVENT,
     TAB_ADD_TELEMETRY_EVENT,
@@ -35,10 +34,12 @@ describe('Chat', () => {
 
     before(() => {
         // Mock global observers for test environment
-        // @ts-ignore
+        // @ts-expect-error: mock implementation for testing
         global.ResizeObserver = null
-        // @ts-ignore
+        // @ts-expect-error: mock implementation for testing
         global.IntersectionObserver = null
+        // @ts-expect-error: mock implementation for testing
+        global.MutationObserver = null
     })
 
     beforeEach(() => {
@@ -64,8 +65,10 @@ describe('Chat', () => {
     })
 
     after(() => {
-        // @ts-ignore
+        // @ts-expect-error: mock implementation for testing
         global.ResizeObserver = undefined
+        // @ts-expect-error: mock implementation for testing
+        global.MutationObserver = undefined
     })
 
     it('publishes ready event when initialized', () => {
@@ -312,9 +315,9 @@ describe('Chat', () => {
             })
             window.dispatchEvent(chatOptionsRequest)
 
-            // @ts-ignore
+            // @ts-expect-error: accessing prototype method
             assert.called(TabFactory.prototype.enableHistory)
-            // @ts-ignore
+            // @ts-expect-error: accessing prototype method
             assert.called(TabFactory.prototype.enableExport)
         }).timeout(20000)
 
@@ -328,9 +331,9 @@ describe('Chat', () => {
             })
             window.dispatchEvent(chatOptionsRequest)
 
-            // @ts-ignore
+            // @ts-expect-error: accessing prototype method
             assert.notCalled(TabFactory.prototype.enableHistory)
-            // @ts-ignore
+            // @ts-expect-error: accessing prototype method
             assert.notCalled(TabFactory.prototype.enableExport)
         }).timeout(20000)
     })

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -92,7 +92,7 @@ import { TabFactory } from './tabs/tabFactory'
 import { ChatClientAdapter } from '../contracts/chatClientAdapter'
 import { toMynahContextCommand, toMynahIcon } from './utils'
 
-const getDefaultTabConfig = (agenticMode?: Boolean) => {
+const getDefaultTabConfig = (agenticMode?: boolean) => {
     return {
         tabTitle: 'Chat',
         promptInputInfo:

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -656,9 +656,9 @@ export const createMynahUi = (
                 loadingChat: true,
                 cancelButtonWhenLoading: true,
             })
-            const chatItem = {
+            const chatItem: ChatItem = {
                 ...chatResult,
-                body: chatResult.body,
+                summary: chatResult.summary as ChatItem['summary'],
                 type: ChatItemType.ANSWER_STREAM,
                 header: header,
                 buttons: buttons,
@@ -687,10 +687,10 @@ export const createMynahUi = (
             isValidAuthFollowUpType(followUpOptions[0].type)
         if (chatResult.body === '' && isValidAuthFollowUp) {
             mynahUi.addChatItem(tabId, {
-                type: ChatItemType.SYSTEM_PROMPT,
-                ...chatResultWithoutType, // type for MynahUI differs from ChatResult types so we ignore it
+                ...(chatResultWithoutType as ChatItem),
                 header: header,
                 buttons: buttons,
+                type: ChatItemType.SYSTEM_PROMPT,
             })
 
             // TODO, prompt should be disabled until user is authenticated
@@ -705,9 +705,8 @@ export const createMynahUi = (
               }
             : {}
 
-        const chatItem = {
-            ...chatResult,
-            body: chatResult.body,
+        const chatItem: ChatItem = {
+            ...(chatResult as ChatItem),
             type: ChatItemType.ANSWER_STREAM,
             header: header,
             buttons: buttons,
@@ -773,8 +772,10 @@ export const createMynahUi = (
         }
 
         if (isPartialResult) {
-            // @ts-ignore - type for MynahUI differs from ChatResult types so we ignore it
-            mynahUi.updateLastChatAnswer(tabId, { ...chatResultWithoutType, header: header })
+            mynahUi.updateLastChatAnswer(tabId, {
+                ...(chatResultWithoutType as ChatItem),
+                header: header,
+            })
             return
         }
 
@@ -790,10 +791,9 @@ export const createMynahUi = (
             followUpOptions[0].type &&
             isValidAuthFollowUpType(followUpOptions[0].type)
         if (chatResult.body === '' && isValidAuthFollowUp) {
-            // @ts-ignore - type for MynahUI differs from ChatResult types so we ignore it
             mynahUi.addChatItem(tabId, {
+                ...(chatResultWithoutType as ChatItem),
                 type: ChatItemType.SYSTEM_PROMPT,
-                ...chatResultWithoutType,
             })
 
             // TODO, prompt should be disabled until user is authenticated

--- a/chat-client/src/client/utils.ts
+++ b/chat-client/src/client/utils.ts
@@ -17,6 +17,7 @@ export function toMynahHeader(header: ChatMessage['header']): ChatItemContent['h
         icon: toMynahIcon(header.icon),
         buttons: toMynahButtons(header.buttons),
         status: header.status ? { ...header.status, icon: toMynahIcon(header.status.icon) } : undefined,
+        summary: header.summary as ChatItemContent['summary'],
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,7 +248,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.37",
                 "@aws/language-server-runtimes-types": "^0.1.31",
-                "@aws/mynah-ui": "^4.34.1"
+                "@aws/mynah-ui": "^4.35.1"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4069,9 +4069,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.34.1",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.34.1.tgz",
-            "integrity": "sha512-CO65lwedf6Iw3a3ULOl+9EHafIekiPlP+n8QciN9a3POfsRamHl0kpBGaGBzBRgsQ/h5R0FvFG/gAuWoiK/YIA==",
+            "version": "4.35.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.35.1.tgz",
+            "integrity": "sha512-DCPHecNEgzfnT/NWcusrQwVEbKC2K7cDOdeaZQW2H926gdPKTVfy61e/7YJYEPRuoKd9AbLPqcMCnqhXO/kMIQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "escape-html": "^1.0.3",


### PR DESCRIPTION
## Problem

Updating mynah-ui to the latest version.

This required some manual effort due to the incompatibility between the `summary` field coming from ChatResult from runtimes and ChatItem from mynah-ui. 


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
