### PR TITLE
fix: there is an extra line when user run the command

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1415,7 +1415,7 @@ export class AgenticChatController implements ChatHandlers {
             return {
                 messageId: toolUse.toolUseId,
                 type: 'tool',
-                body: '```shell\n' + (toolUse.input as unknown as ExecuteBashParams).command + '\n',
+                body: '```shell\n' + (toolUse.input as unknown as ExecuteBashParams).command,
                 header: {
                     body: 'shell',
                     ...(isAccept


### PR DESCRIPTION
## Problem
There is an extra line when user run the command
![image](https://github.com/user-attachments/assets/5b52518c-c7ea-4eb1-a4af-41e36424638f)

## Solution



https://github.com/user-attachments/assets/25146e3b-8227-4061-88d3-73fb0f7a512a
<!---

    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
