### PR TITLE
fix: clear the set to make sure truncate function work as expected

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -40,6 +40,7 @@ export class McpManager {
     public readonly events: EventEmitter
     private static readonly configMutex = new Mutex()
     private static readonly personaMutex = new Mutex()
+    private toolNameMapping: Map<string, { serverName: string; toolName: string }>
 
     private constructor(
         private configPaths: string[],
@@ -54,6 +55,7 @@ export class McpManager {
         this.mcpServerPermissions = new Map<string, MCPServerPermission>()
         this.events = new EventEmitter()
         this.features.logging.info(`MCP manager: initialized with ${configPaths.length} configs`)
+        this.toolNameMapping = new Map<string, { serverName: string; toolName: string }>()
     }
 
     /**
@@ -732,5 +734,21 @@ export class McpManager {
         return Array.from(this.configLoadErrors.entries())
             .map(([server, error]) => `File: ${server}, Error: ${error}`)
             .join('\n\n')
+    }
+
+    public getOriginalToolNames(namespacedName: string): { serverName: string; toolName: string } | undefined {
+        return this.toolNameMapping.get(namespacedName)
+    }
+
+    public clearToolNameMapping(): void {
+        this.toolNameMapping.clear()
+    }
+
+    public getToolNameMapping(): Map<string, { serverName: string; toolName: string }> {
+        return new Map(this.toolNameMapping)
+    }
+
+    public setToolNameMapping(mapping: Map<string, { serverName: string; toolName: string }>): void {
+        this.toolNameMapping = new Map(mapping)
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -305,12 +305,6 @@ export function enabledMCP(params: InitializeParams | undefined): boolean {
 
 export const MAX_TOOL_NAME_LENGTH = 64
 
-const toolNameMapping = new Map<string, { serverName: string; toolName: string }>()
-
-export function getOriginalToolNames(namespacedName: string): { serverName: string; toolName: string } | undefined {
-    return toolNameMapping.get(namespacedName)
-}
-
 /**
  * Create a namespaced tool name from server and tool names.
  * Handles truncation and conflicts according to specific rules.
@@ -319,7 +313,8 @@ export function getOriginalToolNames(namespacedName: string): { serverName: stri
 export function createNamespacedToolName(
     serverName: string,
     toolName: string,
-    allNamespacedTools: Set<string>
+    allNamespacedTools: Set<string>,
+    toolNameMapping: Map<string, { serverName: string; toolName: string }>
 ): string {
     const sep = '___'
     // If tool name alone isn't unique or is too long, try adding server prefix

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -89,7 +89,12 @@ export const McpToolsServer: Server = ({ credentialsProvider, workspace, logging
 
         // 2) add new enabled tools
         for (const def of defs) {
-            const namespaced = createNamespacedToolName(def.serverName, def.toolName, allNamespacedTools)
+            const namespaced = createNamespacedToolName(
+                def.serverName,
+                def.toolName,
+                allNamespacedTools,
+                McpManager.instance.getToolNameMapping()
+            )
             const tool = new McpTool({ logging, workspace, lsp }, def)
 
             // Add explanation field to input schema
@@ -130,6 +135,9 @@ export const McpToolsServer: Server = ({ credentialsProvider, workspace, logging
         const allPersonaPaths = [...wsPersonaPaths, globalPersonaPath]
 
         const mgr = await McpManager.init(allConfigPaths, allPersonaPaths, { logging, workspace, lsp })
+
+        // Clear tool name mapping before registering all tools to avoid conflicts from previous registrations
+        McpManager.instance.clearToolNameMapping()
 
         const byServer: Record<string, McpToolDefinition[]> = {}
         // only register enabled tools


### PR DESCRIPTION
## Problem
When user ask agentic what tools it has, if users ask multiple times, the tool name agentic return would with numbers. 
![image](https://github.com/user-attachments/assets/a899f83f-2544-4ff6-9061-3443a613a262)

## Solution
Add a clear function to reset the Set so every time we truncate the same server_tool, it would be the same name.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
