### PR TITLE
feat: adding current working directory to the stdio transport for mcp…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -206,6 +206,7 @@ export class McpManager {
                 command: cfg.command,
                 args: cfg.args ?? [],
                 env: mergedEnv,
+                cwd: URI.parse(this.features.workspace.getAllWorkspaceFolders()[0].uri).fsPath,
             })
             const client = new Client({
                 name: `mcp-client-${serverName}`,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -214,7 +214,9 @@ export class McpManager {
                     transportConfig.cwd = URI.parse(workspaceFolders[0].uri).fsPath
                 }
             } catch {
-                // No workspace folder available, continue without cwd
+                this.features.logging.debug(
+                    `MCP: No workspace folder available for server [${serverName}], continuing without cwd`
+                )
             }
 
             const transport = new StdioClientTransport(transportConfig)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -202,12 +202,22 @@ export class McpManager {
                     ? Object.fromEntries(Object.entries(cfg.env).filter(([key]) => key && key.trim() !== ''))
                     : {}),
             }
-            const transport = new StdioClientTransport({
+            const transportConfig: any = {
                 command: cfg.command,
                 args: cfg.args ?? [],
                 env: mergedEnv,
-                cwd: URI.parse(this.features.workspace.getAllWorkspaceFolders()[0].uri).fsPath,
-            })
+            }
+
+            try {
+                const workspaceFolders = this.features.workspace.getAllWorkspaceFolders()
+                if (workspaceFolders.length > 0) {
+                    transportConfig.cwd = URI.parse(workspaceFolders[0].uri).fsPath
+                }
+            } catch {
+                // No workspace folder available, continue without cwd
+            }
+
+            const transport = new StdioClientTransport(transportConfig)
             const client = new Client({
                 name: `mcp-client-${serverName}`,
                 version: '1.0.0',


### PR DESCRIPTION
## Problem

For some MCP servers, like in case of SQLite MCP server, when given relative path of the db file in the workspace the server initialization is failing. Q cli on the other hand supports relative paths in arguments.

## Solution

- adding CWD to the stdio transport to fix the issue.


https://github.com/user-attachments/assets/7577a567-cb9f-4e5b-9c02-5daf0dcac32e



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
