### PR TITLE
fix: clear IDE context for followup toolUse/toolResult loop

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2073,6 +2073,16 @@ export class AgenticChatController implements ChatHandlers {
         updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.userInputMessageContext!.toolResults =
             []
         updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.content = content
+        // don't pass in IDE context again in the followup toolUse/toolResult loop as it confuses the model and is not necessary
+        updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.userInputMessageContext!.editorState =
+            {
+                ...updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.userInputMessageContext!
+                    .editorState,
+                document: undefined,
+                relevantDocuments: undefined,
+                cursorState: undefined,
+                useRelevantDocuments: false,
+            }
 
         for (const toolResult of toolResults) {
             this.#debug(`ToolResult: ${JSON.stringify(toolResult)}`)


### PR DESCRIPTION
## Problem
- When we send followup toolUse/toolResult request loop, we still include IDE context which is not needed and can confuse the model

## Solution
- clear IDE context for toolUse/toolResults requests not initiated by the user

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
