### PR TITLE
fix(amazonq): always restore chat tabs when onReady is received

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.test.ts
@@ -502,17 +502,17 @@ describe('TabBarController', () => {
             })
         })
 
-        it('should only load chats once', async () => {
+        it('restore tab can be called multiple times', async () => {
             const mockTabs = [{ historyId: 'history1', conversations: [{ messages: [] }] }] as unknown as Tab[]
             ;(chatHistoryDb.getOpenTabs as sinon.SinonStub).returns(mockTabs)
 
             const restoreTabStub = sinon.stub(tabBarController, 'restoreTab')
 
             await tabBarController.loadChats()
-            await tabBarController.loadChats() // Second call should be ignored
+            await tabBarController.loadChats()
 
-            sinon.assert.calledOnce(restoreTabStub)
-            sinon.assert.calledOnce(telemetryService.emitLoadHistory as sinon.SinonStub)
+            sinon.assert.calledTwice(restoreTabStub)
+            sinon.assert.calledTwice(telemetryService.emitLoadHistory as sinon.SinonStub)
             sinon.assert.calledWith(telemetryService.emitLoadHistory as sinon.SinonStub, {
                 openTabCount: 1,
                 amazonqTimeToLoadHistory: -1,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
@@ -33,7 +33,6 @@ import { CancellationError } from '@aws/lsp-core'
  *
  */
 export class TabBarController {
-    #loadedChats: boolean = false
     #searchTimeout: NodeJS.Timeout | undefined = undefined
     readonly #DebounceTime = 300 // milliseconds
     #features: Features
@@ -299,10 +298,6 @@ export class TabBarController {
      * When IDE is opened, restore chats that were previously open in IDE for the current workspace.
      */
     async loadChats() {
-        if (this.#loadedChats) {
-            return
-        }
-        this.#loadedChats = true
         const openConversations = this.#chatHistoryDb.getOpenTabs()
         if (openConversations) {
             for (const conversation of openConversations) {


### PR DESCRIPTION
## Problem
webviews can be forced to be reloaded, which breaks history and related features that rely on chat-db to have a correct 'view' of what the UI is currently showing.

## Solution
mynah-ui will only send 'aws/chat/ready' once on initialize, so we should not need to guard against restoring tab multiple times if a client is requesting this

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
