### PR TITLE
fix(amazonq): remove storing zips under workspaceContextArtifacts

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
@@ -24,7 +24,6 @@ export const SUPPORTED_WORKSPACE_CONTEXT_LANGUAGES: CodewhispererLanguage[] = [
     'typescript',
     'java',
 ]
-const ARTIFACT_FOLDER_NAME = 'workspaceContextArtifacts'
 const IGNORE_PATTERNS = [
     // Package management and git
     '**/node_modules/**',
@@ -70,16 +69,12 @@ export class ArtifactManager {
     private workspaceFolders: WorkspaceFolder[]
     // TODO, how to handle when two workspace folders have the same name but different URI
     private filesByWorkspaceFolderAndLanguage: Map<WorkspaceFolder, Map<CodewhispererLanguage, FileMetadata[]>>
-    private tempDirPath: string
 
     constructor(workspace: Workspace, logging: Logging, workspaceFolders: WorkspaceFolder[]) {
         this.workspace = workspace
         this.logging = logging
         this.workspaceFolders = workspaceFolders
         this.filesByWorkspaceFolderAndLanguage = new Map<WorkspaceFolder, Map<CodewhispererLanguage, FileMetadata[]>>()
-
-        this.tempDirPath = path.join(this.workspace.fs.getTempDirPath(), ARTIFACT_FOLDER_NAME)
-        this.createFolderIfNotExist(this.tempDirPath)
     }
 
     updateWorkspaceFolders(workspaceFolders: WorkspaceFolder[]) {
@@ -148,8 +143,6 @@ export class ArtifactManager {
 
             this.filesByWorkspaceFolderAndLanguage.delete(folderToDelete)
             this.workspaceFolders = this.workspaceFolders.filter(folder => folder.uri !== workspaceToRemove.uri)
-            const workspaceDirPath = path.join(this.tempDirPath, workspaceToRemove.name)
-            fs.rmSync(workspaceDirPath, { recursive: true, force: true })
         })
     }
 
@@ -311,47 +304,6 @@ export class ArtifactManager {
         return filesMetadata
     }
 
-    cleanup(preserveDependencies: boolean = false, workspaceFolders?: WorkspaceFolder[]) {
-        try {
-            if (workspaceFolders === undefined) {
-                workspaceFolders = this.workspaceFolders
-            }
-            workspaceFolders.forEach(workspaceToRemove => {
-                const workspaceDirPath = path.join(this.tempDirPath, workspaceToRemove.name)
-
-                if (preserveDependencies) {
-                    // Define the zip files to delete
-                    const zipPatternsToDelete = [
-                        'files.zip',
-                        ...SUPPORTED_WORKSPACE_CONTEXT_LANGUAGES.map(lang => `${lang}.zip`),
-                    ]
-
-                    // If directory exists, only delete specific zip files
-                    if (fs.existsSync(workspaceDirPath)) {
-                        const entries = fs.readdirSync(workspaceDirPath)
-                        entries.forEach(entry => {
-                            const entryPath = path.join(workspaceDirPath, entry)
-                            const stat = fs.statSync(entryPath)
-
-                            if (stat.isFile() && zipPatternsToDelete.includes(entry.toLowerCase())) {
-                                fs.rmSync(entryPath, { force: true })
-                                this.log(`Deleted zip file: ${workspaceDirPath}/${entry}`)
-                            }
-                        })
-                    }
-                } else {
-                    // Original cleanup behavior - delete everything
-                    if (fs.existsSync(workspaceDirPath)) {
-                        fs.rmSync(workspaceDirPath, { recursive: true, force: true })
-                        this.log(`Deleted workspace directory: ${workspaceDirPath}`)
-                    }
-                }
-            })
-        } catch (error) {
-            this.logging.warn(`Failed to cleanup workspace artifacts: ${error}`)
-        }
-    }
-
     getLanguagesForWorkspaceFolder(
         workspaceFolder: WorkspaceFolder
     ): Map<CodewhispererLanguage, FileMetadata[]> | undefined {
@@ -371,21 +323,15 @@ export class ArtifactManager {
         subDirectory: string = '',
         zipChunkIndex: number
     ): Promise<FileMetadata> {
-        const zipDirectoryPath = path.join(this.tempDirPath, workspaceFolder.name, subDirectory)
-        this.createFolderIfNotExist(zipDirectoryPath)
         const zipFileName = `${zipChunkIndex}_${Date.now()}.zip`
-        const zipPath = path.join(zipDirectoryPath, zipFileName)
         const zipBuffer = await this.createZipBuffer(files)
-        await fs.promises.writeFile(zipPath, zipBuffer)
-
-        const stats = fs.statSync(zipPath)
 
         return {
-            filePath: zipPath,
+            filePath: '', // Virtual file that only exists in memory
             relativePath: path.join(workspaceFolder.name, subDirectory, zipFileName),
             language,
-            contentLength: stats.size,
-            lastModified: stats.mtimeMs,
+            contentLength: zipBuffer.length,
+            lastModified: Date.now(),
             content: zipBuffer,
             workspaceFolder: workspaceFolder,
         }
@@ -463,11 +409,6 @@ export class ArtifactManager {
         files: FileMetadata[],
         subDirectory: string = ''
     ): Promise<FileMetadata | undefined> {
-        const zipDirectoryPath = path.join(this.tempDirPath, workspaceFolder.name, subDirectory)
-        this.createFolderIfNotExist(zipDirectoryPath)
-
-        const zipPath = path.join(zipDirectoryPath, `${language}.zip`)
-
         let skippedSize = 0
         let skippedFiles = 0
         const filesToInclude: FileMetadata[] = []
@@ -498,16 +439,13 @@ export class ArtifactManager {
         }
 
         const zipBuffer = await this.createZipBuffer(filesToInclude)
-        await fs.promises.writeFile(zipPath, zipBuffer)
-
-        const stats = fs.statSync(zipPath)
 
         return {
-            filePath: zipPath,
+            filePath: '', // Virtual file that only exists in memory
             relativePath: path.join(workspaceFolder.name, subDirectory, `files.zip`),
             language,
-            contentLength: stats.size,
-            lastModified: stats.mtimeMs,
+            contentLength: zipBuffer.length,
+            lastModified: Date.now(),
             content: zipBuffer,
             workspaceFolder: workspaceFolder,
         }
@@ -519,25 +457,18 @@ export class ArtifactManager {
         files: FileMetadata[],
         subDirectory: string = ''
     ): Promise<FileMetadata> {
-        const zipDirectoryPath = path.join(this.tempDirPath, workspaceFolder.name, subDirectory)
-        this.createFolderIfNotExist(zipDirectoryPath)
-
-        const zipPath = path.join(zipDirectoryPath, `files.zip`)
-
         const zip = new JSZip()
         for (const file of files) {
             zip.file(path.basename(file.relativePath), file.content)
         }
         const zipBuffer = await zip.generateAsync({ type: 'nodebuffer' })
-        await fs.promises.writeFile(zipPath, zipBuffer)
-        const stats = fs.statSync(zipPath)
 
         return {
-            filePath: zipPath,
+            filePath: '', // Virtual file that only exists in memory
             relativePath: path.join(workspaceFolder.name, subDirectory, 'files.zip'),
             language,
-            contentLength: stats.size,
-            lastModified: stats.mtimeMs,
+            contentLength: zipBuffer.length,
+            lastModified: Date.now(),
             content: zipBuffer,
             workspaceFolder: workspaceFolder,
         }
@@ -668,12 +599,6 @@ export class ArtifactManager {
             }
         }
         return zipFileMetadata
-    }
-
-    private createFolderIfNotExist(dir: string) {
-        if (!fs.existsSync(dir)) {
-            fs.mkdirSync(dir, { recursive: true })
-        }
     }
 
     private log(...messages: string[]) {

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/LanguageDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/LanguageDependencyHandler.ts
@@ -364,18 +364,4 @@ export abstract class LanguageDependencyHandler<T extends BaseDependencyInfo> {
     protected isDependencyZipped(dependencyName: string, workspaceFolder: WorkspaceFolder): boolean | undefined {
         return this.dependencyMap.get(workspaceFolder)?.get(dependencyName)?.zipped
     }
-
-    public async cleanupZipFiles(zipFileMetadata: FileMetadata[]): Promise<void> {
-        for (const zip of zipFileMetadata) {
-            try {
-                if (fs.existsSync(zip.filePath)) {
-                    fs.unlinkSync(zip.filePath)
-                    this.logging.log(`Cleanup zip file: ${zip.filePath}`)
-                }
-            } catch (error) {
-                // Log error but don't throw to ensure other files are processed
-                this.logging.warn(`Error deleting zip file ${zip.filePath}: ${error}`)
-            }
-        }
-    }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.test.ts
@@ -2,6 +2,7 @@ import { InitializeParams, Server } from '@aws/language-server-runtimes/server-i
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import sinon from 'ts-sinon'
 import { WorkspaceContextServer } from './workspaceContextServer'
+import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 
 describe('WorkspaceContext Server', () => {
     let features: TestFeatures
@@ -33,6 +34,10 @@ describe('WorkspaceContext Server', () => {
                     },
                 },
             } as InitializeParams)
+
+            // Create a stub for the static getInstance method
+            const getInstanceStub = sinon.stub(AmazonQTokenServiceManager, 'getInstance')
+            getInstanceStub.throws(new Error('Deliberate error to exit the test at onInitialized'))
 
             await features.initialize(server)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
@@ -101,9 +101,6 @@ export class WorkspaceFolderManager {
 
                     // Process the dependencies
                     await this.handleDependencyChanges(zips, addWSFolderPathInS3)
-
-                    // Clean up only after successful processing
-                    await handler.cleanupZipFiles(zips)
                 } catch (error) {
                     this.logging.warn(`Error handling dependency change: ${error}`)
                 }
@@ -184,7 +181,6 @@ export class WorkspaceFolderManager {
         sourceCodeMetadata = await this.artifactManager.addWorkspaceFolders(folders)
 
         await this.uploadS3AndQueueEvents(sourceCodeMetadata)
-        this.artifactManager.cleanup(true, folders)
     }
 
     async uploadToS3(fileMetadata: FileMetadata, addWSFolderPathInS3: boolean = true): Promise<string | undefined> {
@@ -235,7 +231,6 @@ export class WorkspaceFolderManager {
         this.stopContinuousMonitoring()
         this.resetRemoteWorkspaceId()
         this.workspaceState.webSocketClient?.destroyClient()
-        this.artifactManager.cleanup()
         this.dependencyDiscoverer.dispose()
     }
 


### PR DESCRIPTION
## Problem

Currently, workspace context workflow is creating zip files and writing them to disk before further processing (uploading to S3, sending notification to backend, etc.), however, when examining the logic, there is no place where it reads from these zip files.

We should avoid saving these unused files to reduce disk usage and prevent leaving residues on users disk.

## Solution

Remove storing zips under `workspaceContextArtifacts`

## Testing

Tested locally and verified that:
1. Zipping and uploading logic works correctly as before.
2. No temporary files are created under `/tmp/aws-language-servers/workspaceContextArtifacts` anymore.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
