### PR TITLE
fix: timeout auto-retry only works for the first time in the loop

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2947,8 +2947,9 @@ export class AgenticChatController implements ChatHandlers {
         contextList?: FileList
     ): Promise<Result<AgenticChatResultWithMetadata, string>> {
         const abortController = new AbortController()
+        let timeoutId: NodeJS.Timeout | undefined
         const timeoutPromise = new Promise<never>((_, reject) => {
-            setTimeout(() => {
+            timeoutId = setTimeout(() => {
                 abortController.abort()
                 reject(
                     new AgenticChatError(
@@ -2969,8 +2970,11 @@ export class AgenticChatController implements ChatHandlers {
             abortController.signal
         )
         try {
-            return await Promise.race([processResponsePromise, timeoutPromise])
+            const result = await Promise.race([processResponsePromise, timeoutPromise])
+            clearTimeout(timeoutId)
+            return result
         } catch (err) {
+            clearTimeout(timeoutId)
             await streamWriter.close()
             if (err instanceof AgenticChatError && err.code === 'ResponseProcessingTimeout') {
                 return { success: false, error: err.message }


### PR DESCRIPTION
## Problem
- if multiple timeouts happen in the same loop, only the first timeout will be auto-retried, the second timeout would lead to stuck request


## Solution
- Properly clean timeout after it happened so that the next auto-retry for timeout will work as intended

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
