### PR TITLE
fix: fix to correctly store permissions if user reverts permission

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1582,8 +1582,11 @@ ${params.message}`,
                             // Handle action clicks (save, cancel, etc.)
                             messager.onMcpServerClick(action.id)
                         },
-                        onClose: () => {},
+                        onClose: () => {
+                            messager.onMcpServerClick('save-permission-change')
+                        },
                         onBackClick: () => {
+                            messager.onMcpServerClick('save-permission-change')
                             messager.onListMcpServers()
                         },
                     },


### PR DESCRIPTION
## Problem

When user updates MCP permission back to the original choice, we are getting that event with no permission information to update, so we are incorrectly updating permissions

## Solution
- we store all permission change events in permissionConfig variable, we save the permissions when user closes permission page, clicks back button or clicks on edit setup button.
- we reset the permissionConfig to undefined after saving the config.



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
