### PR TITLE
fix: add remove function for inactive mcp server

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1402,10 +1402,47 @@ ${params.message}`,
                 title: params.header?.title || 'Add MCP Server',
                 description: params.header?.description || '',
                 status: params.header?.status || {},
+                actions: params.header?.actions?.map(action => ({
+                    ...action,
+                    icon: action.icon ? toMynahIcon(action.icon) : undefined,
+                })),
             },
             filterOptions: processFilterOptions(params.filterOptions),
             filterActions: params.filterActions,
         } as any
+
+        const isEditMode = params.header?.title === 'Edit MCP Server'
+        const hasError = params.header?.status?.status === 'error'
+
+        const serverName = (params.filterOptions?.[1] as any)?.value
+
+        if (isEditMode && hasError) {
+            detailedList.header.actions = [
+                {
+                    id: 'mcp-details-menu',
+                    icon: toMynahIcon('ellipsis'),
+                    items: [
+                        {
+                            id: 'mcp-disable-server',
+                            text: `Disable MCP server`,
+                            data: { serverName },
+                        },
+                        {
+                            id: 'mcp-delete-server',
+                            confirmation: {
+                                cancelButtonText: 'Cancel',
+                                confirmButtonText: 'Delete',
+                                title: 'Delete Filesystem MCP server',
+                                description:
+                                    'This configuration will be deleted and no longer available in Q. \n\n This cannot be undone.',
+                            },
+                            text: `Delete MCP server`,
+                            data: { serverName },
+                        },
+                    ],
+                },
+            ]
+        }
 
         // Process list if present
         if (params.list && params.list.length > 0) {
@@ -1498,6 +1535,10 @@ ${params.message}`,
                         mynahUi.toggleSplashLoader(true, '**Activating MCP Server**')
                         messager.onMcpServerClick(actionParams.id, 'Save configuration', filterValues)
                     }
+                },
+                onTitleActionClick: (action: ChatItemButton) => {
+                    const serverName = (action as any).data?.serverName
+                    messager.onMcpServerClick(action.id, serverName)
                 },
             }
             mynahUi.openDetailedList({ detailedList, events }, true)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1445,7 +1445,7 @@ export class AgenticChatController implements ChatHandlers {
             return {
                 messageId: toolUse.toolUseId,
                 type: 'tool',
-                body: '```shell\n' + (toolUse.input as unknown as ExecuteBashParams).command + '\n',
+                body: '```shell\n' + (toolUse.input as unknown as ExecuteBashParams).command,
                 header: {
                     body: 'shell',
                     ...(isAccept

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -804,6 +804,10 @@ export class McpEventHandler {
 
         try {
             await McpManager.instance.removeServer(serverName)
+            // Refresh the MCP list to show updated server list
+            await this.#handleRefreshMCPList({
+                id: params.id,
+            })
         } catch (error) {
             this.#features.logging.error(`Failed to delete MCP server: ${error}`)
         }


### PR DESCRIPTION
## Problem
We can not remove the mcp servers which failed initialized
## Solution


https://github.com/user-attachments/assets/1d90a00c-7e04-4d5f-8951-570547f239b0






<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
