### PR TITLE
fix: fix to refresh only one server that is enabled

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -759,9 +759,6 @@ export class McpEventHandler {
 
         try {
             await McpManager.instance.updateServerPermission(serverName, perm)
-            await this.#handleRefreshMCPList({
-                id: params.id,
-            })
         } catch (error) {
             this.#features.logging.error(`Failed to enable MCP server: ${error}`)
         }


### PR DESCRIPTION
## Problem
When an mcp server is enabled, all servers are getting refreshed.

## Solution
- fix to refresh only one server that is enabled
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
