### PR TITLE
Revert "revert(amazonq): fix filter languages at workspace context server onDeleteFiles"

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
@@ -255,7 +255,7 @@ export class ArtifactManager {
         const programmingLanguages = new Set<CodewhispererLanguage>()
 
         // Add the file language if we can determine it, but don't return early
-        if (fileLanguage) {
+        if (fileLanguage && SUPPORTED_WORKSPACE_CONTEXT_LANGUAGES.includes(fileLanguage)) {
             programmingLanguages.add(fileLanguage)
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -423,7 +423,7 @@ export const WorkspaceContextServer = (): Server => features => {
 
                 const programmingLanguages = artifactManager.handleDeletedPathAndGetLanguages(file.uri, workspaceFolder)
                 if (programmingLanguages.length === 0) {
-                    logging.log(`No programming languages determined for: ${file.uri}`)
+                    logging.log(`No supported programming languages determined for: ${file.uri}`)
                     continue
                 }
 


### PR DESCRIPTION
This reverts commit 403c26a91f25d0035d92bfd21835b747a0dbafce.

## Problem

The previous commit was removed for the last emergent deployment: https://github.com/aws/language-servers/pull/1694

## Solution

Add back the commit: https://github.com/aws/language-servers/pull/1684

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
