### PR TITLE
fix: remove /manage options from the chat prompt popup

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2502,19 +2502,6 @@ export class AgenticChatController implements ChatHandlers {
                     body: HELP_MESSAGE,
                 }
 
-            // "Manage Subscription" (paid-tier user), or "Upgrade Q" (free-tier user)
-            case QuickAction.Manage:
-                this.#telemetryController.emitChatMetric({
-                    name: ChatTelemetryEventName.RunCommand,
-                    data: {
-                        cwsprChatCommandType: params.quickAction,
-                        cwsprChatCommandName: '/manage',
-                    },
-                })
-
-                void this.onManageSubscription(params.tabId)
-
-                return {}
             default:
                 return {}
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -6,7 +6,7 @@
 import { InitializeParams, Server } from '@aws/language-server-runtimes/server-interface'
 import { AgenticChatController } from './agenticChatController'
 import { ChatSessionManagementService } from '../chat/chatSessionManagementService'
-import { CLEAR_QUICK_ACTION, HELP_QUICK_ACTION, MANAGE_QUICK_ACTION } from '../chat/quickActions'
+import { CLEAR_QUICK_ACTION, HELP_QUICK_ACTION } from '../chat/quickActions'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { makeUserContextObject } from '../../shared/telemetryUtils'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
@@ -42,7 +42,7 @@ export const QAgenticChatServer =
                         quickActions: {
                             quickActionsCommandGroups: [
                                 {
-                                    commands: [HELP_QUICK_ACTION, CLEAR_QUICK_ACTION, MANAGE_QUICK_ACTION],
+                                    commands: [HELP_QUICK_ACTION, CLEAR_QUICK_ACTION],
                                 },
                             ],
                         },

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/quickActions.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/quickActions.ts
@@ -1,7 +1,6 @@
 export enum QuickAction {
     Clear = '/clear',
     Help = '/help',
-    Manage = '/manage',
 }
 
 export const HELP_QUICK_ACTION = {
@@ -14,10 +13,4 @@ export const CLEAR_QUICK_ACTION = {
     command: QuickAction.Clear,
     description: 'Clear this session',
     icon: 'trash',
-}
-
-export const MANAGE_QUICK_ACTION = {
-    command: QuickAction.Manage,
-    description: 'Manage Amazon Q Subscription',
-    icon: 'menu', // 'check-list'
 }


### PR DESCRIPTION
## Problem
/manage option are shown in the / popup in the chat prompt. This option was put in place with the builder-id paid tier launch. However, is not a requirement. 
## Solution
This PR removes the /manage option from quick actions
<img width="432" alt="Screenshot 2025-06-13 at 11 22 23 AM" src="https://github.com/user-attachments/assets/c2044354-25e9-407b-8b6e-7773ffc6d71d" />

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
