### PR TITLE
Add environment variable override to disable indexing library init

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
@@ -121,19 +121,23 @@ export const LocalProjectContextServer =
             logging.log('Updating configuration of local context server')
             try {
                 localProjectContextEnabled = updatedConfig.projectContext?.enableLocalIndexing === true
-
-                logging.log(
-                    `Setting project context indexing enabled to ${updatedConfig.projectContext?.enableLocalIndexing}`
-                )
-                await localProjectContextController.init({
-                    enableGpuAcceleration: updatedConfig?.projectContext?.enableGpuAcceleration,
-                    indexWorkerThreads: updatedConfig?.projectContext?.indexWorkerThreads,
-                    ignoreFilePatterns: updatedConfig.projectContext?.localIndexing?.ignoreFilePatterns,
-                    maxFileSizeMB: updatedConfig.projectContext?.localIndexing?.maxFileSizeMB,
-                    maxIndexSizeMB: updatedConfig.projectContext?.localIndexing?.maxIndexSizeMB,
-                    enableIndexing: localProjectContextEnabled,
-                    indexCacheDirPath: updatedConfig.projectContext?.localIndexing?.indexCacheDirPath,
-                })
+                if (process.env.DISABLE_INDEXING_LIBRARY === 'true') {
+                    logging.log('Skipping local project context initialization')
+                    localProjectContextEnabled = false
+                } else {
+                    logging.log(
+                        `Setting project context indexing enabled to ${updatedConfig.projectContext?.enableLocalIndexing}`
+                    )
+                    await localProjectContextController.init({
+                        enableGpuAcceleration: updatedConfig?.projectContext?.enableGpuAcceleration,
+                        indexWorkerThreads: updatedConfig?.projectContext?.indexWorkerThreads,
+                        ignoreFilePatterns: updatedConfig.projectContext?.localIndexing?.ignoreFilePatterns,
+                        maxFileSizeMB: updatedConfig.projectContext?.localIndexing?.maxFileSizeMB,
+                        maxIndexSizeMB: updatedConfig.projectContext?.localIndexing?.maxIndexSizeMB,
+                        enableIndexing: localProjectContextEnabled,
+                        indexCacheDirPath: updatedConfig.projectContext?.localIndexing?.indexCacheDirPath,
+                    })
+                }
             } catch (error) {
                 logging.error(`Error handling configuration change: ${error}`)
             }


### PR DESCRIPTION
## Problem
The indexing library does not properly support Windows ARM64 and is causing the Flare process to blow up during initialization.

## Solution
Long term we need to add proper support for ARM64. As a short term workaround we need a switch to be able to bypass indexing library initialization in cases like these.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
