### PR TITLE
fix: remove splitting of command passed to execute bash for windows

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -458,9 +458,7 @@ export class ExecuteBash {
                 },
             }
 
-            const shellArgs = IS_WINDOWS_PLATFORM
-                ? ['/u', shellFlag, ...split(params.command)] // Windows: split for proper arg handling
-                : [shellFlag, params.command]
+            const shellArgs = IS_WINDOWS_PLATFORM ? ['/u', shellFlag, params.command] : [shellFlag, params.command]
 
             this.childProcess = new ChildProcess(this.logging, shellName, shellArgs, childProcessOptions)
 


### PR DESCRIPTION
## Description
For execute bash commands such as `mkdir C:\Users\abc\def`, there was logic to split up the string by escape characters which treated windows `\` separators as valid chars to split on. This lead to a directory being created of the form `CUserabcdef` instead of honoring the folder structure. This change removes that split and relies on cmd tool to do the appropriate parsing of commands instead of a explicit split.
 <!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
