### PR TITLE
chore: pass modelSelection as true in ChatOptions to IDE

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -47,6 +47,7 @@ export const QAgenticChatServer =
                             ],
                         },
                         mcpServers: enabledMCP(params),
+                        modelSelection: true,
                         history: true,
                         export: TabBarController.enableChatExport(params)
                     },


### PR DESCRIPTION
## Problem
Currently, clients/IDEs pass if model selection is enabled in webview provider to hide/show the model selection dropdown. However, extensions should be data-driven in indicating to chat UI if model selection is available from server side. 

## Solution
Server could pass its ability of model selection in ChatOptions of awsServerCapabilities during Initialize handshake happened. Then, the clients would be purely data-driven to reduce blast radius. 


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
