### PR TITLE
Revert "fix(amazonq): filter languages at workspace context server onDeleteFiles (#1684)"

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
@@ -255,7 +255,7 @@ export class ArtifactManager {
         const programmingLanguages = new Set<CodewhispererLanguage>()
 
         // Add the file language if we can determine it, but don't return early
-        if (fileLanguage && SUPPORTED_WORKSPACE_CONTEXT_LANGUAGES.includes(fileLanguage)) {
+        if (fileLanguage) {
             programmingLanguages.add(fileLanguage)
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -423,7 +423,7 @@ export const WorkspaceContextServer = (): Server => features => {
 
                 const programmingLanguages = artifactManager.handleDeletedPathAndGetLanguages(file.uri, workspaceFolder)
                 if (programmingLanguages.length === 0) {
-                    logging.log(`No supported programming languages determined for: ${file.uri}`)
+                    logging.log(`No programming languages determined for: ${file.uri}`)
                     continue
                 }
 


### PR DESCRIPTION
This reverts commit 4272eec6ce4554560fdf8888d85d31315db2d964.

## Problem

Locking the previous version of `main`  to fasten the current deployment needed.

Will add the commit back after the current deployment.

## Solution

Revert "fix(amazonq): filter languages at workspace context server onDeleteFiles (#1684)"

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
