### PR TITLE
fix: fix paths array issue in fsRead

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsRead.ts
@@ -105,7 +105,8 @@ export class FsRead {
                 type: 'object',
                 properties: {
                     paths: {
-                        description: 'List of file paths to read in a sequence',
+                        description:
+                            'List of file paths to read in a sequence, e.g. `["/repo/file.py"]` for Unix-like system including Unix/Linux/macOS or `["d:\\repo\\file.py"]` for Windows.',
                         type: 'array',
                         items: {
                             type: 'string',


### PR DESCRIPTION
## Problem
- fsRead on Windows doesn't properly format the path array, causing file read failure.

## Solution
- fix paths array not being respected by LLM for fsRead tool

Now the fsRead succeeds on the first run.
<img width="427" alt="Screenshot 2025-05-30 at 5 10 29 PM" src="https://github.com/user-attachments/assets/cea3176b-71cf-4181-8a4a-bccaf3ecbf39" />

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
