### PR TITLE
fix(amazonq): skip sending websocket request when uploading fails

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
@@ -226,6 +226,7 @@ export class WorkspaceFolderManager {
             )
         } catch (e: any) {
             this.logging.warn(`Error uploading file to S3: ${e.message}`)
+            return
         }
         return s3Url
     }
@@ -604,7 +605,7 @@ export class WorkspaceFolderManager {
 
                 if (!s3Url) {
                     this.logging.warn(
-                        `Failed to get S3 URL for file in workspaceFolder: ${fileMetadata.workspaceFolder.name}`
+                        `Failed to upload to S3 for file in workspaceFolder: ${fileMetadata.workspaceFolder.name}`
                     )
                     continue
                 }


### PR DESCRIPTION
## Problem

We want to skip sending websocket request when uploading to S3 fails

## Solution

Let `uploadToS3` function return `undefined` to the callers when there is an exception.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
