### PR TITLE
fix: remove the tool from the mapping after user delete the server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -91,6 +91,7 @@ export const McpToolsServer: Server = ({ credentialsProvider, workspace, logging
         // 1) remove old tools
         for (const name of registered[server] ?? []) {
             agent.removeTool(name)
+            allNamespacedTools.delete(name)
         }
         registered[server] = []
 


### PR DESCRIPTION
## Problem
When user remove a server, we did not remove the server's tool name from set. Which might case when next time user add the same server, there would be a conflict when we create name mapping for serverName_toolName

https://github.com/user-attachments/assets/6ffd66fb-3054-4e7f-98ec-fbc71203d526

(00:00:55 in this video)

## Solution
We are removing the tool name in set for creating the Map. To make sure when user remove the sever, the tool would be completely removed from the memory as well.

https://github.com/user-attachments/assets/86648754-9555-4e9f-8472-b8959e2181ff


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
