### PR TITLE
feat(amazonq): bundle dependency events from workspace context server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyEventBundler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyEventBundler.ts
@@ -1,0 +1,75 @@
+import { Logging, WorkspaceFolder } from '@aws/language-server-runtimes/server-interface'
+import { DependencyDiscoverer } from './dependencyDiscoverer'
+
+export interface DependencyEvent {
+    language: string
+    paths: string[]
+    workspaceFolder: WorkspaceFolder | undefined
+}
+
+export class DependencyEventBundler {
+    private readonly logging: Logging
+    private readonly dependencyDiscoverer: DependencyDiscoverer
+    private readonly BUNDLER_PROCESS_INTERVAL: number = 500 // 500 milliseconds
+    public eventQueue: DependencyEvent[] = []
+    private eventBundlerInterval: NodeJS.Timeout | undefined
+    private isBundlerWorking: boolean = false
+
+    constructor(logging: Logging, dependencyDiscoverer: DependencyDiscoverer) {
+        this.logging = logging
+        this.dependencyDiscoverer = dependencyDiscoverer
+    }
+
+    /**
+     * Start the bundler process
+     * Bundler process will process all the events in the queue every 500ms
+     * and concatenate all the paths within the same language and workspaceFolder
+     */
+    public startDependencyEventBundler() {
+        this.eventBundlerInterval = setInterval(async () => {
+            if (this.isBundlerWorking) {
+                return
+            }
+            this.isBundlerWorking = true
+            try {
+                const allEvents = this.eventQueue.splice(0)
+
+                // Form bundles based on unique combination of language and workspaceFolder
+                const dependencyEventBundles = allEvents.reduce((accumulator, event) => {
+                    const key = this.getBundleKey(event)
+                    if (!accumulator.has(key)) {
+                        accumulator.set(key, [])
+                    }
+                    accumulator.get(key)?.push(event)
+                    return accumulator
+                }, new Map<string, DependencyEvent[]>())
+
+                // Process bundles one by one, concatenating all the paths within the bundle
+                for (const [bundleKey, bundledEvents] of dependencyEventBundles) {
+                    await this.dependencyDiscoverer.handleDependencyUpdateFromLSP(
+                        bundledEvents[0].language,
+                        bundledEvents.flatMap(event => event.paths),
+                        bundledEvents[0].workspaceFolder
+                    )
+                }
+            } catch (err) {
+                this.logging.error(`Error bundling didChangeDependencyPaths event: ${err}`)
+            } finally {
+                this.isBundlerWorking = false
+            }
+        }, this.BUNDLER_PROCESS_INTERVAL)
+    }
+
+    private getBundleKey(event: DependencyEvent) {
+        if (event.workspaceFolder === undefined) {
+            return `${event.language}-undefined`
+        }
+        return `${event.language}-${event.workspaceFolder.uri}`
+    }
+
+    public dispose(): void {
+        if (this.eventBundlerInterval) {
+            clearInterval(this.eventBundlerInterval)
+        }
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -21,6 +21,7 @@ import { makeUserContextObject } from '../../shared/telemetryUtils'
 import { safeGet } from '../../shared/utils'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 import { FileUploadJobManager, FileUploadJobType } from './fileUploadJobManager'
+import { DependencyEventBundler } from './dependency/dependencyEventBundler'
 import ignore = require('ignore')
 
 const Q_CONTEXT_CONFIGURATION_SECTION = 'aws.q.workspaceContext'
@@ -41,6 +42,7 @@ export const WorkspaceContextServer = (): Server => features => {
     let dependencyDiscoverer: DependencyDiscoverer
     let workspaceFolderManager: WorkspaceFolderManager
     let fileUploadJobManager: FileUploadJobManager
+    let dependencyEventBundler: DependencyEventBundler
     let workflowInitializationInterval: NodeJS.Timeout
     let isWorkflowInitializing: boolean = false
     let isWorkflowInitialized: boolean = false
@@ -214,6 +216,7 @@ export const WorkspaceContextServer = (): Server => features => {
                 workspaceIdentifier
             )
             fileUploadJobManager = new FileUploadJobManager(logging, workspaceFolderManager)
+            dependencyEventBundler = new DependencyEventBundler(logging, dependencyDiscoverer)
             await updateConfiguration()
 
             lsp.workspace.onDidChangeWorkspaceFolders(async params => {
@@ -276,6 +279,7 @@ export const WorkspaceContextServer = (): Server => features => {
                     }
 
                     fileUploadJobManager.startFileUploadJobConsumer()
+                    dependencyEventBundler.startDependencyEventBundler()
                     workspaceFolderManager.initializeWorkspaceStatusMonitor().catch(error => {
                         logging.error(`Error while initializing workspace status monitoring: ${error}`)
                     })
@@ -486,11 +490,11 @@ export const WorkspaceContextServer = (): Server => features => {
             logging.log(`Received onDidChangeDependencyPaths event for ${params.moduleName}`)
 
             const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(params.moduleName)
-            await dependencyDiscoverer.handleDependencyUpdateFromLSP(
-                params.runtimeLanguage,
-                params.paths,
-                workspaceFolder
-            )
+            dependencyEventBundler.eventQueue.push({
+                language: params.runtimeLanguage,
+                paths: params.paths,
+                workspaceFolder: workspaceFolder,
+            })
         } catch (error) {
             logging.error(`Error handling didChangeDependencyPaths event: ${error}`)
         }
@@ -502,6 +506,9 @@ export const WorkspaceContextServer = (): Server => features => {
         clearInterval(workflowInitializationInterval)
         if (fileUploadJobManager) {
             fileUploadJobManager.dispose()
+        }
+        if (dependencyEventBundler) {
+            dependencyEventBundler.dispose()
         }
         if (workspaceFolderManager) {
             workspaceFolderManager.clearAllWorkspaceResources().catch(error => {


### PR DESCRIPTION
## Problem

We observed that individual users are generating excessive API call volume to the CreateUploadUrl endpoint in a very short period of time (milliseconds), creating traffic spikes that impact backend performance (for example, cache miss leads to extra load to downstream services)

There was a fix to prevent this from happening even when LSP sends file events storms:
- https://github.com/aws/language-servers/pull/1700

Further investigation reveals this can also be triggered by `onDidChangeDependencyPaths` events sent from JetBrains IDE, where one automatic project set up can cause events storms to the workspace context server.

## Solution

Bundle dependency events from workspace context server.

Tested that events are sent to the backend instance and processed correctly with this change.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
