### PR TITLE
fix: handle dangling tool results when history is cleared due to size limits

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -439,6 +439,17 @@ export class ChatDatabase {
         //  Make sure max characters ≤ remaining Character Budget
         allMessages = this.trimMessagesToMaxLength(allMessages, remainingCharacterBudget)
 
+        // Edge case: If the history is empty and the next message contains tool results, then we have to just abandon them.
+        if (
+            allMessages.length === 0 &&
+            newUserMessage.userInputMessage?.userInputMessageContext?.toolResults?.length &&
+            newUserMessage.userInputMessage?.userInputMessageContext?.toolResults?.length > 0
+        ) {
+            this.#features.logging.warn('History overflow: abandoning dangling toolResults.')
+            newUserMessage.userInputMessage.userInputMessageContext.toolResults = []
+            newUserMessage.userInputMessage.content = 'The conversation history has overflowed, clearing state'
+        }
+
         const clientType = this.#features.lsp.getClientInitializeParams()?.clientInfo?.name || 'unknown'
 
         tabData.conversations = [


### PR DESCRIPTION
## Problem
We receive `Improperly formed requests` failures due to: `Message with ToolResults must be preceded by AssistantResponseMessage`

There is an edge case where when the context size is exceeded, we remove the history entirely if we cannot find a valid userInputMessage without toolResults to trim up to. This results in validation issues on the backend if the new UserInputMessage contains toolResults (there is no existing previous message with toolUses to pair with the toolResult).

## Solution

Short-term solution: Abandon the toolResult for this case and inform the LLM that the context limit was execeeded.

This is the current approach done by CLI: https://github.com/aws/amazon-q-developer-cli/blob/main/crates/cli/src/cli/chat/conversation_state.rs#L327

TODO:
Long-term: Come up with a way to preserve the history while fitting it in the context char limit

## Testing

Reproduced the issue. Now instead of returning an Improperly formed request, the user is able to continue:



https://github.com/user-attachments/assets/f4ada630-02d5-462b-b910-7efff3ccbfd2



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
