### PR TITLE
fix(amazonq): profile is not set after re-auth

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
@@ -838,27 +838,45 @@ describe('AmazonQTokenServiceManager', () => {
     })
 
     describe('Connection types with no Developer Profiles support', () => {
-        it('returns error when profile update is requested and connection type is none', async () => {
+        it('handles reauthentication scenario when connection type is none but profile ARN is provided', async () => {
             setupServiceManager(true)
             clearCredentials()
 
             assert.strictEqual(amazonQTokenServiceManager.getState(), 'PENDING_CONNECTION')
+            assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'none')
 
-            await assert.rejects(
-                amazonQTokenServiceManager.handleOnUpdateConfiguration(
-                    {
-                        section: 'aws.q',
-                        settings: {
-                            profileArn: 'arn:aws:testprofilearn:us-east-1:11111111111111:profile/QQQQQQQQQQQQ',
-                        },
+            await amazonQTokenServiceManager.handleOnUpdateConfiguration(
+                {
+                    section: 'aws.q',
+                    settings: {
+                        profileArn: 'arn:aws:testprofilearn:us-east-1:11111111111111:profile/QQQQQQQQQQQQ',
                     },
-                    {} as CancellationToken
-                ),
-                new ResponseError(LSPErrorCodes.RequestFailed, 'Amazon Q service is not signed in', {
-                    awsErrorCode: 'E_AMAZON_Q_PENDING_CONNECTION',
-                })
+                },
+                {} as CancellationToken
             )
 
+            assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'identityCenter')
+            assert.strictEqual(amazonQTokenServiceManager.getState(), 'INITIALIZED')
+        })
+
+        it('ignores null profile when connection type is none', async () => {
+            setupServiceManager(true)
+            clearCredentials()
+
+            assert.strictEqual(amazonQTokenServiceManager.getState(), 'PENDING_CONNECTION')
+            assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'none')
+
+            await amazonQTokenServiceManager.handleOnUpdateConfiguration(
+                {
+                    section: 'aws.q',
+                    settings: {
+                        profileArn: null,
+                    },
+                },
+                {} as CancellationToken
+            )
+
+            assert.strictEqual(amazonQTokenServiceManager.getConnectionType(), 'none')
             assert.strictEqual(amazonQTokenServiceManager.getState(), 'PENDING_CONNECTION')
         })
 

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -290,11 +290,14 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
 
         if (this.connectionType === 'none') {
             if (newProfileArn !== null) {
-                throw new AmazonQServicePendingSigninError()
+                // During reauthentication, connection might be temporarily 'none' but user is providing a profile
+                // Set connection type to identityCenter to proceed with profile setting
+                this.connectionType = 'identityCenter'
+                this.state = 'PENDING_Q_PROFILE_UPDATE'
+            } else {
+                this.logServiceState('Received null profile while not connected, ignoring request')
+                return
             }
-
-            this.logServiceState('Received null profile while not connected, ignoring request')
-            return
         }
 
         if (this.connectionType !== 'identityCenter') {


### PR DESCRIPTION
## Problem

During re-auth flow, profile is not set due to connectionType initially being set to "none" and the profileChange handler exits early. This results in users receiving the "Select Q Developer Profile" follow up button immediately following re-auth.

## Solution

Don't exit early/throw an error when connectionType is "none", instead proceed with the profile update.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
