### PR TITLE
fix: fix for overwriting in workspace level config and persona files

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -728,6 +728,7 @@ export class McpManager {
                 let json: any = { mcpServers: {} }
                 try {
                     const raw = await this.features.workspace.fs.readFile(configPath)
+                    this.features.logging.info(`Updating MCP config file: ${configPath}`)
                     const existing = JSON.parse(raw.toString())
                     json = { mcpServers: {}, ...existing }
                 } catch (err: any) {


### PR DESCRIPTION
## Problem
At workspace level config and persona files are getting overwritten and deleting existing mcps when an mcp initialization fails on saving. as workspace level paths arrive as URIs with `file:/` at the start of path.

## Solution
- fixes for URI path format for config and persona files at workspace
- storing newly added servers which have failed, to delete only them and not manually added mcps by users directly to config file.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
