### PR TITLE
fix(amazonq): cancel workspace context server initialization workflow on exit

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -26,6 +26,7 @@ export const WorkspaceContextServer = (): Server => features => {
     let artifactManager: ArtifactManager
     let dependencyDiscoverer: DependencyDiscoverer
     let workspaceFolderManager: WorkspaceFolderManager
+    let workflowInitializationInterval: NodeJS.Timeout
     let isWorkflowInitialized: boolean = false
     let isOptedIn: boolean = false
     let abTestingEvaluated = false
@@ -236,7 +237,7 @@ export const WorkspaceContextServer = (): Server => features => {
              * of workspace folders is updated using *artifactManager.updateWorkspaceFolders(workspaceFolders)* before
              * initializing again.
              */
-            setInterval(async () => {
+            workflowInitializationInterval = setInterval(async () => {
                 if (!isOptedIn) {
                     return
                 }
@@ -501,6 +502,7 @@ export const WorkspaceContextServer = (): Server => features => {
     logging.log('Workspace context server has been initialized')
 
     return () => {
+        clearInterval(workflowInitializationInterval)
         workspaceFolderManager.clearAllWorkspaceResources().catch(error => {
             logging.warn(
                 `Error while clearing workspace resources: ${error instanceof Error ? error.message : 'Unknown error'}`


### PR DESCRIPTION
## Problem

On backend side, we observed a few occurrences that multiple `ListFeatureEvaluations` API calls are made for the same workspace at the same time, which is supposed to be called once during language server initialization:
- https://github.com/aws/language-servers/blob/c515e959538ba654cc30065a2a89a8b103f8ca86/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts#L253

We should prevent previous workspace context server initialization workflow from continuing running when language server restarts.

## Solution

Cancel workspace context server initialization workflow on exit.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
