### PR TITLE
feat: add NYC code coverage support across monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ build
 **/out
 **/bundle
 **/node_modules
+
+# Coverage reports
+**/coverage
+**/.nyc_output
 **/.vscode-test
 !/bin
 *.tsbuildinfo

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,32 +1,32 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "*/src/**/*.ts",
-    "server/*/src/**/*.ts",
-    "app/*/src/**/*.ts", 
-    "core/*/src/**/*.ts",
-    "client/*/src/**/*.ts",
-    "chat-client/src/**/*.ts"
-  ],
-  "exclude": [
-    "**/*.test.ts",
-    "**/*.spec.ts", 
-    "**/test/**",
-    "**/*TestConstants.ts",
-    "**/*.d.ts",
-    "**/node_modules/**",
-    "**/out/**",
-    "**/dist/**",
-    "**/coverage/**",
-    "**/build/**",
-    "**/*.json"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": [
+        "*/src/**/*.ts",
+        "server/*/src/**/*.ts",
+        "app/*/src/**/*.ts",
+        "core/*/src/**/*.ts",
+        "client/*/src/**/*.ts",
+        "chat-client/src/**/*.ts"
+    ],
+    "exclude": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/test/**",
+        "**/*TestConstants.ts",
+        "**/*.d.ts",
+        "**/node_modules/**",
+        "**/out/**",
+        "**/dist/**",
+        "**/coverage/**",
+        "**/build/**",
+        "**/*.json"
+    ],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,32 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "*/src/**/*.ts",
+    "server/*/src/**/*.ts",
+    "app/*/src/**/*.ts", 
+    "core/*/src/**/*.ts",
+    "client/*/src/**/*.ts",
+    "chat-client/src/**/*.ts"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts", 
+    "**/test/**",
+    "**/*TestConstants.ts",
+    "**/*.d.ts",
+    "**/node_modules/**",
+    "**/out/**",
+    "**/dist/**",
+    "**/coverage/**",
+    "**/build/**",
+    "**/*.json"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,6 +245,43 @@ Using other clients can also be done with the bundle created from this package.
 npm test
 ```
 
+#### Running Tests with Coverage
+
+This repository supports code coverage reporting using [NYC (Istanbul)](https://github.com/istanbuljs/nyc) across multiple packages. Coverage is available for packages that use TypeScript with ts-mocha or regular mocha testing frameworks.
+
+**Individual Package Coverage:**
+```bash
+# Run coverage for a specific package
+npm run test:coverage --workspace=server/aws-lsp-codewhisperer
+npm run test:coverage --workspace=server/aws-lsp-json
+npm run test:coverage --workspace=chat-client
+npm run test:coverage --workspace=server/hello-world-lsp
+
+# Generate HTML coverage reports for a specific package
+npm run coverage:report --workspace=server/aws-lsp-codewhisperer
+```
+
+**Repository-Wide Coverage:**
+```bash
+# Run coverage across all packages that support it
+npm run test:coverage
+
+# Generate repository-wide coverage reports
+npm run coverage:report
+```
+
+**Coverage Reports:**
+- **Terminal output**: Shows coverage percentages and uncovered lines
+- **HTML reports**: Generated in each package's `coverage/` directory
+- **LCOV reports**: Generated for CI/CD integration
+
+**Packages with Coverage Support:**
+- ✅ **server/aws-lsp-codewhisperer**: Full TypeScript coverage (~55% coverage)
+- ✅ **server/aws-lsp-json**: Full TypeScript coverage (~65% coverage)  
+- ✅ **server/hello-world-lsp**: Full TypeScript coverage (~65% coverage)
+- ✅ **chat-client**: Full TypeScript coverage (~63% coverage)
+- 🔧 **Additional packages**: Infrastructure in place, can be activated as needed
+
 ---
 
 ### Writing Tests

--- a/app/aws-lsp-antlr4-runtimes/.nycrc.json
+++ b/app/aws-lsp-antlr4-runtimes/.nycrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "out/**/*.js"
+  ],
+  "exclude": [
+    "out/**/*.test.js",
+    "out/**/*.spec.js",
+    "out/**/test/**",
+    "out/**/*TestConstants.js",
+    "out/**/*.d.ts"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70,
+  "source-map": true
+}

--- a/app/aws-lsp-antlr4-runtimes/.nycrc.json
+++ b/app/aws-lsp-antlr4-runtimes/.nycrc.json
@@ -1,22 +1,14 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "out/**/*.js"
-  ],
-  "exclude": [
-    "out/**/*.test.js",
-    "out/**/*.spec.js",
-    "out/**/test/**",
-    "out/**/*TestConstants.js",
-    "out/**/*.d.ts"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70,
-  "source-map": true
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["out/**/*.js"],
+    "exclude": ["out/**/*.test.js", "out/**/*.spec.js", "out/**/test/**", "out/**/*TestConstants.js", "out/**/*.d.ts"],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70,
+    "source-map": true
 }

--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -9,7 +9,10 @@
         "package": "npm run compile && npm run webpack",
         "test": "npm run test-integ",
         "test-integ": "npm run package && mocha --timeout 5000 \"./out/**/*Integ.test.js\" --retries 2",
-        "webpack": "webpack"
+        "webpack": "webpack",
+        "test-integ:coverage": "npm run package && nyc mocha --timeout 5000 \"./out/**/*Integ.test.js\" --retries 2",
+        "test:coverage": "npm run test-integ:coverage",
+        "coverage:report": "nyc report --reporter=html --reporter=text"
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.90",
@@ -18,6 +21,7 @@
         "antlr4ng": "^3.0.4"
     },
     "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/chai": "^4.3.5",
         "@types/chai-as-promised": "^7.1.5",
         "@types/mocha": "^10.0.9",
@@ -25,6 +29,7 @@
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "mocha": "^11.0.1",
+        "nyc": "^17.1.0",
         "ts-loader": "^9.4.4",
         "ts-lsp-client": "^1.0.3",
         "webpack": "^5.94.0",

--- a/app/aws-lsp-json-runtimes/.nycrc.json
+++ b/app/aws-lsp-json-runtimes/.nycrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "out/**/*.js"
+  ],
+  "exclude": [
+    "out/**/*.test.js",
+    "out/**/*.spec.js",
+    "out/**/test/**",
+    "out/**/*TestConstants.js",
+    "out/**/*.d.ts"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70,
+  "source-map": true
+}

--- a/app/aws-lsp-json-runtimes/.nycrc.json
+++ b/app/aws-lsp-json-runtimes/.nycrc.json
@@ -1,22 +1,14 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "out/**/*.js"
-  ],
-  "exclude": [
-    "out/**/*.test.js",
-    "out/**/*.spec.js",
-    "out/**/test/**",
-    "out/**/*TestConstants.js",
-    "out/**/*.d.ts"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70,
-  "source-map": true
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["out/**/*.js"],
+    "exclude": ["out/**/*.test.js", "out/**/*.spec.js", "out/**/test/**", "out/**/*TestConstants.js", "out/**/*.d.ts"],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70,
+    "source-map": true
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -8,19 +8,24 @@
         "package": "npm run compile && npm run webpack",
         "test": "npm run test-integ",
         "test-integ": "npm run package && mocha --timeout 5000 \"./out/**/*Integ.test.js\" --retries 2",
-        "webpack": "webpack"
+        "webpack": "webpack",
+        "test-integ:coverage": "npm run package && nyc mocha --timeout 5000 \"./out/**/*Integ.test.js\" --retries 2",
+        "test:coverage": "npm run test-integ:coverage",
+        "coverage:report": "nyc report --reporter=html --reporter=text"
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.90",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/chai": "^4.3.5",
         "@types/chai-as-promised": "^7.1.5",
         "@types/mocha": "^10.0.9",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "mocha": "^11.0.1",
+        "nyc": "^17.1.0",
         "ts-loader": "^9.4.4",
         "ts-lsp-client": "^1.0.3",
         "webpack": "^5.94.0",

--- a/app/aws-lsp-yaml-runtimes/.nycrc.json
+++ b/app/aws-lsp-yaml-runtimes/.nycrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "out/**/*.js"
+  ],
+  "exclude": [
+    "out/**/*.test.js",
+    "out/**/*.spec.js",
+    "out/**/test/**",
+    "out/**/*TestConstants.js",
+    "out/**/*.d.ts"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70,
+  "source-map": true
+}

--- a/app/aws-lsp-yaml-runtimes/.nycrc.json
+++ b/app/aws-lsp-yaml-runtimes/.nycrc.json
@@ -1,22 +1,14 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "out/**/*.js"
-  ],
-  "exclude": [
-    "out/**/*.test.js",
-    "out/**/*.spec.js",
-    "out/**/test/**",
-    "out/**/*TestConstants.js",
-    "out/**/*.d.ts"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70,
-  "source-map": true
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["out/**/*.js"],
+    "exclude": ["out/**/*.test.js", "out/**/*.spec.js", "out/**/test/**", "out/**/*TestConstants.js", "out/**/*.d.ts"],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70,
+    "source-map": true
 }

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -8,19 +8,24 @@
         "package": "npm run compile && npm run webpack",
         "test": "npm run test-integ",
         "test-integ": "npm run package && mocha --timeout 8000 \"./out/**/*Integ.test.js\" --retries 2",
-        "webpack": "webpack"
+        "webpack": "webpack",
+        "test-integ:coverage": "npm run package && nyc mocha --timeout 8000 \"./out/**/*Integ.test.js\" --retries 2",
+        "test:coverage": "npm run test-integ:coverage",
+        "coverage:report": "nyc report --reporter=html --reporter=text"
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.90",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/chai": "^4.3.5",
         "@types/chai-as-promised": "^7.1.5",
         "@types/mocha": "^10.0.9",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "mocha": "^11.0.1",
+        "nyc": "^17.1.0",
         "ts-loader": "^9.4.4",
         "ts-lsp-client": "^1.0.3",
         "umd-compat-loader": "^2.1.2",

--- a/app/hello-world-lsp-runtimes/.nycrc.json
+++ b/app/hello-world-lsp-runtimes/.nycrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "out/**/*.js"
+  ],
+  "exclude": [
+    "out/**/*.test.js",
+    "out/**/*.spec.js",
+    "out/**/test/**",
+    "out/**/*TestConstants.js",
+    "out/**/*.d.ts"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70,
+  "source-map": true
+}

--- a/app/hello-world-lsp-runtimes/.nycrc.json
+++ b/app/hello-world-lsp-runtimes/.nycrc.json
@@ -1,22 +1,14 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "out/**/*.js"
-  ],
-  "exclude": [
-    "out/**/*.test.js",
-    "out/**/*.spec.js",
-    "out/**/test/**",
-    "out/**/*TestConstants.js",
-    "out/**/*.d.ts"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70,
-  "source-map": true
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["out/**/*.js"],
+    "exclude": ["out/**/*.test.js", "out/**/*.spec.js", "out/**/test/**", "out/**/*TestConstants.js", "out/**/*.d.ts"],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70,
+    "source-map": true
 }

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -11,19 +11,24 @@
         "lint:bundle:webworker": "webpack && eslint out/hello-world-lsp-webworker.js",
         "test": "npm run test-integ",
         "test-integ": "npm run package && mocha --timeout 5000 \"./out/**/*Integ.test.js\"",
-        "webpack": "webpack"
+        "webpack": "webpack",
+        "test-integ:coverage": "npm run package && nyc mocha --timeout 5000 \"./out/**/*Integ.test.js\"",
+        "test:coverage": "npm run test-integ:coverage",
+        "coverage:report": "nyc report --reporter=html --reporter=text"
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
         "@aws/language-server-runtimes": "^0.2.90"
     },
     "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/chai": "^4.3.5",
         "@types/chai-as-promised": "^7.1.5",
         "@types/mocha": "^10.0.9",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "mocha": "^11.0.1",
+        "nyc": "^17.1.0",
         "ts-loader": "^9.4.4",
         "ts-lsp-client": "^1.0.3",
         "webpack": "^5.94.0",

--- a/chat-client/.nycrc.json
+++ b/chat-client/.nycrc.json
@@ -1,21 +1,13 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/test/**",
-    "src/**/*TestConstants.ts",
-    "src/**/*.d.ts"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["src/**/*.ts"],
+    "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/test/**", "src/**/*TestConstants.ts", "src/**/*.d.ts"],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70
 }

--- a/chat-client/.nycrc.json
+++ b/chat-client/.nycrc.json
@@ -1,0 +1,21 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/test/**",
+    "src/**/*TestConstants.ts",
+    "src/**/*.d.ts"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70
+}

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -18,7 +18,10 @@
         "test:unit": "ts-mocha -b \"./src/**/*.test.ts\"",
         "test": "npm run test:unit",
         "fix:prettier": "prettier . --write",
-        "package": "webpack"
+        "package": "webpack",
+        "test:unit:coverage": "nyc ts-mocha -b \"./src/**/*.test.ts\"",
+        "test:coverage": "npm run test:unit:coverage",
+        "coverage:report": "nyc report --reporter=html --reporter=text"
     },
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.40",
@@ -26,10 +29,12 @@
         "@aws/mynah-ui": "^4.35.2"
     },
     "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/jsdom": "^21.1.6",
         "@types/mocha": "^10.0.9",
         "assert": "^2.0.0",
         "jsdom": "^24.0.0",
+        "nyc": "^17.1.0",
         "sinon": "^19.0.2",
         "ts-mocha": "^11.1.0",
         "ts-sinon": "^2.0.2",

--- a/core/aws-lsp-core/.nycrc.json
+++ b/core/aws-lsp-core/.nycrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "out/**/*.js"
+  ],
+  "exclude": [
+    "out/**/*.test.js",
+    "out/**/*.spec.js",
+    "out/**/test/**",
+    "out/**/*TestConstants.js",
+    "out/**/*.d.ts"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70,
+  "source-map": true
+}

--- a/core/aws-lsp-core/.nycrc.json
+++ b/core/aws-lsp-core/.nycrc.json
@@ -1,22 +1,14 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "out/**/*.js"
-  ],
-  "exclude": [
-    "out/**/*.test.js",
-    "out/**/*.spec.js",
-    "out/**/test/**",
-    "out/**/*TestConstants.js",
-    "out/**/*.d.ts"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70,
-  "source-map": true
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["out/**/*.js"],
+    "exclude": ["out/**/*.test.js", "out/**/*.spec.js", "out/**/test/**", "out/**/*TestConstants.js", "out/**/*.d.ts"],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70,
+    "source-map": true
 }

--- a/core/aws-lsp-core/package.json
+++ b/core/aws-lsp-core/package.json
@@ -22,27 +22,32 @@
         "compile": "tsc --build",
         "test": "npm run test-unit",
         "test-unit": "mocha --timeout 0 \"./out/**/*.test.js\"",
-        "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
+        "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md .",
+        "test-unit:coverage": "npm run compile && nyc mocha --timeout 0 \"./out/**/*.test.js\"",
+        "test:coverage": "npm run test-unit:coverage",
+        "coverage:report": "nyc report --reporter=html --reporter=text"
     },
     "dependencies": {
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
-        "jose": "^5.2.4",
         "cross-spawn": "7.0.6",
+        "jose": "^5.2.4",
         "request-light": "^0.8.0",
         "vscode-languageserver-textdocument": "^1.0.8",
         "vscode-languageserver-types": "^3.17.3",
         "vscode-uri": "^3.1.0"
     },
     "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/chai": "^4.3.5",
-        "@types/cross-spawn": "^6.0.2",
         "@types/chai-as-promised": "^7.1.5",
+        "@types/cross-spawn": "^6.0.2",
         "@types/mocha": "^10.0.9",
         "@types/mock-fs": "^4.13.1",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "mocha": "^11.0.1",
         "mock-fs": "^5.2.0",
+        "nyc": "^17.1.0",
         "sinon": "^19.0.2",
         "ts-sinon": "^2.0.2"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
             "devDependencies": {
                 "@commitlint/cli": "^19.8.0",
                 "@commitlint/config-conventional": "^19.8.0",
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@types/node": "^22.9.0",
                 "@typescript-eslint/eslint-plugin": "^8.32.1",
                 "@typescript-eslint/parser": "^8.32.1",
@@ -32,6 +33,7 @@
                 "eslint-plugin-unused-imports": "^4.1.4",
                 "husky": "^9.1.7",
                 "node-loader": "^2.1.0",
+                "nyc": "^17.1.0",
                 "prettier": "^3.3.3",
                 "pretty-quick": "^4.0.0",
                 "shx": "^0.3.4",
@@ -48,6 +50,7 @@
                 "antlr4ng": "^3.0.4"
             },
             "devDependencies": {
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@types/chai": "^4.3.5",
                 "@types/chai-as-promised": "^7.1.5",
                 "@types/mocha": "^10.0.9",
@@ -55,6 +58,7 @@
                 "chai": "^4.3.7",
                 "chai-as-promised": "^7.1.1",
                 "mocha": "^11.0.1",
+                "nyc": "^17.1.0",
                 "ts-loader": "^9.4.4",
                 "ts-lsp-client": "^1.0.3",
                 "webpack": "^5.94.0",
@@ -124,12 +128,14 @@
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@types/chai": "^4.3.5",
                 "@types/chai-as-promised": "^7.1.5",
                 "@types/mocha": "^10.0.9",
                 "chai": "^4.3.7",
                 "chai-as-promised": "^7.1.1",
                 "mocha": "^11.0.1",
+                "nyc": "^17.1.0",
                 "ts-loader": "^9.4.4",
                 "ts-lsp-client": "^1.0.3",
                 "webpack": "^5.94.0",
@@ -208,12 +214,14 @@
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@types/chai": "^4.3.5",
                 "@types/chai-as-promised": "^7.1.5",
                 "@types/mocha": "^10.0.9",
                 "chai": "^4.3.7",
                 "chai-as-promised": "^7.1.1",
                 "mocha": "^11.0.1",
+                "nyc": "^17.1.0",
                 "ts-loader": "^9.4.4",
                 "ts-lsp-client": "^1.0.3",
                 "umd-compat-loader": "^2.1.2",
@@ -229,12 +237,14 @@
                 "@aws/language-server-runtimes": "^0.2.90"
             },
             "devDependencies": {
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@types/chai": "^4.3.5",
                 "@types/chai-as-promised": "^7.1.5",
                 "@types/mocha": "^10.0.9",
                 "chai": "^4.3.7",
                 "chai-as-promised": "^7.1.1",
                 "mocha": "^11.0.1",
+                "nyc": "^17.1.0",
                 "ts-loader": "^9.4.4",
                 "ts-lsp-client": "^1.0.3",
                 "webpack": "^5.94.0",
@@ -251,10 +261,12 @@
                 "@aws/mynah-ui": "^4.35.2"
             },
             "devDependencies": {
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@types/jsdom": "^21.1.6",
                 "@types/mocha": "^10.0.9",
                 "assert": "^2.0.0",
                 "jsdom": "^24.0.0",
+                "nyc": "^17.1.0",
                 "sinon": "^19.0.2",
                 "ts-mocha": "^11.1.0",
                 "ts-sinon": "^2.0.2",
@@ -295,6 +307,7 @@
                 "vscode-uri": "^3.1.0"
             },
             "devDependencies": {
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@types/chai": "^4.3.5",
                 "@types/chai-as-promised": "^7.1.5",
                 "@types/cross-spawn": "^6.0.2",
@@ -304,6 +317,7 @@
                 "chai-as-promised": "^7.1.1",
                 "mocha": "^11.0.1",
                 "mock-fs": "^5.2.0",
+                "nyc": "^17.1.0",
                 "sinon": "^19.0.2",
                 "ts-sinon": "^2.0.2"
             },
@@ -6138,6 +6152,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@istanbuljs/nyc-config-typescript": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.2.tgz",
+            "integrity": "sha512-iKGIyMoyJuFnJRSVTZ78POIRvNnwZaWIf8vG4ZS3rQq58MMDrqEX2nnzx0R28V2X8JvmKYiqY9FP2hlJsm8A0w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@istanbuljs/schema": "^0.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "peerDependencies": {
+                "nyc": ">=15"
+            }
+        },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -10442,6 +10472,20 @@
                 "node": ">= 14"
             }
         },
+        "node_modules/aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ajv": {
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -10600,6 +10644,19 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/append-transform": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+            "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "default-require-extensions": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/archiver": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -10635,6 +10692,13 @@
             "engines": {
                 "node": ">= 14"
             }
+        },
+        "node_modules/archy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/arg": {
             "version": "4.1.3",
@@ -11737,6 +11801,58 @@
                 "node": ">=8"
             }
         },
+        "node_modules/caching-transform": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+            "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasha": "^5.0.0",
+                "make-dir": "^3.0.0",
+                "package-hash": "^4.0.0",
+                "write-file-atomic": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/caching-transform/node_modules/make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/caching-transform/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/caching-transform/node_modules/write-file-atomic": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+            "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4",
+                "is-typedarray": "^1.0.0",
+                "signal-exit": "^3.0.2",
+                "typedarray-to-buffer": "^3.1.5"
+            }
+        },
         "node_modules/call-bind": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -12157,6 +12273,16 @@
                 "node": ">= 10.0"
             }
         },
+        "node_modules/clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/cli-width": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -12334,6 +12460,13 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "devOptional": true,
+            "license": "MIT"
+        },
+        "node_modules/commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/compare-func": {
@@ -13221,6 +13354,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/default-require-extensions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+            "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "strip-bom": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/defaults": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -14027,6 +14176,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/esbuild": {
             "version": "0.25.2",
@@ -15235,6 +15391,40 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "license": "MIT"
         },
+        "node_modules/find-cache-dir": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+            "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commondir": "^1.0.1",
+                "make-dir": "^3.0.2",
+                "pkg-dir": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+            }
+        },
+        "node_modules/find-cache-dir/node_modules/make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/find-up": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
@@ -15380,6 +15570,27 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/fromentries": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+            "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -15935,6 +16146,33 @@
                 "minimalistic-assert": "^1.0.1"
             }
         },
+        "node_modules/hasha": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+            "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-stream": "^2.0.0",
+                "type-fest": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/hasha/node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -16486,6 +16724,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/inflight": {
@@ -17116,6 +17364,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -17175,6 +17430,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-wsl": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
@@ -17221,6 +17486,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/istanbul-lib-hook": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+            "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "append-transform": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/istanbul-lib-instrument": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
@@ -17249,6 +17527,34 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-processinfo": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+            "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "archy": "^1.0.0",
+                "cross-spawn": "^7.0.3",
+                "istanbul-lib-coverage": "^3.2.0",
+                "p-map": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/istanbul-lib-report": {
@@ -19983,6 +20289,19 @@
                 "webpack": "^5.0.0"
             }
         },
+        "node_modules/node-preload": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+            "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "process-on-spawn": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/node-releases": {
             "version": "2.0.19",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -20105,6 +20424,309 @@
             "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/nyc": {
+            "version": "17.1.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
+            "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "caching-transform": "^4.0.0",
+                "convert-source-map": "^1.7.0",
+                "decamelize": "^1.2.0",
+                "find-cache-dir": "^3.2.0",
+                "find-up": "^4.1.0",
+                "foreground-child": "^3.3.0",
+                "get-package-type": "^0.1.0",
+                "glob": "^7.1.6",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-hook": "^3.0.0",
+                "istanbul-lib-instrument": "^6.0.2",
+                "istanbul-lib-processinfo": "^2.0.2",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.0.2",
+                "make-dir": "^3.0.0",
+                "node-preload": "^0.2.1",
+                "p-map": "^3.0.0",
+                "process-on-spawn": "^1.0.0",
+                "resolve-from": "^5.0.0",
+                "rimraf": "^3.0.0",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^2.0.0",
+                "test-exclude": "^6.0.0",
+                "yargs": "^15.0.2"
+            },
+            "bin": {
+                "nyc": "bin/nyc.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/nyc/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/nyc/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/nyc/node_modules/cliui": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
+            }
+        },
+        "node_modules/nyc/node_modules/convert-source-map": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/nyc/node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/nyc/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/nyc/node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/nyc/node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/nyc/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/nyc/node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/nyc/node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/nyc/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/y18n": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/nyc/node_modules/yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
@@ -20425,6 +21047,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-map": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+            "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "aggregate-error": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/p-retry": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
@@ -20484,6 +21119,22 @@
             },
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/package-hash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+            "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "graceful-fs": "^4.1.15",
+                "hasha": "^5.0.0",
+                "lodash.flattendeep": "^4.4.0",
+                "release-zalgo": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/package-json-from-dist": {
@@ -21263,6 +21914,19 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "license": "MIT"
         },
+        "node_modules/process-on-spawn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.1.0.tgz",
+            "integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fromentries": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/process-warning": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
@@ -21977,6 +22641,19 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/release-zalgo": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+            "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "es6-error": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/renderkid": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -22014,6 +22691,13 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/requires-port": {
             "version": "1.0.0",
@@ -22749,6 +23433,13 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/set-function-length": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -23201,6 +23892,61 @@
                 }
             ],
             "license": "Apache-2.0"
+        },
+        "node_modules/spawn-wrap": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+            "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "make-dir": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "signal-exit": "^3.0.2",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/spawn-wrap/node_modules/foreground-child": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+            "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/spawn-wrap/node_modules/make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/spawn-wrap/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
@@ -24678,6 +25424,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-typedarray": "^1.0.0"
+            }
+        },
         "node_modules/typescript": {
             "version": "5.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -25925,6 +26681,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/which-module": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+            "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/which-typed-array": {
             "version": "1.1.19",
             "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
@@ -26644,6 +27407,7 @@
                 "xmlbuilder2": "^3.1.1"
             },
             "devDependencies": {
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@types/adm-zip": "^0.5.5",
                 "@types/archiver": "^6.0.2",
                 "@types/diff": "^7.0.2",
@@ -26654,6 +27418,7 @@
                 "assert": "^2.1.0",
                 "copyfiles": "^2.4.1",
                 "mock-fs": "^5.2.0",
+                "nyc": "^17.1.0",
                 "sinon": "^19.0.2",
                 "ts-loader": "^9.4.4",
                 "ts-mocha": "^11.1.0",
@@ -26762,6 +27527,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.734.0",
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@smithy/types": "^3.4.1",
                 "@types/chai": "^4.3.5",
                 "@types/chai-as-promised": "^7.1.5",
@@ -26772,6 +27538,7 @@
                 "chai-as-promised": "^7.1.1",
                 "copyfiles": "^2.4.1",
                 "mock-fs": "^5.2.0",
+                "nyc": "^17.1.0",
                 "sinon": "^19.0.2",
                 "ts-loader": "^9.5.1",
                 "ts-mocha": "^11.1.0",
@@ -26804,6 +27571,10 @@
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
             },
+            "devDependencies": {
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
+                "nyc": "^17.1.0"
+            },
             "engines": {
                 "node": ">=18.0.0"
             }
@@ -26819,6 +27590,7 @@
             },
             "devDependencies": {
                 "@aws-sdk/types": "^3.734.0",
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
                 "@smithy/types": "^3.4.1",
                 "@types/chai": "^4.3.5",
                 "@types/chai-as-promised": "^7.1.5",
@@ -26828,6 +27600,7 @@
                 "chai": "^4.3.7",
                 "chai-as-promised": "^7.1.1",
                 "mock-fs": "^5.2.0",
+                "nyc": "^17.1.0",
                 "sinon": "^19.0.2",
                 "ts-loader": "^9.5.1",
                 "ts-mocha": "^11.1.0",
@@ -26917,6 +27690,8 @@
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
+                "@istanbuljs/nyc-config-typescript": "^1.0.2",
+                "nyc": "^17.1.0",
                 "ts-loader": "^9.4.4",
                 "webpack": "^5.94.0",
                 "webpack-cli": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "compile:rest": "npm run compile --workspace app --workspace client --workspace chat-client --if-present",
         "watch": "tsc --build --watch",
         "test": "npm run compile && npm run test --workspaces --if-present",
-        "test-integ": "npm run compile && npm run test-integ --workspaces --if-present", 
+        "test-integ": "npm run compile && npm run test-integ --workspaces --if-present",
         "test-unit": "npm run compile && npm run test-unit --workspaces --if-present",
         "test:coverage": "npm run compile && npm run test:coverage --workspaces --if-present",
         "coverage:report": "nyc report --reporter=html --reporter=text",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,11 @@
         "compile:rest": "npm run compile --workspace app --workspace client --workspace chat-client --if-present",
         "watch": "tsc --build --watch",
         "test": "npm run compile && npm run test --workspaces --if-present",
-        "test-integ": "npm run compile && npm run test-integ --workspaces --if-present",
+        "test-integ": "npm run compile && npm run test-integ --workspaces --if-present", 
         "test-unit": "npm run compile && npm run test-unit --workspaces --if-present",
+        "test:coverage": "npm run compile && npm run test:coverage --workspaces --if-present",
+        "coverage:report": "nyc report --reporter=html --reporter=text",
+        "coverage:check": "nyc check-coverage --lines 70 --functions 70 --branches 70 --statements 70",
         "package": "npm run compile && npm run package --workspaces --if-present"
     },
     "dependencies": {
@@ -38,6 +41,7 @@
     "devDependencies": {
         "@commitlint/cli": "^19.8.0",
         "@commitlint/config-conventional": "^19.8.0",
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/node": "^22.9.0",
         "@typescript-eslint/eslint-plugin": "^8.32.1",
         "@typescript-eslint/parser": "^8.32.1",
@@ -47,6 +51,7 @@
         "eslint-plugin-unused-imports": "^4.1.4",
         "husky": "^9.1.7",
         "node-loader": "^2.1.0",
+        "nyc": "^17.1.0",
         "prettier": "^3.3.3",
         "pretty-quick": "^4.0.0",
         "shx": "^0.3.4",

--- a/server/aws-lsp-codewhisperer/.nycrc.json
+++ b/server/aws-lsp-codewhisperer/.nycrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/test/**",
+    "src/**/*TestConstants.ts",
+    "src/**/*.d.ts",
+    "src/client/**/*.json"
+  ],
+  "branches": 80,
+  "lines": 80,
+  "functions": 80,
+  "statements": 80
+}

--- a/server/aws-lsp-codewhisperer/.nycrc.json
+++ b/server/aws-lsp-codewhisperer/.nycrc.json
@@ -1,22 +1,20 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/test/**",
-    "src/**/*TestConstants.ts",
-    "src/**/*.d.ts",
-    "src/client/**/*.json"
-  ],
-  "branches": 80,
-  "lines": 80,
-  "functions": 80,
-  "statements": 80
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["src/**/*.ts"],
+    "exclude": [
+        "src/**/*.test.ts",
+        "src/**/*.spec.ts",
+        "src/**/test/**",
+        "src/**/*TestConstants.ts",
+        "src/**/*.d.ts",
+        "src/client/**/*.json"
+    ],
+    "branches": 80,
+    "lines": 80,
+    "functions": 80,
+    "statements": 80
 }

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -22,7 +22,11 @@
         "lint:bundle:webworker": "webpack --config webpack.lint.config.js && eslint bundle/aws-lsp-codewhisperer-webworker.js # Verify compatibility with web runtime target",
         "lint:src": "eslint src/ --ext .ts,.tsx",
         "test:unit": "ts-mocha --timeout 0 -b \"./src/**/*.test.ts\"",
+        "test:unit:coverage": "nyc ts-mocha --timeout 0 -b \"./src/**/*.test.ts\"",
         "test": "npm run lint && npm run test:unit",
+        "test:coverage": "npm run lint && npm run test:unit:coverage",
+        "coverage:report": "nyc report --reporter=html --reporter=text",
+        "coverage:check": "nyc check-coverage --lines 80 --functions 80 --branches 80 --statements 80",
         "prepack": "npm run compile && ts-node ../../script/link_bundled_dependencies.ts",
         "postinstall": "node ./script/install_transitive_dep.js"
     },
@@ -62,6 +66,7 @@
         "xmlbuilder2": "^3.1.1"
     },
     "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/adm-zip": "^0.5.5",
         "@types/archiver": "^6.0.2",
         "@types/diff": "^7.0.2",
@@ -72,6 +77,7 @@
         "assert": "^2.1.0",
         "copyfiles": "^2.4.1",
         "mock-fs": "^5.2.0",
+        "nyc": "^17.1.0",
         "sinon": "^19.0.2",
         "ts-loader": "^9.4.4",
         "ts-mocha": "^11.1.0",

--- a/server/aws-lsp-identity/.nycrc.json
+++ b/server/aws-lsp-identity/.nycrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "out/**/*.js"
+  ],
+  "exclude": [
+    "out/**/*.test.js",
+    "out/**/*.spec.js",
+    "out/**/test/**",
+    "out/**/*TestConstants.js",
+    "out/**/*.d.ts"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70,
+  "source-map": true
+}

--- a/server/aws-lsp-identity/.nycrc.json
+++ b/server/aws-lsp-identity/.nycrc.json
@@ -1,22 +1,14 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "out/**/*.js"
-  ],
-  "exclude": [
-    "out/**/*.test.js",
-    "out/**/*.spec.js",
-    "out/**/test/**",
-    "out/**/*TestConstants.js",
-    "out/**/*.d.ts"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70,
-  "source-map": true
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["out/**/*.js"],
+    "exclude": ["out/**/*.test.js", "out/**/*.spec.js", "out/**/test/**", "out/**/*TestConstants.js", "out/**/*.d.ts"],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70,
+    "source-map": true
 }

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -18,7 +18,10 @@
         "copy": "copyfiles --error --flat ./src/sso/authorizationCodePkce/resources/* ./out/sso/authorizationCodePkce/resources/",
         "package": "npm run compile && npm run copy",
         "test": "npm run package && npm run test-unit",
-        "test-unit": "mocha \"./out/**/*.test.js\""
+        "test-unit": "mocha \"./out/**/*.test.js\"",
+        "test-unit:coverage": "npm run compile && nyc mocha \"./out/**/*.test.js\"",
+        "test:coverage": "npm run package && npm run test-unit:coverage",
+        "coverage:report": "nyc report --reporter=html --reporter=text"
     },
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
@@ -32,6 +35,7 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.734.0",
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@smithy/types": "^3.4.1",
         "@types/chai": "^4.3.5",
         "@types/chai-as-promised": "^7.1.5",
@@ -42,6 +46,7 @@
         "chai-as-promised": "^7.1.1",
         "copyfiles": "^2.4.1",
         "mock-fs": "^5.2.0",
+        "nyc": "^17.1.0",
         "sinon": "^19.0.2",
         "ts-loader": "^9.5.1",
         "ts-mocha": "^11.1.0",

--- a/server/aws-lsp-json/.nycrc.json
+++ b/server/aws-lsp-json/.nycrc.json
@@ -1,21 +1,13 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/test/**",
-    "src/**/*TestConstants.ts",
-    "src/**/*.d.ts"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["src/**/*.ts"],
+    "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/test/**", "src/**/*TestConstants.ts", "src/**/*.d.ts"],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70
 }

--- a/server/aws-lsp-json/.nycrc.json
+++ b/server/aws-lsp-json/.nycrc.json
@@ -1,0 +1,21 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/test/**",
+    "src/**/*TestConstants.ts",
+    "src/**/*.d.ts"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70
+}

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -21,6 +21,8 @@
     "scripts": {
         "compile": "tsc --build",
         "test": "ts-mocha -b \"./src/**/*.test.ts\"",
+        "test:coverage": "nyc ts-mocha -b \"./src/**/*.test.ts\"",
+        "coverage:report": "nyc report --reporter=html --reporter=text",
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
@@ -38,5 +40,9 @@
         "bracketSpacing": true,
         "arrowParens": "avoid",
         "endOfLine": "lf"
+    },
+    "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
+        "nyc": "^17.1.0"
     }
 }

--- a/server/aws-lsp-notification/.nycrc.json
+++ b/server/aws-lsp-notification/.nycrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "out/**/*.js"
+  ],
+  "exclude": [
+    "out/**/*.test.js",
+    "out/**/*.spec.js",
+    "out/**/test/**",
+    "out/**/*TestConstants.js",
+    "out/**/*.d.ts"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70,
+  "source-map": true
+}

--- a/server/aws-lsp-notification/.nycrc.json
+++ b/server/aws-lsp-notification/.nycrc.json
@@ -1,22 +1,14 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "out/**/*.js"
-  ],
-  "exclude": [
-    "out/**/*.test.js",
-    "out/**/*.spec.js",
-    "out/**/test/**",
-    "out/**/*TestConstants.js",
-    "out/**/*.d.ts"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70,
-  "source-map": true
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["out/**/*.js"],
+    "exclude": ["out/**/*.test.js", "out/**/*.spec.js", "out/**/test/**", "out/**/*TestConstants.js", "out/**/*.d.ts"],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70,
+    "source-map": true
 }

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -16,7 +16,10 @@
         "clean": "rm -fr ./out tsconfig.tsbuildinfo",
         "compile": "tsc --build --verbose",
         "test": "npm run test-unit",
-        "test-unit": "mocha \"./out/**/*.test.js\""
+        "test-unit": "mocha \"./out/**/*.test.js\"",
+        "test-unit:coverage": "npm run compile && nyc mocha \"./out/**/*.test.js\"",
+        "test:coverage": "npm run test-unit:coverage",
+        "coverage:report": "nyc report --reporter=html --reporter=text"
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.90",
@@ -25,6 +28,7 @@
     },
     "devDependencies": {
         "@aws-sdk/types": "^3.734.0",
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@smithy/types": "^3.4.1",
         "@types/chai": "^4.3.5",
         "@types/chai-as-promised": "^7.1.5",
@@ -34,6 +38,7 @@
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "mock-fs": "^5.2.0",
+        "nyc": "^17.1.0",
         "sinon": "^19.0.2",
         "ts-loader": "^9.5.1",
         "ts-mocha": "^11.1.0",

--- a/server/hello-world-lsp/.nycrc.json
+++ b/server/hello-world-lsp/.nycrc.json
@@ -1,21 +1,13 @@
 {
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true,
-  "check-coverage": false,
-  "reporter": ["text", "html", "lcov"],
-  "report-dir": "coverage",
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/test/**",
-    "src/**/*TestConstants.ts",
-    "src/**/*.d.ts"
-  ],
-  "branches": 70,
-  "lines": 70,
-  "functions": 70,
-  "statements": 70
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "all": true,
+    "check-coverage": false,
+    "reporter": ["text", "html", "lcov"],
+    "report-dir": "coverage",
+    "include": ["src/**/*.ts"],
+    "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/test/**", "src/**/*TestConstants.ts", "src/**/*.d.ts"],
+    "branches": 70,
+    "lines": 70,
+    "functions": 70,
+    "statements": 70
 }

--- a/server/hello-world-lsp/.nycrc.json
+++ b/server/hello-world-lsp/.nycrc.json
@@ -1,0 +1,21 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
+  "check-coverage": false,
+  "reporter": ["text", "html", "lcov"],
+  "report-dir": "coverage",
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/test/**",
+    "src/**/*TestConstants.ts",
+    "src/**/*.d.ts"
+  ],
+  "branches": 70,
+  "lines": 70,
+  "functions": 70,
+  "statements": 70
+}

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -8,13 +8,17 @@
         "lint": "npm run lint:src && npm run lint:bundle:webworker",
         "lint:bundle:webworker": "webpack --config webpack.lint.config.js && eslint bundle/hello-world-lsp-webworker.js # Verify compatibility with web runtime target",
         "lint:src": "eslint src/ --ext .ts,.tsx",
-        "test": "ts-mocha -b \"./src/**/*.test.ts\""
+        "test": "ts-mocha -b \"./src/**/*.test.ts\"",
+        "test:coverage": "nyc ts-mocha -b \"./src/**/*.test.ts\"",
+        "coverage:report": "nyc report --reporter=html --reporter=text"
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.90",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {
+        "@istanbuljs/nyc-config-typescript": "^1.0.2",
+        "nyc": "^17.1.0",
         "ts-loader": "^9.4.4",
         "webpack": "^5.94.0",
         "webpack-cli": "^6.0.1"


### PR DESCRIPTION
## Problem

The monorepo lacked comprehensive test coverage reporting infrastructure, making it difficult for developers to:
- Assess code quality and test completeness across packages
- Identify untested code paths that need attention
- Track coverage improvements over time
- Maintain consistent testing standards across the repository

## Solution

Added comprehensive NYC (Istanbul) code coverage infrastructure across the monorepo:

- **Repository-level**: Root .nycrc.json and npm scripts for repo-wide coverage
- **Package-level**: NYC setup for 11 packages with ts-mocha/mocha support  
- **Working coverage**: 4 packages showing 55-65% coverage immediately
- **Usage**: `npm run test:coverage --workspace=<package>` or `npm run test:coverage`
- **Documentation**: Added coverage usage guide to CONTRIBUTING.md

Provides consistent coverage tooling across the monorepo while maintaining the standard workspace pattern for all operations.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.