### PR TITLE
Add WebForms to Blazor transformation support

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -171,6 +171,9 @@ export class ArtifactManager {
             ...(request.EnableRazorViewTransform !== undefined && {
                 EnableRazorViewTransform: request.EnableRazorViewTransform,
             }),
+            ...(request.EnableWebFormsToBlazorTransform !== undefined && {
+                EnableWebFormsToBlazorTransform: request.EnableWebFormsToBlazorTransform,
+            }),
             Packages: packages,
         } as RequirementJson
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -22,6 +22,7 @@ export interface StartTransformRequest extends ExecuteCommandParams {
     ProjectMetadata: TransformProjectMetadata[]
     TransformNetStandardProjects: boolean
     EnableRazorViewTransform: boolean
+    EnableWebFormsToBlazorTransform: boolean
     PackageReferences?: PackageReferenceMetadata[]
 }
 
@@ -102,6 +103,7 @@ export interface RequirementJson {
     Projects: Project[]
     TransformNetStandardProjects: boolean
     EnableRazorViewTransform: boolean
+    EnableWebFormsToBlazorTransform: boolean
 }
 
 export interface ExternalReference {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/converter.test.ts
@@ -58,6 +58,7 @@ const sampleUserInputRequest: StartTransformRequest = {
     ],
     TransformNetStandardProjects: false,
     EnableRazorViewTransform: false,
+    EnableWebFormsToBlazorTransform: false,
     command: '',
     PackageReferences: [],
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/mockData.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/mockData.ts
@@ -5,6 +5,7 @@ export const EXAMPLE_REQUEST: StartTransformRequest = {
     SolutionConfigPaths: [],
     TransformNetStandardProjects: true,
     EnableRazorViewTransform: true,
+    EnableWebFormsToBlazorTransform: false,
     SolutionRootPath: 'D:\\TestProjects-master\\TestProjects-master\\netcoreapp3.1\\CoreMVC',
     TargetFramework: 'net8.0',
     ProgramLanguage: 'csharp',

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
@@ -16,6 +16,7 @@ const sampleStartTransformRequest: StartTransformRequest = {
     ProjectMetadata: [],
     TransformNetStandardProjects: false,
     EnableRazorViewTransform: false,
+    EnableWebFormsToBlazorTransform: false,
     command: '',
     PackageReferences: [],
 }


### PR DESCRIPTION

## Description
This PR adds support for WebForms to Blazor transformations by introducing a new `EnableWebFormsToBlazorTransform` flag in the netTransform component. This flag works similarly to the existing `EnableRazorViewTransform` flag and allows the IDE to specify when WebForms to Blazor transformations should be enabled.

## Changes
- Added `EnableWebFormsToBlazorTransform` flag to the `RequirementJson` interface
- Added `EnableWebFormsToBlazorTransform` flag to the `StartTransformRequest` interface
- Updated the `createRequirementJsonContent` method to include the new flag in the generated JSON
- Updated test files with appropriate default values for the new flag

## Testing
All existing tests pass, confirming backward compatibility with existing functionality.

## Related Work
This change supports the new WebForms to Blazor transformation checkbox recently added to the IDE.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
