### PR TITLE
fix: After user validation failed, scope should choose global

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -347,7 +347,7 @@ export class McpEventHandler {
                             value: 'workspace',
                         },
                     ],
-                    value: existingValues.scope || 'global',
+                    value: 'global',
                 },
                 {
                     type: 'textinput',


### PR DESCRIPTION
## Problem
When user validate failed, the scope was in This 'workspace - Only used in this workspace.' option
## Solution

<!---

https://github.com/user-attachments/assets/f28d2435-5eb9-4300-989c-1a14b3039bc7




https://github.com/user-attachments/assets/2f8ca996-924d-439a-860e-0d9c4b62e24b




    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
