### PR TITLE
fix: add latency metrics for invokeLLM metric

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -178,6 +178,9 @@ export class ChatTelemetryController {
         result: string,
         languageServerVersion: string,
         latency?: number[],
+        toolCallLatency?: number[],
+        cwsprChatTimeToFirstChunk?: number,
+        cwsprChatTimeBetweenChunks?: number[],
         agenticCodingMode?: boolean
     ) {
         this.#telemetry.emitMetric({
@@ -186,11 +189,14 @@ export class ChatTelemetryController {
                 [CONVERSATION_ID_METRIC_KEY]: conversationId,
                 cwsprChatConversationType: conversationType,
                 credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
-                cwsprToolName: toolNames?.join(','),
-                cwsprToolUseId: toolUseId?.join(','),
+                cwsprToolName: toolNames?.join(',') ?? '',
+                cwsprToolUseId: toolUseId?.join(',') ?? '',
                 result,
                 languageServerVersion: languageServerVersion,
                 latency: latency?.join(','),
+                toolCallLatency: toolCallLatency?.join(','),
+                cwsprChatTimeToFirstChunk: cwsprChatTimeToFirstChunk,
+                cwsprChatTimeBetweenChunks: cwsprChatTimeBetweenChunks?.join(','),
                 requestId,
                 enabled: agenticCodingMode,
             },


### PR DESCRIPTION
## Problem
- missing some latency metrics which is required by science

## Solution
- `amazonq_invokeLLM` metric has these fields:
    - `llmLatency`: time of LLM request until when the full response comes back from LLM and is processed
    - `toolCallLatency`: time between when user requests to use a tool, and when the user sees the tool has finished executing
    - `timeToFirstChunk`: time of when the LLM request is sent, and when the user sees the first token in the LLM response, ie ("Hi")
    - `timeBetweenChunks`: the time in between each chunk coming in from LLM response stream (The first chunk might be "Hi", the second chunk is "I want", the 3rd chunk is "to help", etc)




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
