### PR TITLE
fix: default model should be undefined until feature is enabled

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
@@ -5,4 +5,6 @@ export const outputLimitExceedsPartialMsg = 'output exceeds maximum character li
 export const responseTimeoutMs = 170_000
 export const responseTimeoutPartialMsg = 'Response processing timed out after'
 export const clientTimeoutMs = 180_000
-export const defaultModelId = 'CLAUDE_3_7_SONNET_20250219_V1_0' // TODO: this can't be imported from chat-client, so we hardcode it here
+export const defaultModelId = undefined
+// TODO: Uncomment this line when model selection is ready to release
+// export const defaultModelId = 'CLAUDE_3_7_SONNET_20250219_V1_0' // TODO: this can't be imported from chat-client, so we hardcode it here


### PR DESCRIPTION
## Problem

Clients are using the default value of sonnet 3.7 even though dropdown has not been enabled yet

## Solution

Temporarily set default model to undefined

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
