### PR TITLE
chore: add workspace context server to the agent-standalone bundle

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/src/agent-standalone.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/src/agent-standalone.ts
@@ -6,6 +6,7 @@ import {
     QConfigurationServerTokenProxy,
     QLocalProjectContextServerTokenProxy,
     QNetTransformServerTokenProxy,
+    WorkspaceContextServerTokenProxy,
 } from '@aws/lsp-codewhisperer'
 import { IdentityServer } from '@aws/lsp-identity'
 import { BashToolsServer, FsToolsServer } from '@aws/lsp-codewhisperer/out/language-server/agenticChat/tools/toolServer'
@@ -26,6 +27,7 @@ const props = createTokenRuntimeProps(VERSION, [
     FsToolsServer,
     BashToolsServer,
     QLocalProjectContextServerTokenProxy,
+    WorkspaceContextServerTokenProxy,
     // McpToolsServer,
     // LspToolsServer,
 ])


### PR DESCRIPTION
## Notes
Adding `WorkspaceContextServerTokenProxy` to the agent-standalone bundle so that the bundle used for local testing 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
