### PR TITLE
fix: diff reports no lines added or removed

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1003,7 +1003,7 @@ export class AgenticChatController implements ChatHandlers {
 
                 if (toolUse.name === 'fsWrite') {
                     const input = toolUse.input as unknown as FsWriteParams
-                    const document = await this.#triggerContext.getTextDocument(input.path)
+                    const document = await this.#triggerContext.getTextDocumentFromPath(input.path, true, true)
                     session.toolUseLookup.set(toolUse.toolUseId, {
                         ...toolUse,
                         fileChange: { before: document?.getText() },
@@ -1058,7 +1058,13 @@ export class AgenticChatController implements ChatHandlers {
                         break
                     case 'fsWrite':
                         const input = toolUse.input as unknown as FsWriteParams
-                        const doc = await this.#triggerContext.getTextDocument(input.path)
+                        // Load from the filesystem instead of workspace.
+                        // Workspace is likely out of date - when files
+                        // are modified external to the IDE, many IDEs
+                        // will only update their file contents (which
+                        // then propagates to the LSP) if/when that
+                        // document receives focus.
+                        const doc = await this.#triggerContext.getTextDocumentFromPath(input.path, false, true)
                         const chatResult = await this.#getFsWriteChatResult(toolUse, doc, session)
                         const cachedToolUse = session.toolUseLookup.get(toolUse.toolUseId)
                         if (cachedToolUse) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -242,7 +242,7 @@ export class AgenticChatTriggerContext {
         if (textDocumentIdentifier?.uri === undefined) {
             return
         }
-        const textDocument = await this.getTextDocument(textDocumentIdentifier.uri)
+        const textDocument = await this.getTextDocumentFromUri(textDocumentIdentifier.uri)
 
         return textDocument
             ? this.#documentContextExtractor.extractDocumentContext(
@@ -255,14 +255,14 @@ export class AgenticChatTriggerContext {
     }
 
     /**
-     * Fetch the current textDocument such that:
+     * Fetch the current textDocument using a URI, such that:
      * 1. If the document is synced with LSP, return the synced textDocument
      * 2. If the document is not synced with LSP, read the file from the file system
      * 3. If the file cannot be read, return undefined
      * @param uri
      * @returns
      */
-    async getTextDocument(uri: string) {
+    async getTextDocumentFromUri(uri: string) {
         // Note: version is unused, and languageId can be determined from file extension.
         const syncedTextDocument = await this.#workspace.getTextDocument(uri)
         if (syncedTextDocument) {
@@ -271,9 +271,104 @@ export class AgenticChatTriggerContext {
         try {
             const content = await this.#workspace.fs.readFile(URI.parse(uri).fsPath)
             return TextDocument.create(uri, '', 0, content)
-        } catch {
+        } catch (err) {
+            this.#logging.error(`Unable to load from ${path}: ${err}`)
             return
         }
+    }
+
+    /**
+     * Fetch the current textDocument using a filesystem path, such that:
+     * 1. If the document is synced with LSP, return the synced textDocument
+     * 2. If the document is not synced with LSP, read the file from the file system
+     * 3. If the file cannot be read, return undefined
+     * @param path - path of file to load, not in URI format
+     * @param useWorkspace - attempt to load from the LSP workspace
+     * @param useFs - attempt to load directly from the filesystem, prioritizing workspace first
+     * @returns
+     */
+    async getTextDocumentFromPath(path: string, useWorkspace: boolean, useFs: boolean) {
+        try {
+            if (useWorkspace) {
+                // fetching documents from the workspace requires a URI formatted string
+                // eg: "file:///foo/bar.txt" or "file:///C:/foo/bar.txt"
+                var uris = this.getPossiblePathUris(path)
+
+                for (const uriStr of uris) {
+                    // Note: version is unused, and languageId can be determined from file extension.
+                    const wsTextDocument = await this.#workspace.getTextDocument(uriStr)
+                    if (wsTextDocument) {
+                        return wsTextDocument
+                    }
+                }
+
+                // If we get here, one of the following is possible:
+                // - the document exists, but we did not have the right lookup key
+                // - the document exists, but is not open in the editor
+                // - the document does not exist
+            }
+
+            if (useFs) {
+                const content = await this.#workspace.fs.readFile(path)
+                return TextDocument.create(path, '', 0, content)
+            }
+        } catch (err) {
+            this.#logging.error(`Unable to load from ${path}: ${err}`)
+            return
+        }
+    }
+
+    /**
+     * Given a path, return a set of the possible uri strings that could be used
+     * to represent the file in the workspace.
+     *
+     * This solves a problem where URI-parsing a windows path
+     * like C:\Foo\bar.txt creates a uri string of
+     *  file:///c%3A/Foo/bar.txt, but the workspace stores the file as
+     *  file:///C:/Foo/bar.txt or file:///c:/Foo/bar.txt
+     *
+     * The reason for this is the vscode-languageserver implementation used
+     * an implementation of URI that preserved colons, however the vscode-uri
+     * implementation of URI uses a "more correct" version that encodes the colons.
+     *
+     * Some of this function's implementation was inspired by the vscode-uri
+     * implementation of uriToFsPath
+     * https://github.com/microsoft/vscode-uri/blob/edfdccd976efaf4bb8fdeca87e97c47257721729/src/uri.ts#L564
+     */
+    getPossiblePathUris(path: string): string[] {
+        const uris = new Set<string>()
+
+        const uriStr = URI.file(path).toString()
+        uris.add(uriStr)
+
+        // On Windows the tool-generated path can have a different drive letter case
+        // from the URI stored in the lsp workspace. So we need to try
+        // lowercase and uppercase drive letters.
+        if (
+            process.platform === 'win32' &&
+            uriStr.startsWith('file:///') &&
+            uriStr.substring(9, 12).toLowerCase() == '%3a'
+        ) {
+            const driveLower = uriStr[8].toLowerCase()
+            const driveUpper = uriStr[8].toUpperCase()
+            const leadingPath = uriStr.substring(0, 8) // "file:///"
+            const encodedColonTrailingPath = uriStr.substring(9) // "%3A/Foo/bar.txt"
+            const colonTrailingPath = ':' + uriStr.substring(12) // ":/Foo/bar.txt"
+
+            // Some IDEs (eg: VS Code) index the workspace files using encoded paths.
+            // file:///c%3A/Foo/bar.txt
+            uris.add(leadingPath + driveLower + encodedColonTrailingPath)
+            // file:///C%3A/Foo/bar.txt
+            uris.add(leadingPath + driveUpper + encodedColonTrailingPath)
+
+            // Some IDEs (eg: VS) index the workspace files using paths containing colons.
+            // file:///c:/Foo/bar.txt
+            uris.add(leadingPath + driveLower + colonTrailingPath)
+            // file:///C:/Foo/bar.txt
+            uris.add(leadingPath + driveUpper + colonTrailingPath)
+        }
+
+        return [...uris]
     }
 
     async #getRelevantDocuments(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContexts.test.ts
@@ -7,6 +7,7 @@ import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as assert from 'assert'
 import * as fs from 'fs/promises'
 import { TextDocument } from 'vscode-languageserver-textdocument'
+import * as path from 'path'
 import * as sinon from 'sinon'
 import { AgenticChatTriggerContext } from './agenticChatTriggerContext'
 import { DocumentContext, DocumentContextExtractor } from '../../chat/contexts/documentContext'
@@ -194,11 +195,19 @@ describe('AgenticChatTriggerContext', () => {
         )
         assert.deepStrictEqual(chatParamsWithMore.conversationState?.workspaceId, 'test-workspace-123')
     })
-    describe('getTextDocument', function () {
+    describe('getTextDocument*', function () {
         let tempFolder: TestFolder
+
+        const mockDocument = {
+            uri: 'file://this/is/my/file.py',
+            languageId: 'python',
+            version: 0,
+        } as TextDocument
+        let mockDocumentFilepath: string
 
         before(async () => {
             tempFolder = await TestFolder.create()
+            mockDocumentFilepath = path.join(tempFolder.path, 'this/is/my/file.py')
         })
 
         afterEach(async () => {
@@ -209,44 +218,166 @@ describe('AgenticChatTriggerContext', () => {
             await tempFolder.delete()
         })
 
-        it('returns text document if it is synced', async function () {
-            const mockDocument = {
-                uri: 'file://this/is/my/file.py',
-                languageId: 'python',
-                version: 0,
-            } as TextDocument
-            testFeatures.workspace.getTextDocument.resolves(mockDocument)
+        describe('getTextDocumentFromUri', function () {
+            it('returns text document if it is synced', async function () {
+                testFeatures.workspace.getTextDocument.resolves(mockDocument)
 
-            const result = await new AgenticChatTriggerContext(testFeatures).getTextDocument(mockDocument.uri)
-            assert.deepStrictEqual(result, mockDocument)
+                const result = await new AgenticChatTriggerContext(testFeatures).getTextDocumentFromUri(
+                    mockDocument.uri
+                )
+                assert.deepStrictEqual(result, mockDocument)
+            })
+
+            it('falls back to file system if it is not synced', async function () {
+                const pythonContent = 'print("hello")'
+                const pythonFilePath = await tempFolder.write('pythonFile.py', pythonContent)
+                const uri = URI.file(pythonFilePath).toString()
+                testFeatures.workspace.getTextDocument.resolves(undefined)
+                testFeatures.workspace = {
+                    ...testFeatures.workspace,
+                    fs: {
+                        ...testFeatures.workspace.fs,
+                        readFile: path => fs.readFile(path, { encoding: 'utf-8' }),
+                    },
+                }
+                const result = await new AgenticChatTriggerContext(testFeatures).getTextDocumentFromUri(uri)
+
+                assert.ok(result)
+                assert.strictEqual(result.uri, uri)
+                assert.strictEqual(result.getText(), pythonContent)
+            })
+
+            it('returns undefined if both sync and fs fails', async function () {
+                const uri = 'file://not/a/real/path'
+                testFeatures.workspace.getTextDocument.resolves(undefined)
+
+                const result = await new AgenticChatTriggerContext(testFeatures).getTextDocumentFromUri(uri)
+
+                assert.deepStrictEqual(result, undefined)
+            })
         })
 
-        it('falls back to file system if it is not synced', async function () {
-            const pythonContent = 'print("hello")'
-            const pythonFilePath = await tempFolder.write('pythonFile.py', pythonContent)
-            const uri = URI.file(pythonFilePath).toString()
-            testFeatures.workspace.getTextDocument.resolves(undefined)
-            testFeatures.workspace = {
-                ...testFeatures.workspace,
-                fs: {
-                    ...testFeatures.workspace.fs,
-                    readFile: path => fs.readFile(path, { encoding: 'utf-8' }),
-                },
-            }
-            const result = await new AgenticChatTriggerContext(testFeatures).getTextDocument(uri)
+        describe('getTextDocumentFromPath', function () {
+            let fsContent: string
+            let fsPath: string
 
-            assert.ok(result)
-            assert.strictEqual(result.uri, uri)
-            assert.strictEqual(result.getText(), pythonContent)
-        })
+            this.beforeEach(async () => {
+                fsContent = 'print("hello")'
+                fsPath = await tempFolder.write('pythonFile.py', fsContent)
 
-        it('returns undefined if both sync and fs fails', async function () {
-            const uri = 'file://not/a/real/path'
-            testFeatures.workspace.getTextDocument.resolves(undefined)
+                testFeatures.workspace = {
+                    ...testFeatures.workspace,
+                    fs: {
+                        ...testFeatures.workspace.fs,
+                        readFile: path => fs.readFile(path, { encoding: 'utf-8' }),
+                    },
+                }
+            })
 
-            const result = await new AgenticChatTriggerContext(testFeatures).getTextDocument(uri)
+            describe('when text document is synced', function () {
+                this.beforeEach(async () => {
+                    testFeatures.workspace.getTextDocument.resolves(mockDocument)
+                })
 
-            assert.deepStrictEqual(result, undefined)
+                it('returns text document', async function () {
+                    const result = await new AgenticChatTriggerContext(testFeatures).getTextDocumentFromPath(
+                        mockDocumentFilepath,
+                        true,
+                        true
+                    )
+                    assert.deepStrictEqual(result, mockDocument)
+                })
+
+                it('loads from file system if workspace is not used', async function () {
+                    const result = await new AgenticChatTriggerContext(testFeatures).getTextDocumentFromPath(
+                        fsPath,
+                        false,
+                        true
+                    )
+
+                    assert.ok(result)
+                    assert.strictEqual(result.uri, fsPath)
+                    assert.strictEqual(result.getText(), fsContent)
+                })
+
+                if (process.platform === 'win32') {
+                    describe('Windows path to uri combinations', function () {
+                        for (const workspaceUri of [
+                            'file:///c%3A/Foo/bar.txt',
+                            'file:///C%3A/Foo/bar.txt',
+                            'file:///c:/Foo/bar.txt',
+                            'file:///C:/Foo/bar.txt',
+                        ]) {
+                            describe(`when workspace uri is: ${workspaceUri}`, function () {
+                                for (const path of ['c:\\Foo\\bar.txt', 'C:\\Foo\\bar.txt']) {
+                                    it(`loads when path is ${path}`, async function () {
+                                        const storedDocument = {
+                                            uri: workspaceUri,
+                                            languageId: 'python',
+                                            version: 0,
+                                        } as TextDocument
+
+                                        testFeatures.workspace.getTextDocument.callsFake((uri: string) => {
+                                            if (uri === workspaceUri) {
+                                                return Promise.resolve(storedDocument)
+                                            }
+                                            return Promise.resolve(undefined)
+                                        })
+
+                                        const result = await new AgenticChatTriggerContext(
+                                            testFeatures
+                                        ).getTextDocumentFromPath(path, true, false)
+
+                                        assert.ok(result)
+                                        assert.strictEqual(result.uri, workspaceUri)
+                                        assert.strictEqual(result, storedDocument)
+                                    })
+                                }
+                            })
+                        }
+                    })
+                }
+            })
+
+            describe('when text document is not synced', function () {
+                this.beforeEach(async () => {
+                    testFeatures.workspace.getTextDocument.resolves(undefined)
+                })
+
+                it('falls back to file system', async function () {
+                    const result = await new AgenticChatTriggerContext(testFeatures).getTextDocumentFromPath(
+                        fsPath,
+                        true,
+                        true
+                    )
+
+                    assert.ok(result)
+                    assert.strictEqual(result.uri, fsPath)
+                    assert.strictEqual(result.getText(), fsContent)
+                })
+
+                it('returns undefined if the file system is not used', async function () {
+                    const result = await new AgenticChatTriggerContext(testFeatures).getTextDocumentFromPath(
+                        fsPath,
+                        true,
+                        false
+                    )
+
+                    assert.deepStrictEqual(result, undefined)
+                })
+
+                it('returns undefined if fs fails', async function () {
+                    const filePath = path.join(tempFolder.path, 'not-a-real-path.txt')
+
+                    const result = await new AgenticChatTriggerContext(testFeatures).getTextDocumentFromPath(
+                        filePath,
+                        true,
+                        true
+                    )
+
+                    assert.deepStrictEqual(result, undefined)
+                })
+            })
         })
     })
 })


### PR DESCRIPTION
## Problem

When agentic chat modifies existing files, chat often reports the delta as +0 -0 (no file changes) on Windows systems.

![image](https://github.com/user-attachments/assets/35575a0d-df72-423f-bdb1-9699be2f8690)

This causes the following problems:
- clicking on the diff shows the entire file as a new change, instead of just the changed contents
- clicking Undo will delete the file, because chat thinks the file was newly added as a result of the modification

## Causes

- [getTextDocument](https://github.com/aws/language-servers/blob/9082323d1affe9cb71001aa76a216b690e892b06/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts#L265) is called with a mixture of strings that contain [uris](https://github.com/aws/language-servers/blob/9082323d1affe9cb71001aa76a216b690e892b06/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts#L245) and local filesystem paths ([1](https://github.com/aws/language-servers/blob/9082323d1affe9cb71001aa76a216b690e892b06/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts#L1006), [2](https://github.com/aws/language-servers/blob/9082323d1affe9cb71001aa76a216b690e892b06/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts#L1061))
- getTextDocument calls `workspace.getTextDocument` which is expecting a string in **uri** format. The calls made using local filesystem paths fail 100% of the time.
- when calls to `workspace.getTextDocument` fail, getTextDocument falls back to directly reading from the filesystem, however it tries to do this by parsing the given input (which is sometimes a local file path) into a Uri. This frequently throws an error, which causes getTextDocument to return undefined. Calling code incorrectly assumes this means its working with a new file.
- when getTextDocument is successful, the chat controller calls it again after modifying the file, which attempts to load from the LSP workspace (workspace.getTextDocument). There are times when the LSP workspace is not updated with the latest content, because some IDEs are slow to pick up changes from files altered outside of the IDE process. For example, some IDEs don't register file content changes when they do not have active focus until after the IDE receives focus again. As a result, the chat controller thinks the file contents before and after a change are the same.
- on Windows, there is some variation in the URI used to store each file in the LSP workspace. For example, VS Code currently looks like `file:///C%3A/Foo/bar.txt` but Visual Studio looks like `file:///C:/Foo/bar.txt`. When requesting LSP workspace files, the URI must be exact, and is case sensitive.

## Solution

- separate the getTextDocument calls, so callers can explicitly request content using a uri (`getTextDocumentFromUri`) or a filepath (`getTextDocumentFromPath`)
- when requesting a testDocument using a filepath on Windows, attempt to retrieve the document from the LSP workspace using a combination of different URI styles, and drive casings.
  - This increases the success rate obtaining the content from the LSP workspace.
  - This reduces the likelihood the system thinks the file is newly created
- only fetch file contents from the filesystem (not the LSP workspace) after the fsWrite tool alters a file, so that calling code has the true file contents from after a file modification.
  - This reduces the likelihood the system thinks the file has not been modified

This change was tested in Visual Studio, and using the sample VS Code extension in this repo. In both cases, I was able to see the problem occur before my change, and disappear after my change.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
