### PR TITLE
fix: mcp server should always load persona from workspace first

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -1010,7 +1010,12 @@ export class McpEventHandler {
      * @returns The persona path to use (workspace if exists, otherwise global)
      */
     async #getPersonaPath(): Promise<string> {
-        // Get the global path as fallback
+        const allPermissions = McpManager.instance.getAllPermissions()
+        for (const [, permission] of allPermissions) {
+            if (permission.__configPath__) {
+                return permission.__configPath__
+            }
+        }
         const globalPersonaPath = getGlobalPersonaConfigPath(this.#features.workspace.fs.getUserHomeDir())
 
         // Get workspace folders and check for workspace persona path

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -296,6 +296,10 @@ export class McpManager {
         return new Map(this.mcpServers)
     }
 
+    public getAllPermissions(): Map<string, MCPServerPermission> {
+        return new Map(this.mcpServerPermissions)
+    }
+
     /**
      * Map server names to their available tool names.
      */


### PR DESCRIPTION
## Problem
If a project persona is present, we seem to be reading from it, but writing to the global persona. This means that if a project persona is present, any changes you make in the IDE are not persisted.
## Solution
We are trying to use the persona from workspace right now? If we can not find one, we use global's.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
