### PR TITLE
fix: use alpha manifest temporarily

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/constants.ts
@@ -2,12 +2,15 @@ export const MISSING_BEARER_TOKEN_ERROR = 'credentialsProvider does not have bea
 export const INVALID_TOKEN = 'The bearer token included in the request is invalid.'
 export const GENERIC_UNAUTHORIZED_ERROR = 'User is not authorized to make this call'
 export const BUILDER_ID_START_URL = 'https://view.awsapps.com/start'
-export const DEFAULT_AWS_Q_ENDPOINT_URL = 'https://codewhisperer.us-east-1.amazonaws.com/'
-export const DEFAULT_AWS_Q_REGION = 'us-east-1'
+// export const DEFAULT_AWS_Q_ENDPOINT_URL = 'https://codewhisperer.us-east-1.amazonaws.com/'
+// export const DEFAULT_AWS_Q_REGION = 'us-east-1'
+// temp: alpha manifest
+export const DEFAULT_AWS_Q_ENDPOINT_URL = 'https://rts.alpha-us-west-2.codewhisperer.ai.aws.dev/'
+export const DEFAULT_AWS_Q_REGION = 'us-west-2'
 
 export const AWS_Q_ENDPOINTS = new Map([
     [DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL],
-    ['us-east-1', 'https://codewhisperer.us-east-1.amazonaws.com/'],
+    ['us-east-1', DEFAULT_AWS_Q_ENDPOINT_URL],
     ['eu-central-1', 'https://q.eu-central-1.amazonaws.com/'],
 ])
 


### PR DESCRIPTION
## Description
Temporarily points to alpha service endpoints similar to this [change](https://github.com/aws/language-servers/commit/005189fdb702c690e818d3f4e3e03a714c5436e1)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
