### PR TITLE
chore(amazonq): extend remote workspace monitor interval from 5 mins to 30 mins

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
@@ -43,7 +43,7 @@ export class WorkspaceFolderManager {
     private credentialsProvider: CredentialsProvider
     private readonly INITIAL_CHECK_INTERVAL = 40 * 1000 // 40 seconds
     private readonly INITIAL_CONNECTION_TIMEOUT = 2 * 60 * 1000 // 2 minutes
-    private readonly CONTINUOUS_MONITOR_INTERVAL = 5 * 60 * 1000 // 5 minutes
+    private readonly CONTINUOUS_MONITOR_INTERVAL = 30 * 60 * 1000 // 30 minutes
     private readonly MESSAGE_PUBLISH_INTERVAL: number = 100 // 100 milliseconds
     private continuousMonitorInterval: NodeJS.Timeout | undefined
     private optOutMonitorInterval: NodeJS.Timeout | undefined


### PR DESCRIPTION
## Problem

We want to reduce the call volume to backend `ListWorkspaceMetadata` API.

## Solution

Extend remote workspace monitoring workflow interval from 5 mins to 30 mins, tuning the value to balance the need for timely detection of server-side opt-in status and remote workspace state changes against backend load reduction.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
