### PR TITLE
feat: add packageId property to references in req.json

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -188,7 +188,7 @@ export class ArtifactManager {
         )
         if (thirdPartyPackage) {
             artifactReference.isThirdPartyPackage = true
-
+            artifactReference.packageId = thirdPartyPackage.Id
             if (thirdPartyPackage.NetCompatibleAssemblyRelativePath && thirdPartyPackage.NetCompatibleAssemblyPath) {
                 const privatePackageRelativePath = path
                     .join(

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -139,6 +139,7 @@ export interface References {
     isThirdPartyPackage: boolean
     netCompatibleRelativePath?: string
     netCompatibleVersion?: string
+    packageId?: string
 }
 
 export interface PackageReferenceMetadata {
@@ -149,4 +150,5 @@ export interface PackageReferenceMetadata {
     NetCompatibleAssemblyPath?: string
     NetCompatibleAssemblyRelativePath?: string
     NetCompatiblePackageFilePath?: string
+    CurrentVersionAssemblyPath?: string
 }


### PR DESCRIPTION
## Problem
For old style project files that use the `Reference` element and the package.config file, there is no way for the AWS Transform service to easily map the package to the assembly file if the names are mismatched.

## Solution
For private packages, if we are able, provide the PackageId in the requirement.json so the service can match the package to the reference.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
