### PR TITLE
fix(amazonq): serialize S3 uploads for file events from workspace context server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/fileUploadJobManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/fileUploadJobManager.ts
@@ -1,0 +1,162 @@
+import { FileCreate, FileRename, Logging, TextDocumentIdentifier } from '@aws/language-server-runtimes/server-interface'
+import { WorkspaceFolderManager } from './workspaceFolderManager'
+import { FileMetadata } from './artifactManager'
+import { cleanUrl } from './util'
+
+export enum FileUploadJobType {
+    DID_SAVE_TEXT_DOCUMENT,
+    DID_CREATE_FILE,
+    DID_RENAME_FILE,
+}
+
+export interface FileUploadJob {
+    eventType: FileUploadJobType
+    fileMetadata: FileMetadata
+    file: TextDocumentIdentifier | FileCreate | FileRename
+}
+
+export class FileUploadJobManager {
+    private readonly logging: Logging
+    private readonly workspaceFolderManager: WorkspaceFolderManager
+    private readonly FILE_UPLOAD_JOB_PROCESS_INTERVAL: number = 100 // 100 milliseconds
+    public jobQueue: FileUploadJob[] = []
+    private jobConsumerInterval: NodeJS.Timeout | undefined
+    private isJobConsumerWorking: boolean = false
+
+    constructor(logging: Logging, workspaceFolderManager: WorkspaceFolderManager) {
+        this.logging = logging
+        this.workspaceFolderManager = workspaceFolderManager
+    }
+
+    public startFileUploadJobConsumer() {
+        this.jobConsumerInterval = setInterval(async () => {
+            if (this.isJobConsumerWorking) {
+                return
+            }
+            this.isJobConsumerWorking = true
+            try {
+                const event = this.jobQueue.shift()
+                if (!event) {
+                    return
+                }
+
+                const worksapceState = this.workspaceFolderManager.getWorkspaceState()
+                if (!worksapceState.workspaceId) {
+                    // We can safely dispose any event when workspaceId is not set or gone, since
+                    // workspaceFolderManager.continuousMonitorInterval will create a new snapshot
+                    // later, which will guarantee the workspace state is re-calibrated
+                    this.jobQueue = []
+                    return
+                }
+                const workspaceId = worksapceState.workspaceId
+
+                switch (event.eventType) {
+                    case FileUploadJobType.DID_SAVE_TEXT_DOCUMENT:
+                        await this.processDidSaveTextDocument(
+                            workspaceId,
+                            event.fileMetadata,
+                            event.file as TextDocumentIdentifier
+                        )
+                        break
+                    case FileUploadJobType.DID_CREATE_FILE:
+                        await this.processDidCreateFile(workspaceId, event.fileMetadata, event.file as FileCreate)
+                        break
+                    case FileUploadJobType.DID_RENAME_FILE:
+                        await this.processDidRenameFile(workspaceId, event.fileMetadata, event.file as FileRename)
+                        break
+                }
+            } catch (err) {
+                this.logging.error(`Error processing file upload event: ${err}`)
+            } finally {
+                this.isJobConsumerWorking = false
+            }
+        }, this.FILE_UPLOAD_JOB_PROCESS_INTERVAL)
+    }
+
+    private async processDidSaveTextDocument(
+        workspaceId: string,
+        fileMetadata: FileMetadata,
+        textDocument: TextDocumentIdentifier
+    ): Promise<void> {
+        const s3Url = await this.workspaceFolderManager.uploadToS3(fileMetadata)
+        if (!s3Url) {
+            return
+        }
+
+        const message = JSON.stringify({
+            method: 'textDocument/didSave',
+            params: {
+                textDocument: {
+                    uri: textDocument.uri,
+                },
+                workspaceChangeMetadata: {
+                    workspaceId: workspaceId,
+                    s3Path: cleanUrl(s3Url),
+                    programmingLanguage: fileMetadata.language,
+                },
+            },
+        })
+        this.workspaceFolderManager.getWorkspaceState().messageQueue.push(message)
+    }
+
+    private async processDidCreateFile(
+        workspaceId: string,
+        fileMetadata: FileMetadata,
+        file: FileCreate
+    ): Promise<void> {
+        const s3Url = await this.workspaceFolderManager.uploadToS3(fileMetadata)
+        if (!s3Url) {
+            return
+        }
+
+        const message = JSON.stringify({
+            method: 'workspace/didCreateFiles',
+            params: {
+                files: [
+                    {
+                        uri: file.uri,
+                    },
+                ],
+                workspaceChangeMetadata: {
+                    workspaceId: workspaceId,
+                    s3Path: cleanUrl(s3Url),
+                    programmingLanguage: fileMetadata.language,
+                },
+            },
+        })
+        this.workspaceFolderManager.getWorkspaceState().messageQueue.push(message)
+    }
+
+    private async processDidRenameFile(
+        workspaceId: string,
+        fileMetadata: FileMetadata,
+        file: FileRename
+    ): Promise<void> {
+        const s3Url = await this.workspaceFolderManager.uploadToS3(fileMetadata)
+        if (!s3Url) {
+            return
+        }
+
+        const message = JSON.stringify({
+            method: 'workspace/didRenameFiles',
+            params: {
+                files: [
+                    {
+                        old_uri: file.oldUri,
+                        new_uri: file.newUri,
+                    },
+                ],
+                workspaceChangeMetadata: {
+                    workspaceId: workspaceId,
+                    s3Path: cleanUrl(s3Url),
+                    programmingLanguage: fileMetadata.language,
+                },
+            },
+        })
+        this.workspaceFolderManager.getWorkspaceState().messageQueue.push(message)
+    }
+
+    public dispose(): void {
+        clearInterval(this.jobConsumerInterval)
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -6,7 +6,7 @@ import {
     WorkspaceFolder,
 } from '@aws/language-server-runtimes/server-interface'
 import * as crypto from 'crypto'
-import { cleanUrl, isDirectory, isEmptyDirectory, isLoggedInUsingBearerToken } from './util'
+import { isDirectory, isEmptyDirectory, isLoggedInUsingBearerToken } from './util'
 import { ArtifactManager, FileMetadata, SUPPORTED_WORKSPACE_CONTEXT_LANGUAGES } from './artifactManager'
 import { WorkspaceFolderManager } from './workspaceFolderManager'
 import { URI } from 'vscode-uri'
@@ -15,6 +15,7 @@ import { getCodeWhispererLanguageIdFromPath } from '../../shared/languageDetecti
 import { makeUserContextObject } from '../../shared/telemetryUtils'
 import { safeGet } from '../../shared/utils'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
+import { FileUploadJobManager, FileUploadJobType } from './fileUploadJobManager'
 
 const Q_CONTEXT_CONFIGURATION_SECTION = 'aws.q.workspaceContext'
 
@@ -26,6 +27,7 @@ export const WorkspaceContextServer = (): Server => features => {
     let artifactManager: ArtifactManager
     let dependencyDiscoverer: DependencyDiscoverer
     let workspaceFolderManager: WorkspaceFolderManager
+    let fileUploadJobManager: FileUploadJobManager
     let workflowInitializationInterval: NodeJS.Timeout
     let isWorkflowInitializing: boolean = false
     let isWorkflowInitialized: boolean = false
@@ -198,6 +200,7 @@ export const WorkspaceContextServer = (): Server => features => {
                 credentialsProvider,
                 workspaceIdentifier
             )
+            fileUploadJobManager = new FileUploadJobManager(logging, workspaceFolderManager)
             await updateConfiguration()
 
             lsp.workspace.onDidChangeWorkspaceFolders(async params => {
@@ -259,6 +262,7 @@ export const WorkspaceContextServer = (): Server => features => {
                         return
                     }
 
+                    fileUploadJobManager.startFileUploadJobConsumer()
                     workspaceFolderManager.initializeWorkspaceStatusMonitor().catch(error => {
                         logging.error(`Error while initializing workspace status monitoring: ${error}`)
                     })
@@ -318,29 +322,14 @@ export const WorkspaceContextServer = (): Server => features => {
                 logging.log(`No workspaceFolder found for ${event.textDocument.uri} discarding the save event`)
                 return
             }
-            const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
 
             const fileMetadata = await artifactManager.processNewFile(workspaceFolder, event.textDocument.uri)
-            const s3Url = await workspaceFolderManager.uploadToS3(fileMetadata)
-            if (!s3Url) {
-                return
-            }
 
-            const message = JSON.stringify({
-                method: 'textDocument/didSave',
-                params: {
-                    textDocument: {
-                        uri: event.textDocument.uri,
-                    },
-                    workspaceChangeMetadata: {
-                        workspaceId: workspaceId,
-                        s3Path: cleanUrl(s3Url),
-                        programmingLanguage: programmingLanguage,
-                    },
-                },
+            fileUploadJobManager.jobQueue.push({
+                eventType: FileUploadJobType.DID_SAVE_TEXT_DOCUMENT,
+                fileMetadata: fileMetadata,
+                file: event.textDocument,
             })
-            const workspaceState = workspaceFolderManager.getWorkspaceState()
-            workspaceState.messageQueue.push(message)
         } catch (error) {
             logging.error(`Error handling save event: ${error}`)
         }
@@ -353,7 +342,6 @@ export const WorkspaceContextServer = (): Server => features => {
             }
             logging.log(`Received didCreateFiles event of length ${event.files.length}`)
 
-            const workspaceState = workspaceFolderManager.getWorkspaceState()
             for (const file of event.files) {
                 const isDir = isDirectory(file.uri)
                 const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(file.uri, workspaceFolders)
@@ -375,29 +363,12 @@ export const WorkspaceContextServer = (): Server => features => {
                     filesMetadata = [await artifactManager.processNewFile(workspaceFolder, file.uri)]
                 }
 
-                const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
                 for (const fileMetadata of filesMetadata) {
-                    const s3Url = await workspaceFolderManager.uploadToS3(fileMetadata)
-                    if (!s3Url) {
-                        continue
-                    }
-
-                    const message = JSON.stringify({
-                        method: 'workspace/didCreateFiles',
-                        params: {
-                            files: [
-                                {
-                                    uri: file.uri,
-                                },
-                            ],
-                            workspaceChangeMetadata: {
-                                workspaceId: workspaceId,
-                                s3Path: cleanUrl(s3Url),
-                                programmingLanguage: fileMetadata.language,
-                            },
-                        },
+                    fileUploadJobManager.jobQueue.push({
+                        eventType: FileUploadJobType.DID_CREATE_FILE,
+                        fileMetadata: fileMetadata,
+                        file: file,
                     })
-                    workspaceState.messageQueue.push(message)
                 }
             }
         } catch (error) {
@@ -417,17 +388,19 @@ export const WorkspaceContextServer = (): Server => features => {
             for (const file of event.files) {
                 const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(file.uri, workspaceFolders)
                 if (!workspaceFolder) {
-                    logging.log(`Workspace details not found for deleted file: ${file.uri}`)
                     continue
                 }
 
                 const programmingLanguages = artifactManager.handleDeletedPathAndGetLanguages(file.uri, workspaceFolder)
                 if (programmingLanguages.length === 0) {
-                    logging.log(`No supported programming languages determined for: ${file.uri}`)
                     continue
                 }
 
-                const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
+                const workspaceId = workspaceState.workspaceId
+                if (!workspaceId) {
+                    continue
+                }
+
                 // Send notification for each programming language
                 for (const language of programmingLanguages) {
                     const message = JSON.stringify({
@@ -460,7 +433,6 @@ export const WorkspaceContextServer = (): Server => features => {
 
             logging.log(`Received didRenameFiles event of length ${event.files.length}`)
 
-            const workspaceState = workspaceFolderManager.getWorkspaceState()
             for (const file of event.files) {
                 const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(file.newUri, workspaceFolders)
                 if (!workspaceFolder) {
@@ -469,29 +441,12 @@ export const WorkspaceContextServer = (): Server => features => {
 
                 const filesMetadata = await artifactManager.handleRename(workspaceFolder, file.oldUri, file.newUri)
 
-                const workspaceId = await workspaceFolderManager.waitForRemoteWorkspaceId()
                 for (const fileMetadata of filesMetadata) {
-                    const s3Url = await workspaceFolderManager.uploadToS3(fileMetadata)
-                    if (!s3Url) {
-                        continue
-                    }
-                    const message = JSON.stringify({
-                        method: 'workspace/didRenameFiles',
-                        params: {
-                            files: [
-                                {
-                                    old_uri: file.oldUri,
-                                    new_uri: file.newUri,
-                                },
-                            ],
-                            workspaceChangeMetadata: {
-                                workspaceId: workspaceId,
-                                s3Path: cleanUrl(s3Url),
-                                programmingLanguage: fileMetadata.language,
-                            },
-                        },
+                    fileUploadJobManager.jobQueue.push({
+                        eventType: FileUploadJobType.DID_RENAME_FILE,
+                        fileMetadata: fileMetadata,
+                        file: file,
                     })
-                    workspaceState.messageQueue.push(message)
                 }
             }
         } catch (error) {
@@ -521,6 +476,9 @@ export const WorkspaceContextServer = (): Server => features => {
 
     return () => {
         clearInterval(workflowInitializationInterval)
+        if (fileUploadJobManager) {
+            fileUploadJobManager.dispose()
+        }
         if (workspaceFolderManager) {
             workspaceFolderManager.clearAllWorkspaceResources().catch(error => {
                 logging.warn(


### PR DESCRIPTION
## Problem

We observed that individual users are generating excessive API call volume to the `CreateUploadUrl` endpoint in a very short period of time (milliseconds).

This occurs when the LSP processes large batches of file events and sends them to the workspace context server. Since these file events are processed in parallel, they trigger simultaneous S3 upload requests, creating traffic spikes that impact backend performance (for example, cache miss leads to extra load to downstream services).

## Solution

Serialize S3 uploads for file events from workspace context server, which includes:
- onDidSaveTextDocument
- onDidCreateFiles
- onDidRenameFiles

Tested that events are sent to the backend instance and processed correctly with this change.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
