### PR TITLE
fix: correct icon for mcp button

### DIFF
--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -142,7 +142,7 @@ export class TabFactory {
         if (this.mcp) {
             tabBarButtons.push({
                 id: McpServerTabButtonId,
-                icon: MynahIcons.MCP,
+                icon: MynahIcons.TOOLS,
                 description: 'Configure MCP servers',
             })
         }

--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -142,7 +142,7 @@ export class TabFactory {
         if (this.mcp) {
             tabBarButtons.push({
                 id: McpServerTabButtonId,
-                icon: MynahIcons.MCP,
+                icon: MynahIcons.TOOLS,
                 description: 'Opening MCP Servers configuration',
             })
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -306,7 +306,10 @@ export class McpEventHandler {
         if (existingValues.name) {
             const serverName = existingValues.name
             const serverState = McpManager.instance.getAllServerConfigs().get(serverName)
-            if (serverState?.__configPath__ === getGlobalMcpConfigPath(this.#features.workspace.fs.getUserHomeDir())) {
+            if (
+                !serverState ||
+                serverState?.__configPath__ === getGlobalMcpConfigPath(this.#features.workspace.fs.getUserHomeDir())
+            ) {
                 existingValues.scope = 'global'
             } else {
                 existingValues.scope = 'workspace'


### PR DESCRIPTION
## Problem
- wrong icon for mcp
- when adding an invalid mcp server and pressing save, scope would change from global to workspace


https://github.com/user-attachments/assets/181ae952-b122-4250-86a5-27660dbb1d33




## Solution
- correct icon for mcp according to figma
- when adding an invalid mcp server and pressing save, scope will persist to whatever user chooses

![Screenshot 2025-06-10 at 3 48 24 PM](https://github.com/user-attachments/assets/367e2589-121a-43c0-bc20-ec9ac7a6f101)

https://github.com/user-attachments/assets/8460d04f-96f4-439d-b8dc-2800f3a9ffa9



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
