### PR TITLE
fix: make whole row clickable in mcp servers list view

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1138,7 +1138,7 @@ ${params.message}`,
         isMcpServersListActive = true
         // Convert the ListMcpServersResult to the format expected by mynahUi.openDetailedList
         const detailedList: any = {
-            selectable: false,
+            selectable: true,
             textDirection: 'row',
             header: params.header
                 ? {
@@ -1290,10 +1290,11 @@ ${params.message}`,
                     }
                 },
                 onItemSelect: (item: DetailedListItem) => {
-                    if (!item.id) {
-                        throw new Error('MCP server id is not defined')
+                    // actionId: open-mcp-server if valid server or mcp-fix-server if server needs to be fixed
+                    const actionId = item.actions?.[0].id
+                    if (actionId) {
+                        messager.onMcpServerClick(actionId, item.title)
                     }
-                    messager.onMcpServerClick(item.id)
                 },
                 onItemClick: (item: DetailedListItem) => {
                     if (item.id) {


### PR DESCRIPTION
## Problem

Issue from bug bash:
- In "MCP servers" table, make the entire row (highlighted in red rectangle in the screenshot) clickable. Users are not going to know that they need to click on the small ">" icon on the right to view details.
![Screenshot 2025-05-28 at 3 13 15 PM](https://github.com/user-attachments/assets/f0258c19-8f7a-4cec-9560-3b32b22b3b3a)


### TODO:
- first row highlighted by default
- still a blue outline around the first mcp server even when selecting another mcp server
- same issues with history tab

## Solution
https://github.com/user-attachments/assets/3501898e-f5f0-458d-86bb-611b5db9c46d






<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.







    - Link to related issues/commits.




    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
