### PR TITLE
fix: update default persona file spec and  tool permisions strings

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -881,7 +881,7 @@ export class McpEventHandler {
         toolsWithPermissions.forEach(item => {
             const toolName = item.tool.toolName
             const currentPermission = this.#getCurrentPermission(item.permission)
-            // For Built-in server, use a special function that doesn't include the 'Disable' option
+            // For Built-in server, use a special function that doesn't include the 'Deny' option
             const permissionOptions = this.#buildPermissionOptions(item.permission)
 
             filterOptions.push({
@@ -902,11 +902,11 @@ export class McpEventHandler {
      */
     #getCurrentPermission(permission: string): string {
         if (permission === McpPermissionType.alwaysAllow) {
-            return 'Always run'
+            return 'Always allow'
         } else if (permission === McpPermissionType.deny) {
-            return 'Disable'
+            return 'Deny'
         } else {
-            return 'Ask to run'
+            return 'Ask'
         }
     }
 
@@ -917,15 +917,15 @@ export class McpEventHandler {
         const permissionOptions: PermissionOption[] = []
 
         if (currentPermission !== McpPermissionType.alwaysAllow) {
-            permissionOptions.push({ label: 'Always run', value: McpPermissionType.alwaysAllow })
+            permissionOptions.push({ label: 'Always allow', value: McpPermissionType.alwaysAllow })
         }
 
         if (currentPermission !== McpPermissionType.ask) {
-            permissionOptions.push({ label: 'Ask to run', value: McpPermissionType.ask })
+            permissionOptions.push({ label: 'Ask', value: McpPermissionType.ask })
         }
 
         if (currentPermission !== McpPermissionType.deny) {
-            permissionOptions.push({ label: 'Disable', value: McpPermissionType.deny })
+            permissionOptions.push({ label: 'Deny', value: McpPermissionType.deny })
         }
 
         return permissionOptions

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -134,11 +134,23 @@ const DEFAULT_PERSONA_RAW = `{
   ],
   "toolPerms": {
     "builtIn": {
-      "execute_bash": "alwaysAllow",
-      "fs_read":       "alwaysAllow",
-      "fs_write":      "ask",
-      "report_issue":  "alwaysAllow",
-      "use_aws":       "alwaysAllow"
+      "execute_bash": {
+        "alwaysAllow": [
+          {
+            "preset": "readOnly"
+          }
+        ]
+      },
+      "fs_read": "alwaysAllow",
+      "fs_write": "ask",
+      "report_issue": "alwaysAllow",
+      "use_aws": {
+        "alwaysAllow": [
+          {
+            "preset": "readOnly"
+          }
+        ]
+      }
     }
   },
   "context": {


### PR DESCRIPTION
## Problem
- Address some of Arun's P0 bugs
    1. Default persona file does not match spec
    2. Tool permission labels does not match persona file 

## Solution
1. toolPerms for `execute_bash` and `use_aws` need to be:
```
"alwaysAllow": [ 
  {"preset": "readOnly"}
]
```
2. Change the tool permission labels as follows:
    - "Ask to run" --> "Ask"
    - "Always run" --> "Always allow"
    - "Disabled" --> "Deny"

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
