### PR TITLE
fix: rename fuzzySearch tool name

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -109,7 +109,7 @@ import { FsWrite, FsWriteParams } from './tools/fsWrite'
 import { ExecuteBash, ExecuteBashParams } from './tools/executeBash'
 import { ExplanatoryParams, ToolApprovalException } from './tools/toolShared'
 import { GrepSearch, SanitizedRipgrepOutput } from './tools/grepSearch'
-import { FuzzySearch, FuzzySearchParams } from './tools/fuzzySearch'
+import { FileSearch, FileSearchParams } from './tools/fileSearch'
 import { loggingUtils } from '@aws/lsp-core'
 import { diffLines } from 'diff'
 import {
@@ -932,7 +932,7 @@ export class AgenticChatController implements ChatHandlers {
                     case 'fsRead':
                     case 'listDirectory':
                     case 'grepSearch':
-                    case 'fuzzySearch':
+                    case 'fileSearch':
                     case 'fsWrite':
                     case 'executeBash': {
                         const toolMap = {
@@ -941,7 +941,7 @@ export class AgenticChatController implements ChatHandlers {
                             fsWrite: { Tool: FsWrite },
                             executeBash: { Tool: ExecuteBash },
                             grepSearch: { Tool: GrepSearch },
-                            fuzzySearch: { Tool: FuzzySearch },
+                            fileSearch: { Tool: FileSearch },
                         }
 
                         const { Tool } = toolMap[toolUse.name as keyof typeof toolMap]
@@ -1039,13 +1039,13 @@ export class AgenticChatController implements ChatHandlers {
                 switch (toolUse.name) {
                     case 'fsRead':
                     case 'listDirectory':
-                    case 'fuzzySearch':
+                    case 'fileSearch':
                         const initialListDirResult = this.#processReadOrListOrSearch(toolUse, chatResultStream)
                         if (initialListDirResult) {
                             await chatResultStream.writeResultBlock(initialListDirResult)
                         }
                         break
-                    // no need to write tool result for listDir,fsRead,fuzzySearch into chat stream
+                    // no need to write tool result for listDir,fsRead,fileSearch into chat stream
                     case 'executeBash':
                         // no need to write tool result for listDir and fsRead into chat stream
                         // executeBash will stream the output instead of waiting until the end
@@ -1464,8 +1464,8 @@ export class AgenticChatController implements ChatHandlers {
                 }
                 break
 
-            case 'fuzzySearch':
-                const searchPath = (toolUse.input as unknown as FuzzySearchParams).path
+            case 'fileSearch':
+                const searchPath = (toolUse.input as unknown as FileSearchParams).path
                 header = {
                     body: 'File Search',
                     status: {
@@ -1704,7 +1704,7 @@ export class AgenticChatController implements ChatHandlers {
         if (toolUse.name === 'fsRead') {
             currentPaths = (toolUse.input as unknown as FsReadParams)?.paths
         } else {
-            currentPaths.push((toolUse.input as unknown as ListDirectoryParams | FuzzySearchParams)?.path)
+            currentPaths.push((toolUse.input as unknown as ListDirectoryParams | FileSearchParams)?.path)
         }
 
         if (!currentPaths) return
@@ -1733,7 +1733,7 @@ export class AgenticChatController implements ChatHandlers {
             title =
                 toolUse.name === 'fsRead'
                     ? `${itemCount} file${itemCount > 1 ? 's' : ''} read`
-                    : toolUse.name === 'fuzzySearch'
+                    : toolUse.name === 'fileSearch'
                       ? `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} searched`
                       : `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} listed`
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.test.ts
@@ -1,12 +1,12 @@
 import * as assert from 'assert'
-import { FuzzySearch } from './fuzzySearch'
+import { FileSearch } from './fileSearch'
 import { testFolder } from '@aws/lsp-core'
 import * as path from 'path'
 import * as fs from 'fs/promises'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 
-describe('FuzzySearch Tool', () => {
+describe('FileSearch Tool', () => {
     let tempFolder: testFolder.TestFolder
     let testFeatures: TestFeatures
 
@@ -35,36 +35,36 @@ describe('FuzzySearch Tool', () => {
     })
 
     it('invalidates empty path', async () => {
-        const fuzzySearch = new FuzzySearch(testFeatures)
+        const fileSearch = new FileSearch(testFeatures)
         await assert.rejects(
-            fuzzySearch.validate({ path: '', queryName: 'test' }),
+            fileSearch.validate({ path: '', queryName: 'test' }),
             /Path cannot be empty/i,
             'Expected an error about empty path'
         )
     })
 
     it('invalidates invalid threshold pattern', async () => {
-        const fuzzySearch = new FuzzySearch(testFeatures)
+        const fileSearch = new FileSearch(testFeatures)
         await assert.rejects(
-            fuzzySearch.validate({ path: tempFolder.path, queryName: 'test', threshold: -1 }),
+            fileSearch.validate({ path: tempFolder.path, queryName: 'test', threshold: -1 }),
             /Invalid threshold/i,
             'Expected an error about invalid threshold'
         )
     })
 
     it('invalidates empty maxDepth', async () => {
-        const fuzzySearch = new FuzzySearch(testFeatures)
+        const fileSearch = new FileSearch(testFeatures)
         await assert.rejects(
-            fuzzySearch.validate({ path: tempFolder.path, queryName: 'test', maxDepth: -1 }),
+            fileSearch.validate({ path: tempFolder.path, queryName: 'test', maxDepth: -1 }),
             /MaxDepth cannot be negative/i,
             'Expected an error about negative maxDepth'
         )
     })
 
     it('invalidates empty queryName', async () => {
-        const fuzzySearch = new FuzzySearch(testFeatures)
+        const fileSearch = new FileSearch(testFeatures)
         await assert.rejects(
-            fuzzySearch.validate({ path: tempFolder.path, queryName: '' }),
+            fileSearch.validate({ path: tempFolder.path, queryName: '' }),
             /queryName cannot be empty/i,
             'Expected an error about empty queryName'
         )
@@ -75,8 +75,8 @@ describe('FuzzySearch Tool', () => {
         await tempFolder.write('fileB.md', '# fileB content')
         await tempFolder.write('fileC.js', 'console.log("fileC");')
 
-        const fuzzySearch = new FuzzySearch(testFeatures)
-        const result = await fuzzySearch.invoke({
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
             path: tempFolder.path,
             queryName: 'txt',
             maxDepth: 0,
@@ -97,8 +97,8 @@ describe('FuzzySearch Tool', () => {
         await subfolder.write('fileB.txt', 'fileB content')
         await tempFolder.write('fileC.md', '# fileC content')
 
-        const fuzzySearch = new FuzzySearch(testFeatures)
-        const result = await fuzzySearch.invoke({
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
             path: tempFolder.path,
             queryName: 'txt',
         })
@@ -124,8 +124,8 @@ describe('FuzzySearch Tool', () => {
         await subfolder1.write('level1.txt', 'level1 content')
         await subfolder2.write('level2.txt', 'level2 content')
 
-        const fuzzySearch = new FuzzySearch(testFeatures)
-        const result = await fuzzySearch.invoke({
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
             path: tempFolder.path,
             queryName: 'txt',
             maxDepth: 1,
@@ -146,8 +146,8 @@ describe('FuzzySearch Tool', () => {
         await tempFolder.write('FileUpper.txt', 'upper case filename')
         await tempFolder.write('fileLower.txt', 'lower case filename')
 
-        const fuzzySearch = new FuzzySearch(testFeatures)
-        const result = await fuzzySearch.invoke({
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
             path: tempFolder.path,
             queryName: 'file',
             maxDepth: 0,
@@ -166,8 +166,8 @@ describe('FuzzySearch Tool', () => {
         await tempFolder.write('FileUpper.txt', 'upper case filename')
         await tempFolder.write('fileLower.txt', 'lower case filename')
 
-        const fuzzySearch = new FuzzySearch(testFeatures)
-        const result = await fuzzySearch.invoke({
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
             path: tempFolder.path,
             queryName: 'file',
             maxDepth: 0,
@@ -188,8 +188,8 @@ describe('FuzzySearch Tool', () => {
         await tempFolder.write('regular.txt', 'regular content')
         await nodeModules.write('excluded.txt', 'excluded content')
 
-        const fuzzySearch = new FuzzySearch(testFeatures)
-        const result = await fuzzySearch.invoke({
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
             path: tempFolder.path,
             queryName: 'txt',
         })
@@ -205,18 +205,18 @@ describe('FuzzySearch Tool', () => {
 
     it('throws error if path does not exist', async () => {
         const missingPath = path.join(tempFolder.path, 'no_such_directory')
-        const fuzzySearch = new FuzzySearch(testFeatures)
+        const fileSearch = new FileSearch(testFeatures)
 
         await assert.rejects(
-            fuzzySearch.invoke({ path: missingPath, queryName: '.*' }),
+            fileSearch.invoke({ path: missingPath, queryName: '.*' }),
             /Failed to search directory/i,
             'Expected an error about non-existent path'
         )
     })
 
     it('expands ~ path', async () => {
-        const fuzzySearch = new FuzzySearch(testFeatures)
-        const result = await fuzzySearch.invoke({
+        const fileSearch = new FileSearch(testFeatures)
+        const result = await fileSearch.invoke({
             path: '~',
             queryName: '.*',
             maxDepth: 0,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.ts
@@ -1,4 +1,4 @@
-// FuzzySearch tool based on ListDirectory implementation
+// FileSearch tool based on ListDirectory implementation
 import { CommandValidation, InvokeOutput, requiresPathAcceptance, validatePath } from './toolShared'
 import { workspaceUtils } from '@aws/lsp-core'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
@@ -7,7 +7,7 @@ import { DEFAULT_EXCLUDE_DIRS, DEFAULT_EXCLUDE_FILES } from '../../chat/constant
 import { CancellationToken } from '@aws/language-server-runtimes/protocol'
 const Fuse = require('fuse.js')
 
-export interface FuzzySearchParams {
+export interface FileSearchParams {
     path: string
     queryName: string
     maxDepth?: number
@@ -15,7 +15,7 @@ export interface FuzzySearchParams {
     threshold?: number
 }
 
-export class FuzzySearch {
+export class FileSearch {
     private readonly logging: Features['logging']
     private readonly workspace: Features['workspace']
     private readonly lsp: Features['lsp']
@@ -26,7 +26,7 @@ export class FuzzySearch {
         this.lsp = features.lsp
     }
 
-    public async validate(params: FuzzySearchParams): Promise<void> {
+    public async validate(params: FileSearchParams): Promise<void> {
         if (params.maxDepth !== undefined && params.maxDepth < 0) {
             throw new Error('MaxDepth cannot be negative.')
         }
@@ -43,19 +43,16 @@ export class FuzzySearch {
         }
     }
 
-    public async queueDescription(params: FuzzySearchParams, updates: WritableStream, requiresAcceptance: boolean) {
+    public async queueDescription(params: FileSearchParams, updates: WritableStream, requiresAcceptance: boolean) {
         // deprecated, no-op
         return
     }
 
-    public async requiresAcceptance(
-        params: FuzzySearchParams,
-        approvedPaths?: Set<string>
-    ): Promise<CommandValidation> {
+    public async requiresAcceptance(params: FileSearchParams, approvedPaths?: Set<string>): Promise<CommandValidation> {
         return requiresPathAcceptance(params.path, this.workspace, this.logging, approvedPaths)
     }
 
-    public async invoke(params: FuzzySearchParams, token?: CancellationToken): Promise<InvokeOutput> {
+    public async invoke(params: FileSearchParams, token?: CancellationToken): Promise<InvokeOutput> {
         const path = sanitize(params.path)
         try {
             // Get all files and directories
@@ -109,7 +106,7 @@ export class FuzzySearch {
 
     public getSpec() {
         return {
-            name: 'fuzzySearch',
+            name: 'fileSearch',
             description:
                 'Search for files and directories in a target path using fuzzy name matching.\n\n' +
                 '## Overview\n' +
@@ -117,7 +114,7 @@ export class FuzzySearch {
                 'It ignores common build and dependency directories.\n\n' +
                 '## When to use\n' +
                 '- When you need to locate files or folders by approximate names\n' +
-                "- When you don't know exact names\n" +
+                "- When you don't know exact names of files or directories\n" +
                 '- When you want to skip a listDirectory step\n\n' +
                 '## When not to use\n' +
                 '- When you need to search file contents\n' +

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -8,14 +8,14 @@ import { LspReadDocumentContents, LspReadDocumentContentsParams } from './lspRea
 import { LspApplyWorkspaceEdit } from './lspApplyWorkspaceEdit'
 import { McpManager } from './mcp/mcpManager'
 import { McpTool } from './mcp/mcpTool'
-import { FuzzySearch, FuzzySearchParams } from './fuzzySearch'
+import { FileSearch, FileSearchParams } from './fileSearch'
 import { GrepSearch, GrepSearchParams } from './grepSearch'
 
 export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     const fsReadTool = new FsRead({ workspace, lsp, logging })
     const fsWriteTool = new FsWrite({ workspace, lsp, logging })
     const listDirectoryTool = new ListDirectory({ workspace, logging, lsp })
-    const fuzzySearchTool = new FuzzySearch({ workspace, lsp, logging })
+    const fileSearchTool = new FileSearch({ workspace, lsp, logging })
     const grepSearchTool = new GrepSearch({ workspace, logging, lsp })
 
     agent.addTool(fsReadTool.getSpec(), async (input: FsReadParams) => {
@@ -33,9 +33,9 @@ export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
         return await listDirectoryTool.invoke(input, token)
     })
 
-    agent.addTool(fuzzySearchTool.getSpec(), async (input: FuzzySearchParams, token?: CancellationToken) => {
-        await fuzzySearchTool.validate(input)
-        return await fuzzySearchTool.invoke(input, token)
+    agent.addTool(fileSearchTool.getSpec(), async (input: FileSearchParams, token?: CancellationToken) => {
+        await fileSearchTool.validate(input)
+        return await fileSearchTool.invoke(input, token)
     })
 
     agent.addTool(grepSearchTool.getSpec(), async (input: GrepSearchParams, token?: CancellationToken) => {


### PR DESCRIPTION
## Problem
- Tool name is not clear to customer

## Solution
- Rename it to fileSearch

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
