### PR TITLE
fix: use json for persona, add default persona

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -20,7 +20,6 @@ import { isEmptyEnv, loadMcpServerConfigs, loadPersonaPermissions } from './mcpU
 import { AgenticChatError } from '../../errors'
 import { EventEmitter } from 'events'
 import { Mutex } from 'async-mutex'
-import * as yaml from 'yaml'
 import path = require('path')
 import { URI } from 'vscode-uri'
 
@@ -572,7 +571,7 @@ export class McpManager {
 
                 // handle permission updates
                 if (perm.toolPerms) {
-                    const existing = p.toYaml().toolPerms?.[serverName] ?? {}
+                    const existing = p.toJson().toolPerms?.[serverName] ?? {}
                     const merged = { ...existing, ...perm.toolPerms }
                     p.replaceToolPerms(serverName, merged)
                 } else {
@@ -660,9 +659,9 @@ export class McpManager {
                     raw = (await this.features.workspace.fs.readFile(personaPath)).toString()
                 } catch {}
 
-                const model = PersonaModel.fromYaml(raw ? yaml.parse(raw) : {})
+                const model = PersonaModel.fromJson(raw ? JSON.parse(raw) : {})
                 mutator(model)
-                await this.features.workspace.fs.writeFile(personaPath, yaml.stringify(model.toYaml()))
+                await this.features.workspace.fs.writeFile(personaPath, JSON.stringify(model.toJson(), null, 2))
                 this.features.logging.debug(`Persona file write complete: ${personaPath}`)
             })
             .catch((e: any) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTypes.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTypes.ts
@@ -49,7 +49,7 @@ export interface PersonaConfig {
 export class PersonaModel {
     constructor(private cfg: PersonaConfig) {}
 
-    static fromYaml(doc: any): PersonaModel {
+    static fromJson(doc: any): PersonaModel {
         const cfg: PersonaConfig = {
             mcpServers: Array.isArray(doc?.['mcpServers']) ? doc['mcpServers'] : [],
             toolPerms: typeof doc?.['toolPerms'] === 'object' ? doc['toolPerms'] : {},
@@ -57,7 +57,7 @@ export class PersonaModel {
         return new PersonaModel(cfg)
     }
 
-    toYaml(): PersonaConfig {
+    toJson(): PersonaConfig {
         return this.cfg
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.test.ts
@@ -136,7 +136,7 @@ describe('loadPersonaPermissions', () => {
         expect(p.enabled).to.be.true
         expect(p.toolPerms).to.deep.equal({})
 
-        // The default file should have been written under ~/.aws/amazonq/personas/default.yaml
+        // The default file should have been written under ~/.aws/amazonq/personas/default.json
         const personaPath = getGlobalPersonaConfigPath(tmpDir)
         expect(fs.existsSync(personaPath)).to.be.true
         const content = fs.readFileSync(personaPath, 'utf-8')
@@ -148,13 +148,13 @@ describe('persona path helpers', () => {
     it('getWorkspacePersonaConfigPaths()', () => {
         const uris = ['uri1', 'uri2']
         expect(getWorkspacePersonaConfigPaths(uris)).to.deep.equal([
-            'uri1/.amazonq/personas/default.yaml',
-            'uri2/.amazonq/personas/default.yaml',
+            'uri1/.amazonq/personas/default.json',
+            'uri2/.amazonq/personas/default.json',
         ])
     })
 
     it('getGlobalPersonaConfigPath()', () => {
-        expect(getGlobalPersonaConfigPath('/home/me')).to.equal('/home/me/.aws/amazonq/personas/default.yaml')
+        expect(getGlobalPersonaConfigPath('/home/me')).to.equal('/home/me/.aws/amazonq/personas/default.json')
     })
 })
 


### PR DESCRIPTION
## Problem
QCLI decided to use json for persona and also need some default values, we need to aligned in order to not breaking QCLI user. 

## Solution
Change persona file to json, add default permissions.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
