### PR TITLE
fix: fix for scope change to keep only copy of mcp server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -633,12 +633,8 @@ export class McpEventHandler {
         this.#shouldDisplayListMCPServers = false
 
         if (isEditMode && originalServerName) {
-            if (serverName !== originalServerName) {
-                await McpManager.instance.removeServer(originalServerName)
-                await McpManager.instance.addServer(serverName, config, configPath, personaPath)
-            } else {
-                await McpManager.instance.updateServer(serverName, config, configPath)
-            }
+            await McpManager.instance.removeServer(originalServerName)
+            await McpManager.instance.addServer(serverName, config, configPath, personaPath)
         } else {
             // Create new server
             await McpManager.instance.addServer(serverName, config, configPath, personaPath)


### PR DESCRIPTION
## Problem

Currently we store mcp server config in both config files after scope change.

## Solution
- we remove server from old config file and store it in new config file.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
