### PR TITLE
chore(amazonq): bump mynah-ui to 4.35.5

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.40",
         "@aws/language-server-runtimes-types": "^0.1.39",
-        "@aws/mynah-ui": "^4.35.4"
+        "@aws/mynah-ui": "^4.35.5"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -249,7 +249,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.40",
                 "@aws/language-server-runtimes-types": "^0.1.39",
-                "@aws/mynah-ui": "^4.35.4"
+                "@aws/mynah-ui": "^4.35.5"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4121,9 +4121,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.35.4",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.35.4.tgz",
-            "integrity": "sha512-LuOexbuMSKYCl/Qa7zj9d4/ueTLK3ltoYHeA0I7gOpPC/vYACxqjVqX6HPhNCE+L5zBKNMN2Z+FUaox+fYhvAQ==",
+            "version": "4.35.5",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.35.5.tgz",
+            "integrity": "sha512-HFzNiVexMLPt4GUBcCBgObr2WKjmLg0EKH7/nPPaThEvQAVZYOapMYKoxaS/IrEa6BqWsE36V4++F3Bh7Vf7uw==",
             "hasInstallScript": true,
             "dependencies": {
                 "escape-html": "^1.0.3",


### PR DESCRIPTION
## Problem
The new mynah-ui version has a bug where the `Pin context with ⌥ Enter` hint should not be displayed in the quick action overlay (when typing /), since the overlay lists quick actions, not context items.

https://github.com/aws/mynah-ui/releases/tag/v4.35.5

## Solution
Upgrade to the latest mynah-ui version

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
