### PR TITLE
fix: send AmazonQ.md as a rule, do not automatically send README.md

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
@@ -105,18 +105,6 @@ export class AdditionalContextProvider {
                 await this.collectMarkdownFilesRecursively(workspaceFolder, rulesPath, rulesFiles)
             }
 
-            // Check for README.md in workspace root
-            const readmePath = path.join(workspaceFolder, 'README.md')
-            const readmeExists = await this.features.workspace.fs.exists(readmePath)
-            if (readmeExists) {
-                rulesFiles.push({
-                    workspaceFolder: workspaceFolder,
-                    type: 'file',
-                    relativePath: 'README.md',
-                    id: readmePath,
-                })
-            }
-
             // Check for AmazonQ.md in workspace root
             const amazonQPath = path.join(workspaceFolder, 'AmazonQ.md')
             const amazonQExists = await this.features.workspace.fs.exists(amazonQPath)
@@ -170,7 +158,10 @@ export class AdditionalContextProvider {
             return 'code'
         }
         if (prompt.filePath.endsWith(promptFileExtension)) {
-            if (pathUtils.isInDirectory(path.join('.amazonq', 'rules'), prompt.relativePath)) {
+            if (
+                pathUtils.isInDirectory(path.join('.amazonq', 'rules'), prompt.relativePath) ||
+                path.basename(prompt.relativePath) === 'AmazonQ.md'
+            ) {
                 return 'rule'
             } else if (pathUtils.isInDirectory(getUserPromptsDirectory(), prompt.filePath)) {
                 return 'prompt'


### PR DESCRIPTION
## Problem
Sending `README.md` automatically as context is confusing the model and decreasing response quality. Additionally, AmazonQ.md is being sent as a `file` type instead of `prompt` type, so backend was not adhering to prompt instructions in AmazonQ.md.


## Solution
Remove README.md from being automatically sent as context. Send AmazonQ.md as `rule` type so system prompt recognizes it as a prompt instruction instead of a "normal" file added as context.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
