### PR TITLE
fix: fix to correctly load the permissions

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2353,7 +2353,11 @@ export class AgenticChatController implements ChatHandlers {
     onTabAdd(params: TabAddParams) {
         this.#telemetryController.activeTabId = params.tabId
 
-        this.#chatSessionManagementService.createSession(params.tabId)
+        const sessionResult = this.#chatSessionManagementService.createSession(params.tabId)
+        if (sessionResult.success && sessionResult.data) {
+            // Set the logging object on the session
+            sessionResult.data.setLogging(this.#features.logging)
+        }
 
         const modelId = this.#chatHistoryDb.getModelId()
         this.#features.chat.chatOptionsUpdate({ modelId: modelId, tabId: params.tabId })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -1061,6 +1061,7 @@ export class McpEventHandler {
             //     defaultPermission = serverName === 'Built-in' ? 'alwaysAllow' : 'ask'
             // }
 
+            // If the value is an empty string (''), skip this tool to preserve its existing permission in the persona file
             if (val === '') continue
             switch (val) {
                 case McpPermissionType.alwaysAllow:

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -1061,6 +1061,7 @@ export class McpEventHandler {
             //     defaultPermission = serverName === 'Built-in' ? 'alwaysAllow' : 'ask'
             // }
 
+            if (val === '') continue
             switch (val) {
                 case McpPermissionType.alwaysAllow:
                     perm.toolPerms[key] = McpPermissionType.alwaysAllow

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -648,7 +648,10 @@ export class McpEventHandler {
         // need to check server state now, as there is possibility of error during server initialization
         const serverStatusError = this.#getServerStatusError(serverName)
         if (serverStatusError) {
-            // error case: stays on add/edit page and show error to user
+            // error case: remove config from config file but persist in memory
+            await McpManager.instance.removeServerFromConfigFile(serverName)
+
+            // stays on add/edit page and show error to user
             if (isEditMode) {
                 params.id = 'edit-mcp'
                 params.title = originalServerName!

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -286,14 +286,6 @@ export class McpManager {
             star?.toolPerms['*'] ??
             McpPermissionType.ask
 
-        this.features.logging.debug(
-            `Permission for ${server}::${tool}: ${result} (from: ` +
-                `server specific=${srv?.toolPerms[tool]}, ` +
-                `server wildcard=${srv?.toolPerms['*']}, ` +
-                `global specific=${star?.toolPerms[tool]}, ` +
-                `global wildcard=${star?.toolPerms['*']})`
-        )
-
         return result
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -278,13 +278,23 @@ export class McpManager {
     public getToolPerm(server: string, tool: string): McpPermissionType {
         const srv = this.mcpServerPermissions.get(server)
         const star = this.mcpServerPermissions.get('*')
-        return (
+
+        const result =
             srv?.toolPerms[tool] ??
             srv?.toolPerms['*'] ??
             star?.toolPerms[tool] ??
             star?.toolPerms['*'] ??
             McpPermissionType.ask
+
+        this.features.logging.debug(
+            `Permission for ${server}::${tool}: ${result} (from: ` +
+                `server specific=${srv?.toolPerms[tool]}, ` +
+                `server wildcard=${srv?.toolPerms['*']}, ` +
+                `global specific=${star?.toolPerms[tool]}, ` +
+                `global wildcard=${star?.toolPerms['*']})`
         )
+
+        return result
     }
 
     /**
@@ -750,6 +760,30 @@ export class McpManager {
         return Array.from(this.configLoadErrors.entries())
             .map(([server, error]) => `File: ${server}, Error: ${error}`)
             .join('\n\n')
+    }
+
+    /**
+     * Remove a server from the config file but keep it in memory.
+     * This is used when there's a server status error during initialization.
+     */
+    public async removeServerFromConfigFile(serverName: string): Promise<void> {
+        try {
+            const cfg = this.mcpServers.get(serverName)
+            if (!cfg || !cfg.__configPath__) {
+                this.features.logging.warn(
+                    `Cannot remove config for server '${serverName}': Config not found or missing path`
+                )
+                return
+            }
+
+            await this.mutateConfigFile(cfg.__configPath__, json => {
+                delete json.mcpServers[serverName]
+            })
+
+            this.features.logging.info(`Removed server '${serverName}' from config file but kept in memory`)
+        } catch (err) {
+            this.features.logging.error(`Error removing server '${serverName}' from config file: ${err}`)
+        }
     }
 
     public getOriginalToolNames(namespacedName: string): { serverName: string; toolName: string } | undefined {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -231,9 +231,18 @@ export async function loadPersonaPermissions(
             result.set(name, { enabled: true, toolPerms: {}, __configPath__: file })
         }
 
-        // apply toolPerms only to enabled servers
+        // Check if wildcard is present in mcpServers
+        const hasWildcard = enabled.has('*')
+
+        // apply toolPerms to servers
         for (const [name, perms] of Object.entries(cfg['toolPerms'] ?? {})) {
-            if (enabled.has(name)) {
+            // If there's a wildcard in mcpServers, or if this server is explicitly enabled
+            if (hasWildcard || enabled.has(name)) {
+                // Create entry for this server if it doesn't exist yet
+                if (!result.has(name)) {
+                    result.set(name, { enabled: true, toolPerms: {}, __configPath__: file })
+                }
+
                 const rec = result.get(name)!
                 rec.toolPerms = perms as Record<string, McpPermissionType>
             } else if (isWorkspace && result.has(name)) {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -13,6 +13,8 @@ import {
 import { ChatResult } from '@aws/language-server-runtimes/server-interface'
 import { AgenticChatError, isInputTooLongError, isRequestAbortedError, wrapErrorWithCode } from '../agenticChat/errors'
 import { AmazonQBaseServiceManager } from '../../shared/amazonQServiceManager/BaseAmazonQServiceManager'
+import { loggingUtils } from '@aws/lsp-core'
+import { Logging } from '@aws/language-server-runtimes/server-interface'
 
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 type FileChange = { before?: string; after?: string }
@@ -39,6 +41,7 @@ export class ChatSessionService {
     // Map to store approved paths to avoid repeated validation
     #approvedPaths: Set<string> = new Set<string>()
     #serviceManager?: AmazonQBaseServiceManager
+    #logging?: Logging
 
     public getConversationType(): string {
         return this.#conversationType
@@ -111,8 +114,9 @@ export class ChatSessionService {
         this.#approvedPaths.add(normalizedPath)
     }
 
-    constructor(serviceManager?: AmazonQBaseServiceManager) {
+    constructor(serviceManager?: AmazonQBaseServiceManager, logging?: Logging) {
         this.#serviceManager = serviceManager
+        this.#logging = logging
     }
 
     public async sendMessage(request: SendMessageCommandInput): Promise<SendMessageCommandOutput> {
@@ -152,6 +156,12 @@ export class ChatSessionService {
             try {
                 return await client.generateAssistantResponse(request, this.#abortController)
             } catch (e) {
+                // Log the error using the logging property if available, otherwise fall back to console.error
+                if (this.#logging) {
+                    this.#logging.error(`Error in generateAssistantResponse: ${loggingUtils.formatErr(e)}`)
+                } else {
+                    console.error(`Error in generateAssistantResponse: ${loggingUtils.formatErr(e)}`)
+                }
                 if (isRequestAbortedError(e)) {
                     const requestId =
                         e instanceof CodeWhispererStreamingServiceException ? e.$metadata?.requestId : undefined
@@ -220,5 +230,13 @@ export class ChatSessionService {
 
     public abortRequest(): void {
         this.#abortController?.abort()
+    }
+
+    /**
+     * Sets the logging object for this session
+     * @param logging The logging object to use
+     */
+    public setLogging(logging: Logging): void {
+        this.#logging = logging
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -159,8 +159,6 @@ export class ChatSessionService {
                 // Log the error using the logging property if available, otherwise fall back to console.error
                 if (this.#logging) {
                     this.#logging.error(`Error in generateAssistantResponse: ${loggingUtils.formatErr(e)}`)
-                } else {
-                    console.error(`Error in generateAssistantResponse: ${loggingUtils.formatErr(e)}`)
                 }
                 if (isRequestAbortedError(e)) {
                     const requestId =


### PR DESCRIPTION
## Problem
- Permissions are not being loaded correctly from the persona file. Therefore are not being honored properly.
- mcp config file is being edited incase of mcp server initialization failure.

## Solution
- fixes persona file loading with wildcard for permissions.
- honors permission accordingly during tool executions
- logging for errors
- Removing mcp server from config file incase of failure in initialization.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
