### PR TITLE
chore(amazonq): skip checking remote workspace status when no workspaceFolders

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
@@ -417,6 +417,11 @@ export class WorkspaceFolderManager {
     }
 
     private async checkRemoteWorkspaceStatusAndReact(skipUploads: boolean = false) {
+        if (this.workspaceFolders.length === 0) {
+            this.logging.log(`No workspace folders added, skipping workspace status check`)
+            return
+        }
+
         this.logging.log(`Checking remote workspace status for workspace [${this.workspaceIdentifier}]`)
         const { metadata, optOut, error } = await this.listWorkspaceMetadata(this.workspaceIdentifier)
 


### PR DESCRIPTION
## Problem

Right now, we are checking remote workspace status even when there is no workspace folders, for example, when chatting to Amazon Q in an IDE window without opening any folder or workspace.

## Solution

Skip checking remote workspace status when no workspaceFolders.

Tested the logic:
![image](https://github.com/user-attachments/assets/f05cdd0c-e8af-44c3-95aa-4d2ae3c4514e)

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
