### PR TITLE
fix: do not have empty args or env in config while updating server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -472,10 +472,26 @@ export class McpManager {
 
             await this.mutateConfigFile(configPath, json => {
                 json.mcpServers ||= {}
-                json.mcpServers[serverName] = {
-                    ...json.mcpServers[serverName],
-                    ...configUpdates,
+                const updatedConfig = { ...(json.mcpServers[serverName] || {}) }
+                if (configUpdates.command !== undefined) updatedConfig.command = configUpdates.command
+                if (configUpdates.initializationTimeout !== undefined)
+                    updatedConfig.initializationTimeout = configUpdates.initializationTimeout
+                if (configUpdates.timeout !== undefined) updatedConfig.timeout = configUpdates.timeout
+                if (configUpdates.args !== undefined) {
+                    if (configUpdates.args.length > 0) {
+                        updatedConfig.args = configUpdates.args
+                    } else {
+                        delete updatedConfig.args
+                    }
                 }
+                if (configUpdates.env !== undefined) {
+                    if (!isEmptyEnv(configUpdates.env)) {
+                        updatedConfig.env = configUpdates.env
+                    } else {
+                        delete updatedConfig.env
+                    }
+                }
+                json.mcpServers[serverName] = updatedConfig
             })
 
             const newCfg: MCPServerConfig = {


### PR DESCRIPTION
## Problem
- When updating a server and not including any args or env variables, it would update the mcp.json file with an empty args list or empty env variables like this:
```
{
  "mcpServers": {
    "json": {
      "command": "npx",
      "timeout": 0,
      "args": [
        "@gongrzhe/server-json-mcp@1.0.3"
      ],
      "env": {
        "": ""
      }
    }
  }
}
```
## Solution
- After updating server in UI without any args or env variables, mcp.json file will look like this:
```
{
  "mcpServers": {
    "json": {
      "command": "npx",
      "timeout": 0,
      "args": [
        "@gongrzhe/server-json-mcp@1.0.3"
      ]
    }
  }
}
```


https://github.com/user-attachments/assets/85b55a30-42bb-4c07-ac72-9e15ea27193a




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
