### PR TITLE
fix: fix for empty description of mcp tools

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -128,7 +128,7 @@ export const McpToolsServer: Server = ({ credentialsProvider, workspace, logging
             agent.addTool(
                 {
                     name: cleanedName,
-                    description: def.description?.trim() || 'empty description',
+                    description: def.description?.trim() || 'undefined',
                     inputSchema: inputSchemaWithExplanation,
                 },
                 input => tool.invoke(input)


### PR DESCRIPTION
## Problem
MCP tools with empty description are failing all chat requests due to RTS validation for description field.

## Solution
- Added empty description field if description is an empty string to fix for request validation.
- Added validation for tool names

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
