### PR TITLE
fix: mcp server list highlighting

### DIFF
--- a/chat-client/src/client/mcpMynahUi.test.ts
+++ b/chat-client/src/client/mcpMynahUi.test.ts
@@ -101,7 +101,7 @@ describe('McpMynahUi', () => {
 
             // Verify the parameters
             const callArgs = (mynahUi.openDetailedList as sinon.SinonStub).firstCall.args[0]
-            assert.strictEqual(callArgs.detailedList.selectable, true)
+            assert.strictEqual(callArgs.detailedList.selectable, 'clickable')
             assert.strictEqual(callArgs.detailedList.textDirection, 'row')
             assert.strictEqual(callArgs.detailedList.header.title, 'Test Title')
             assert.strictEqual(callArgs.detailedList.header.description, 'Test Description')
@@ -246,20 +246,22 @@ describe('McpMynahUi', () => {
             sinon.assert.calledOnce(mockSheet.close)
 
             // Test onItemSelect event
-            const mockItem = {
+            const mockSelectItem = {
+                id: 'mcp-server-click',
                 title: 'Server 1',
                 actions: [{ id: 'open-mcp-server' }],
             } as DetailedListItem
-            events.onItemSelect(mockItem)
+            events.onItemSelect(mockSelectItem)
             sinon.assert.calledWith(messager.onMcpServerClick as sinon.SinonStub, 'open-mcp-server', 'Server 1')
 
             // Test onItemClick event
             const mockClickItem = {
                 id: 'mcp-server-click',
                 title: 'Server 1',
+                actions: [{ id: 'open-mcp-server' }],
             } as DetailedListItem
             events.onItemClick(mockClickItem)
-            sinon.assert.calledWith(messager.onMcpServerClick as sinon.SinonStub, 'mcp-server-click')
+            sinon.assert.calledWith(messager.onMcpServerClick as sinon.SinonStub, 'open-mcp-server', 'Server 1')
 
             // Test onActionClick event
             const mockAction = { id: 'add-new-mcp' } as ChatItemButton

--- a/chat-client/src/client/mcpMynahUi.ts
+++ b/chat-client/src/client/mcpMynahUi.ts
@@ -264,7 +264,7 @@ export class McpMynahUi {
         this.isMcpServersListActive = true
         // Convert the ListMcpServersResult to the format expected by mynahUi.openDetailedList
         const detailedList: any = {
-            selectable: true,
+            selectable: 'clickable',
             textDirection: 'row',
             header: params.header
                 ? {
@@ -416,15 +416,16 @@ export class McpMynahUi {
                     }
                 },
                 onItemSelect: (item: DetailedListItem) => {
-                    // actionId: open-mcp-server if valid server or mcp-fix-server if server needs to be fixed
                     const actionId = item.actions?.[0].id
                     if (actionId) {
                         this.messager.onMcpServerClick(actionId, item.title)
                     }
                 },
                 onItemClick: (item: DetailedListItem) => {
-                    if (item.id) {
-                        this.messager.onMcpServerClick(item.id)
+                    // actionId: open-mcp-server if valid server or mcp-fix-server if server needs to be fixed
+                    const actionId = item.actions?.[0].id
+                    if (actionId) {
+                        this.messager.onMcpServerClick(actionId, item.title)
                     }
                 },
                 onActionClick: (action: ChatItemButton, item?: DetailedListItem) => {


### PR DESCRIPTION
## Problem
- first row highlighting persists even when not hovered over
- first row has border when hovering over other rows

https://github.com/user-attachments/assets/f3edc4bb-5027-432d-8cd9-44172c79c959



## Solution
- only highlight over the row you are hovering over

https://github.com/user-attachments/assets/ede45363-92aa-4eb1-90aa-c3942a1efecc



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
