### PR TITLE
fix: adding normalizePathFromUri to mcpUtils to handle uri paths

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -16,6 +16,7 @@ import {
     getWorkspaceMcpConfigPaths,
     getWorkspacePersonaConfigPaths,
     sanitizeName,
+    normalizePathFromUri,
 } from './mcpUtils'
 import {
     McpPermissionType,
@@ -636,9 +637,7 @@ export class McpEventHandler {
             const workspaceMcpPaths = getWorkspaceMcpConfigPaths(workspacePaths)
             configPath =
                 Array.isArray(workspaceMcpPaths) && workspaceMcpPaths.length > 0
-                    ? workspaceMcpPaths[0].startsWith('file:')
-                        ? URI.parse(workspaceMcpPaths[0]).fsPath
-                        : workspaceMcpPaths[0]
+                    ? normalizePathFromUri(workspaceMcpPaths[0], this.#features.logging)
                     : configPath
 
             // Get the appropriate persona path using our helper method
@@ -1177,10 +1176,8 @@ export class McpEventHandler {
 
             if (Array.isArray(workspacePersonaPaths) && workspacePersonaPaths.length > 0) {
                 try {
-                    // Convert URI format to filesystem path if needed
-                    const personaPath = workspacePersonaPaths[0].startsWith('file:')
-                        ? URI.parse(workspacePersonaPaths[0]).fsPath
-                        : workspacePersonaPaths[0]
+                    // Convert URI format to filesystem path if needed using the utility function
+                    const personaPath = normalizePathFromUri(workspacePersonaPaths[0], this.#features.logging)
 
                     // Check if the workspace persona path exists
                     const fileExists = await this.#features.workspace.fs.exists(personaPath)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -353,6 +353,30 @@ export function sanitizeName(orig: string): string {
     return sanitized
 }
 
+/**
+ * Safely converts a path that might be in URI format to a filesystem path
+ * @param path The path that might be in URI format
+ * @param logging Optional logger for error reporting
+ * @returns The normalized filesystem path
+ */
+export function normalizePathFromUri(path: string, logging?: Logger): string {
+    if (!path) {
+        return path
+    }
+
+    try {
+        if (path.startsWith('file:')) {
+            return URI.parse(path).fsPath
+        }
+        return path
+    } catch (e) {
+        if (logging) {
+            logging.warn(`Failed to parse URI path: ${path}. Error: ${e}`)
+        }
+        return path // Return original path if parsing fails
+    }
+}
+
 export const MAX_TOOL_NAME_LENGTH = 64
 
 /**


### PR DESCRIPTION
## Problem
normalize path from URI was being used in multiple places in mcpEventHandler

## Solution
- created a function to handle it along with unit tests.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
