### PR TITLE
fix: add more detailed log when mcp server initialize failed and tooltip change

### DIFF
--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -143,7 +143,7 @@ export class TabFactory {
             tabBarButtons.push({
                 id: McpServerTabButtonId,
                 icon: MynahIcons.MCP,
-                description: 'Opening MCP Servers configuration',
+                description: 'Configure MCP servers',
             })
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -216,7 +216,7 @@ export class McpManager {
                 if (err.code === 'ENOENT') {
                     errorMessage = `Command '${cfg.command}' not found. Please ensure it's installed and available in your PATH.`
                 } else if (err.code === 'EINVAL') {
-                    errorMessage = `Invalid arguments'. Please check the command and arguments.`
+                    errorMessage = `Invalid arguments. Please check the command and arguments.`
                 } else if (err.code === -32000) {
                     errorMessage = `MCP protocol error. The server may not be properly configured.`
                 }


### PR DESCRIPTION
## Problem
When user failed adding a MCP server, the error is not been proper logged and it's very confusing.
## Solution
Classify three different kinds of logs to make it clearer to user what happened when they failed adding a mcp server
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
