### PR TITLE
chore: bumping mynah-ui version to 4.35.3

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.40",
         "@aws/language-server-runtimes-types": "^0.1.34",
-        "@aws/mynah-ui": "^4.35.2"
+        "@aws/mynah-ui": "^4.35.3"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -249,7 +249,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.40",
                 "@aws/language-server-runtimes-types": "^0.1.34",
-                "@aws/mynah-ui": "^4.35.2"
+                "@aws/mynah-ui": "^4.35.3"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4122,9 +4122,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.35.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.35.2.tgz",
-            "integrity": "sha512-UfE1PRf+83AqQ5uXhdDTcaKHxFKsXIV6MCMz+ctghAuXpkQro2ksjfFAvL8tPUiHaGGYkUa3Ol/SoN9xsyLNpw==",
+            "version": "4.35.3",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.35.3.tgz",
+            "integrity": "sha512-BCp3MgjoCGL7NkUH3ush+xUlXtsXMlon7FlWT/s7W3Fm44Eh3ylrKx7c3Vzg2X+jbaWf0Jii4OGfomO+0NcRDQ==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {


### PR DESCRIPTION
## Notes
- Bumping mynah-ui version to [4.35.3](https://github.com/aws/mynah-ui/releases/tag/v4.35.3)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
