### PR TITLE
fix: only show invalid json error on list mcp server page

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -205,8 +205,9 @@ export class McpEventHandler {
         const header = {
             title: 'MCP Servers',
             description: "Add MCP servers to extend Q's capabilities.",
-            status: combinedErrors
-                ? { title: combinedErrors, icon: 'cancel-circle', status: 'error' as Status }
+            // only  show error on list mcp server page if unable to read mcp.json file
+            status: configLoadErrors
+                ? { title: configLoadErrors, icon: 'cancel-circle', status: 'error' as Status }
                 : undefined,
         }
 
@@ -226,7 +227,6 @@ export class McpEventHandler {
             'save-mcp': () => this.#handleSaveMcp(params),
             'open-mcp-server': () => this.#handleOpenMcpServer(params),
             'edit-mcp': () => this.#handleEditMcpServer(params),
-
             'mcp-permission-change': () => this.#handleMcpPermissionChange(params),
             'refresh-mcp-list': () => this.#handleRefreshMCPList(params),
             'mcp-enable-server': () => this.#handleEnableMcpServer(params),

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -733,11 +733,6 @@ export class McpManager {
         if (server) {
             this.setState(server, McpServerStatus.FAILED, 0, msg)
             this.emitToolsChanged(server)
-
-            // Store the error in the configLoadErrors map
-            if (server !== undefined) {
-                this.configLoadErrors.set(server, msg)
-            }
         }
     }
 


### PR DESCRIPTION
## Problem
- Don't show MCP server initialization errors in the MCP overview screen. (As if there are a lot of MCP servers each with long error messages, this can get overwhelming.) 
   
## Solution
- The only error which will show on list mcp servers screen is if they have an invalid mcp.json config file
- If there are server specific errors, user will click see this error once they click into an MCP server


https://github.com/user-attachments/assets/e7a76236-e391-4f89-a3a0-e0458f1e98bf










<!---
    REMINDER:




    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.



    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
