### PR TITLE
fix: changing server name for invalid server will show the correct error

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -670,7 +670,7 @@ export class McpEventHandler {
             // Stay on add/edit page and show error to user
             if (isEditMode) {
                 params.id = 'edit-mcp'
-                params.title = originalServerName!
+                params.title = serverName
                 return this.#handleEditMcpServer(params)
             } else {
                 params.id = 'add-new-mcp'


### PR DESCRIPTION
## Problem
1) User has an invalid server
2) An invalid server appears in the MCP servers list with a "Fix Configuration" button
3) User clicks the "Fix Configuration" button, changes the server name, and saves the configuration
4) The error message still references the original server name instead of the updated one

https://github.com/user-attachments/assets/5c678fab-6254-4a63-9436-f94289575189


## Solution
- Update the error handling logic to track and display the most recently entered server name rather than referencing the original invalid configuration.

https://github.com/user-attachments/assets/9f7049c5-08c3-4126-8684-c0a7532318db










<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
