### PR TITLE
fix: model doesn't update in session for new tabs

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -305,6 +305,18 @@ describe('AgenticChatController', () => {
         sinon.assert.calledWithExactly(activeTabSpy.set, mockTabId)
     })
 
+    it('onTabAdd updates model ID in chat options and session', () => {
+        const modelId = 'test-model-id'
+        sinon.stub(ChatDatabase.prototype, 'getModelId').returns(modelId)
+
+        chatController.onTabAdd({ tabId: mockTabId })
+
+        sinon.assert.calledWithExactly(testFeatures.chat.chatOptionsUpdate, { modelId, tabId: mockTabId })
+
+        const session = chatSessionManagementService.getSession(mockTabId).data
+        assert.strictEqual(session!.modelId, modelId)
+    })
+
     it('onTabChange sets active tab id in telemetryController and emits metrics', () => {
         chatController.onTabChange({ tabId: mockTabId })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2233,10 +2233,15 @@ export class AgenticChatController implements ChatHandlers {
     onTabAdd(params: TabAddParams) {
         this.#telemetryController.activeTabId = params.tabId
 
-        this.#chatSessionManagementService.createSession(params.tabId)
-
         const modelId = this.#chatHistoryDb.getModelId()
         this.#features.chat.chatOptionsUpdate({ modelId: modelId, tabId: params.tabId })
+
+        const sessionResult = this.#chatSessionManagementService.createSession(params.tabId)
+        const { data: session, success } = sessionResult
+        if (!success) {
+            return new ResponseError<ChatResult>(ErrorCodes.InternalError, sessionResult.error)
+        }
+        session.modelId = modelId
     }
 
     onTabChange(params: TabChangeParams) {


### PR DESCRIPTION
## Problem

When opening a new tab, the last selected modelId is persisted in the UI but is not getting passed to the next request.

## Solution

In onTabAdd, also update the session modelId (in addition to sending an update to the UI)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
