### PR TITLE
feat: apply a max 200MB total history size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23810,11 +23810,10 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-            "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+            "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
@@ -24818,6 +24817,11 @@
             "engines": {
                 "node": ">=14.17"
             }
+        },
+        "node_modules/typescript-collections": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/typescript-collections/-/typescript-collections-1.3.3.tgz",
+            "integrity": "sha512-7sI4e/bZijOzyURng88oOFZCISQPTHozfE2sUu5AviFYk5QV7fYGb6YiDl+vKjF/pICA354JImBImL9XJWUvdQ=="
         },
         "node_modules/umd-compat-loader": {
             "version": "2.1.2",
@@ -26766,6 +26770,7 @@
                 "lokijs": "^1.5.12",
                 "picomatch": "^4.0.2",
                 "shlex": "2.1.2",
+                "typescript-collections": "^1.3.3",
                 "uuid": "^11.0.5",
                 "vscode-uri": "^3.1.0",
                 "ws": "^8.18.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -60,6 +60,7 @@
         "lokijs": "^1.5.12",
         "picomatch": "^4.0.2",
         "shlex": "2.1.2",
+        "typescript-collections": "^1.3.3",
         "uuid": "^11.0.5",
         "vscode-uri": "^3.1.0",
         "ws": "^8.18.0",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -356,18 +356,6 @@ describe('AgenticChatController', () => {
         assert.strictEqual(session!.modelId, modelId)
     })
 
-    it('onTabAdd updates model ID in chat options and session', () => {
-        const modelId = 'test-model-id'
-        sinon.stub(ChatDatabase.prototype, 'getModelId').returns(modelId)
-
-        chatController.onTabAdd({ tabId: mockTabId })
-
-        sinon.assert.calledWithExactly(testFeatures.chat.chatOptionsUpdate, { modelId, tabId: mockTabId })
-
-        const session = chatSessionManagementService.getSession(mockTabId).data
-        assert.strictEqual(session!.modelId, modelId)
-    })
-
     it('onTabChange sets active tab id in telemetryController and emits metrics', () => {
         chatController.onTabChange({ tabId: mockTabId })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -167,7 +167,9 @@ describe('AgenticChatController', () => {
     let chatController: AgenticChatController
     let telemetryService: TelemetryService
     let telemetry: Telemetry
+    let chatDbInitializedStub: sinon.SinonStub
     let getMessagesStub: sinon.SinonStub
+    let addMessagePairStub: sinon.SinonStub
 
     const setCredentials = setCredentialsForAmazonQTokenServiceManagerFactory(() => testFeatures)
 
@@ -281,7 +283,9 @@ describe('AgenticChatController', () => {
             onClientTelemetry: sinon.stub(),
         }
 
-        getMessagesStub = sinon.stub(ChatDatabase.prototype, 'getMessages')
+        getMessagesStub = sinon.stub(ChatDatabase.prototype, 'getMessages').returns([])
+        addMessagePairStub = sinon.stub(ChatDatabase.prototype, 'addMessagePair')
+        chatDbInitializedStub = sinon.stub(ChatDatabase.prototype, 'isInitialized')
 
         telemetryService = new TelemetryService(serviceManager, mockCredentialsProvider, telemetry, logging)
         chatController = new AgenticChatController(
@@ -338,6 +342,18 @@ describe('AgenticChatController', () => {
         chatController.onTabAdd({ tabId: mockTabId })
 
         sinon.assert.calledWithExactly(activeTabSpy.set, mockTabId)
+    })
+
+    it('onTabAdd updates model ID in chat options and session', () => {
+        const modelId = 'test-model-id'
+        sinon.stub(ChatDatabase.prototype, 'getModelId').returns(modelId)
+
+        chatController.onTabAdd({ tabId: mockTabId })
+
+        sinon.assert.calledWithExactly(testFeatures.chat.chatOptionsUpdate, { modelId, tabId: mockTabId })
+
+        const session = chatSessionManagementService.getSession(mockTabId).data
+        assert.strictEqual(session!.modelId, modelId)
     })
 
     it('onTabAdd updates model ID in chat options and session', () => {
@@ -455,7 +471,25 @@ describe('AgenticChatController', () => {
                 { type: 'prompt', body: 'Previous question' },
                 { type: 'answer', body: 'Previous answer' },
             ]
+            const expectedRequestHistory = [
+                {
+                    userInputMessage: {
+                        content: 'Previous question',
+                        origin: 'IDE',
+                        userInputMessageContext: {},
+                        userIntent: undefined,
+                    },
+                },
+                {
+                    assistantResponseMessage: {
+                        content: 'Previous answer',
+                        messageId: undefined,
+                        toolUses: [],
+                    },
+                },
+            ]
 
+            chatDbInitializedStub.returns(true)
             getMessagesStub.returns(mockHistory)
 
             // Make the request
@@ -471,7 +505,7 @@ describe('AgenticChatController', () => {
 
             // Verify that the history was passed to the request
             const requestInput: GenerateAssistantResponseCommandInput = generateAssistantResponseStub.firstCall.firstArg
-            assert.deepStrictEqual(requestInput.conversationState?.history, mockHistory)
+            assert.deepStrictEqual(requestInput.conversationState?.history, expectedRequestHistory)
         })
 
         it('skips adding user message to history when token is cancelled', async () => {
@@ -481,12 +515,10 @@ describe('AgenticChatController', () => {
                 onCancellationRequested: () => ({ dispose: () => null }),
             }
 
-            const addMessageSpy = sinon.spy(ChatDatabase.prototype, 'addMessage')
-
             // Execute with cancelled token
             await chatController.onChatPrompt({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, cancelledToken)
 
-            sinon.assert.notCalled(addMessageSpy)
+            sinon.assert.notCalled(addMessagePairStub)
         })
 
         it('skips adding user message to history when prompt ID is no longer current', async () => {
@@ -494,13 +526,11 @@ describe('AgenticChatController', () => {
             const session = chatSessionManagementService.getSession(mockTabId).data!
             const isCurrentPromptStub = sinon.stub(session, 'isCurrentPrompt').returns(false)
 
-            const addMessageSpy = sinon.spy(ChatDatabase.prototype, 'addMessage')
-
             // Execute with non-current prompt ID
             await chatController.onChatPrompt({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, mockCancellationToken)
 
             sinon.assert.called(isCurrentPromptStub)
-            sinon.assert.notCalled(addMessageSpy)
+            sinon.assert.notCalled(addMessagePairStub)
         })
 
         it('handles tool use responses and makes multiple requests', async () => {
@@ -555,14 +585,16 @@ describe('AgenticChatController', () => {
                 },
             ]
 
-            getMessagesStub
-                .onFirstCall()
-                .returns([])
-                .onSecondCall()
-                .returns([
-                    { userInputMessage: { content: 'Hello with tool' } },
-                    { assistantResponseMessage: { content: 'I need to use a tool. ' } },
-                ])
+            chatDbInitializedStub.returns(true)
+            getMessagesStub.onFirstCall().returns([])
+            getMessagesStub.onSecondCall().returns([
+                { type: 'prompt', body: 'Hello with tool' },
+                {
+                    type: 'answer',
+                    body: 'I need to use a tool. ',
+                    toolUses: [{ toolUseId: mockToolUseId, name: mockToolName, input: { key: mockToolInput } }],
+                },
+            ])
 
             // Reset the stub and set up to return different responses on consecutive calls
             generateAssistantResponseStub.restore()
@@ -685,13 +717,18 @@ describe('AgenticChatController', () => {
                 },
             ]
 
+            chatDbInitializedStub.returns(true)
             getMessagesStub
                 .onFirstCall()
                 .returns([])
                 .onSecondCall()
                 .returns([
-                    { userInputMessage: { content: 'Hello with failing tool' } },
-                    { assistantResponseMessage: { content: 'I need to use a tool that will fail. ' } },
+                    { type: 'prompt', body: 'Hello with failing tool' },
+                    {
+                        type: 'answer',
+                        body: 'I need to use a tool that will fail. ',
+                        toolUses: [{ toolUseId: mockToolUseId, name: mockToolName, input: { key: mockToolInput } }],
+                    },
                 ])
 
             // Reset the stub and set up to return different responses on consecutive calls
@@ -859,15 +896,24 @@ describe('AgenticChatController', () => {
             ]
 
             const historyAfterTool1 = [
-                { userInputMessage: { content: 'Hello with multiple tools' } },
-                { assistantResponseMessage: { content: 'I need to use tool 1. ' } },
+                { type: 'prompt', body: 'Hello with multiple tools' },
+                {
+                    type: 'answer',
+                    body: 'I need to use tool 1. ',
+                    toolUses: [{ toolUseId: mockToolUseId1, name: mockToolName1, input: { key: mockToolInput1 } }],
+                },
             ]
             const historyAfterTool2 = [
                 ...historyAfterTool1,
-                { userInputMessage: { content: 'Hello with multiple tools' } },
-                { assistantResponseMessage: { content: 'Now I need to use tool 2. ' } },
+                { type: 'prompt', body: 'Hello with multiple tools' },
+                {
+                    type: 'answer',
+                    body: 'Now I need to use tool 2. ',
+                    toolUses: [{ toolUseId: mockToolUseId2, name: mockToolName2, input: { key: mockToolInput2 } }],
+                },
             ]
 
+            chatDbInitializedStub.returns(true)
             getMessagesStub
                 .onFirstCall()
                 .returns([])
@@ -1686,6 +1732,7 @@ describe('AgenticChatController', () => {
         })
 
         it('returns a ResponseError if response streams return an invalid state event', async () => {
+            getMessagesStub.returns([])
             sendMessageStub.callsFake(() => {
                 return Promise.resolve({
                     $metadata: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -456,7 +456,13 @@ describe('AgenticChatController', () => {
         it('includes chat history from the database in the request input', async () => {
             // Mock chat history
             const mockHistory = [
-                { type: 'prompt', body: 'Previous question' },
+                {
+                    type: 'prompt',
+                    body: 'Previous question',
+                    userInputMessageContext: {
+                        toolResults: [],
+                    },
+                },
                 { type: 'answer', body: 'Previous answer' },
             ]
             const expectedRequestHistory = [
@@ -464,7 +470,7 @@ describe('AgenticChatController', () => {
                     userInputMessage: {
                         content: 'Previous question',
                         origin: 'IDE',
-                        userInputMessageContext: {},
+                        userInputMessageContext: { toolResults: [] },
                         userIntent: undefined,
                     },
                 },
@@ -576,7 +582,13 @@ describe('AgenticChatController', () => {
             chatDbInitializedStub.returns(true)
             getMessagesStub.onFirstCall().returns([])
             getMessagesStub.onSecondCall().returns([
-                { type: 'prompt', body: 'Hello with tool' },
+                {
+                    type: 'prompt',
+                    body: 'Hello with tool',
+                    userInputMessageContext: {
+                        toolResults: [],
+                    },
+                },
                 {
                     type: 'answer',
                     body: 'I need to use a tool. ',
@@ -711,7 +723,13 @@ describe('AgenticChatController', () => {
                 .returns([])
                 .onSecondCall()
                 .returns([
-                    { type: 'prompt', body: 'Hello with failing tool' },
+                    {
+                        type: 'prompt',
+                        body: 'Hello with failing tool',
+                        userInputMessageContext: {
+                            toolResults: [],
+                        },
+                    },
                     {
                         type: 'answer',
                         body: 'I need to use a tool that will fail. ',
@@ -884,7 +902,13 @@ describe('AgenticChatController', () => {
             ]
 
             const historyAfterTool1 = [
-                { type: 'prompt', body: 'Hello with multiple tools' },
+                {
+                    type: 'prompt',
+                    body: 'Hello with multiple tools',
+                    userInputMessageContext: {
+                        toolResults: [],
+                    },
+                },
                 {
                     type: 'answer',
                     body: 'I need to use tool 1. ',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -169,7 +169,7 @@ describe('AgenticChatController', () => {
     let telemetry: Telemetry
     let chatDbInitializedStub: sinon.SinonStub
     let getMessagesStub: sinon.SinonStub
-    let addMessagePairStub: sinon.SinonStub
+    let addMessageStub: sinon.SinonStub
 
     const setCredentials = setCredentialsForAmazonQTokenServiceManagerFactory(() => testFeatures)
 
@@ -284,7 +284,7 @@ describe('AgenticChatController', () => {
         }
 
         getMessagesStub = sinon.stub(ChatDatabase.prototype, 'getMessages').returns([])
-        addMessagePairStub = sinon.stub(ChatDatabase.prototype, 'addMessagePair')
+        addMessageStub = sinon.stub(ChatDatabase.prototype, 'addMessage')
         chatDbInitializedStub = sinon.stub(ChatDatabase.prototype, 'isInitialized')
 
         telemetryService = new TelemetryService(serviceManager, mockCredentialsProvider, telemetry, logging)
@@ -518,7 +518,7 @@ describe('AgenticChatController', () => {
             // Execute with cancelled token
             await chatController.onChatPrompt({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, cancelledToken)
 
-            sinon.assert.notCalled(addMessagePairStub)
+            sinon.assert.notCalled(addMessageStub)
         })
 
         it('skips adding user message to history when prompt ID is no longer current', async () => {
@@ -530,7 +530,7 @@ describe('AgenticChatController', () => {
             await chatController.onChatPrompt({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, mockCancellationToken)
 
             sinon.assert.called(isCurrentPromptStub)
-            sinon.assert.notCalled(addMessagePairStub)
+            sinon.assert.notCalled(addMessageStub)
         })
 
         it('handles tool use responses and makes multiple requests', async () => {
@@ -1732,7 +1732,6 @@ describe('AgenticChatController', () => {
         })
 
         it('returns a ResponseError if response streams return an invalid state event', async () => {
-            getMessagesStub.returns([])
             sendMessageStub.callsFake(() => {
                 return Promise.resolve({
                     $metadata: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -765,12 +765,6 @@ export class AgenticChatController implements ChatHandlers {
                         shouldDisplayMessage: shouldDisplayMessage,
                         timestamp: new Date(),
                     })
-
-                    // Async process: Trimming history asynchronously if the size exceeds the max
-                    // This process will take several seconds
-                    this.#chatHistoryDb.trimHistoryToMaxSize().catch(err => {
-                        this.#features.logging.error(`Error trimming history: ${err}`)
-                    })
                 }
             } else {
                 this.#features.logging.warn('No ChatResult body in response, skipping adding to history')

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -693,18 +693,19 @@ export class AgenticChatController implements ChatHandlers {
             // Add the current user message to the history DB
             if (currentMessage && conversationIdentifier) {
                 if (this.#isPromptCanceled(token, session, promptId)) {
+                    // Only skip adding message to history, continue executing to avoid unexpected stop for the conversation
                     this.#debug('Skipping adding user message to history - cancelled by user')
-                    throw new CancellationError('user')
+                } else {
+                    this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier, {
+                        body: currentMessage.userInputMessage?.content ?? '',
+                        type: 'prompt' as any,
+                        userIntent: currentMessage.userInputMessage?.userIntent,
+                        origin: currentMessage.userInputMessage?.origin,
+                        userInputMessageContext: currentMessage.userInputMessage?.userInputMessageContext,
+                        shouldDisplayMessage: shouldDisplayMessage,
+                        timestamp: new Date(),
+                    })
                 }
-                this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier, {
-                    body: currentMessage.userInputMessage?.content ?? '',
-                    type: 'prompt' as any,
-                    userIntent: currentMessage.userInputMessage?.userIntent,
-                    origin: currentMessage.userInputMessage?.origin,
-                    userInputMessageContext: currentMessage.userInputMessage?.userInputMessageContext,
-                    shouldDisplayMessage: shouldDisplayMessage,
-                    timestamp: new Date(),
-                })
             }
             shouldDisplayMessage = true
 
@@ -722,19 +723,19 @@ export class AgenticChatController implements ChatHandlers {
             // This is needed to handle the case where the response stream times out
             // and we want to auto-retry
             if (!result.success && result.error.startsWith(responseTimeoutPartialMsg)) {
-                if (this.#isPromptCanceled(token, session, promptId)) {
-                    this.#debug('Skipping adding messages to history - cancelled by user')
-                    throw new CancellationError('user')
-                }
-
                 const content =
                     'You took too long to respond - try to split up the work into smaller steps. Do not apologize.'
-                this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier ?? '', {
-                    body: 'Response timed out - message took too long to generate',
-                    type: 'answer',
-                    shouldDisplayMessage: false,
-                    timestamp: new Date(),
-                })
+                if (this.#isPromptCanceled(token, session, promptId)) {
+                    // Only skip adding message to the history DB, continue executing to avoid unexpected stop for the conversation
+                    this.#debug('Skipping adding messages to history - cancelled by user')
+                } else {
+                    this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier ?? '', {
+                        body: 'Response timed out - message took too long to generate',
+                        type: 'answer',
+                        shouldDisplayMessage: false,
+                        timestamp: new Date(),
+                    })
+                }
                 currentRequestInput = this.#updateRequestInputWithToolResults(currentRequestInput, [], content)
                 shouldDisplayMessage = false
                 // set the in progress tool use UI status to Error
@@ -742,32 +743,32 @@ export class AgenticChatController implements ChatHandlers {
                 continue
             }
 
-            //  Add the user prompt and the assistantResponse message to the history DB
+            // Add the current assistantResponse message to the history DB
             if (result.data?.chatResult.body !== undefined) {
                 if (this.#isPromptCanceled(token, session, promptId)) {
+                    // Only skip adding message to the history DB, continue executing to avoid unexpected stop for the conversation
                     this.#debug('Skipping adding messages to history - cancelled by user')
-                    throw new CancellationError('user')
+                } else {
+                    this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier ?? '', {
+                        body: result.data?.chatResult.body,
+                        type: 'answer' as any,
+                        codeReference: result.data.chatResult.codeReference,
+                        relatedContent:
+                            result.data.chatResult.relatedContent?.content &&
+                            result.data.chatResult.relatedContent.content.length > 0
+                                ? result.data?.chatResult.relatedContent
+                                : undefined,
+                        toolUses: Object.keys(result.data?.toolUses!)
+                            .filter(k => result.data!.toolUses[k].stop)
+                            .map(k => ({
+                                toolUseId: result.data!.toolUses[k].toolUseId,
+                                name: result.data!.toolUses[k].name,
+                                input: result.data!.toolUses[k].input,
+                            })),
+                        shouldDisplayMessage: shouldDisplayMessage,
+                        timestamp: new Date(),
+                    })
                 }
-
-                this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier ?? '', {
-                    body: result.data?.chatResult.body,
-                    type: 'answer' as any,
-                    codeReference: result.data.chatResult.codeReference,
-                    relatedContent:
-                        result.data.chatResult.relatedContent?.content &&
-                        result.data.chatResult.relatedContent.content.length > 0
-                            ? result.data?.chatResult.relatedContent
-                            : undefined,
-                    toolUses: Object.keys(result.data?.toolUses!)
-                        .filter(k => result.data!.toolUses[k].stop)
-                        .map(k => ({
-                            toolUseId: result.data!.toolUses[k].toolUseId,
-                            name: result.data!.toolUses[k].name,
-                            input: result.data!.toolUses[k].input,
-                        })),
-                    shouldDisplayMessage: shouldDisplayMessage,
-                    timestamp: new Date(),
-                })
             } else {
                 this.#features.logging.warn('No ChatResult body in response, skipping adding to history')
             }
@@ -963,11 +964,6 @@ export class AgenticChatController implements ChatHandlers {
         const results: ToolResult[] = []
 
         for (const toolUse of toolUses) {
-            // Check for cancellation before processing each tool
-            if (token?.isCancellationRequested) {
-                throw new CancellationError('user')
-            }
-
             // Store buttonBlockId to use it in `catch` block if needed
             let cachedButtonBlockId
             if (!toolUse.name || !toolUse.toolUseId) continue

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
@@ -21,6 +21,8 @@ import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { ChatHistoryActionType } from '../../shared/telemetry/types'
 import { CancellationError } from '@aws/lsp-core'
 
+const MaxRestoredHistoryMessages = 250
+
 /**
  * Controller for managing chat history and export functionality.
  *
@@ -285,9 +287,13 @@ export class TabBarController {
      */
     async restoreTab(selectedTab?: Tab | null) {
         if (selectedTab) {
-            const messages = selectedTab.conversations.flatMap((conv: Conversation) =>
-                conv.messages.filter(msg => msg.shouldDisplayMessage != false).flatMap(msg => messageToChatMessage(msg))
-            )
+            const messages = selectedTab.conversations
+                .flatMap((conv: Conversation) =>
+                    conv.messages
+                        .filter(msg => msg.shouldDisplayMessage != false)
+                        .flatMap(msg => messageToChatMessage(msg))
+                )
+                .slice(-MaxRestoredHistoryMessages)
 
             const { tabId } = await this.#features.chat.openTab({ newTabOptions: { data: { messages } } })
             this.#chatHistoryDb.setHistoryIdMapping(tabId, selectedTab.historyId)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
@@ -140,7 +140,7 @@ describe('ChatDatabase', () => {
                 },
             } as ChatMessage
 
-            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            const isValid = chatDb.validateAndFixNewMessageToolResults(messages, newUserMessage)
             assert.strictEqual(isValid, false)
         })
 
@@ -172,7 +172,7 @@ describe('ChatDatabase', () => {
                 },
             } as ChatMessage
 
-            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            const isValid = chatDb.validateAndFixNewMessageToolResults(messages, newUserMessage)
             assert.strictEqual(isValid, true)
 
             const toolResults = newUserMessage.userInputMessage!.userInputMessageContext?.toolResults || []
@@ -202,7 +202,7 @@ describe('ChatDatabase', () => {
                 },
             } as ChatMessage
 
-            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            const isValid = chatDb.validateAndFixNewMessageToolResults(messages, newUserMessage)
             assert.strictEqual(isValid, true)
 
             const toolResults = newUserMessage.userInputMessage!.userInputMessageContext?.toolResults || []
@@ -237,7 +237,7 @@ describe('ChatDatabase', () => {
                 },
             } as ChatMessage
 
-            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            const isValid = chatDb.validateAndFixNewMessageToolResults(messages, newUserMessage)
             assert.strictEqual(isValid, false)
         })
 
@@ -265,7 +265,7 @@ describe('ChatDatabase', () => {
                 },
             } as ChatMessage
 
-            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            const isValid = chatDb.validateAndFixNewMessageToolResults(messages, newUserMessage)
             assert.strictEqual(isValid, true)
 
             const toolResults = newUserMessage.userInputMessage!.userInputMessageContext?.toolResults || []
@@ -314,7 +314,7 @@ describe('ChatDatabase', () => {
                 },
             } as ChatMessage
 
-            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            const isValid = chatDb.validateAndFixNewMessageToolResults(messages, newUserMessage)
 
             const toolResults = newUserMessage.userInputMessage!.userInputMessageContext?.toolResults || []
             assert.strictEqual(toolResults.length, 2, 'Should have correct number of tool results')
@@ -349,7 +349,7 @@ describe('ChatDatabase', () => {
                 },
             } as ChatMessage
 
-            const isValid = chatDb.validateNewMessageToolResults(messages, newUserMessage)
+            const isValid = chatDb.validateAndFixNewMessageToolResults(messages, newUserMessage)
             assert.strictEqual(isValid, false)
         })
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
@@ -75,15 +75,13 @@ describe('ChatDatabase', () => {
 
             const originalMessages = [...messages]
 
-            chatDb.ensureValidMessageSequence(messages, {
-                userInputMessage: { content: 'New message', userInputMessageContext: {} },
-            } as StreamingMessage)
+            chatDb.ensureValidMessageSequence('tab-1', messages)
 
             assert.strictEqual(messages.length, 4, 'Should not modify valid sequence')
             assert.deepStrictEqual(messages, originalMessages, 'Messages should remain unchanged')
         })
 
-        it('should remove assistant messages from the beginning and end', () => {
+        it('should remove assistant messages from the beginning', () => {
             const messages: Message[] = [
                 { type: 'answer', body: 'Assistant first message' },
                 { type: 'answer', body: 'Assistant second message' },
@@ -91,37 +89,32 @@ describe('ChatDatabase', () => {
                 { type: 'answer', body: 'Assistant response' },
             ]
 
-            //  Should not be possible
-            chatDb.ensureValidMessageSequence(messages, {
-                assistantResponseMessage: { content: 'New assisstant message' },
-            } as StreamingMessage)
+            chatDb.ensureValidMessageSequence('tab-1', messages)
 
-            assert.strictEqual(messages.length, 1, 'Should have removed assistant messages from the beginning and end')
+            assert.strictEqual(messages.length, 2, 'Should have removed assistant messages from the beginning')
             assert.strictEqual(messages[0].type, 'prompt', 'First message should be from user')
+            assert.strictEqual(messages[1].type, 'answer', 'Last message should be from assistant')
         })
 
-        it('should remove user message from the end', () => {
+        it('should add a dummy response at the end', () => {
             const messages: Message[] = [
                 { type: 'prompt', body: 'User first message' },
                 { type: 'answer', body: 'Assistant response' },
                 { type: 'prompt', body: 'User trailing message' },
             ]
 
-            chatDb.ensureValidMessageSequence(messages, {
-                userInputMessage: { content: 'New message', userInputMessageContext: {} },
-            } as StreamingMessage)
+            chatDb.ensureValidMessageSequence('tab-1', messages)
 
-            assert.strictEqual(messages.length, 2, 'Should have removed user message from the end')
+            assert.strictEqual(messages.length, 4, 'Should have added a cancellation response')
             assert.strictEqual(messages[0].type, 'prompt', 'First message should be from user')
-            assert.strictEqual(messages[1].type, 'answer', 'Last message should be from assistant')
+            assert.strictEqual(messages[3].type, 'answer', 'Last message should be from assistant')
+            assert.strictEqual(messages[3].shouldDisplayMessage, false, 'The message should be hidden')
         })
 
         it('should handle empty message array', () => {
             const messages: Message[] = []
 
-            chatDb.ensureValidMessageSequence(messages, {
-                userInputMessage: { content: 'New message', userInputMessageContext: {} },
-            } as StreamingMessage)
+            chatDb.ensureValidMessageSequence('tab-1', messages)
 
             assert.strictEqual(messages.length, 0, 'Empty array should remain empty')
         })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import sinon from 'ts-sinon'
 import { ChatDatabase } from './chatDb'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
-import { Message } from './util'
+import { Message, Tab } from './util'
 import { ChatMessage, ToolResultStatus } from '@aws/codewhisperer-streaming-client'
 import * as fs from 'fs'
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert'
 import sinon from 'ts-sinon'
 import { ChatDatabase } from './chatDb'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
-import { Message, Tab } from './util'
+import { Message } from './util'
 import { ChatMessage, ToolResultStatus } from '@aws/codewhisperer-streaming-client'
 import * as fs from 'fs'
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -35,7 +35,7 @@ export class ToolResultValidationError extends Error {
 }
 
 export const EMPTY_CONVERSATION_LIST_ID = 'empty'
-// Maximum number of messages to send in request
+// Maximum number of history messages to include in each request to the LLM
 const maxConversationHistoryMessages = 250
 
 /**
@@ -396,7 +396,7 @@ export class ChatDatabase {
                     isOpen: true,
                     tabType: tabType,
                     title: tabTitle,
-                    conversations: [{ conversationId, clientType, messages: [message] }],
+                    conversations: [{ conversationId, clientType, updatedAt: new Date(), messages: [message] }],
                 })
             }
         }
@@ -423,9 +423,9 @@ export class ChatDatabase {
     }
 
     /**
-     * Prepare the history messages for service request `GenerateAssistantResponseCommandInput` to maintain the following invariants:
+     * Prepare the history messages for service request and fix the persisted history in DB to maintain the following invariants:
      * 1. The history contains at most MaxConversationHistoryMessages messages. Oldest messages are dropped.
-     * 2. The first message is from the user and the last message is from the assistant.
+     * 2. The first message is from the user and without any tool usage results, and the last message is from the assistant.
      *    The history contains alternating sequene of userMessage followed by assistantMessages
      * 3. The toolUse and toolResult relationship is valid
      * 4. The history character length is <= MaxConversationHistoryCharacters - newUserMessageCharacterCount. Oldest messages are dropped.
@@ -467,6 +467,17 @@ export class ChatDatabase {
         return allMessages
     }
 
+    /**
+     * Finds a suitable "break point" index in the message sequence.
+     *
+     * It ensures that the "break point" is at a clean conversation boundary where:
+     * 1. The message is from a user (type === 'prompt')
+     * 2. The message doesn't contain tool results that would break tool use/result pairs
+     * 3. The message has a non-empty body
+     *
+     * @param allMessages The array of conversation messages to search through
+     * @returns The index to trim from, or undefined if no suitable trimming point is found
+     */
     private findIndexToTrim(allMessages: Message[]): number | undefined {
         for (let i = 2; i < allMessages.length; i++) {
             const message = allMessages[i]
@@ -588,13 +599,23 @@ export class ChatDatabase {
             return
         }
 
-        //  Make sure the first message is from the user (type === 'prompt'), else drop
+        // Make sure the first message sent to LLM is from the user (type === 'prompt'), else drop
         while (messages.length > 0 && messages[0].type === ('answer' as ChatItemType)) {
             messages.shift()
             this.#features.logging.debug('Dropped first message since it is not from user')
         }
 
-        //  Make sure the last message is from the assistant (type === 'answer'), else add a cancellation response
+        // Make sure the first user message doesn't have tool usage results.
+        while (
+            messages.length > 0 &&
+            messages[0].type === ('prompt' as ChatItemType) &&
+            !this.isValidUserMessageWithoutToolResults(messages[0])
+        ) {
+            messages.splice(0, 2) // Remove first user-assistant pair
+            this.#features.logging.debug('Dropped the first message pair since the user message has tool usage results')
+        }
+
+        //  Make sure the last message is from the assistant (type === 'answer'), else add a dummy response
         if (messages.length > 0 && messages[messages.length - 1].type === ('prompt' as ChatItemType)) {
             // Add an assistant response to both request and DB to maintain a valid sequence
             const dummyResponse: Message = {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -50,7 +50,6 @@ export class ChatDatabase {
      */
     #historyIdMapping: Map<string, string> = new Map()
     #dbDirectory: string
-    #dbName: string
     #features: Features
     #initialized: boolean = false
     #loadTimeMs?: number
@@ -66,8 +65,8 @@ export class ChatDatabase {
             '.aws/amazonq/history'
         )
         const workspaceId = this.getWorkspaceIdentifier()
-        this.#dbName = `chat-history-${workspaceId}.json`
-        const dbPath = path.join(this.#dbDirectory, this.#dbName)
+        const dbName = `chat-history-${workspaceId}.json`
+        const dbPath = path.join(this.#dbDirectory, dbName)
 
         this.#features.logging.log(`Initializing database at ${dbPath}`)
 
@@ -81,7 +80,7 @@ export class ChatDatabase {
 
         const startTime = Date.now()
 
-        this.#db = new Loki(this.#dbName, {
+        this.#db = new Loki(dbName, {
             adapter: new FileSystemAdapter(features.workspace, this.#dbDirectory),
             autosave: true,
             autoload: true,
@@ -90,7 +89,7 @@ export class ChatDatabase {
             persistenceMethod: 'fs',
         })
 
-        this.#historyMaintainer = new ChatHistoryMaintainer(features, this.#dbDirectory, this.#dbName, this.#db)
+        this.#historyMaintainer = new ChatHistoryMaintainer(features, this.#dbDirectory, dbName, this.#db)
         // Async process: Trimming history asynchronously if the size exceeds the max
         // This process will take several seconds
         this.#historyMaintainer.trimHistoryToMaxSize().catch(err => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -611,7 +611,8 @@ export class ChatDatabase {
             messages[0].type === ('prompt' as ChatItemType) &&
             !this.isValidUserMessageWithoutToolResults(messages[0])
         ) {
-            messages.splice(0, 2) // Remove first user-assistant pair
+            // Remove first user-assistant pair - here we assume that the mid-sequence messages are always in the alternating user-assistant pattern
+            messages.splice(0, 2)
             this.#features.logging.debug('Dropped the first message pair since the user message has tool usage results')
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -8,7 +8,6 @@ import {
     Conversation,
     FileSystemAdapter,
     groupTabsByDate,
-    isEmptyAssistantMessage,
     Message,
     Settings,
     SettingsCollection,
@@ -348,14 +347,6 @@ export class ChatDatabase {
      */
     addMessage(tabId: string, tabType: TabType, conversationId: string, message: Message) {
         if (this.isInitialized()) {
-            // Skip adding to history DB if it's an empty response
-            if (isEmptyAssistantMessage(message)) {
-                this.#features.logging.debug(
-                    'The assistant response is empty. Skipped adding this message and removed last user prompt from the history DB'
-                )
-                return
-            }
-
             const clientType = this.#features.lsp.getClientInitializeParams()?.clientInfo?.name || 'unknown'
             const tabCollection = this.#db.getCollection<Tab>(TabCollection)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -17,8 +17,6 @@ import {
     TabCollection,
     TabType,
     updateOrCreateConversation,
-    initializeHistoryPriorityQueue,
-    getOldestMessageTimestamp,
 } from './util'
 import * as crypto from 'crypto'
 import * as path from 'path'
@@ -27,26 +25,11 @@ import { ConversationItemGroup } from '@aws/language-server-runtimes/protocol'
 import { ChatMessage, ToolResultStatus } from '@aws/codewhisperer-streaming-client'
 import { ChatItemType } from '@aws/mynah-ui'
 import { getUserHomeDir } from '@aws/lsp-core/out/util/path'
+import { ChatHistoryMaintainer } from './chatHistoryMaintainer'
 
 export const EMPTY_CONVERSATION_LIST_ID = 'empty'
-// Maximum number of characters to send in request
-const maxConversationHistoryCharacters = 600_000
 // Maximum number of messages to send in request
 const maxConversationHistoryMessages = 250
-// Maximum history file size across all workspace, 200MB
-const maxHistorySizeInBytes = 200 * 1024 * 1024
-// 75% of the max size, 150MB
-const maxAfterTrimHistorySizeInBytes = 150 * 1024 * 1024
-/**
- * The combination of messageBatchDeleteIterationBeforeRecalculateDBSize and messageBatchDeleteSizeForSingleTab can heavily impact the
- * latency of trimming history since calculating the history file size is slow. We can tune these numbers according to the average message size
- */
-// Batch deletion iteration count when trimming history before re-calculating total history size
-const messageBatchDeleteIterationBeforeRecalculateDBSize = 200
-// Batch deletion message size when trimming history for a specific tab before re-checking the oldest message among all workspace history
-const messageBatchDeleteSizeForSingleTab = 10
-// In each iteration, we calculate the total history size and try to delete [messageBatchDeleteSizeForSingleTab * messageBatchDeleteIterationBeforeRecalculateDBSize] messages
-const maxTrimHistoryLoopIteration = 100
 
 /**
  * A singleton database class that manages chat history persistence using LokiJS.
@@ -72,6 +55,7 @@ export class ChatDatabase {
     #initialized: boolean = false
     #loadTimeMs?: number
     #dbFileSize?: number
+    #historyMaintainer: ChatHistoryMaintainer
 
     constructor(features: Features) {
         this.#features = features
@@ -104,6 +88,13 @@ export class ChatDatabase {
             autoloadCallback: () => this.databaseInitialize(startTime),
             autosaveInterval: 1000,
             persistenceMethod: 'fs',
+        })
+
+        this.#historyMaintainer = new ChatHistoryMaintainer(features, this.#dbDirectory, this.#dbName, this.#db)
+        // Async process: Trimming history asynchronously if the size exceeds the max
+        // This process will take several seconds
+        this.#historyMaintainer.trimHistoryToMaxSize().catch(err => {
+            this.#features.logging.error(`Error trimming history: ${err}`)
         })
     }
 
@@ -472,6 +463,14 @@ export class ChatDatabase {
     }
 
     /**
+     * If the sum of all history file size exceeds the limit, start trimming the oldest conversation
+     * across all the workspace until the folder size is below the target size.
+     */
+    async trimHistoryToMaxSize() {
+        await this.#historyMaintainer.trimHistoryToMaxSize()
+    }
+
+    /**
      * Calculates the size of a database file
      * @param dbPath Path to the database file
      * @returns Promise that resolves to the file size in bytes, or 0 if there's an error
@@ -479,216 +478,6 @@ export class ChatDatabase {
     private async calculateDatabaseSize(dbPath: string): Promise<number> {
         const result = await this.#features.workspace.fs.getFileSize(dbPath)
         return result.size
-    }
-
-    /**
-     * Calculates the total size of all history database files in the directory
-     * @returns The total size of all database files in bytes
-     */
-    private async calculateAllHistorySize(dbFiles?: string[]): Promise<number> {
-        if (!dbFiles) {
-            dbFiles = (await this.listDatabaseFiles()).map(file => file.name)
-        }
-
-        // Calculate the total size of all database files
-        let totalSize = 0
-        for (const file of dbFiles) {
-            const filePath = path.join(this.#dbDirectory, file)
-            let fileSize
-            try {
-                fileSize = await this.calculateDatabaseSize(filePath)
-            } catch (err) {
-                this.#features.logging.error(`Error getting db file size: ${err}`)
-                fileSize = 0
-            }
-            totalSize += fileSize
-        }
-
-        return totalSize
-    }
-
-    /**
-     * Lists all database files in the history directory
-     * @returns Promise that resolves to an array of database file entries
-     */
-    private async listDatabaseFiles() {
-        try {
-            // List all files in the directory using readdir
-            const dirEntries = await this.#features.workspace.fs.readdir(this.#dbDirectory)
-
-            // Filter for database files (they should follow the pattern chat-history-*.json)
-            return dirEntries.filter(
-                entry => entry.isFile() && entry.name.startsWith('chat-history-') && entry.name.endsWith('.json')
-            )
-        } catch (err) {
-            this.#features.logging.error(`Error listing database files: ${err}`)
-            return []
-        }
-    }
-
-    /**
-     * If the sum of all history file size exceeds the limit, start trimming the oldest conversation
-     * across all the workspace until the folder size is below maxAfterTrimHistoryFolderSizeInBytes.
-     */
-    async trimHistoryToMaxSize() {
-        // Get the size of all history DB files
-        const historyTotalSizeInBytes = await this.calculateAllHistorySize()
-        this.#features.logging.info(
-            `Current history total size: ${historyTotalSizeInBytes} Bytes, max allowed: ${maxHistorySizeInBytes} Bytes`
-        )
-
-        // If we're under the limit, no need to trim
-        if (historyTotalSizeInBytes <= maxHistorySizeInBytes) {
-            return
-        }
-        this.#features.logging.info(
-            `History total size (${historyTotalSizeInBytes} Bytes) exceeds limit (${maxHistorySizeInBytes} Bytes), trimming history`
-        )
-
-        const trimStart = performance.now()
-        await this.trimHistoryForAllWorkspace()
-        const trimEnd = performance.now()
-        this.#features.logging.info(`Trimming history took ${trimEnd - trimStart} ms`)
-    }
-
-    private async trimHistoryForAllWorkspace() {
-        // Load all databases
-        const allDbFiles = (await this.listDatabaseFiles()).map(file => file.name)
-        // DB name to {collection, db} Map
-        const allDbsMap = await this.loadAllDbFiles(allDbFiles)
-        this.#features.logging.info(`Loaded ${allDbsMap.size} databases in ${this.#dbDirectory}`)
-        if (allDbsMap.size < allDbFiles.length) {
-            this.#features.logging.warn(
-                `Found ${allDbFiles.length - allDbsMap.size} bad DB files, will skip them when calculating history size`
-            )
-        }
-
-        const tabQueue = initializeHistoryPriorityQueue()
-
-        // Add tabs to the queue
-        for (const [dbName, dbRef] of allDbsMap.entries()) {
-            const tabCollection = dbRef.collection
-            if (!tabCollection) continue
-
-            const tabs = tabCollection.find()
-            for (const tab of tabs) {
-                // Use the first message under the first conversation to get the oldestMessageDate, if no timestamp under the message, use 0.
-                const oldestMessageDate = getOldestMessageTimestamp(tab)
-                tabQueue.add({
-                    tab: tab,
-                    collection: tabCollection,
-                    dbName: dbName,
-                    oldestMessageDate: oldestMessageDate,
-                })
-            }
-        }
-
-        // Keep trimming until we're under the target size
-        let iterationCount = 0
-        while (!tabQueue.isEmpty()) {
-            // Check current total size
-            const totalSize = await this.calculateAllHistorySize(Array.from(allDbsMap.keys()))
-
-            // If we're under the target size, we're done
-            if (totalSize <= maxAfterTrimHistorySizeInBytes) {
-                this.#features.logging.info(`Successfully trimmed history to ${totalSize} bytes`)
-                break
-            }
-            // Infinite loop protection
-            if (++iterationCount > maxTrimHistoryLoopIteration) {
-                this.#features.logging.warn(
-                    `Exceeded max iteration count (${maxTrimHistoryLoopIteration}) when trimming history, current total size: ${totalSize}`
-                )
-                break
-            }
-
-            // Do a batch deletion so that we don't re-calculate the size for every deletion,
-            // messages should be deleted in pairs(prompt, answer)
-            let updatedDbs = new Set<string>()
-            for (let i = 0; i < messageBatchDeleteIterationBeforeRecalculateDBSize / 2; i++) {
-                const queueItem = tabQueue.dequeue()
-                const tab = queueItem?.tab
-                const collection = queueItem?.collection
-                const dbName = queueItem?.dbName
-                if (!tab || !collection || !dbName) break
-
-                updatedDbs.add(dbName)
-                if (!tab.conversations) {
-                    collection.remove(tab)
-                    continue
-                }
-
-                // Remove messages under a tab
-                let pairsRemoved = 0
-                while (
-                    pairsRemoved < messageBatchDeleteSizeForSingleTab / 2 &&
-                    this.removeOldestMessagePairFromHistory(tab)
-                ) {
-                    pairsRemoved++
-                }
-
-                if (!tab.conversations || tab.conversations.length === 0) {
-                    // If the tab has no conversations left, remove it
-                    collection.remove(tab)
-                } else {
-                    collection.update(tab)
-                    // Re-add the tab to the queue with updated oldest date
-                    const newOldestDate = getOldestMessageTimestamp(tab)
-                    tabQueue.enqueue({ tab: tab, collection, dbName: dbName, oldestMessageDate: newOldestDate })
-                }
-            }
-
-            // Save the updated database if it's not the current one, the current db should have autosave enabled
-            for (const [dbName, dbRef] of allDbsMap.entries()) {
-                if (updatedDbs.has(dbName)) {
-                    this.#features.logging.debug(
-                        `Removed old messages from ${dbName}, historyId: ${dbRef.collection.findOne()?.historyId}, saving changes`
-                    )
-                    await new Promise<void>(resolve => {
-                        dbRef.db.saveDatabase(() => resolve())
-                    })
-                }
-            }
-        }
-
-        // Close the databases except the current workspace DB
-        for (const [dbName, dbRef] of allDbsMap.entries()) {
-            if (dbName !== this.#dbName) {
-                dbRef.db.close()
-            }
-        }
-    }
-
-    private async loadAllDbFiles(allDbFiles: string[]) {
-        const allDbsMap = new Map<string, { collection: Collection<Tab>; db: Loki }>()
-        for (const dbFile of allDbFiles) {
-            try {
-                if (dbFile === this.#dbName) {
-                    // Current workspace DB
-                    const collection = this.#db.getCollection<Tab>(TabCollection)
-                    allDbsMap.set(dbFile, { collection: collection, db: this.#db })
-                    continue
-                }
-
-                const db = new Loki(dbFile, {
-                    adapter: new FileSystemAdapter(this.#features.workspace, this.#dbDirectory),
-                    persistenceMethod: 'fs',
-                })
-                await new Promise<void>(resolve => {
-                    db.loadDatabase({}, () => resolve())
-                })
-                const collection = db.getCollection<Tab>(TabCollection)
-
-                if (collection) {
-                    allDbsMap.set(dbFile, { collection: collection, db: db })
-                } else {
-                    this.#features.logging.warn(`No ${TabCollection} collection found in database ${dbFile}`)
-                }
-            } catch (err) {
-                this.#features.logging.error(`Error loading DB file ${dbFile}: ${err}`)
-            }
-        }
-        return allDbsMap
     }
 
     private findIndexToTrim(allMessages: Message[]): number | undefined {
@@ -747,30 +536,6 @@ export class ChatDatabase {
             this.#features.logging.debug('Removing the last prompt message from the history DB')
             messages.pop()
         }
-    }
-
-    /**
-     * Remove the oldest message pair, based on assumptions:
-     * 1. The messages are always stored in pair(prompt, answer)
-     * 2. The messages are always stored in chronological order(new messages are added to the tail of the list)
-     * @returns True if successfully trimmed the history.
-     */
-    private removeOldestMessagePairFromHistory(tabData: Tab): boolean {
-        if (!tabData.conversations || tabData.conversations.length === 0) {
-            this.#features.logging.debug(`No conversations found in tab ${tabData.historyId}`)
-            return false
-        }
-
-        const conversation = tabData.conversations[0]
-
-        // Remove messages in pairs from the beginning
-        if (conversation.messages?.length > 2) {
-            conversation.messages.splice(0, 2)
-        } else {
-            // Remove the entire conversation if it has few messages
-            tabData.conversations.splice(0, 1)
-        }
-        return true
     }
 
     private trimMessagesToMaxLength(messages: Message[], remainingCharacterBudget: number): Message[] {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -8,6 +8,7 @@ import {
     Conversation,
     FileSystemAdapter,
     groupTabsByDate,
+    isEmptyAssistantMessage,
     Message,
     messageToStreamingMessage,
     Settings,
@@ -16,6 +17,8 @@ import {
     TabCollection,
     TabType,
     updateOrCreateConversation,
+    initializeHistoryPriorityQueue,
+    getOldestMessageTimestamp,
 } from './util'
 import * as crypto from 'crypto'
 import * as path from 'path'
@@ -26,8 +29,24 @@ import { ChatItemType } from '@aws/mynah-ui'
 import { getUserHomeDir } from '@aws/lsp-core/out/util/path'
 
 export const EMPTY_CONVERSATION_LIST_ID = 'empty'
-// Maximum number of messages to keep in history
-const MaxConversationHistoryMessages = 250
+// Maximum number of characters to send in request
+const maxConversationHistoryCharacters = 600_000
+// Maximum number of messages to send in request
+const maxConversationHistoryMessages = 250
+// Maximum history file size across all workspace, 200MB
+const maxHistorySizeInBytes = 200 * 1024 * 1024
+// 75% of the max size, 150MB
+const maxAfterTrimHistorySizeInBytes = 150 * 1024 * 1024
+/**
+ * The combination of messageBatchDeleteIterationBeforeRecalculateDBSize and messageBatchDeleteSizeForSingleTab can heavily impact the
+ * latency of trimming history since calculating the history file size is slow. We can tune these numbers according to the average message size
+ */
+// Batch deletion iteration count when trimming history before re-calculating total history size
+const messageBatchDeleteIterationBeforeRecalculateDBSize = 200
+// Batch deletion message size when trimming history for a specific tab before re-checking the oldest message among all workspace history
+const messageBatchDeleteSizeForSingleTab = 10
+// In each iteration, we calculate the total history size and try to delete [messageBatchDeleteSizeForSingleTab * messageBatchDeleteIterationBeforeRecalculateDBSize] messages
+const maxTrimHistoryLoopIteration = 100
 
 /**
  * A singleton database class that manages chat history persistence using LokiJS.
@@ -48,6 +67,7 @@ export class ChatDatabase {
      */
     #historyIdMapping: Map<string, string> = new Map()
     #dbDirectory: string
+    #dbName: string
     #features: Features
     #initialized: boolean = false
     #loadTimeMs?: number
@@ -62,14 +82,13 @@ export class ChatDatabase {
             '.aws/amazonq/history'
         )
         const workspaceId = this.getWorkspaceIdentifier()
-        const dbName = `chat-history-${workspaceId}.json`
-        const dbPath = path.join(this.#dbDirectory, dbName)
+        this.#dbName = `chat-history-${workspaceId}.json`
+        const dbPath = path.join(this.#dbDirectory, this.#dbName)
 
         this.#features.logging.log(`Initializing database at ${dbPath}`)
 
-        this.#features.workspace.fs
-            .getFileSize(dbPath)
-            .then(({ size }) => {
+        this.calculateDatabaseSize(dbPath)
+            .then(size => {
                 this.#dbFileSize = size
             })
             .catch(err => {
@@ -78,7 +97,7 @@ export class ChatDatabase {
 
         const startTime = Date.now()
 
-        this.#db = new Loki(dbName, {
+        this.#db = new Loki(this.#dbName, {
             adapter: new FileSystemAdapter(features.workspace, this.#dbDirectory),
             autosave: true,
             autoload: true,
@@ -271,8 +290,9 @@ export class ChatDatabase {
             )
             const tabData = historyId ? tabCollection.findOne({ historyId }) : undefined
             if (tabData) {
-                const allMessages = tabData.conversations.flatMap((conversation: Conversation) =>
-                    conversation.messages.map(msg => messageToStreamingMessage(msg))
+                const allMessages = tabData.conversations.flatMap(
+                    (conversation: Conversation) => conversation.messages
+                    // .map(msg => messageToStreamingMessage(msg))
                 )
                 if (numMessages !== undefined) {
                     return allMessages.slice(-numMessages)
@@ -321,6 +341,7 @@ export class ChatDatabase {
      *
      * This method manages chat messages in the following way:
      * - Creates a new history ID if none exists for the tab
+     * - Drops the message and the previous user prompt if it's an empty assistant response
      * - Updates existing conversation or creates new one
      * - Updates tab title with last user prompt added to conversation
      * - Updates tab's last updated time
@@ -343,6 +364,19 @@ export class ChatDatabase {
             }
 
             const tabData = historyId ? tabCollection.findOne({ historyId }) : undefined
+
+            // Skip adding to history DB if it's an empty assistant response
+            if (isEmptyAssistantMessage(message)) {
+                this.#features.logging.debug(
+                    'The message is empty partial assistant. Skipped adding this message and removed last user prompt from the history DB'
+                )
+                if (tabData) {
+                    // Remove the last user prompt as well
+                    this.removeLastPromptFromConversation(tabData.conversations, conversationId)
+                }
+                return
+            }
+
             const tabTitle =
                 (message.type === 'prompt' && message.shouldDisplayMessage !== false && message.body.trim().length > 0
                     ? message.body
@@ -394,52 +428,33 @@ export class ChatDatabase {
     }
 
     /**
-     * Fixes the history to maintain the following invariants:
+     * Prepare the history messages for service request `GenerateAssistantResponseCommandInput` to maintain the following invariants:
      * 1. The history contains at most MaxConversationHistoryMessages messages. Oldest messages are dropped.
-     * 2. The first message is from the user. Oldest messages are dropped if needed.
-     * 3. The last message is from the assistant. The last message is dropped if it is from the user.
-     * 4. The history contains alternating sequene of userMessage followed by assistantMessages
-     * 5. The toolUse and toolResult relationship is valid
-     * 6. The history character length is <= MaxConversationHistoryCharacters - newUserMessageCharacterCount. Oldest messages are dropped.
+     * 2. The last assistant message is not empty
+     * 3. The first message is from the user and the last message is from the assistant.
+     *    The history contains alternating sequene of userMessage followed by assistantMessages
+     * 4. The history character length is <= MaxConversationHistoryCharacters - newUserMessageCharacterCount. Oldest messages are dropped.
      */
-    fixAndValidateHistory(
-        tabId: string,
-        newUserMessage: ChatMessage,
-        conversationId: string,
-        remainingCharacterBudget: number
-    ): boolean {
+    getPreprocessedRequestHistory(tabId: string, newUserMessage: ChatMessage, remainingCharacterBudget: number) {
         if (!this.#initialized) {
-            return true
-        }
-        const historyId = this.#historyIdMapping.get(tabId)
-        this.#features.logging.info(`Fixing history: tabId=${tabId}, historyId=${historyId || 'undefined'}`)
-
-        if (!historyId) {
-            return true
+            return []
         }
 
-        const tabCollection = this.#db.getCollection<Tab>(TabCollection)
-        const tabData = tabCollection.findOne({ historyId })
-        if (!tabData) {
-            return true
+        this.#features.logging.info(`Preprocessing request history: tabId=${tabId}`)
+
+        // 1. Make sure the length of the history messages don't exceed MaxConversationHistoryMessages
+        let allMessages = this.getMessages(tabId, maxConversationHistoryMessages)
+        if (allMessages.length === 0) {
+            return []
         }
 
-        let allMessages = tabData.conversations.flatMap((conversation: Conversation) => conversation.messages)
-        this.#features.logging.info(`Found ${allMessages.length} messages in conversation`)
+        // 2. Drop empty assistant partial if it’s the last message
+        this.removeEmptyAssistantMessage(allMessages)
 
-        //  Make sure we don't exceed MaxConversationHistoryMessages
-        allMessages = this.trimHistoryToMaxLength(allMessages)
-
-        //  Drop empty assistant partial if it’s the last message
-        this.handleEmptyAssistantMessage(allMessages)
-
-        //  Ensure messages in history a valid for server side checks
+        // 3. Ensure messages in history a valid for server side checks
         this.ensureValidMessageSequence(allMessages, newUserMessage)
 
-        // Ensure lastMessage in history toolUse and newMessage toolResult relationship is valid
-        const isValid = this.validateNewMessageToolResults(allMessages, newUserMessage)
-
-        //  Make sure max characters ≤ remaining Character Budget
+        // 4. Make sure max characters ≤ remaining Character Budget
         allMessages = this.trimMessagesToMaxLength(allMessages, remainingCharacterBudget)
 
         // Edge case: If the history is empty and the next message contains tool results, then we have to just abandon them.
@@ -453,38 +468,227 @@ export class ChatDatabase {
             newUserMessage.userInputMessage.content = 'The conversation history has overflowed, clearing state'
         }
 
-        const clientType = this.#features.lsp.getClientInitializeParams()?.clientInfo?.name || 'unknown'
-
-        tabData.conversations = [
-            {
-                conversationId: conversationId,
-                clientType: clientType,
-                messages: allMessages,
-            },
-        ]
-        tabData.updatedAt = new Date()
-        tabCollection.update(tabData)
-        this.#features.logging.info(`Updated tab data in collection`)
-        return isValid
+        return allMessages
     }
 
-    private trimHistoryToMaxLength(messages: Message[]): Message[] {
-        while (messages.length > MaxConversationHistoryMessages) {
-            // Find the next valid user message to start from
-            const indexToTrim = this.findIndexToTrim(messages)
-            if (indexToTrim !== undefined && indexToTrim > 0) {
-                this.#features.logging.debug(
-                    `Removing the first ${indexToTrim} elements to maintain valid history length`
-                )
-                messages.splice(0, indexToTrim)
-            } else {
-                this.#features.logging.debug(
-                    'Could not find a valid point to trim, reset history to reduce history size'
-                )
-                return []
+    /**
+     * Calculates the size of a database file
+     * @param dbPath Path to the database file
+     * @returns Promise that resolves to the file size in bytes, or 0 if there's an error
+     */
+    private async calculateDatabaseSize(dbPath: string): Promise<number> {
+        const result = await this.#features.workspace.fs.getFileSize(dbPath)
+        return result.size
+    }
+
+    /**
+     * Calculates the total size of all history database files in the directory
+     * @returns The total size of all database files in bytes
+     */
+    private async calculateAllHistorySize(dbFiles?: string[]): Promise<number> {
+        if (!dbFiles) {
+            dbFiles = (await this.listDatabaseFiles()).map(file => file.name)
+        }
+
+        // Calculate the total size of all database files
+        let totalSize = 0
+        for (const file of dbFiles) {
+            const filePath = path.join(this.#dbDirectory, file)
+            let fileSize
+            try {
+                fileSize = await this.calculateDatabaseSize(filePath)
+            } catch (err) {
+                this.#features.logging.error(`Error getting db file size: ${err}`)
+                fileSize = 0
+            }
+            totalSize += fileSize
+        }
+
+        return totalSize
+    }
+
+    /**
+     * Lists all database files in the history directory
+     * @returns Promise that resolves to an array of database file entries
+     */
+    private async listDatabaseFiles() {
+        try {
+            // List all files in the directory using readdir
+            const dirEntries = await this.#features.workspace.fs.readdir(this.#dbDirectory)
+
+            // Filter for database files (they should follow the pattern chat-history-*.json)
+            return dirEntries.filter(
+                entry => entry.isFile() && entry.name.startsWith('chat-history-') && entry.name.endsWith('.json')
+            )
+        } catch (err) {
+            this.#features.logging.error(`Error listing database files: ${err}`)
+            return []
+        }
+    }
+
+    /**
+     * If the sum of all history file size exceeds the limit, start trimming the oldest conversation
+     * across all the workspace until the folder size is below maxAfterTrimHistoryFolderSizeInBytes.
+     */
+    async trimHistoryToMaxSize() {
+        // Get the size of all history DB files
+        const historyTotalSizeInBytes = await this.calculateAllHistorySize()
+        this.#features.logging.info(
+            `Current history total size: ${historyTotalSizeInBytes} Bytes, max allowed: ${maxHistorySizeInBytes} Bytes`
+        )
+
+        // If we're under the limit, no need to trim
+        if (historyTotalSizeInBytes <= maxHistorySizeInBytes) {
+            return
+        }
+        this.#features.logging.info(
+            `History total size (${historyTotalSizeInBytes} Bytes) exceeds limit (${maxHistorySizeInBytes} Bytes), trimming history`
+        )
+
+        const trimStart = performance.now()
+        await this.trimHistoryForAllWorkspace()
+        const trimEnd = performance.now()
+        this.#features.logging.info(`Trimming history took ${trimEnd - trimStart} ms`)
+    }
+
+    private async trimHistoryForAllWorkspace() {
+        // Load all databases
+        const allDbFiles = (await this.listDatabaseFiles()).map(file => file.name)
+        // DB name to {collection, db} Map
+        const allDbsMap = await this.loadAllDbFiles(allDbFiles)
+        this.#features.logging.info(`Loaded ${allDbsMap.size} databases in ${this.#dbDirectory}`)
+        if (allDbsMap.size < allDbFiles.length) {
+            this.#features.logging.warn(
+                `Found ${allDbFiles.length - allDbsMap.size} bad DB files, will skip them when calculating history size`
+            )
+        }
+
+        const tabQueue = initializeHistoryPriorityQueue()
+
+        // Add tabs to the queue
+        for (const [dbName, dbRef] of allDbsMap.entries()) {
+            const tabCollection = dbRef.collection
+            if (!tabCollection) continue
+
+            const tabs = tabCollection.find()
+            for (const tab of tabs) {
+                // Use the first message under the first conversation to get the oldestMessageDate, if no timestamp under the message, use 0.
+                const oldestMessageDate = getOldestMessageTimestamp(tab)
+                tabQueue.add({
+                    tab: tab,
+                    collection: tabCollection,
+                    dbName: dbName,
+                    oldestMessageDate: oldestMessageDate,
+                })
             }
         }
-        return messages
+
+        // Keep trimming until we're under the target size
+        let iterationCount = 0
+        while (!tabQueue.isEmpty()) {
+            // Check current total size
+            const totalSize = await this.calculateAllHistorySize(Array.from(allDbsMap.keys()))
+
+            // If we're under the target size, we're done
+            if (totalSize <= maxAfterTrimHistorySizeInBytes) {
+                this.#features.logging.info(`Successfully trimmed history to ${totalSize} bytes`)
+                break
+            }
+            // Infinite loop protection
+            if (++iterationCount > maxTrimHistoryLoopIteration) {
+                this.#features.logging.warn(
+                    `Exceeded max iteration count (${maxTrimHistoryLoopIteration}) when trimming history, current total size: ${totalSize}`
+                )
+                break
+            }
+
+            // Do a batch deletion so that we don't re-calculate the size for every deletion,
+            // messages should be deleted in pairs(prompt, answer)
+            let updatedDbs = new Set<string>()
+            for (let i = 0; i < messageBatchDeleteIterationBeforeRecalculateDBSize / 2; i++) {
+                const queueItem = tabQueue.dequeue()
+                const tab = queueItem?.tab
+                const collection = queueItem?.collection
+                const dbName = queueItem?.dbName
+                if (!tab || !collection || !dbName) break
+
+                updatedDbs.add(dbName)
+                if (!tab.conversations) {
+                    collection.remove(tab)
+                    continue
+                }
+
+                // Remove messages under a tab
+                let pairsRemoved = 0
+                while (
+                    pairsRemoved < messageBatchDeleteSizeForSingleTab / 2 &&
+                    this.removeOldestMessagePairFromHistory(tab)
+                ) {
+                    pairsRemoved++
+                }
+
+                if (!tab.conversations || tab.conversations.length === 0) {
+                    // If the tab has no conversations left, remove it
+                    collection.remove(tab)
+                } else {
+                    collection.update(tab)
+                    // Re-add the tab to the queue with updated oldest date
+                    const newOldestDate = getOldestMessageTimestamp(tab)
+                    tabQueue.enqueue({ tab: tab, collection, dbName: dbName, oldestMessageDate: newOldestDate })
+                }
+            }
+
+            // Save the updated database if it's not the current one, the current db should have autosave enabled
+            for (const [dbName, dbRef] of allDbsMap.entries()) {
+                if (updatedDbs.has(dbName)) {
+                    this.#features.logging.debug(
+                        `Removed old messages from ${dbName}, historyId: ${dbRef.collection.findOne()?.historyId}, saving changes`
+                    )
+                    await new Promise<void>(resolve => {
+                        dbRef.db.saveDatabase(() => resolve())
+                    })
+                }
+            }
+        }
+
+        // Close the databases except the current workspace DB
+        for (const [dbName, dbRef] of allDbsMap.entries()) {
+            if (dbName !== this.#dbName) {
+                dbRef.db.close()
+            }
+        }
+    }
+
+    private async loadAllDbFiles(allDbFiles: string[]) {
+        const allDbsMap = new Map<string, { collection: Collection<Tab>; db: Loki }>()
+        for (const dbFile of allDbFiles) {
+            try {
+                if (dbFile === this.#dbName) {
+                    // Current workspace DB
+                    const collection = this.#db.getCollection<Tab>(TabCollection)
+                    allDbsMap.set(dbFile, { collection: collection, db: this.#db })
+                    continue
+                }
+
+                const db = new Loki(dbFile, {
+                    adapter: new FileSystemAdapter(this.#features.workspace, this.#dbDirectory),
+                    persistenceMethod: 'fs',
+                })
+                await new Promise<void>(resolve => {
+                    db.loadDatabase({}, () => resolve())
+                })
+                const collection = db.getCollection<Tab>(TabCollection)
+
+                if (collection) {
+                    allDbsMap.set(dbFile, { collection: collection, db: db })
+                } else {
+                    this.#features.logging.warn(`No ${TabCollection} collection found in database ${dbFile}`)
+                }
+            } catch (err) {
+                this.#features.logging.error(`Error loading DB file ${dbFile}: ${err}`)
+            }
+        }
+        return allDbsMap
     }
 
     private findIndexToTrim(allMessages: Message[]): number | undefined {
@@ -502,7 +706,12 @@ export class ChatDatabase {
         return !!ctx && (!ctx.toolResults || ctx.toolResults.length === 0) && message.body !== ''
     }
 
-    private handleEmptyAssistantMessage(messages: Message[]): void {
+    /**
+     * If the last answer is empty, remove the last answer and user prompt.
+     * @param messages
+     * @returns
+     */
+    private removeEmptyAssistantMessage(messages: Message[]): void {
         if (messages.length < 2) {
             return
         }
@@ -518,6 +727,50 @@ export class ChatDatabase {
             )
             messages.splice(-2)
         }
+    }
+
+    /**
+     * Remove the last user prompt from the conversation
+     */
+    private removeLastPromptFromConversation(conversations: Conversation[], conversationId: string) {
+        const conversation = conversations.find(conv => conv.conversationId === conversationId)
+        if (!conversation) {
+            return
+        }
+
+        const messages = conversation.messages
+        if (!messages.length) {
+            return
+        }
+
+        if (messages[messages.length - 1].type === ('prompt' as ChatItemType)) {
+            this.#features.logging.debug('Removing the last prompt message from the history DB')
+            messages.pop()
+        }
+    }
+
+    /**
+     * Remove the oldest message pair, based on assumptions:
+     * 1. The messages are always stored in pair(prompt, answer)
+     * 2. The messages are always stored in chronological order(new messages are added to the tail of the list)
+     * @returns True if successfully trimmed the history.
+     */
+    private removeOldestMessagePairFromHistory(tabData: Tab): boolean {
+        if (!tabData.conversations || tabData.conversations.length === 0) {
+            this.#features.logging.debug(`No conversations found in tab ${tabData.historyId}`)
+            return false
+        }
+
+        const conversation = tabData.conversations[0]
+
+        // Remove messages in pairs from the beginning
+        if (conversation.messages?.length > 2) {
+            conversation.messages.splice(0, 2)
+        } else {
+            // Remove the entire conversation if it has few messages
+            tabData.conversations.splice(0, 1)
+        }
+        return true
     }
 
     private trimMessagesToMaxLength(messages: Message[], remainingCharacterBudget: number): Message[] {
@@ -595,13 +848,13 @@ export class ChatDatabase {
             return
         }
 
-        //  Make sure the first stored message is from the user (type === 'prompt'), else drop
+        //  Make sure the first message is from the user (type === 'prompt'), else drop
         while (messages.length > 0 && messages[0].type === ('answer' as ChatItemType)) {
             messages.shift()
             this.#features.logging.debug('Dropped first message since it is not from user')
         }
 
-        //  Make sure the last stored message is from the assistant (type === 'answer'), else drop
+        //  Make sure the last message is from the assistant (type === 'answer'), else drop
         if (messages.length > 0 && messages[messages.length - 1].type === ('prompt' as ChatItemType)) {
             // When user aborts some in-progress tooluse event, we should still send the previous toolResult back
             if (messages[messages.length - 1].userInputMessageContext?.toolResults) {
@@ -630,7 +883,19 @@ export class ChatDatabase {
         }
     }
 
-    validateNewMessageToolResults(messages: Message[], newUserMessage: ChatMessage): boolean {
+    /**
+     * This method modifies the new user message and ensuring that tool results in a new user message
+     * properly correspond to tool uses from the previous assistant message.
+     *
+     * This validation should be performed before sending requests and is critical for maintaining
+     * a coherent conversation flow when tools are involved, ensuring the AI model has accurate context
+     * about which tools were actually used and which were cancelled or failed.
+     *
+     * @param messages The conversation history messages
+     * @param newUserMessage The new user message being added to the conversation
+     * @returns true if the message is valid or was successfully fixed, false if invalid
+     */
+    validateAndFixNewMessageToolResults(messages: Message[], newUserMessage: ChatMessage): boolean {
         if (newUserMessage?.userInputMessage?.userInputMessageContext) {
             const newUserMessageContext = newUserMessage.userInputMessage.userInputMessageContext
             const toolResults = newUserMessageContext.toolResults || []

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -10,13 +10,13 @@ import {
     groupTabsByDate,
     isEmptyAssistantMessage,
     Message,
-    messageToStreamingMessage,
     Settings,
     SettingsCollection,
     Tab,
     TabCollection,
     TabType,
-    updateOrCreateConversation,
+    updateOrCreateConversationWithMessagePair,
+    calculateDatabaseSize,
 } from './util'
 import * as crypto from 'crypto'
 import * as path from 'path'
@@ -26,6 +26,13 @@ import { ChatMessage, ToolResultStatus } from '@aws/codewhisperer-streaming-clie
 import { ChatItemType } from '@aws/mynah-ui'
 import { getUserHomeDir } from '@aws/lsp-core/out/util/path'
 import { ChatHistoryMaintainer } from './chatHistoryMaintainer'
+
+export class ToolResultValidationError extends Error {
+    constructor(message?: string) {
+        super(message)
+        this.name = 'ToolResultValidationError'
+    }
+}
 
 export const EMPTY_CONVERSATION_LIST_ID = 'empty'
 // Maximum number of messages to send in request
@@ -70,12 +77,12 @@ export class ChatDatabase {
 
         this.#features.logging.log(`Initializing database at ${dbPath}`)
 
-        this.calculateDatabaseSize(dbPath)
+        calculateDatabaseSize(this.#features, dbPath)
             .then(size => {
                 this.#dbFileSize = size
             })
             .catch(err => {
-                this.#features.logging.log(`Error getting db file size: ${err}`)
+                this.#features.logging.warn(`Error getting db file size: ${err}`)
             })
 
         const startTime = Date.now()
@@ -107,6 +114,13 @@ export class ChatDatabase {
     public close() {
         this.#db.close()
         ChatDatabase.#instance = undefined
+    }
+
+    /**
+     * Returns whether the database has been initialized.
+     */
+    isInitialized(): boolean {
+        return this.#initialized
     }
 
     setHistoryIdMapping(tabId: string, historyId: string) {
@@ -162,7 +176,7 @@ export class ChatDatabase {
     }
 
     getOpenTabs() {
-        if (this.#initialized) {
+        if (this.isInitialized()) {
             const collection = this.#db.getCollection<Tab>(TabCollection)
             return collection.find({ isOpen: true })
         }
@@ -173,7 +187,7 @@ export class ChatDatabase {
     }
 
     getTab(historyId: string) {
-        if (this.#initialized) {
+        if (this.isInitialized()) {
             const collection = this.#db.getCollection<Tab>(TabCollection)
             return collection.findOne({ historyId })
         }
@@ -196,7 +210,7 @@ export class ChatDatabase {
      * Delete a conversation from history when /clear command is sent on an open tab
      */
     clearTab(tabId: string) {
-        if (this.#initialized) {
+        if (this.isInitialized()) {
             const tabCollection = this.#db.getCollection<Tab>(TabCollection)
             const historyId = this.#historyIdMapping.get(tabId)
             if (historyId) {
@@ -210,7 +224,7 @@ export class ChatDatabase {
     }
 
     updateTabOpenState(tabId: string, isOpen: boolean) {
-        if (this.#initialized) {
+        if (this.isInitialized()) {
             const tabCollection = this.#db.getCollection<Tab>(TabCollection)
             const historyId = this.#historyIdMapping.get(tabId)
             if (historyId) {
@@ -239,7 +253,7 @@ export class ChatDatabase {
         let searchResults: ConversationItemGroup[] = []
         const startTime = Date.now()
 
-        if (this.#initialized) {
+        if (this.isInitialized()) {
             if (!filter) {
                 this.#features.logging.log(`Empty search filter, returning all history`)
                 return { results: this.getHistory(), searchTime: Date.now() - startTime }
@@ -272,7 +286,7 @@ export class ChatDatabase {
      * @param numMessages Optional number of most recent messages to return. If not provided, returns all messages.
      */
     getMessages(tabId: string, numMessages?: number) {
-        if (this.#initialized) {
+        if (this.isInitialized()) {
             const tabCollection = this.#db.getCollection<Tab>(TabCollection)
             const historyId = this.#historyIdMapping.get(tabId)
             this.#features.logging.log(
@@ -280,10 +294,7 @@ export class ChatDatabase {
             )
             const tabData = historyId ? tabCollection.findOne({ historyId }) : undefined
             if (tabData) {
-                const allMessages = tabData.conversations.flatMap(
-                    (conversation: Conversation) => conversation.messages
-                    // .map(msg => messageToStreamingMessage(msg))
-                )
+                const allMessages = tabData.conversations.flatMap((conversation: Conversation) => conversation.messages)
                 if (numMessages !== undefined) {
                     return allMessages.slice(-numMessages)
                 }
@@ -297,7 +308,7 @@ export class ChatDatabase {
      * Get all conversations for the current workspace, grouped by last updated time
      */
     getHistory(): ConversationItemGroup[] {
-        if (this.#initialized) {
+        if (this.isInitialized()) {
             const tabCollection = this.#db.getCollection<Tab>(TabCollection)
             const tabs = tabCollection.find()
             let groupedTabs = groupTabsByDate(tabs)
@@ -315,7 +326,7 @@ export class ChatDatabase {
      * Deletes a conversation from history
      */
     deleteHistory(historyId: string) {
-        if (this.#initialized) {
+        if (this.isInitialized()) {
             const tabCollection = this.#db.getCollection<Tab>(TabCollection)
             tabCollection.findAndRemove({ historyId })
             this.#features.logging.log(`Removed conversation from history with historyId=${historyId}`)
@@ -327,73 +338,95 @@ export class ChatDatabase {
     }
 
     /**
-     * Adds a message to a conversation within a specified tab.
+     * Adds a prompt message and an answer message to a conversation within a specified tab.
      *
      * This method manages chat messages in the following way:
      * - Creates a new history ID if none exists for the tab
-     * - Drops the message and the previous user prompt if it's an empty assistant response
+     * - Skip adding the messages if the assistant response is empty
      * - Updates existing conversation or creates new one
-     * - Updates tab title with last user prompt added to conversation
+     * - Updates tab title with the user prompt added to conversation
      * - Updates tab's last updated time
+     *
+     * @param tabId The ID of the tab to add messages to
+     * @param tabType The type of tab
+     * @param conversationId The ID of the conversation
+     * @param promptMessage The user prompt message
+     * @param answerMessage The assistant answer message
      */
-    addMessage(tabId: string, tabType: TabType, conversationId: string, message: Message) {
-        if (this.#initialized) {
-            const clientType = this.#features.lsp.getClientInitializeParams()?.clientInfo?.name || 'unknown'
-            const tabCollection = this.#db.getCollection<Tab>(TabCollection)
-
-            this.#features.logging.log(
-                `Adding message to history: tabId=${tabId}, tabType=${tabType}, conversationId=${conversationId}`
+    addMessagePair(
+        tabId: string,
+        tabType: TabType,
+        conversationId: string,
+        promptMessage: Message,
+        answerMessage: Message
+    ) {
+        if (!this.isInitialized()) {
+            return
+        }
+        // Skip adding to history DB if assistant response is empty
+        if (isEmptyAssistantMessage(answerMessage)) {
+            this.#features.logging.debug(
+                'The assistant response is empty. Skipped adding this message and removed last user prompt from the history DB'
             )
+            return
+        }
 
-            let historyId = this.#historyIdMapping.get(tabId)
+        const clientType = this.#features.lsp.getClientInitializeParams()?.clientInfo?.name || 'unknown'
+        const tabCollection = this.#db.getCollection<Tab>(TabCollection)
 
-            if (!historyId) {
-                historyId = crypto.randomUUID()
-                this.#features.logging.log(`Creating new historyId=${historyId} for tabId=${tabId}`)
-                this.setHistoryIdMapping(tabId, historyId)
-            }
+        this.#features.logging.log(
+            `Adding message pair to history: tabId=${tabId}, tabType=${tabType}, conversationId=${conversationId}`
+        )
 
-            const tabData = historyId ? tabCollection.findOne({ historyId }) : undefined
+        let historyId = this.#historyIdMapping.get(tabId)
 
-            // Skip adding to history DB if it's an empty assistant response
-            if (isEmptyAssistantMessage(message)) {
-                this.#features.logging.debug(
-                    'The message is empty partial assistant. Skipped adding this message and removed last user prompt from the history DB'
-                )
-                if (tabData) {
-                    // Remove the last user prompt as well
-                    this.removeLastPromptFromConversation(tabData.conversations, conversationId)
-                }
-                return
-            }
+        if (!historyId) {
+            historyId = crypto.randomUUID()
+            this.#features.logging.log(`Creating new historyId=${historyId} for tabId=${tabId}`)
+            this.setHistoryIdMapping(tabId, historyId)
+        }
 
-            const tabTitle =
-                (message.type === 'prompt' && message.shouldDisplayMessage !== false && message.body.trim().length > 0
-                    ? message.body
-                    : tabData?.title) || 'Amazon Q Chat'
-            message = this.formatChatHistoryMessage(message)
-            if (tabData) {
-                this.#features.logging.log(`Updating existing tab with historyId=${historyId}`)
-                tabData.conversations = updateOrCreateConversation(
-                    tabData.conversations,
-                    conversationId,
-                    message,
-                    clientType
-                )
-                tabData.updatedAt = new Date()
-                tabData.title = tabTitle
-                tabCollection.update(tabData)
-            } else {
-                this.#features.logging.log(`Creating new tab with historyId=${historyId}`)
-                tabCollection.insert({
-                    historyId,
-                    updatedAt: new Date(),
-                    isOpen: true,
-                    tabType: tabType,
-                    title: tabTitle,
-                    conversations: [{ conversationId, clientType, messages: [message] }],
-                })
-            }
+        const tabData = historyId ? tabCollection?.findOne({ historyId }) : undefined
+
+        // Format both messages
+        const formattedPromptMessage = this.formatChatHistoryMessage(promptMessage)
+        const formattedAnswerMessage = this.formatChatHistoryMessage(answerMessage)
+
+        // Use prompt message for tab title if appropriate
+        const tabTitle =
+            (promptMessage.shouldDisplayMessage !== false && promptMessage.body.trim().length > 0
+                ? promptMessage.body
+                : tabData?.title) || 'Amazon Q Chat'
+
+        if (tabData) {
+            this.#features.logging.log(`Updating existing tab with historyId=${historyId}`)
+            // Add both messages at once to the conversation
+            tabData.conversations = updateOrCreateConversationWithMessagePair(
+                tabData.conversations,
+                conversationId,
+                formattedPromptMessage,
+                formattedAnswerMessage,
+                clientType
+            )
+            tabData.updatedAt = new Date()
+            tabData.title = tabTitle
+            tabCollection.update(tabData)
+        } else {
+            this.#features.logging.log(`Creating new tab with historyId=${historyId}`)
+            tabCollection.insert({
+                historyId,
+                updatedAt: new Date(),
+                isOpen: true,
+                tabType: tabType,
+                title: tabTitle,
+                conversations: [
+                    {
+                        conversationId,
+                        clientType,
+                        messages: [formattedPromptMessage, formattedAnswerMessage],
+                    },
+                ],
+            })
         }
     }
 
@@ -423,10 +456,11 @@ export class ChatDatabase {
      * 2. The last assistant message is not empty
      * 3. The first message is from the user and the last message is from the assistant.
      *    The history contains alternating sequene of userMessage followed by assistantMessages
-     * 4. The history character length is <= MaxConversationHistoryCharacters - newUserMessageCharacterCount. Oldest messages are dropped.
+     * 4. The toolUse and toolResult relationship is valid
+     * 5. The history character length is <= MaxConversationHistoryCharacters - newUserMessageCharacterCount. Oldest messages are dropped.
      */
     getPreprocessedRequestHistory(tabId: string, newUserMessage: ChatMessage, remainingCharacterBudget: number) {
-        if (!this.#initialized) {
+        if (!this.isInitialized()) {
             return []
         }
 
@@ -444,7 +478,11 @@ export class ChatDatabase {
         // 3. Ensure messages in history a valid for server side checks
         this.ensureValidMessageSequence(allMessages, newUserMessage)
 
-        // 4. Make sure max characters ≤ remaining Character Budget
+        // 4. Ensure lastMessage in history toolUse and newMessage toolResult relationship is valid
+        this.validateAndFixNewMessageToolResults(allMessages, newUserMessage)
+
+        // 5. NOTE: Keep this trimming logic at the end of the preprocess.
+        // Make sure max characters ≤ remaining Character Budget, must be put at the end of preprocessing
         allMessages = this.trimMessagesToMaxLength(allMessages, remainingCharacterBudget)
 
         // Edge case: If the history is empty and the next message contains tool results, then we have to just abandon them.
@@ -459,24 +497,6 @@ export class ChatDatabase {
         }
 
         return allMessages
-    }
-
-    /**
-     * If the sum of all history file size exceeds the limit, start trimming the oldest conversation
-     * across all the workspace until the folder size is below the target size.
-     */
-    async trimHistoryToMaxSize() {
-        await this.#historyMaintainer.trimHistoryToMaxSize()
-    }
-
-    /**
-     * Calculates the size of a database file
-     * @param dbPath Path to the database file
-     * @returns Promise that resolves to the file size in bytes, or 0 if there's an error
-     */
-    private async calculateDatabaseSize(dbPath: string): Promise<number> {
-        const result = await this.#features.workspace.fs.getFileSize(dbPath)
-        return result.size
     }
 
     private findIndexToTrim(allMessages: Message[]): number | undefined {
@@ -514,26 +534,6 @@ export class ChatDatabase {
                 'Last message is empty partial assistant. Removed last assistant message and user message'
             )
             messages.splice(-2)
-        }
-    }
-
-    /**
-     * Remove the last user prompt from the conversation
-     */
-    private removeLastPromptFromConversation(conversations: Conversation[], conversationId: string) {
-        const conversation = conversations.find(conv => conv.conversationId === conversationId)
-        if (!conversation) {
-            return
-        }
-
-        const messages = conversation.messages
-        if (!messages.length) {
-            return
-        }
-
-        if (messages[messages.length - 1].type === ('prompt' as ChatItemType)) {
-            this.#features.logging.debug('Removing the last prompt message from the history DB')
-            messages.pop()
         }
     }
 
@@ -657,26 +657,26 @@ export class ChatDatabase {
      *
      * @param messages The conversation history messages
      * @param newUserMessage The new user message being added to the conversation
-     * @returns true if the message is valid or was successfully fixed, false if invalid
+     * @throws ToolResultValidationError if the message is invalid and not able to be fixed
      */
-    validateAndFixNewMessageToolResults(messages: Message[], newUserMessage: ChatMessage): boolean {
+    validateAndFixNewMessageToolResults(messages: Message[], newUserMessage: ChatMessage) {
         if (newUserMessage?.userInputMessage?.userInputMessageContext) {
             const newUserMessageContext = newUserMessage.userInputMessage.userInputMessageContext
             const toolResults = newUserMessageContext.toolResults || []
             if (messages.length === 0) {
                 if (toolResults && toolResults.length > 0) {
-                    this.#features.logging.warn('New message has tool results but last message has no tool uses')
-                    return false
+                    throw new ToolResultValidationError(
+                        'New message has tool results but last message has no tool uses'
+                    )
                 }
-                return true
+                return
             }
             const lastMsg = messages[messages.length - 1]
             const lastMsgToolUses = lastMsg?.toolUses || []
 
             // If last message has no tool uses but new message has tool results, this is invalid
             if (toolResults && toolResults.length > 0 && lastMsgToolUses.length === 0) {
-                this.#features.logging.warn('New message has tool results but last message has no tool uses')
-                return false
+                throw new ToolResultValidationError('New message has tool results but last message has no tool uses')
             }
 
             const toolUseIds = new Set(lastMsgToolUses.map(toolUse => toolUse.toolUseId))
@@ -705,10 +705,9 @@ export class ChatDatabase {
                 newUserMessageContext.toolResults.length === 0 &&
                 (!newUserMessage.userInputMessage.content || newUserMessage.userInputMessage.content?.trim() == '')
             ) {
-                return false
+                throw new ToolResultValidationError('Empty message with no tool results')
             }
         }
-        return true
     }
 
     getSettings(): Settings | undefined {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatHistoryMaintainer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatHistoryMaintainer.test.ts
@@ -1,0 +1,244 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert'
+import sinon from 'ts-sinon'
+import { ChatHistoryMaintainer } from './chatHistoryMaintainer'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { Tab } from './util'
+import * as Loki from 'lokijs'
+
+/**
+ * Helper function to create a mock tab with multiple conversations and messages
+ * @param tabId The ID of the tab
+ * @param numConversations Number of conversations to create
+ * @param messagesPerConversation Number of messages per conversation
+ * @returns A mock Tab object
+ */
+function createMockTabWithManyConversations(
+    tabId: string,
+    numConversations: number,
+    messagesPerConversation: number
+): Tab {
+    const conversations = []
+
+    for (let convIndex = 0; convIndex < numConversations; convIndex++) {
+        const messages = []
+
+        for (let msgIndex = 0; msgIndex < messagesPerConversation; msgIndex++) {
+            // Add alternating prompt and answer messages
+            if (msgIndex % 2 === 0) {
+                messages.push({
+                    type: 'prompt' as const,
+                    body: `User message ${convIndex}-${msgIndex}`,
+                })
+            } else {
+                messages.push({
+                    type: 'answer' as const,
+                    body: `Assistant response ${convIndex}-${msgIndex}`,
+                })
+            }
+        }
+
+        conversations.push({
+            conversationId: `conv-${convIndex}`,
+            clientType: 'test',
+            messages: messages,
+        })
+    }
+
+    return {
+        historyId: tabId,
+        isOpen: false,
+        updatedAt: new Date(`2023-0${(tabId.charCodeAt(0) % 9) + 1}-01`), // Generate different dates based on tabId
+        tabType: 'cwc',
+        title: `Test Tab ${tabId}`,
+        conversations: conversations,
+    }
+}
+
+describe('ChatHistoryMaintainer', () => {
+    let mockFeatures: Features
+    let mockDb: Loki
+    let historyMaintainer: ChatHistoryMaintainer
+    let listDatabaseFilesStub: sinon.SinonStub
+    let calculateAllHistorySizeStub: sinon.SinonStub
+    let loadAllDbFilesStub: sinon.SinonStub
+    let mockTab1: Tab
+    let mockTab2: Tab
+    let mockCollection1: {
+        update: any
+        remove: any
+        find?: sinon.SinonStub<any[], any>
+        findOne?: sinon.SinonStub<any[], any>
+    }
+    let mockCollection2: {
+        update: any
+        remove: any
+        find?: sinon.SinonStub<any[], any>
+        findOne?: sinon.SinonStub<any[], any>
+    }
+    let mockDb1: { saveDatabase: any; close: any; getCollection?: sinon.SinonStub<any[], any> }
+    let mockDb2: { saveDatabase: any; close: any; getCollection?: sinon.SinonStub<any[], any> }
+
+    beforeEach(() => {
+        mockFeatures = {
+            logging: {
+                debug: sinon.stub(),
+                warn: sinon.stub(),
+                log: sinon.stub(),
+                info: sinon.stub(),
+                error: sinon.stub(),
+            },
+            runtime: {
+                platform: 'node',
+            },
+            workspace: {
+                fs: {
+                    getServerDataDirPath: sinon.stub().returns('/tmp'),
+                    getFileSize: sinon.stub().resolves({ size: 0 }),
+                    mkdir: sinon.stub().resolves(undefined),
+                    writeFile: sinon.stub().resolves(undefined),
+                    readdir: sinon.stub().resolves([
+                        { name: 'chat-history-1.json', isFile: () => true },
+                        { name: 'chat-history-2.json', isFile: () => true },
+                    ]),
+                },
+            },
+        } as unknown as Features
+
+        mockDb = {
+            getCollection: sinon.stub(),
+            close: sinon.stub(),
+        } as unknown as Loki
+
+        // Create mock tab with 20 conversations, each with 100 messages
+        mockTab1 = createMockTabWithManyConversations('tab1', 20, 100)
+
+        // Create a smaller mock tab for comparison
+        mockTab2 = createMockTabWithManyConversations('tab2', 2, 10)
+
+        // Create mock collections
+        mockCollection1 = {
+            find: sinon.stub().returns([mockTab1]),
+            findOne: sinon.stub().returns(mockTab1),
+            update: sinon.stub(),
+            remove: sinon.stub(),
+        }
+
+        mockCollection2 = {
+            find: sinon.stub().returns([mockTab2]),
+            findOne: sinon.stub().returns(mockTab2),
+            update: sinon.stub(),
+            remove: sinon.stub(),
+        }
+
+        // Create mock databases
+        mockDb1 = {
+            getCollection: sinon.stub().returns(mockCollection1),
+            saveDatabase: sinon.stub().callsArg(0),
+            close: sinon.stub(),
+        }
+
+        mockDb2 = {
+            getCollection: sinon.stub().returns(mockCollection2),
+            saveDatabase: sinon.stub().callsArg(0),
+            close: sinon.stub(),
+        }
+
+        // Create the history maintainer with test methods for easier mocking
+        historyMaintainer = new ChatHistoryMaintainer(
+            mockFeatures,
+            '/tmp/.aws/amazonq/history',
+            'chat-history-test.json',
+            mockDb
+        )
+
+        // Mock the methods we need to test
+        calculateAllHistorySizeStub = sinon.stub(historyMaintainer, 'calculateAllHistorySize' as any)
+        calculateAllHistorySizeStub.onFirstCall().resolves(250 * 1024 * 1024) // First call: over the limit
+        calculateAllHistorySizeStub.onSecondCall().resolves(250 * 1024 * 1024) // Second call: Start trimming, over the limit
+        calculateAllHistorySizeStub.onThirdCall().resolves(140 * 1024 * 1024) // Third call: Finished triming, under the limit
+
+        loadAllDbFilesStub = sinon.stub(historyMaintainer, 'loadAllDbFiles' as any).resolves(
+            new Map([
+                ['chat-history-1.json', { collection: mockCollection1, db: mockDb1 }],
+                ['chat-history-2.json', { collection: mockCollection2, db: mockDb2 }],
+            ])
+        )
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('trimHistoryToMaxSize', () => {
+        it('should trim history until size is below the limit', async () => {
+            // Call the method being tested
+            await historyMaintainer.trimHistoryToMaxSize()
+
+            // Verify workspace.fs.readdir was called
+            assert.strictEqual(
+                (mockFeatures.workspace.fs.readdir as sinon.SinonStub).called,
+                true,
+                'workspace.fs.readdir should be called'
+            )
+
+            // Verify loadAllDbFiles was called
+            assert.strictEqual(loadAllDbFilesStub.callCount, 1, 'loadAllDbFiles should be called once')
+
+            // Verify calculateAllHistorySize was called
+            assert.strictEqual(
+                calculateAllHistorySizeStub.callCount,
+                3,
+                'calculateAllHistorySize should be called three times'
+            )
+
+            // Verify update or remove operation was performed
+            assert.strictEqual(
+                mockCollection1.update.called,
+                true,
+                'Update should be called because collection has many messages and deletion cannot be done in one batch'
+            )
+            assert.strictEqual(
+                mockCollection1.remove.called,
+                false,
+                'Remove should not be called because the number of messages under collection1 has exceeded the single trimming loop (messageBatchDeleteSizeForSingleTab * messageBatchDeleteIterationBeforeRecalculateDBSize)'
+            )
+            assert.strictEqual(mockCollection2.update.called, true, 'Update should be called for collection2')
+            assert.strictEqual(
+                mockCollection2.remove.called,
+                true,
+                'Remove should be called after all messages are deleted from the conversation'
+            )
+
+            // Verify database save operations
+            assert.strictEqual(
+                mockDb1.saveDatabase.called && mockDb2.saveDatabase.called,
+                true,
+                'SaveDatabase should be called'
+            )
+
+            // Verify database close operations
+            assert.strictEqual(mockDb1.close.callCount, 1, 'Database1 close should be called')
+            assert.strictEqual(mockDb2.close.callCount, 1, 'Database2 close should be called')
+        })
+
+        it('should handle already under limit case', async () => {
+            // Override calculateAllHistorySize to return size under limit
+            calculateAllHistorySizeStub.onFirstCall().resolves(100 * 1024 * 1024) // Under the limit
+
+            // Call the method being tested
+            await historyMaintainer.trimHistoryToMaxSize()
+
+            // Verify calculateAllHistorySize was called just once
+            assert.strictEqual(
+                calculateAllHistorySizeStub.callCount,
+                1,
+                'calculateAllHistorySize should be called once'
+            )
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatHistoryMaintainer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatHistoryMaintainer.ts
@@ -295,23 +295,6 @@ export class ChatHistoryMaintainer {
         })
     }
 
-    /**
-     * Safely deletes a database with proper error handling
-     * @param db The Loki database instance to delete
-     * @returns Promise that resolves when deletion completes or rejects on error
-     */
-    private async deleteDatabase(db: Loki): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            db.deleteDatabase(err => {
-                if (err) {
-                    reject(err)
-                } else {
-                    resolve()
-                }
-            })
-        })
-    }
-
     private async loadAllDbFiles(allDbFiles: string[]) {
         const allDbsMap = new Map<string, DbReference>()
         for (const dbFile of allDbFiles) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatHistoryMaintainer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatHistoryMaintainer.ts
@@ -1,0 +1,289 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as Loki from 'lokijs'
+import * as path from 'path'
+import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import {
+    FileSystemAdapter,
+    Tab,
+    TabCollection,
+    initializeHistoryPriorityQueue,
+    getOldestMessageTimestamp,
+} from './util'
+
+// Maximum history file size across all workspace, 200MB
+export const maxHistorySizeInBytes = 200 * 1024 * 1024
+// 75% of the max size, 150MB
+export const maxAfterTrimHistorySizeInBytes = 150 * 1024 * 1024
+/**
+ * The combination of messageBatchDeleteIterationBeforeRecalculateDBSize and messageBatchDeleteSizeForSingleTab can heavily impact the
+ * latency of trimming history since calculating the history file size is slow. We can tune these numbers according to the average message size
+ */
+// Batch deletion iteration count when trimming history before re-calculating total history size
+export const messageBatchDeleteIterationBeforeRecalculateDBSize = 200
+// Batch deletion message size when trimming history for a specific tab before re-checking the oldest message among all workspace history
+export const messageBatchDeleteSizeForSingleTab = 10
+// In each iteration, we calculate the total history size and try to delete [messageBatchDeleteSizeForSingleTab * messageBatchDeleteIterationBeforeRecalculateDBSize] messages
+export const maxTrimHistoryLoopIteration = 100
+
+/**
+ * ChatHistoryMaintainer is responsible for maintaining the chat history database,
+ * including trimming history when it exceeds size limits.
+ */
+export class ChatHistoryMaintainer {
+    #features: Features
+    #dbDirectory: string
+    #dbName: string
+    #db: Loki
+
+    constructor(features: Features, dbDirectory: string, dbName: string, db: Loki) {
+        this.#features = features
+        this.#dbDirectory = dbDirectory
+        this.#dbName = dbName
+        this.#db = db
+    }
+
+    /**
+     * If the sum of all history file size exceeds the limit, start trimming the oldest conversation
+     * across all the workspace until the folder size is below maxAfterTrimHistorySizeInBytes.
+     */
+    async trimHistoryToMaxSize() {
+        // Get the size of all history DB files
+        const historyTotalSizeInBytes = await this.calculateAllHistorySize()
+        this.#features.logging.info(
+            `Current history total size: ${historyTotalSizeInBytes} Bytes, max allowed: ${maxHistorySizeInBytes} Bytes`
+        )
+
+        // If we're under the limit, no need to trim
+        if (historyTotalSizeInBytes <= maxHistorySizeInBytes) {
+            return
+        }
+        this.#features.logging.info(
+            `History total size (${historyTotalSizeInBytes} Bytes) exceeds limit (${maxHistorySizeInBytes} Bytes), trimming history`
+        )
+
+        const trimStart = performance.now()
+        await this.trimHistoryForAllWorkspaces()
+        const trimEnd = performance.now()
+        this.#features.logging.info(`Trimming history took ${trimEnd - trimStart} ms`)
+    }
+
+    /**
+     * Calculates the size of a database file
+     * @param dbPath Path to the database file
+     * @returns Promise that resolves to the file size in bytes, or 0 if there's an error
+     */
+    private async calculateDatabaseSize(dbPath: string): Promise<number> {
+        const result = await this.#features.workspace.fs.getFileSize(dbPath)
+        return result.size
+    }
+
+    /**
+     * Calculates the total size of all history database files in the directory
+     * @returns The total size of all database files in bytes
+     */
+    private async calculateAllHistorySize(dbFiles?: string[]): Promise<number> {
+        if (!dbFiles) {
+            dbFiles = (await this.listDatabaseFiles()).map(file => file.name)
+        }
+
+        // Calculate the total size of all database files
+        let totalSize = 0
+        for (const file of dbFiles) {
+            const filePath = path.join(this.#dbDirectory, file)
+            let fileSize
+            try {
+                fileSize = await this.calculateDatabaseSize(filePath)
+            } catch (err) {
+                this.#features.logging.error(`Error getting db file size: ${err}`)
+                fileSize = 0
+            }
+            totalSize += fileSize
+        }
+
+        return totalSize
+    }
+
+    /**
+     * Lists all database files in the history directory
+     * @returns Promise that resolves to an array of database file entries
+     */
+    private async listDatabaseFiles() {
+        try {
+            // List all files in the directory using readdir
+            const dirEntries = await this.#features.workspace.fs.readdir(this.#dbDirectory)
+
+            // Filter for database files (they should follow the pattern chat-history-*.json)
+            return dirEntries.filter(
+                entry => entry.isFile() && entry.name.startsWith('chat-history-') && entry.name.endsWith('.json')
+            )
+        } catch (err) {
+            this.#features.logging.error(`Error listing database files: ${err}`)
+            return []
+        }
+    }
+
+    private async trimHistoryForAllWorkspaces() {
+        // Load all databases
+        const allDbFiles = (await this.listDatabaseFiles()).map(file => file.name)
+        // DB name to {collection, db} Map
+        const allDbsMap = await this.loadAllDbFiles(allDbFiles)
+        this.#features.logging.info(`Loaded ${allDbsMap.size} databases in ${this.#dbDirectory}`)
+        if (allDbsMap.size < allDbFiles.length) {
+            this.#features.logging.warn(
+                `Found ${allDbFiles.length - allDbsMap.size} bad DB files, will skip them when calculating history size`
+            )
+        }
+
+        const tabQueue = initializeHistoryPriorityQueue()
+
+        // Add tabs to the queue
+        for (const [dbName, dbRef] of allDbsMap.entries()) {
+            const tabCollection = dbRef.collection
+            if (!tabCollection) continue
+
+            const tabs = tabCollection.find()
+            for (const tab of tabs) {
+                // Use the first message under the first conversation to get the oldestMessageDate, if no timestamp under the message, use 0.
+                const oldestMessageDate = getOldestMessageTimestamp(tab)
+                tabQueue.add({
+                    tab: tab,
+                    collection: tabCollection,
+                    dbName: dbName,
+                    oldestMessageDate: oldestMessageDate,
+                })
+            }
+        }
+
+        // Keep trimming until we're under the target size
+        let iterationCount = 0
+        while (!tabQueue.isEmpty()) {
+            // Check current total size
+            const totalSize = await this.calculateAllHistorySize(Array.from(allDbsMap.keys()))
+
+            // If we're under the target size, we're done
+            if (totalSize <= maxAfterTrimHistorySizeInBytes) {
+                this.#features.logging.info(`Successfully trimmed history to ${totalSize} bytes`)
+                break
+            }
+            // Infinite loop protection
+            if (++iterationCount > maxTrimHistoryLoopIteration) {
+                this.#features.logging.warn(
+                    `Exceeded max iteration count (${maxTrimHistoryLoopIteration}) when trimming history, current total size: ${totalSize}`
+                )
+                break
+            }
+
+            // Do a batch deletion so that we don't re-calculate the size for every deletion,
+            // messages should be deleted in pairs(prompt, answer)
+            let updatedDbs = new Set<string>()
+            for (let i = 0; i < messageBatchDeleteIterationBeforeRecalculateDBSize / 2; i++) {
+                const queueItem = tabQueue.dequeue()
+                const tab = queueItem?.tab
+                const collection = queueItem?.collection
+                const dbName = queueItem?.dbName
+                if (!tab || !collection || !dbName) break
+
+                updatedDbs.add(dbName)
+                if (!tab.conversations) {
+                    collection.remove(tab)
+                    continue
+                }
+
+                // Remove messages under a tab
+                let pairsRemoved = 0
+                while (
+                    pairsRemoved < messageBatchDeleteSizeForSingleTab / 2 &&
+                    this.removeOldestMessagePairFromTab(tab)
+                ) {
+                    pairsRemoved++
+                }
+
+                if (!tab.conversations || tab.conversations.length === 0) {
+                    // If the tab has no conversations left, remove it
+                    collection.remove(tab)
+                } else {
+                    collection.update(tab)
+                    // Re-add the tab to the queue with updated oldest date
+                    const newOldestDate = getOldestMessageTimestamp(tab)
+                    tabQueue.enqueue({ tab: tab, collection, dbName: dbName, oldestMessageDate: newOldestDate })
+                }
+            }
+
+            // Save the updated database if it's not the current one, the current db should have autosave enabled
+            for (const [dbName, dbRef] of allDbsMap.entries()) {
+                if (updatedDbs.has(dbName)) {
+                    this.#features.logging.debug(`Removed old messages from ${dbName}, saving changes`)
+                    await new Promise<void>(resolve => {
+                        dbRef.db.saveDatabase(() => resolve())
+                    })
+                }
+            }
+        }
+
+        // Close the databases except the current workspace DB
+        for (const [dbName, dbRef] of allDbsMap.entries()) {
+            if (dbName !== this.#dbName) {
+                dbRef.db.close()
+            }
+        }
+    }
+
+    private async loadAllDbFiles(allDbFiles: string[]) {
+        const allDbsMap = new Map<string, { collection: Collection<Tab>; db: Loki }>()
+        for (const dbFile of allDbFiles) {
+            try {
+                if (dbFile === this.#dbName) {
+                    // Current workspace DB
+                    const collection = this.#db.getCollection<Tab>(TabCollection)
+                    allDbsMap.set(dbFile, { collection: collection, db: this.#db })
+                    continue
+                }
+
+                const db = new Loki(dbFile, {
+                    adapter: new FileSystemAdapter(this.#features.workspace, this.#dbDirectory),
+                    persistenceMethod: 'fs',
+                })
+                await new Promise<void>(resolve => {
+                    db.loadDatabase({}, () => resolve())
+                })
+                const collection = db.getCollection<Tab>(TabCollection)
+
+                if (collection) {
+                    allDbsMap.set(dbFile, { collection: collection, db: db })
+                } else {
+                    this.#features.logging.warn(`No ${TabCollection} collection found in database ${dbFile}`)
+                }
+            } catch (err) {
+                this.#features.logging.error(`Error loading DB file ${dbFile}: ${err}`)
+            }
+        }
+        return allDbsMap
+    }
+
+    /**
+     * Remove the oldest message pair, based on assumptions:
+     * 1. The messages are always stored in pair(prompt, answer)
+     * 2. The messages are always stored in chronological order(new messages are added to the tail of the list)
+     * @returns True if successfully trimmed the history.
+     */
+    private removeOldestMessagePairFromTab(tabData: Tab): boolean {
+        if (!tabData.conversations || tabData.conversations.length === 0) {
+            this.#features.logging.debug(`No conversations found in tab ${tabData.historyId}`)
+            return false
+        }
+
+        const conversation = tabData.conversations[0]
+
+        // Remove messages in pairs from the beginning
+        if (conversation.messages?.length > 2) {
+            conversation.messages.splice(0, 2)
+        } else {
+            // Remove the entire conversation if it has few messages
+            tabData.conversations.splice(0, 1)
+        }
+        return true
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
@@ -17,7 +17,7 @@ import {
     initializeHistoryPriorityQueue,
     messageToChatMessage,
     messageToStreamingMessage,
-    updateOrCreateConversationWithMessagePair,
+    updateOrCreateConversation,
 } from './util'
 import { ChatMessage } from '@aws/language-server-runtimes/protocol'
 import { Workspace } from '@aws/language-server-runtimes/server-interface'
@@ -162,34 +162,23 @@ describe('ChatDb Utilities', () => {
         })
     })
 
-    describe('updateOrCreateConversationWithMessagePair', () => {
-        it('should add message pair to existing conversation', () => {
+    describe('updateOrCreateConversation', () => {
+        it('should add message to existing conversation', () => {
             const conversations = [
                 {
                     conversationId: 'conv-1',
                     clientType: 'vscode',
-                    messages: [
-                        { body: 'Message 1', type: 'prompt' as ChatMessage['type'] },
-                        { body: 'Response 1', type: 'answer' as ChatMessage['type'] },
-                    ],
+                    messages: [{ body: 'Message 1', type: 'prompt' as ChatMessage['type'] }],
                 },
             ]
 
-            const promptMessage = { body: 'Message 2', type: 'prompt' as ChatMessage['type'] }
-            const answerMessage = { body: 'Response 2', type: 'answer' as ChatMessage['type'] }
+            const newMessage = { body: 'Message 2', type: 'answer' as ChatMessage['type'] }
 
-            const result = updateOrCreateConversationWithMessagePair(
-                conversations,
-                'conv-1',
-                promptMessage,
-                answerMessage,
-                'vscode'
-            )
+            const result = updateOrCreateConversation(conversations, 'conv-1', newMessage, 'vscode')
 
             assert.strictEqual(result.length, 1)
-            assert.strictEqual(result[0].messages.length, 4)
-            assert.deepStrictEqual(result[0].messages[2], promptMessage)
-            assert.deepStrictEqual(result[0].messages[3], answerMessage)
+            assert.strictEqual(result[0].messages.length, 2)
+            assert.deepStrictEqual(result[0].messages[1], newMessage)
         })
 
         it('should create new conversation when conversationId does not exist', () => {
@@ -197,30 +186,18 @@ describe('ChatDb Utilities', () => {
                 {
                     conversationId: 'conv-1',
                     clientType: 'vscode',
-                    messages: [
-                        { body: 'Message 1', type: 'prompt' as ChatMessage['type'] },
-                        { body: 'Response 1', type: 'answer' as ChatMessage['type'] },
-                    ],
+                    messages: [{ body: 'Message 1', type: 'prompt' as ChatMessage['type'] }],
                 },
             ]
 
-            const promptMessage = { body: 'Message 2', type: 'prompt' as ChatMessage['type'] }
-            const answerMessage = { body: 'Response 2', type: 'answer' as ChatMessage['type'] }
+            const newMessage = { body: 'Message 2', type: 'prompt' as ChatMessage['type'] }
 
-            const result = updateOrCreateConversationWithMessagePair(
-                conversations,
-                'conv-2',
-                promptMessage,
-                answerMessage,
-                'vscode'
-            )
+            const result = updateOrCreateConversation(conversations, 'conv-2', newMessage, 'vscode')
 
             assert.strictEqual(result.length, 2)
             assert.strictEqual(result[1].conversationId, 'conv-2')
             assert.strictEqual(result[1].clientType, 'vscode')
-            assert.strictEqual(result[1].messages.length, 2)
-            assert.deepStrictEqual(result[1].messages[0], promptMessage)
-            assert.deepStrictEqual(result[1].messages[1], answerMessage)
+            assert.deepStrictEqual(result[1].messages, [newMessage])
         })
 
         it('should update conversation with updatedAt timestamp', () => {
@@ -230,23 +207,13 @@ describe('ChatDb Utilities', () => {
                     conversationId: 'conv-1',
                     clientType: 'vscode',
                     updatedAt: new Date(now.getTime() - 1000), // 1 second ago
-                    messages: [
-                        { body: 'Message 1', type: 'prompt' as ChatMessage['type'] },
-                        { body: 'Response 1', type: 'answer' as ChatMessage['type'] },
-                    ],
+                    messages: [{ body: 'Message 1', type: 'prompt' as ChatMessage['type'] }],
                 },
             ]
 
-            const promptMessage = { body: 'Message 2', type: 'prompt' as ChatMessage['type'] }
-            const answerMessage = { body: 'Response 2', type: 'answer' as ChatMessage['type'] }
+            const newMessage = { body: 'Message 2', type: 'prompt' as ChatMessage['type'] }
 
-            const result = updateOrCreateConversationWithMessagePair(
-                conversations,
-                'conv-1',
-                promptMessage,
-                answerMessage,
-                'vscode'
-            )
+            const result = updateOrCreateConversation(conversations, 'conv-1', newMessage, 'vscode')
 
             assert.strictEqual(result.length, 1)
             assert.ok(result[0].updatedAt instanceof Date)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
@@ -9,9 +9,12 @@ import * as path from 'path'
 import {
     FileSystemAdapter,
     Message,
+    Tab,
     TabType,
     chatMessageToMessage,
+    getOldestMessageTimestamp,
     groupTabsByDate,
+    initializeHistoryPriorityQueue,
     messageToChatMessage,
     messageToStreamingMessage,
     updateOrCreateConversation,
@@ -447,6 +450,162 @@ describe('ChatDb Utilities', () => {
                 sinon.assert.calledOnce(callback)
                 assert(callback.firstCall.args[0] instanceof Error)
             })
+        })
+    })
+
+    describe('HistoryOrdering', () => {
+        it('should create history priority queue, oldest history message first', () => {
+            const queue = initializeHistoryPriorityQueue()
+
+            // Create tabs with different timestamps
+            const now = new Date()
+            const oneHourAgo = new Date(now.getTime() - 3600000)
+            const twoHoursAgo = new Date(now.getTime() - 7200000)
+            const threeHoursAgo = new Date(now.getTime() - 10800000)
+
+            // Create mock collections
+            const mockCollection = {} as Collection<Tab>
+
+            // Create tabs with different message timestamps
+            // Final timestamp for ordering is oneHourAgo(from message timestamp)
+            const tabWithRecentMessage = {
+                historyId: 'recent',
+                updatedAt: oneHourAgo,
+                isOpen: true,
+                tabType: 'cwc' as TabType,
+                title: 'Recent Tab',
+                conversations: [
+                    {
+                        conversationId: 'conv1',
+                        clientType: 'test',
+                        messages: [
+                            {
+                                body: 'test',
+                                type: 'prompt',
+                                timestamp: oneHourAgo,
+                            },
+                        ],
+                    },
+                ],
+            } as Tab
+
+            // Final timestamp for ordering is twoHoursAgo(from message timestamp)
+            const tabWithOldMessage = {
+                historyId: 'old',
+                updatedAt: twoHoursAgo, // More recent tab update
+                isOpen: true,
+                tabType: 'cwc' as TabType,
+                title: 'Old Tab',
+                conversations: [
+                    {
+                        conversationId: 'conv2',
+                        clientType: 'test',
+                        messages: [
+                            {
+                                body: 'test',
+                                type: 'prompt',
+                                timestamp: twoHoursAgo, // But older message
+                            },
+                        ],
+                    },
+                ],
+            } as Tab
+
+            // Final timestamp for ordering is now(from tab.updatedAt)
+            const recentTabWithNoTimestamp = {
+                historyId: 'no-timestamp',
+                updatedAt: oneHourAgo,
+                isOpen: true,
+                tabType: 'cwc' as TabType,
+                title: 'No Timestamp Tab',
+                conversations: [
+                    {
+                        conversationId: 'conv3',
+                        clientType: 'test',
+                        messages: [
+                            {
+                                body: 'test',
+                                type: 'prompt',
+                                // No timestamp
+                            },
+                        ],
+                    },
+                ],
+            } as Tab
+
+            // Final timestamp for ordering is threeHoursAgo(from tab.updatedAt)
+            const olderTabWithNoTimestamp = {
+                historyId: 'no-timestamp-older',
+                updatedAt: threeHoursAgo,
+                isOpen: true,
+                tabType: 'cwc' as TabType,
+                title: 'No Timestamp Tab',
+                conversations: [
+                    {
+                        conversationId: 'conv3',
+                        clientType: 'test',
+                        messages: [
+                            {
+                                body: 'test',
+                                type: 'prompt',
+                                // No timestamp
+                            },
+                        ],
+                    },
+                ],
+            } as Tab
+
+            // Confirm getOldestMessageDate gives the correct Date
+            assert.strictEqual(getOldestMessageTimestamp(tabWithRecentMessage).getTime(), oneHourAgo.getTime())
+            assert.strictEqual(getOldestMessageTimestamp(tabWithOldMessage).getTime(), twoHoursAgo.getTime())
+            assert.strictEqual(getOldestMessageTimestamp(recentTabWithNoTimestamp).getTime(), 0) // Zero timestamp for no timestamp
+            assert.strictEqual(getOldestMessageTimestamp(olderTabWithNoTimestamp).getTime(), 0) // Zero timestamp for no timestamp
+
+            // Add items to queue
+            queue.enqueue({
+                tab: tabWithRecentMessage,
+                collection: mockCollection,
+                dbName: 'db1',
+                oldestMessageDate: getOldestMessageTimestamp(tabWithRecentMessage),
+            })
+
+            queue.enqueue({
+                tab: tabWithOldMessage,
+                collection: mockCollection,
+                dbName: 'db2',
+                oldestMessageDate: getOldestMessageTimestamp(tabWithOldMessage),
+            })
+
+            queue.enqueue({
+                tab: recentTabWithNoTimestamp,
+                collection: mockCollection,
+                dbName: 'db3',
+                oldestMessageDate: getOldestMessageTimestamp(recentTabWithNoTimestamp),
+            })
+
+            queue.enqueue({
+                tab: olderTabWithNoTimestamp,
+                collection: mockCollection,
+                dbName: 'db4',
+                oldestMessageDate: getOldestMessageTimestamp(olderTabWithNoTimestamp),
+            })
+
+            // Verify queue ordering - should dequeue oldest first
+            const first = queue.dequeue()
+            const second = queue.dequeue()
+            const third = queue.dequeue()
+            const fourth = queue.dequeue()
+
+            // No timestamp should come first (oldest)
+            assert.strictEqual(first?.tab.historyId, 'no-timestamp-older')
+            assert.strictEqual(second?.tab.historyId, 'no-timestamp')
+            // Old message should come second
+            assert.strictEqual(third?.tab.historyId, 'old')
+            // Recent message should come last
+            assert.strictEqual(fourth?.tab.historyId, 'recent')
+
+            // Queue should be empty now
+            assert.strictEqual(queue.isEmpty(), true)
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
@@ -182,14 +182,6 @@ export function chatMessageToMessage(chatMessage: StreamingMessage): Message {
     }
 }
 
-export function isEmptyAssistantMessage(message: Message) {
-    return (
-        message.type === ('answer' as ChatItemType) &&
-        (!message.body || message.body.trim().length === 0) &&
-        (!message.toolUses || message.toolUses.length === 0)
-    )
-}
-
 /**
  *
  * This adapter implements the LokiPersistenceAdapter interface for file system operations using web-compatible shared fs utils.

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
@@ -83,10 +83,10 @@ export type Message = {
 }
 
 /**
- * Represents a tab with its database collection reference, database name, and timestamp information
+ * Represents a tab with its database metadata, including collection reference, database name, and timestamp information
  * for use in history trimming operations.
  */
-export type TabWithContext = {
+export type TabWithDbMetadata = {
     tab: Tab
     collection: Collection<Tab> // The reference of chat DB collection
     dbName: string // The chat DB name
@@ -366,7 +366,7 @@ export function initializeHistoryPriorityQueue() {
     }
 
     // Create a priority queue with tabs and the collection it belongs to, and sorted by oldest message date
-    return new PriorityQueue<TabWithContext>(tabDateComparator)
+    return new PriorityQueue<TabWithDbMetadata>(tabDateComparator)
 }
 
 /**
@@ -385,12 +385,11 @@ export function getOldestMessageTimestamp(tabData: Tab): Date {
         if (!conversation.messages || conversation.messages.length === 0) {
             continue
         }
-        for (const message of conversation.messages) {
-            if (message.timestamp) {
-                return new Date(message.timestamp)
-            } else {
-                return new Date(0)
-            }
+        // Just need to check the first message which is the oldest one
+        if (conversation.messages[0].timestamp) {
+            return new Date(conversation.messages[0].timestamp)
+        } else {
+            return new Date(0)
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
@@ -281,42 +281,6 @@ export function updateOrCreateConversation(
     }
 }
 
-/**
- * Updates an existing conversation or creates a new one with a message pair.
- * This is a helper function for adding both prompt and answer messages at once.
- */
-export function updateOrCreateConversationWithMessagePair(
-    conversations: Conversation[],
-    conversationId: string,
-    promptMessage: Message,
-    answerMessage: Message,
-    clientType: string
-): Conversation[] {
-    const existingConversation = conversations.find(conv => conv.conversationId === conversationId)
-
-    if (existingConversation) {
-        return conversations.map(conv =>
-            conv.conversationId === conversationId
-                ? {
-                      ...conv,
-                      updatedAt: new Date(),
-                      messages: [...conv.messages, promptMessage, answerMessage],
-                  }
-                : conv
-        )
-    } else {
-        return [
-            ...conversations,
-            {
-                conversationId,
-                clientType,
-                updatedAt: new Date(),
-                messages: [promptMessage, answerMessage],
-            },
-        ]
-    }
-}
-
 export function groupTabsByDate(tabs: Tab[]): ConversationItemGroup[] {
     const now = new Date()
     const today = new Date(now.setHours(0, 0, 0, 0))

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
@@ -21,6 +21,8 @@ import {
     AssistantResponseMessage,
 } from '@aws/codewhisperer-streaming-client'
 import { Workspace } from '@aws/language-server-runtimes/server-interface'
+import { ChatItemType } from '@aws/mynah-ui'
+import { PriorityQueue } from 'typescript-collections'
 
 // Ported from https://github.com/aws/aws-toolkit-vscode/blob/master/packages/core/src/shared/db/chatDb/util.ts
 
@@ -61,6 +63,7 @@ export type Settings = {
 export type Conversation = {
     conversationId: string
     clientType: string
+    updatedAt?: Date
     messages: Message[]
 }
 
@@ -74,6 +77,7 @@ export type Message = {
     origin?: Origin
     userInputMessageContext?: UserInputMessageContext
     toolUses?: ToolUse[]
+    timestamp?: Date
     shouldDisplayMessage?: boolean
 }
 
@@ -160,6 +164,14 @@ export function chatMessageToMessage(chatMessage: StreamingMessage): Message {
     }
 }
 
+export function isEmptyAssistantMessage(message: Message) {
+    return (
+        message.type === ('answer' as ChatItemType) &&
+        (!message.body || message.body.trim().length === 0) &&
+        (!message.toolUses || message.toolUses.length === 0)
+    )
+}
+
 /**
  *
  * This adapter implements the LokiPersistenceAdapter interface for file system operations using web-compatible shared fs utils.
@@ -234,7 +246,9 @@ export function updateOrCreateConversation(
 
     if (existingConversation) {
         return conversations.map(conv =>
-            conv.conversationId === conversationId ? { ...conv, messages: [...conv.messages, newMessage] } : conv
+            conv.conversationId === conversationId
+                ? { ...conv, updatedAt: new Date(), messages: [...conv.messages, newMessage] }
+                : conv
         )
     } else {
         return [
@@ -242,6 +256,7 @@ export function updateOrCreateConversation(
             {
                 conversationId,
                 clientType,
+                updatedAt: new Date(),
                 messages: [newMessage],
             },
         ]
@@ -302,6 +317,72 @@ export function groupTabsByDate(tabs: Tab[]): ConversationItemGroup[] {
             icon: 'calendar',
             items: group.tabs.map(tabToDetailedListItem),
         }))
+}
+
+/**
+ * Initialize a priority queue to store all workspace tab history, the tab contains the oldest message first.
+ * If the messages don't have a timestamp, oldest tab first.
+ */
+export function initializeHistoryPriorityQueue() {
+    // Create a comparator function for dates (oldest first)
+    // The PriorityQueue implementation uses maxHeap: greater value fist.
+    // So we need to return bTimestamp - aTimestamp if a is older than b.
+    function dateComparator(
+        a: { tab: Tab; collection: Collection<Tab>; oldestMessageDate: Date },
+        b: { tab: Tab; collection: Collection<Tab>; oldestMessageDate: Date }
+    ): number {
+        if (a.oldestMessageDate.getTime() === 0 && b.oldestMessageDate.getTime() === 0) {
+            // Legacy message data without timestamp, use the updatedAt timestamp of the tab to compare
+            const aUpdatedAt = a.tab.updatedAt
+            const bUpdatedAt = b.tab.updatedAt
+            // LokiJS automatically convert the indexed updatedAt into number for better performance, we have an index on Tab.updatedAt
+            if (typeof aUpdatedAt === 'number' && typeof bUpdatedAt === 'number') {
+                return bUpdatedAt - aUpdatedAt
+            }
+            // For robustness, adding Date type comparator as well
+            if (aUpdatedAt instanceof Date && bUpdatedAt instanceof Date) {
+                return bUpdatedAt.getTime() - aUpdatedAt.getTime()
+            }
+        }
+        return b.oldestMessageDate.getTime() - a.oldestMessageDate.getTime()
+    }
+
+    // Create a priority queue with tabs and the collection it belongs to, and sorted by oldest message date
+    return new PriorityQueue<{
+        tab: Tab
+        collection: Collection<Tab>
+        dbName: string
+        oldestMessageDate: Date
+    }>(dateComparator)
+}
+
+/**
+ * Gets the timestamp of the oldest message in a tab
+ * @param tabData The tab to check
+ * @returns The Date of the oldest message, or 0 if no messages under the tab or the message doesn't have a timestamp
+ */
+export function getOldestMessageTimestamp(tabData: Tab): Date {
+    if (!tabData.conversations) {
+        return new Date(0)
+    }
+
+    // The conversations and messages under the same tab should always be in chronological order
+    for (const conversation of tabData.conversations) {
+        // Skip empty conversations
+        if (!conversation.messages || conversation.messages.length === 0) {
+            continue
+        }
+        for (const message of conversation.messages) {
+            if (message.timestamp) {
+                return new Date(message.timestamp)
+            } else {
+                return new Date(0)
+            }
+        }
+    }
+
+    // Legacy data doesn't have a timestamp, so just treating it as 0 since they are older than any data that has a timestamp
+    return new Date(0)
 }
 
 function getTabTypeIcon(tabType: TabType): IconType {


### PR DESCRIPTION
## Problem
1. Current history logic is mixing up the history sent to service and the history persisted in disk.
2. The limit on history size is 600,000 chars or 250 messages, which is way to small.

## Solution
1. Separate the "fix history" logic for service requests and DB
    - History for service requests:
       - Length is less than 250 messages(ensured when retrieving from DB) and 600,000 chars
       - Drop the last empty assistant message and the user prompt before that
       - Ensure the messages have a valid sequence - alternating sequence of user prompt followed by a assistant message
       - Validate and fix tool usage
     - Persisted history in DB:
        - addMessage now skips empty assistant message
        - (Already in place) Skip adding message if the agent loop is cancelled, this is likely the root cause of incorrect message sequence.
2. Maintain a max 200MB total history file size
    - An async check/trim is performed on startup
       - If the total valid history size under the history folder is larger than 200MB, remove the oldest messages across all history files until the total history size is under 75% of the limit. The implementation uses a priority queue to order the messages. The process takes 1.5 sec when avg message size is 5000 chars.
       - Added timestamps to persisted conversations and messages
       - Legacy records don't have timestamps in conversations and messages, use the updatedAt under Tab as the timestamp for all those messages when ordering

## Pending items
- Fix the agenticChatController unit tests(which is causing the CI failure) ✅ 
- Fix the merge issue ✅ 
- Fix improper variable names ✅ 
- Dedupe `calculateDatabaseSize` ✅ 
- ~~Error handling within `calculateDatabaseSize`~~
- Improvement: Store messages in pairs ✅ 
- Handle this edge case: https://github.com/aws/language-servers/pull/1527, will do in the next PR.
- When a cancellation happen, the last user prompt got removed. Need to retain that user prompt instead of removing. ✅ 
- Need a similar logic as `trimHistoryToMaxLength` to make sure the sequence of the message starts at a valid point. ✅ 

## Future improvements
1. Delete empty history file
2. Telemetry for history trimming time

## Previous PRs: 
- https://github.com/aws/language-servers/pull/1374
- https://github.com/aws/language-servers/pull/1416
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
