### PR TITLE
feat(amazonq): model throttling message as card instead of chat message

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -60,7 +60,7 @@ import {
 } from './utils'
 import { ChatHistory, ChatHistoryList } from './features/history'
 import { pairProgrammingModeOff, pairProgrammingModeOn, programmerModeCard } from './texts/pairProgramming'
-import { getModelSelectionChatItem } from './texts/modelSelection'
+import { getModelSelectionChatItem, modelUnavailableBanner } from './texts/modelSelection'
 import {
     freeTierLimitSticky,
     upgradeSuccessSticky,
@@ -877,7 +877,7 @@ export const createMynahUi = (
             return false // invalid mode
         }
 
-        tabId = !!tabId ? tabId : getOrCreateTabId()!
+        tabId = tabId ? tabId : getOrCreateTabId()!
         const store = mynahUi.getTabData(tabId).getStore() || {}
 
         // Detect if the tab is already showing the "Upgrade Q" UI.
@@ -976,6 +976,13 @@ export const createMynahUi = (
             params.data?.messages.forEach(updatedMessage => {
                 if (!updatedMessage.messageId) {
                     // Do not process messages without known ID.
+                    return
+                }
+
+                if (updatedMessage.messageId === 'modelUnavailable') {
+                    mynahUi.updateStore(tabId, {
+                        promptInputStickyCard: modelUnavailableBanner,
+                    })
                     return
                 }
 

--- a/chat-client/src/client/texts/modelSelection.ts
+++ b/chat-client/src/client/texts/modelSelection.ts
@@ -35,3 +35,14 @@ export const getModelSelectionChatItem = (modelId: string): ChatItem => ({
     fullWidth: true,
     body: `Switched model to ${modelRecord[modelId as BedrockModel].label}`,
 })
+
+export const modelUnavailableBanner: Partial<ChatItem> = {
+    messageId: 'model-unavailable-banner',
+    header: {
+        icon: 'warning',
+        iconStatus: 'warning',
+        body: '### Model Unavailable',
+    },
+    body: `The model you selected is temporarily unavailable. Please switch to a different model and try again.`,
+    canBeDismissed: true,
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2188,7 +2188,12 @@ export class AgenticChatController implements ChatHandlers {
                         tabId: tabId,
                         data: { messages: [{ messageId: 'modelUnavailable' }] },
                     })
-                    const emptyChatResult: ChatResult = {}
+                    const emptyChatResult: ChatResult = {
+                        type: 'answer',
+                        body: '',
+                        messageId: errorMessageId,
+                        buttons: [],
+                    }
                     return emptyChatResult
                 }
                 return responseData

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2179,6 +2179,18 @@ export class AgenticChatController implements ChatHandlers {
                 buttons: [],
             }
             if (err.code === 'QModelResponse') {
+                // special case for throttling where we show error card instead of chat message
+                if (
+                    err.message ===
+                    `The model you selected is temporarily unavailable. Please switch to a different model and try again.`
+                ) {
+                    this.#features.chat.sendChatUpdate({
+                        tabId: tabId,
+                        data: { messages: [{ messageId: 'modelUnavailable' }] },
+                    })
+                    const emptyChatResult: ChatResult = {}
+                    return emptyChatResult
+                }
                 return responseData
             }
             return new ResponseError<ChatResult>(LSPErrorCodes.RequestFailed, err.message, responseData)


### PR DESCRIPTION
## Problem & Solution

For better customer experience, we are showing throttling message as an error card instead of a chat message. 

VSC:
<img width="200" alt="Screenshot 2025-06-13 at 4 26 01 PM" src="https://github.com/user-attachments/assets/da565185-1a88-466b-bb5f-fefaae695be2" />

JB:
<img width="200" alt="Screenshot 2025-06-13 at 5 40 58 PM" src="https://github.com/user-attachments/assets/be34a27a-eb9b-4573-8f70-62212e9489a7" />



Note: To unblock release, there will need to be another PR to update MyNahUi version once they released the new version. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
