### PR TITLE
fix: fix for correct initialization of tools with namespacing for ref…

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1592,8 +1592,6 @@ ${params.message}`,
             )
         } else if (['mcp-disable-server', 'mcp-delete-server', 'mcp-enable-server'].includes(params.id)) {
             messager.onListMcpServers()
-        } else if (params.id === 'refresh-mcp-list') {
-            messager.onListMcpServers({ 'refresh-mcp-list': 'refresh-mcp-list' })
         } else if (params.id === 'update-mcp-list') {
             if (isMcpServersListActive) {
                 messager.onListMcpServers()

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -552,8 +552,15 @@ export class McpManager {
         this.features.logging.info('Reinitializing MCP servers')
 
         try {
+            // Save the current tool name mapping to preserve tool names across reinitializations
+            const savedToolNameMapping = this.getToolNameMapping()
+
             // close clients, clear state, but don't reset singleton
             await this.close(true)
+
+            // Restore the saved tool name mapping
+            this.setToolNameMapping(savedToolNameMapping)
+
             await this.discoverAllServers()
 
             const reinitializedServerCount = McpManager.#instance?.mcpServers.size

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -337,6 +337,19 @@ export function createNamespacedToolName(
     allNamespacedTools: Set<string>,
     toolNameMapping: Map<string, { serverName: string; toolName: string }>
 ): string {
+    // First, check if this server/tool combination already has a mapping
+    // If it does, reuse that name to maintain consistency across reinitializations
+    for (const [existingName, mapping] of toolNameMapping.entries()) {
+        if (mapping.serverName === serverName && mapping.toolName === toolName) {
+            // If the name is already in the set, it's already registered
+            // If not, add it to the set
+            if (!allNamespacedTools.has(existingName)) {
+                allNamespacedTools.add(existingName)
+            }
+            return existingName
+        }
+    }
+
     const sep = '___'
     // If tool name alone isn't unique or is too long, try adding server prefix
     const fullName = `${serverName}${sep}${toolName}`


### PR DESCRIPTION
…resh

## Problem
When refreshed, we are seeing tools get initialized with wrong names causing chat item summary failures

## Solution
- Setting correct namespace when refreshing
- when refresh is complete, we don't force list mcp servers page

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
