### PR TITLE
chore: add eslint rule to prevent usage of global crypto

### DIFF
--- a/server/aws-lsp-codewhisperer/.eslintrc.js
+++ b/server/aws-lsp-codewhisperer/.eslintrc.js
@@ -9,6 +9,13 @@ module.exports = {
     rules: {
         'import/no-nodejs-modules': 'warn',
         '@typescript-eslint/no-floating-promises': 'error',
+        'no-restricted-globals': [
+            'error',
+            {
+                name: 'crypto',
+                message: 'Do not use global crypto object which only exists in browsers and fails for node runtimes',
+            },
+        ],
     },
     ignorePatterns: ['**/*.test.ts', 'out/', 'src.gen/', 'src/client/**/*.d.ts'],
     overrides: [


### PR DESCRIPTION
### Problem

Given the crypto module is available in both nodejs and in the web api, it is very easy to forget importing the crypto module. This means if we forget to import crypto, crypto function calls will not be caught during compilation or testing and the error will only become apparent during runtime when running with node. See https://github.com/aws/language-servers/pull/1408

### Solution
Added an ESLint rule to specifically catch usage of the browser's global crypto object

I also tested the `no-undef` rule but it was causing many other parts of the codebase to be flagged as errors. It could be worth a later exploration but this is a simpler fix

### Testing
- Verified that when the crypto import is commented out in `workspaceContextServer.ts`, ESLint correctly flags the error when running `lint` and also in the IDE:

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/bfec2aa9-7231-4789-bace-d3b3fd12a3bf" />

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
