### PR TITLE
fix: prevent muting messages with completed status

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -932,7 +932,7 @@ export const createMynahUi = (
         const contentHorizontalAlignment: ChatItem['contentHorizontalAlignment'] = undefined
 
         // If message.header?.status?.text is Stopped or Rejected or Ignored or Completed etc.. card should be in disabled state.
-        const shouldMute = message.header?.status?.text !== undefined
+        const shouldMute = message.header?.status?.text !== undefined && message.header?.status?.text !== 'Completed'
 
         return {
             body: message.body,


### PR DESCRIPTION
## Overview
- Fixed a bug in the chat UI where messages with `Completed` status were incorrectly being muted
- Updated the condition to exclude "Completed" status messages from being muted in the UI

## Changes by File
- **chat-client/src/client/mynahUi.ts**: Modified the `shouldMute` condition to exclude messages with `Completed` status, ensuring they display normally in the UI.

## Notes
- This change only affects the visual presentation of messages with "Completed" status
- No other functionality changes were made

## Screenshots
![image](https://github.com/user-attachments/assets/ef55bcda-20ae-4dac-ad91-df49d46c91dd)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
