### PR TITLE
fix: when user add a new server, it would load global persona at first time

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -624,8 +624,7 @@ export class McpEventHandler {
         }
 
         let configPath = getGlobalMcpConfigPath(this.#features.workspace.fs.getUserHomeDir())
-        let personaPath = getGlobalPersonaConfigPath(this.#features.workspace.fs.getUserHomeDir())
-
+        let personaPath = await this.#getPersonaPath()
         if (params.optionsValues['scope'] !== 'global') {
             // Get workspace folders and convert to paths
             const workspaceFolders = this.#features.workspace.getAllWorkspaceFolders()
@@ -839,10 +838,6 @@ export class McpEventHandler {
 
         try {
             await McpManager.instance.removeServer(serverName)
-            // Refresh the MCP list to show updated server list
-            await this.#handleRefreshMCPList({
-                id: params.id,
-            })
         } catch (error) {
             this.#features.logging.error(`Failed to delete MCP server: ${error}`)
         }


### PR DESCRIPTION
## Problem
When user add a new server, even if there is a project level persona, it would still load global persona first.
## Solution
1. instead of setting personaPath as globalPath inside #handleSaveMcp, we are calling #getPersonaPath() to get persona 
path.
2. After user remove a mcp server, we should not refresh the whole list, it would cause unnecessary time consuming and resource usage.

https://github.com/user-attachments/assets/c9eca4fa-05cd-4a1a-a514-babe89238cf9


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
