### PR TITLE
fix: return QModelResponse as a response not an error

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -1011,9 +1011,8 @@ describe('AgenticChatController', () => {
             )
 
             // These checks will fail if a response error is returned.
-            const typedChatResult = chatResult as ResponseError<ChatResult>
-            assert.strictEqual(typedChatResult.message, errorMsg)
-            assert.strictEqual(typedChatResult.data?.body, errorMsg)
+            const typedChatResult = chatResult as ChatResult
+            assert.strictEqual(typedChatResult.body, errorMsg)
         })
 
         it('truncate input to 500k character ', async function () {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -519,19 +519,6 @@ export class AgenticChatController implements ChatHandlers {
                     buttons: [],
                 }
             }
-            if (err instanceof Error && getErrorCode(err) === 'QModelResponse') {
-                const requestID = getRequestID(err)
-                const errorBody =
-                    getErrorCode(err) === 'QModelResponse' && requestID
-                        ? `${err.message} \n\nRequest ID: ${requestID} `
-                        : err.message
-                return {
-                    type: 'answer',
-                    body: errorBody,
-                    messageId: errorMessageId,
-                    buttons: [],
-                }
-            }
             return this.#handleRequestError(
                 session.conversationId,
                 err,
@@ -2012,10 +1999,21 @@ export class AgenticChatController implements ChatHandlers {
                 // Clear the chat history in the database for this tab
                 this.#chatHistoryDb.clearTab(tabId)
             }
-
+            const errorBody =
+                err.code === 'QModelResponse' && requestID
+                    ? `${err.message} \n\nRequest ID: ${requestID} `
+                    : err.message
+            if (err.code === 'QModelResponse') {
+                return {
+                    type: 'answer',
+                    body: errorBody,
+                    messageId: errorMessageId,
+                    buttons: [],
+                }
+            }
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
                 type: 'answer',
-                body: err.message,
+                body: errorBody,
                 messageId: errorMessageId,
                 buttons: [],
             })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -74,15 +74,7 @@ import { ChatSessionManagementService } from '../chat/chatSessionManagementServi
 import { ChatTelemetryController } from '../chat/telemetry/chatTelemetryController'
 import { QuickAction } from '../chat/quickActions'
 import { Metric } from '../../shared/telemetry/metric'
-import {
-    getErrorCode,
-    getErrorMessage,
-    getHttpStatusCode,
-    getRequestID,
-    isAwsError,
-    isNullish,
-    isObject,
-} from '../../shared/utils'
+import { getErrorMessage, getHttpStatusCode, getRequestID, isAwsError, isNullish, isObject } from '../../shared/utils'
 import { HELP_MESSAGE, loadingMessage } from '../chat/constants'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1995,20 +1995,16 @@ export class AgenticChatController implements ChatHandlers {
                 err.code === 'QModelResponse' && requestID
                     ? `${err.message} \n\nRequest ID: ${requestID} `
                     : err.message
-            if (err.code === 'QModelResponse') {
-                return {
-                    type: 'answer',
-                    body: errorBody,
-                    messageId: errorMessageId,
-                    buttons: [],
-                }
-            }
-            return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
+            const responseData: ChatResult = {
                 type: 'answer',
                 body: errorBody,
                 messageId: errorMessageId,
                 buttons: [],
-            })
+            }
+            if (err.code === 'QModelResponse') {
+                return responseData
+            }
+            return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, responseData)
         }
         this.#features.logging.error(`Unknown Error: ${loggingUtils.formatErr(err)}`)
         return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -150,7 +150,8 @@ export class ChatSessionService {
 
         if (client instanceof StreamingClientServiceToken) {
             try {
-                return await client.generateAssistantResponse(request, this.#abortController)
+                throw new Error('trial')
+                // return await client.generateAssistantResponse(request, this.#abortController)
             } catch (e) {
                 if (isRequestAbortedError(e)) {
                     const requestId =
@@ -173,13 +174,8 @@ export class ChatSessionService {
                     )
                 }
                 let error = wrapErrorWithCode(e, 'QModelResponse')
-                if (
-                    request.conversationState?.currentMessage?.userInputMessage?.modelId !== undefined &&
-                    (error.cause as any)?.$metadata?.httpStatusCode === 500 &&
-                    error.message ===
-                        'Encountered unexpectedly high load when processing the request, please try again.'
-                ) {
-                    error.message = ` The model you've selected is temporarily unavailable. Please select Auto or a different model and try again.`
+                if (error) {
+                    error.message = `The model you've selected is temporarily unavailable. Please select Auto or a different model and try again.`
                 }
                 throw error
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -150,9 +150,7 @@ export class ChatSessionService {
 
         if (client instanceof StreamingClientServiceToken) {
             try {
-                // Todo: return to its previous stage
-                throw new Error('trial')
-                // return await client.generateAssistantResponse(request, this.#abortController)
+                return await client.generateAssistantResponse(request, this.#abortController)
             } catch (e) {
                 if (isRequestAbortedError(e)) {
                     const requestId =
@@ -175,8 +173,13 @@ export class ChatSessionService {
                     )
                 }
                 let error = wrapErrorWithCode(e, 'QModelResponse')
-                if (error) {
-                    error.message = `The model you've selected is temporarily unavailable. Please select Auto or a different model and try again.`
+                if (
+                    request.conversationState?.currentMessage?.userInputMessage?.modelId !== undefined &&
+                    (error.cause as any)?.$metadata?.httpStatusCode === 500 &&
+                    error.message ===
+                        'Encountered unexpectedly high load when processing the request, please try again.'
+                ) {
+                    error.message = ` The model you've selected is temporarily unavailable. Please select Auto or a different model and try again.`
                 }
                 throw error
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -150,6 +150,7 @@ export class ChatSessionService {
 
         if (client instanceof StreamingClientServiceToken) {
             try {
+                // Todo: return to its previous stage
                 throw new Error('trial')
                 // return await client.generateAssistantResponse(request, this.#abortController)
             } catch (e) {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -179,7 +179,7 @@ export class ChatSessionService {
                     error.message ===
                         'Encountered unexpectedly high load when processing the request, please try again.'
                 ) {
-                    error.message = ` The model you've selected is temporarily unavailable. Please select Auto or a different model and try again.`
+                    error.message = `The model you selected is temporarily unavailable. Please switch to a different model and try again.`
                 }
                 throw error
             }

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -222,6 +222,10 @@ export function getErrorMessage(error: any): string {
     return String(error)
 }
 
+export function getErrorCode(error: any): string {
+    return hasCode(error) ? error.code : String(error)
+}
+
 export function getRequestID(error: any): string | undefined {
     if (hasCause(error) && error.cause.$metadata?.requestId) {
         return error.cause.$metadata.requestId

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -222,10 +222,6 @@ export function getErrorMessage(error: any): string {
     return String(error)
 }
 
-export function getErrorCode(error: any): string {
-    return hasCode(error) ? error.code : String(error)
-}
-
 export function getRequestID(error: any): string | undefined {
     if (hasCause(error) && error.cause.$metadata?.requestId) {
         return error.cause.$metadata.requestId


### PR DESCRIPTION
## Problem
1. Inconsistent Error Handling Across IDEs 
Currently, Flare throws _QModelResponse_ errors directly, requiring each IDE to catch and handle them separately, which leads to inconsistent UI experiences across different IDEs compared to VS Code.
![image/](https://github.com/user-attachments/assets/0e21a338-cd1b-4c4f-b16d-1a56465ce332 "VSCode UI")

![image/](https://github.com/user-attachments/assets/30da344c-829f-48bf-9185-83c5c5154a17 "VS UI")
![image/](https://github.com/user-attachments/assets/12317cbb-48b8-405a-a72d-dcd60010590b "Eclipse UI")


2. Model Selection Error Code Issues
_QModelResponse_ errors don't send a error code back to IDE, as we only receive a body with errorMessageId inside instead of standardized error codes, which makes us hard to have a generalized way to handle logic for QModelResponse Error. 

## Solution
VS Code as a source of truth tries to show the error message from QModelResponse error directly to chat UI. We've modified the error handling approach to return a result instead of throwing exceptions for QModelResponse errors. This ensures that errors are displayed consistently in the chat UI across all IDE integrations and reduces the implementation burden on individual IDE teams. 

This change serves as a quick fix for the current UI inconsistency and reduces the implementation load on the IDE side. **A more comprehensive standardized error code system will be implemented when more bandwidth is available, but this interim solution addresses the most pressing issues with error handling across our IDE integrations.**

## Current Status
VS Code and Visual Studio implementations have been tested and confirmed working, and we're waiting for test from JetBrains and Eclipse teams before merging.
![image](https://github.com/user-attachments/assets/34dbe72d-6c95-40c3-a88b-9bc3dc560523 "VSC current UI")
![image](https://github.com/user-attachments/assets/9987975f-2b8b-4a75-9777-4cc287c4206e "VS current UI")

  


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
