### PR TITLE
fix: When user enable the server, only refresh that server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -759,7 +759,7 @@ export class McpEventHandler {
 
         try {
             await McpManager.instance.updateServerPermission(serverName, perm)
-            await this.#handleRefreshMCPList({
+            await this.#refreshSingleServer({
                 id: params.id,
             })
         } catch (error) {
@@ -806,10 +806,6 @@ export class McpEventHandler {
 
         try {
             await McpManager.instance.removeServer(serverName)
-            // Refresh the MCP list to show updated server list
-            await this.#handleRefreshMCPList({
-                id: params.id,
-            })
         } catch (error) {
             this.#features.logging.error(`Failed to delete MCP server: ${error}`)
         }
@@ -1100,5 +1096,19 @@ export class McpEventHandler {
         }
 
         return undefined
+    }
+
+    async #refreshSingleServer(params: McpServerClickParams) {
+        const serverName = params.title
+        if (!serverName) {
+            return { id: params.id }
+        }
+        this.#shouldDisplayListMCPServers = true
+        try {
+            await McpManager.instance.reinitializeOneServer(serverName)
+        } catch (err) {
+            this.#features.logging.error(`Failed to reinitialize MCP server ${serverName}: ${err}`)
+        }
+        return { id: params.id }
     }
 }


### PR DESCRIPTION
## Problem
We are refresh all severs too often such as:
1. When user enable a single server
2. When user delete a server
## Solution
1. Introducing the refreshSingleServer function
2. Remove the refresh mechanism after user delete a server
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
