### PR TITLE
fix(paidtier): "Upgrade success" message is unreliable

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -922,12 +922,15 @@ export const createMynahUi = (
             // Change the sticky banner to show a progress spinner.
             const card: typeof freeTierLimitSticky = {
                 ...(isFreeTierLimitUi ? freeTierLimitSticky : upgradePendingSticky),
-                icon: 'progress',
+            }
+            card.header = {
+                ...card.header,
+                icon: upgradePendingSticky.header?.icon,
+                iconStatus: upgradePendingSticky.header?.iconStatus,
             }
             mynahUi.updateStore(tabId, {
-                // Show a progress ribbon.
                 promptInputVisible: true,
-                promptInputStickyCard: isFreeTierLimitUi ? card : null,
+                promptInputStickyCard: card,
             })
         } else if (mode === 'paidtier') {
             mynahUi.updateStore(tabId, {

--- a/chat-client/src/client/texts/paidTier.ts
+++ b/chat-client/src/client/texts/paidTier.ts
@@ -13,8 +13,8 @@ export const upgradeQButton: ChatItemButton = {
     // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/q.svg
     // https://github.com/aws/mynah-ui/blob/main/src/components/icon/icons/rocket.svg
     // icon: MynahIcons.Q,
-    description: `Upgrade to ${qProName}`,
     text: `Subscribe to ${qProName}`,
+    // description: `Upgrade to ${qProName}`,
     status: 'primary',
     disabled: false,
 }
@@ -65,12 +65,14 @@ export const freeTierLimitSticky: Partial<ChatItem> = {
 
 export const upgradePendingSticky: Partial<ChatItem> = {
     messageId: 'upgrade-pending-banner',
-    body: 'Waiting for subscription status...',
-    status: 'info',
-    buttons: [],
+    body: freeTierLimitSticky.body,
+    buttons: [upgradeQButton],
+    header: {
+        icon: 'progress',
+        iconStatus: undefined,
+        body: '### Waiting for subscription status...',
+    },
     canBeDismissed: true,
-    icon: 'progress',
-    // iconStatus: 'info',
 }
 
 export const upgradeSuccessSticky: Partial<ChatItem> = {
@@ -137,7 +139,7 @@ export const paidTierPromptInput: TextBasedFormItem = {
     placeholder: '111111111111',
     type: 'textinput',
     id: 'paid-tier',
-    tooltip: `Upgrade to ${qProName}`,
+    // tooltip: `Upgrade to ${qProName}`,
     value: 'true',
     icon: 'magic',
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2642,10 +2642,12 @@ export class AgenticChatController implements ChatHandlers {
      * Updates the "Upgrade Q" (subscription tier) state of the UI in the chat component. If `mode` is not given, the user's subscription status is checked by calling the Q service.
      *
      * `mode` behavior:
-     * - 'freetier': treated as 'freetier-limit' if `this.#paidTierMode='freetier-limit'`.
-     * - 'freetier-limit': also show "Free Tier limit reached" card in chat.
-     *     - This mode is "sticky" until 'paidtier' is passed to override it.
-     * - 'paidtier': disable any "free-tier limit" UI.
+     *  - 'freetier': chat-ui clears "limit reached" UI, if any.
+     *  - 'freetier-limit':
+     *      - client (IDE) shows a message.
+     *      - chat-ui shows a chat card.
+     *  - 'paidtier': disable any "free-tier limit" UI.
+     *  - 'upgrade-pending': chat-ui shows a progress spinner.
      */
     setPaidTierMode(tabId?: string, mode?: PaidTierMode) {
         const isBuilderId = getSsoConnectionType(this.#features.credentialsProvider) === 'builderId'
@@ -2739,7 +2741,7 @@ export class AgenticChatController implements ChatHandlers {
                             this.#log('onManageSubscription: missing encodedVerificationUrl in server response')
                             this.#features.lsp.window
                                 .showMessage({
-                                    message: 'Subscription request failed. Check the account id.',
+                                    message: 'Subscription request failed.',
                                     type: MessageType.Error,
                                 })
                                 .catch(e => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -87,7 +87,7 @@ import {
     getHttpStatusCode,
     getRequestID,
     getSsoConnectionType,
-    isFreeTierLimitError,
+    isUsageLimitError,
     isNullish,
 } from '../../shared/utils'
 import { HELP_MESSAGE, loadingMessage } from '../chat/constants'
@@ -1404,7 +1404,7 @@ export class AgenticChatController implements ChatHandlers {
      */
     isUserAction(err: unknown, token?: CancellationToken, session?: ChatSessionService): boolean {
         return (
-            !isFreeTierLimitError(err) &&
+            !isUsageLimitError(err) &&
             (CancellationError.isUserCancelled(err) ||
                 err instanceof ToolApprovalException ||
                 isRequestAbortedError(err) ||
@@ -2113,12 +2113,14 @@ export class AgenticChatController implements ChatHandlers {
         metric.metric.cwsprChatConversationId = conversationId
         await this.#telemetryController.emitAddMessageMetric(tabId, metric.metric, 'Failed')
 
-        if (isFreeTierLimitError(err)) {
-            this.setPaidTierMode(tabId, 'freetier-limit')
+        if (isUsageLimitError(err)) {
+            if (this.#paidTierMode !== 'paidtier') {
+                this.setPaidTierMode(tabId, 'freetier-limit')
+            }
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, {
                 type: 'answer',
-                body: `AmazonQFreeTierLimitError: Free tier limit reached. ${requestID ? `\n\nRequest ID: ${requestID}` : ''}`,
-                messageId: 'freetier-limit',
+                body: `AmazonQUsageLimitError: Monthly limit reached. ${requestID ? `\n\nRequest ID: ${requestID}` : ''}`,
+                messageId: 'monthly-usage-limit',
                 buttons: [],
             })
         }
@@ -2160,7 +2162,7 @@ export class AgenticChatController implements ChatHandlers {
             return createAuthFollowUpResult(authFollowType)
         }
 
-        if (isFreeTierLimitError(err) || customerFacingErrorCodes.includes(err.code)) {
+        if (isUsageLimitError(err) || customerFacingErrorCodes.includes(err.code)) {
             this.#features.logging.error(`${loggingUtils.formatErr(err)}`)
             if (err.code === 'InputTooLong') {
                 // Clear the chat history in the database for this tab
@@ -2655,7 +2657,7 @@ export class AgenticChatController implements ChatHandlers {
             return
         }
 
-        if (this.#paidTierMode === 'freetier-limit' && mode === 'freetier') {
+        if (mode === 'freetier' && this.#paidTierMode === 'freetier-limit') {
             // mode = 'freetier-limit' // Sticky while 'freetier'.
         } else if (mode === 'freetier-limit' && mode !== this.#paidTierMode) {
             this.showFreeTierLimitMsgOnClient(tabId)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -6,7 +6,7 @@ type AgenticChatErrorCode =
     | 'FailedResult' // general error when processing tool results
     | 'InputTooLong' // too much context given to backend service.
     | 'PromptCharacterLimit' // customer prompt exceeds
-    | 'AmazonQFreeTierLimitError' // Free Tier limit was reached.
+    | 'AmazonQUsageLimitError' // Monthly usage limit was reached (usually free-tier user).
     | 'ResponseProcessingTimeout' // response didn't finish streaming in the allowed time
     | 'MCPServerInitTimeout' // mcp server failed to start within allowed time
     | 'MCPToolExecTimeout' // mcp tool call failed to complete within allowed time
@@ -17,7 +17,7 @@ export const customerFacingErrorCodes: AgenticChatErrorCode[] = [
     'QModelResponse',
     'InputTooLong',
     'PromptCharacterLimit',
-    'AmazonQFreeTierLimitError',
+    'AmazonQUsageLimitError',
 ]
 
 export const unactionableErrorCodes: Partial<Record<AgenticChatErrorCode, string>> = {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -15,8 +15,7 @@ import { AgenticChatError, isInputTooLongError, isRequestAbortedError, wrapError
 import { AmazonQBaseServiceManager } from '../../shared/amazonQServiceManager/BaseAmazonQServiceManager'
 import { loggingUtils } from '@aws/lsp-core'
 import { Logging } from '@aws/language-server-runtimes/server-interface'
-import { getRequestID, isFreeTierLimitError } from '../../shared/utils'
-import { AmazonQFreeTierLimitError } from '../../shared/amazonQServiceManager/errors'
+import { getRequestID, isUsageLimitError } from '../../shared/utils'
 
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
 type FileChange = { before?: string; after?: string }
@@ -164,10 +163,10 @@ export class ChatSessionService {
                 }
 
                 const requestId = getRequestID(e)
-                if (isFreeTierLimitError(e)) {
+                if (isUsageLimitError(e)) {
                     throw new AgenticChatError(
                         'Request aborted',
-                        'AmazonQFreeTierLimitError',
+                        'AmazonQUsageLimitError',
                         e instanceof Error ? e : undefined,
                         requestId
                     )

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/errors.ts
@@ -86,9 +86,9 @@ export class AmazonQServiceConnectionExpiredError extends AmazonQError {
     }
 }
 
-export class AmazonQFreeTierLimitError extends AmazonQError {
+export class AmazonQUsageLimitError extends AmazonQError {
     constructor(cause?: unknown, message: string = 'Free tier limit reached.') {
-        super(message, 'E_AMAZON_Q_FREE_TIER_LIMIT', cause)
-        this.name = 'AmazonQFreeTierLimitError'
+        super(message, 'E_AMAZON_Q_USAGE_LIMIT', cause)
+        this.name = 'AmazonQUsageLimitError'
     }
 }

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -13,11 +13,11 @@ import {
     SendMessageCommandOutput as SendMessageCommandOutputQDeveloperStreaming,
 } from '@amzn/amazon-q-developer-streaming-client'
 import { CredentialsProvider, SDKInitializator, Logging } from '@aws/language-server-runtimes/server-interface'
-import { getBearerTokenFromProvider, isFreeTierLimitError } from './utils'
+import { getBearerTokenFromProvider, isUsageLimitError } from './utils'
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { CredentialProviderChain, Credentials } from 'aws-sdk'
 import { clientTimeoutMs } from '../language-server/agenticChat/constants'
-import { AmazonQFreeTierLimitError } from './amazonQServiceManager/errors'
+import { AmazonQUsageLimitError } from './amazonQServiceManager/errors'
 
 export type SendMessageCommandInput =
     | SendMessageCommandInputCodeWhispererStreaming
@@ -104,8 +104,8 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
 
             return response
         } catch (e) {
-            if (isFreeTierLimitError(e)) {
-                throw new AmazonQFreeTierLimitError(e)
+            if (isUsageLimitError(e)) {
+                throw new AmazonQUsageLimitError(e)
             }
             throw e
         } finally {
@@ -132,8 +132,8 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
             return response
         } catch (e) {
             // TODO add a test for this
-            if (isFreeTierLimitError(e)) {
-                throw new AmazonQFreeTierLimitError(e)
+            if (isUsageLimitError(e)) {
+                throw new AmazonQUsageLimitError(e)
             }
             throw e
         } finally {

--- a/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
@@ -15,7 +15,7 @@ import {
     getSsoConnectionType,
     getUnmodifiedAcceptedTokens,
     isAwsThrottlingError,
-    isFreeTierLimitError,
+    isUsageLimitError,
     isQuotaExceededError,
     isStringOrNull,
     safeGet,
@@ -291,10 +291,10 @@ describe('isAwsThrottlingError', function () {
     })
 })
 
-describe('isFreeTierLimitError', function () {
+describe('isMonthlyLimitError', function () {
     it('false for non-throttling errors', function () {
         const regularError = new Error('Some error')
-        assert.strictEqual(isFreeTierLimitError(regularError), false)
+        assert.strictEqual(isUsageLimitError(regularError), false)
 
         const e = new Error()
         ;(e as any).name = 'AWSError'
@@ -302,7 +302,7 @@ describe('isFreeTierLimitError', function () {
         ;(e as any).code = 'SomeOtherError'
         ;(e as any).time = new Date()
 
-        assert.strictEqual(isFreeTierLimitError(e), false)
+        assert.strictEqual(isUsageLimitError(e), false)
     })
 
     it('false for throttling errors without MONTHLY_REQUEST_COUNT reason', function () {
@@ -313,18 +313,18 @@ describe('isFreeTierLimitError', function () {
         ;(throttlingError as any).time = new Date()
         ;(throttlingError as any).reason = 'SOME_OTHER_REASON'
 
-        assert.strictEqual(isFreeTierLimitError(throttlingError), false)
+        assert.strictEqual(isUsageLimitError(throttlingError), false)
     })
 
     it('true for throttling errors with MONTHLY_REQUEST_COUNT reason', function () {
-        const freeTierLimitError = new Error()
-        ;(freeTierLimitError as any).name = 'ThrottlingException'
-        ;(freeTierLimitError as any).message = 'Free tier limit reached'
-        ;(freeTierLimitError as any).code = 'ThrottlingException'
-        ;(freeTierLimitError as any).time = new Date()
-        ;(freeTierLimitError as any).reason = ThrottlingExceptionReason.MONTHLY_REQUEST_COUNT
+        const usageLimitError = new Error()
+        ;(usageLimitError as any).name = 'ThrottlingException'
+        ;(usageLimitError as any).message = 'Free tier limit reached'
+        ;(usageLimitError as any).code = 'ThrottlingException'
+        ;(usageLimitError as any).time = new Date()
+        ;(usageLimitError as any).reason = ThrottlingExceptionReason.MONTHLY_REQUEST_COUNT
 
-        assert.strictEqual(isFreeTierLimitError(freeTierLimitError), true)
+        assert.strictEqual(isUsageLimitError(usageLimitError), true)
     })
 })
 

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -47,20 +47,21 @@ export function isAwsThrottlingError(e: unknown): e is ThrottlingException {
 }
 
 /**
- * Special case of throttling error: "free tier" limit reached.
+ * Special case of throttling error: monthly limit reached. This is most common
+ * for "free tier" users, but is technically possible for "pro tier" also.
  *
  * See `client/token/bearer-token-service.json`.
  */
-export function isFreeTierLimitError(e: unknown): e is ThrottlingException {
+export function isUsageLimitError(e: unknown): e is ThrottlingException {
     if (!e) {
         return false
     }
 
-    if (hasCode(e) && (e.code === 'AmazonQFreeTierLimitError' || e.code === 'E_AMAZON_Q_FREE_TIER_LIMIT')) {
+    if (hasCode(e) && (e.code === 'AmazonQUsageLimitError' || e.code === 'E_AMAZON_Q_USAGE_LIMIT')) {
         return true
     }
 
-    if ((e as Error).name === 'AmazonQFreeTierLimitError') {
+    if ((e as Error).name === 'AmazonQUsageLimitError') {
         return true
     }
 
@@ -81,7 +82,7 @@ export function isQuotaExceededError(e: unknown): e is AWSError {
     }
 
     // From client/token/bearer-token-service.json
-    if (isFreeTierLimitError(e)) {
+    if (isUsageLimitError(e)) {
         return true
     }
 


### PR DESCRIPTION
- Fix spinner placement.
- Ensure "upgrade successful" notification happens without needing to switch tabs.
- Check for pro-tier before showing the "Upgrade to Pro" message.

## Screens

- limit reached
    - <img width="1495" alt="image" src="https://github.com/user-attachments/assets/fcec4534-9458-4a6b-905a-0d743476652b" />
- upgrade in progress
    - <img width="402" alt="image" src="https://github.com/user-attachments/assets/ca5f022b-a268-4750-a2aa-36b297739a1a" />




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
