### PR TITLE
feat: surface file operation errors in tooltip

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -146,7 +146,13 @@ import {
     responseTimeoutPartialMsg,
     defaultModelId,
 } from './constants'
-import { AgenticChatError, customerFacingErrorCodes, isRequestAbortedError, unactionableErrorCodes } from './errors'
+import {
+    AgenticChatError,
+    customerFacingErrorCodes,
+    isRequestAbortedError,
+    unactionableErrorCodes,
+    getCustomerFacingErrorMessage,
+} from './errors'
 import { URI } from 'vscode-uri'
 import { CommandCategory } from './tools/executeBash'
 import { UserWrittenCodeTracker } from '../../shared/userWrittenCodeTracker'
@@ -1364,6 +1370,7 @@ export class AgenticChatController implements ChatHandlers {
                     const existingCard = chatResultStream.getMessageBlockId(toolUse.toolUseId)
                     const fsParam = toolUse.input as unknown as FsWriteParams | FsReplaceParams
                     const fileName = path.basename(fsParam.path)
+                    const customerFacingError = getCustomerFacingErrorMessage(err)
                     const errorResult = {
                         type: 'tool',
                         messageId: toolUse.toolUseId,
@@ -1380,6 +1387,7 @@ export class AgenticChatController implements ChatHandlers {
                                 status: 'error',
                                 icon: 'error',
                                 text: 'Error',
+                                description: customerFacingError,
                             },
                         },
                     } as ChatResult

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.test.ts
@@ -19,7 +19,7 @@ import {
 
 describe('errors', () => {
     describe('FileOperationError classes', () => {
-        test('creates error classes with correct customer messages', () => {
+        it('creates error classes with correct customer messages', () => {
             const directoryError = new DirectoryNotFoundError('ENOENT: no such file or directory')
             expect(directoryError.message).toBe('ENOENT: no such file or directory')
             expect(directoryError.customerMessage).toBe(
@@ -40,7 +40,7 @@ describe('errors', () => {
     })
 
     describe('createFileOperationError', () => {
-        test('maps common file system errors', () => {
+        it('maps common file system errors', () => {
             const error1 = createFileOperationError(new Error('ENOENT: no such file or directory'))
             expect(error1).toBeInstanceOf(DirectoryNotFoundError)
             expect(error1.customerMessage).toBe('The directory does not exist. Please create the directory first.')
@@ -58,7 +58,7 @@ describe('errors', () => {
             expect(error5).toBeInstanceOf(TooManyOpenFilesError)
         })
 
-        test('maps fsWrite specific errors', () => {
+        it('maps fsWrite specific errors', () => {
             const error1 = createFileOperationError(new Error('Path must not be empty'))
             expect(error1).toBeInstanceOf(EmptyPathError)
 
@@ -72,7 +72,7 @@ describe('errors', () => {
             expect(error4).toBeInstanceOf(EmptyAppendContentError)
         })
 
-        test('maps fsReplace specific errors', () => {
+        it('maps fsReplace specific errors', () => {
             const error1 = createFileOperationError(new Error('Diffs must not be empty'))
             expect(error1).toBeInstanceOf(EmptyDiffsError)
 
@@ -90,7 +90,7 @@ describe('errors', () => {
             expect(error4).toBeInstanceOf(MultipleMatchesError)
         })
 
-        test('returns generic FileOperationError for unknown errors', () => {
+        it('returns generic FileOperationError for unknown errors', () => {
             const unknownError = new Error('Some unknown error occurred')
             const result = createFileOperationError(unknownError)
             expect(result).toBeInstanceOf(FileOperationError)
@@ -100,21 +100,21 @@ describe('errors', () => {
     })
 
     describe('getCustomerFacingErrorMessage', () => {
-        test('returns customer message from FileOperationError', () => {
+        it('returns customer message from FileOperationError', () => {
             const error = new EmptyPathError()
             expect(getCustomerFacingErrorMessage(error)).toBe(
                 'The file path cannot be empty. Please provide a valid file path.'
             )
         })
 
-        test('creates and returns customer message from standard Error', () => {
+        it('creates and returns customer message from standard Error', () => {
             const error = new Error('ENOENT: no such file or directory')
             expect(getCustomerFacingErrorMessage(error)).toBe(
                 'The directory does not exist. Please create the directory first.'
             )
         })
 
-        test('handles non-Error objects', () => {
+        it('handles non-Error objects', () => {
             expect(getCustomerFacingErrorMessage('string error')).toBe('string error')
             expect(getCustomerFacingErrorMessage(null)).toBe('null')
             expect(getCustomerFacingErrorMessage(undefined)).toBe('undefined')

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.test.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert'
 import {
     DirectoryNotFoundError,
     EmptyAppendContentError,
@@ -21,103 +22,93 @@ describe('errors', () => {
     describe('FileOperationError classes', () => {
         it('creates error classes with correct customer messages', () => {
             const directoryError = new DirectoryNotFoundError('ENOENT: no such file or directory')
-            expect(directoryError.message).toBe('ENOENT: no such file or directory')
-            expect(directoryError.customerMessage).toBe(
-                'The directory does not exist. Please create the directory first.'
-            )
+            assert.strictEqual(directoryError.message, 'ENOENT: no such file or directory')
+            assert.strictEqual(directoryError.customerMessage, 'The directory does not exist.')
 
             const permissionError = new PermissionDeniedError('EACCES: permission denied')
-            expect(permissionError.customerMessage).toBe(
-                'Permission denied. You do not have sufficient permissions to modify this file.'
-            )
+            assert.strictEqual(permissionError.customerMessage, 'Permission denied.')
 
             const emptyPathError = new EmptyPathError()
-            expect(emptyPathError.message).toBe('Path must not be empty')
-            expect(emptyPathError.customerMessage).toBe(
-                'The file path cannot be empty. Please provide a valid file path.'
-            )
+            assert.strictEqual(emptyPathError.message, 'Path must not be empty')
+            assert.strictEqual(emptyPathError.customerMessage, 'The file path cannot be empty.')
         })
     })
 
     describe('createFileOperationError', () => {
         it('maps common file system errors', () => {
             const error1 = createFileOperationError(new Error('ENOENT: no such file or directory'))
-            expect(error1).toBeInstanceOf(DirectoryNotFoundError)
-            expect(error1.customerMessage).toBe('The directory does not exist. Please create the directory first.')
+            assert.ok(error1 instanceof DirectoryNotFoundError)
+            assert.strictEqual(error1.customerMessage, 'The directory does not exist.')
 
             const error2 = createFileOperationError(new Error('EACCES: permission denied'))
-            expect(error2).toBeInstanceOf(PermissionDeniedError)
+            assert.ok(error2 instanceof PermissionDeniedError)
 
             const error3 = createFileOperationError(new Error('EISDIR: is a directory'))
-            expect(error3).toBeInstanceOf(IsDirectoryError)
+            assert.ok(error3 instanceof IsDirectoryError)
 
             const error4 = createFileOperationError(new Error('ENOSPC: no space left on device'))
-            expect(error4).toBeInstanceOf(NoSpaceError)
+            assert.ok(error4 instanceof NoSpaceError)
 
             const error5 = createFileOperationError(new Error('EMFILE: too many open files'))
-            expect(error5).toBeInstanceOf(TooManyOpenFilesError)
+            assert.ok(error5 instanceof TooManyOpenFilesError)
         })
 
         it('maps fsWrite specific errors', () => {
             const error1 = createFileOperationError(new Error('Path must not be empty'))
-            expect(error1).toBeInstanceOf(EmptyPathError)
+            assert.ok(error1 instanceof EmptyPathError)
 
             const error2 = createFileOperationError(new Error('fileText must be provided for create command'))
-            expect(error2).toBeInstanceOf(MissingContentError)
+            assert.ok(error2 instanceof MissingContentError)
 
             const error3 = createFileOperationError(new Error('The file already exists with the same content'))
-            expect(error3).toBeInstanceOf(FileExistsWithSameContentError)
+            assert.ok(error3 instanceof FileExistsWithSameContentError)
 
             const error4 = createFileOperationError(new Error('Content to append must not be empty'))
-            expect(error4).toBeInstanceOf(EmptyAppendContentError)
+            assert.ok(error4 instanceof EmptyAppendContentError)
         })
 
         it('maps fsReplace specific errors', () => {
             const error1 = createFileOperationError(new Error('Diffs must not be empty'))
-            expect(error1).toBeInstanceOf(EmptyDiffsError)
+            assert.ok(error1 instanceof EmptyDiffsError)
 
             const error2 = createFileOperationError(
                 new Error('The provided path must exist in order to replace contents into it')
             )
-            expect(error2).toBeInstanceOf(FileNotExistsError)
+            assert.ok(error2 instanceof FileNotExistsError)
 
             const error3 = createFileOperationError(new Error('No occurrences of "some text" were found'))
-            expect(error3).toBeInstanceOf(TextNotFoundError)
+            assert.ok(error3 instanceof TextNotFoundError)
 
             const error4 = createFileOperationError(
                 new Error('Multiple occurrences of "some text" were found when only 1 is expected')
             )
-            expect(error4).toBeInstanceOf(MultipleMatchesError)
+            assert.ok(error4 instanceof MultipleMatchesError)
         })
 
         it('returns generic FileOperationError for unknown errors', () => {
             const unknownError = new Error('Some unknown error occurred')
             const result = createFileOperationError(unknownError)
-            expect(result).toBeInstanceOf(FileOperationError)
-            expect(result.message).toBe('Some unknown error occurred')
-            expect(result.customerMessage).toBe('Some unknown error occurred')
+            assert.ok(result instanceof FileOperationError)
+            assert.strictEqual(result.message, 'Some unknown error occurred')
+            assert.strictEqual(result.customerMessage, 'Some unknown error occurred')
         })
     })
 
     describe('getCustomerFacingErrorMessage', () => {
         it('returns customer message from FileOperationError', () => {
             const error = new EmptyPathError()
-            expect(getCustomerFacingErrorMessage(error)).toBe(
-                'The file path cannot be empty. Please provide a valid file path.'
-            )
+            assert.strictEqual(getCustomerFacingErrorMessage(error), 'The file path cannot be empty.')
         })
 
         it('creates and returns customer message from standard Error', () => {
             const error = new Error('ENOENT: no such file or directory')
-            expect(getCustomerFacingErrorMessage(error)).toBe(
-                'The directory does not exist. Please create the directory first.'
-            )
+            assert.strictEqual(getCustomerFacingErrorMessage(error), 'The directory does not exist.')
         })
 
         it('handles non-Error objects', () => {
-            expect(getCustomerFacingErrorMessage('string error')).toBe('string error')
-            expect(getCustomerFacingErrorMessage(null)).toBe('null')
-            expect(getCustomerFacingErrorMessage(undefined)).toBe('undefined')
+            assert.strictEqual(getCustomerFacingErrorMessage('string error'), 'string error')
+            assert.strictEqual(getCustomerFacingErrorMessage(null), 'null')
+            assert.strictEqual(getCustomerFacingErrorMessage(undefined), 'undefined')
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.test.ts
@@ -1,0 +1,123 @@
+import {
+    DirectoryNotFoundError,
+    EmptyAppendContentError,
+    EmptyDiffsError,
+    EmptyPathError,
+    FileExistsWithSameContentError,
+    FileNotExistsError,
+    FileOperationError,
+    IsDirectoryError,
+    MissingContentError,
+    MultipleMatchesError,
+    NoSpaceError,
+    PermissionDeniedError,
+    TextNotFoundError,
+    TooManyOpenFilesError,
+    createFileOperationError,
+    getCustomerFacingErrorMessage,
+} from './errors'
+
+describe('errors', () => {
+    describe('FileOperationError classes', () => {
+        test('creates error classes with correct customer messages', () => {
+            const directoryError = new DirectoryNotFoundError('ENOENT: no such file or directory')
+            expect(directoryError.message).toBe('ENOENT: no such file or directory')
+            expect(directoryError.customerMessage).toBe(
+                'The directory does not exist. Please create the directory first.'
+            )
+
+            const permissionError = new PermissionDeniedError('EACCES: permission denied')
+            expect(permissionError.customerMessage).toBe(
+                'Permission denied. You do not have sufficient permissions to modify this file.'
+            )
+
+            const emptyPathError = new EmptyPathError()
+            expect(emptyPathError.message).toBe('Path must not be empty')
+            expect(emptyPathError.customerMessage).toBe(
+                'The file path cannot be empty. Please provide a valid file path.'
+            )
+        })
+    })
+
+    describe('createFileOperationError', () => {
+        test('maps common file system errors', () => {
+            const error1 = createFileOperationError(new Error('ENOENT: no such file or directory'))
+            expect(error1).toBeInstanceOf(DirectoryNotFoundError)
+            expect(error1.customerMessage).toBe('The directory does not exist. Please create the directory first.')
+
+            const error2 = createFileOperationError(new Error('EACCES: permission denied'))
+            expect(error2).toBeInstanceOf(PermissionDeniedError)
+
+            const error3 = createFileOperationError(new Error('EISDIR: is a directory'))
+            expect(error3).toBeInstanceOf(IsDirectoryError)
+
+            const error4 = createFileOperationError(new Error('ENOSPC: no space left on device'))
+            expect(error4).toBeInstanceOf(NoSpaceError)
+
+            const error5 = createFileOperationError(new Error('EMFILE: too many open files'))
+            expect(error5).toBeInstanceOf(TooManyOpenFilesError)
+        })
+
+        test('maps fsWrite specific errors', () => {
+            const error1 = createFileOperationError(new Error('Path must not be empty'))
+            expect(error1).toBeInstanceOf(EmptyPathError)
+
+            const error2 = createFileOperationError(new Error('fileText must be provided for create command'))
+            expect(error2).toBeInstanceOf(MissingContentError)
+
+            const error3 = createFileOperationError(new Error('The file already exists with the same content'))
+            expect(error3).toBeInstanceOf(FileExistsWithSameContentError)
+
+            const error4 = createFileOperationError(new Error('Content to append must not be empty'))
+            expect(error4).toBeInstanceOf(EmptyAppendContentError)
+        })
+
+        test('maps fsReplace specific errors', () => {
+            const error1 = createFileOperationError(new Error('Diffs must not be empty'))
+            expect(error1).toBeInstanceOf(EmptyDiffsError)
+
+            const error2 = createFileOperationError(
+                new Error('The provided path must exist in order to replace contents into it')
+            )
+            expect(error2).toBeInstanceOf(FileNotExistsError)
+
+            const error3 = createFileOperationError(new Error('No occurrences of "some text" were found'))
+            expect(error3).toBeInstanceOf(TextNotFoundError)
+
+            const error4 = createFileOperationError(
+                new Error('Multiple occurrences of "some text" were found when only 1 is expected')
+            )
+            expect(error4).toBeInstanceOf(MultipleMatchesError)
+        })
+
+        test('returns generic FileOperationError for unknown errors', () => {
+            const unknownError = new Error('Some unknown error occurred')
+            const result = createFileOperationError(unknownError)
+            expect(result).toBeInstanceOf(FileOperationError)
+            expect(result.message).toBe('Some unknown error occurred')
+            expect(result.customerMessage).toBe('Some unknown error occurred')
+        })
+    })
+
+    describe('getCustomerFacingErrorMessage', () => {
+        test('returns customer message from FileOperationError', () => {
+            const error = new EmptyPathError()
+            expect(getCustomerFacingErrorMessage(error)).toBe(
+                'The file path cannot be empty. Please provide a valid file path.'
+            )
+        })
+
+        test('creates and returns customer message from standard Error', () => {
+            const error = new Error('ENOENT: no such file or directory')
+            expect(getCustomerFacingErrorMessage(error)).toBe(
+                'The directory does not exist. Please create the directory first.'
+            )
+        })
+
+        test('handles non-Error objects', () => {
+            expect(getCustomerFacingErrorMessage('string error')).toBe('string error')
+            expect(getCustomerFacingErrorMessage(null)).toBe('null')
+            expect(getCustomerFacingErrorMessage(undefined)).toBe('undefined')
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -88,13 +88,13 @@ export class FileOperationError extends Error {
 // Common file system errors
 export class DirectoryNotFoundError extends FileOperationError {
     constructor(message: string) {
-        super(message, 'The directory does not exist. Please create the directory first.')
+        super(message, 'The directory does not exist.')
     }
 }
 
 export class PermissionDeniedError extends FileOperationError {
     constructor(message: string) {
-        super(message, 'Permission denied. You do not have sufficient permissions to modify this file.')
+        super(message, 'Permission denied.')
     }
 }
 
@@ -106,29 +106,26 @@ export class IsDirectoryError extends FileOperationError {
 
 export class NoSpaceError extends FileOperationError {
     constructor(message: string) {
-        super(message, 'No space left on device. Please free up some disk space.')
+        super(message, 'No space left on device.')
     }
 }
 
 export class TooManyOpenFilesError extends FileOperationError {
     constructor(message: string) {
-        super(message, 'Too many open files. Please close some files and try again.')
+        super(message, 'Too many open files.')
     }
 }
 
 // fsWrite specific errors
 export class EmptyPathError extends FileOperationError {
     constructor() {
-        super('Path must not be empty', 'The file path cannot be empty. Please provide a valid file path.')
+        super('Path must not be empty', 'The file path cannot be empty.')
     }
 }
 
 export class MissingContentError extends FileOperationError {
     constructor() {
-        super(
-            'fileText must be provided for create command',
-            'No content provided for the file. Please specify the content to write.'
-        )
+        super('fileText must be provided for create command', 'No content provided for the file.')
     }
 }
 
@@ -143,35 +140,26 @@ export class FileExistsWithSameContentError extends FileOperationError {
 
 export class EmptyAppendContentError extends FileOperationError {
     constructor() {
-        super(
-            'Content to append must not be empty',
-            'No content provided to append. Please specify the content to add to the file.'
-        )
+        super('Content to append must not be empty', 'No content provided to append.')
     }
 }
 
 // fsReplace specific errors
 export class EmptyDiffsError extends FileOperationError {
     constructor() {
-        super('Diffs must not be empty', 'No changes specified. Please provide the content to replace.')
+        super('Diffs must not be empty', 'No changes specified.')
     }
 }
 
 export class FileNotExistsError extends FileOperationError {
     constructor() {
-        super(
-            'The provided path must exist in order to replace contents into it',
-            'The file does not exist. Please create the file first or check the path.'
-        )
+        super('The provided path must exist in order to replace contents into it', 'The file does not exist.')
     }
 }
 
 export class TextNotFoundError extends FileOperationError {
     constructor(text: string) {
-        super(
-            `No occurrences of "${text}" were found`,
-            'The text to replace was not found in the file. Please check your input.'
-        )
+        super(`No occurrences of "${text}" were found`, 'The text to replace was not found in the file.')
     }
 }
 
@@ -179,7 +167,7 @@ export class MultipleMatchesError extends FileOperationError {
     constructor(text: string) {
         super(
             `Multiple occurrences of "${text}" were found when only 1 is expected`,
-            'Multiple instances of the text to replace were found. Please provide more context to identify the specific text to replace.'
+            'Multiple instances of the text to replace were found.'
         )
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -71,3 +71,194 @@ export function isRequestAbortedError(error: unknown): boolean {
 
     return false
 }
+
+/**
+ * Base class for file operation errors with customer-facing messages
+ */
+export class FileOperationError extends Error {
+    constructor(
+        message: string,
+        public readonly customerMessage: string
+    ) {
+        super(message)
+        this.name = this.constructor.name
+    }
+}
+
+// Common file system errors
+export class DirectoryNotFoundError extends FileOperationError {
+    constructor(message: string) {
+        super(message, 'The directory does not exist. Please create the directory first.')
+    }
+}
+
+export class PermissionDeniedError extends FileOperationError {
+    constructor(message: string) {
+        super(message, 'Permission denied. You do not have sufficient permissions to modify this file.')
+    }
+}
+
+export class IsDirectoryError extends FileOperationError {
+    constructor(message: string) {
+        super(message, 'The specified path is a directory, not a file.')
+    }
+}
+
+export class NoSpaceError extends FileOperationError {
+    constructor(message: string) {
+        super(message, 'No space left on device. Please free up some disk space.')
+    }
+}
+
+export class TooManyOpenFilesError extends FileOperationError {
+    constructor(message: string) {
+        super(message, 'Too many open files. Please close some files and try again.')
+    }
+}
+
+// fsWrite specific errors
+export class EmptyPathError extends FileOperationError {
+    constructor() {
+        super('Path must not be empty', 'The file path cannot be empty. Please provide a valid file path.')
+    }
+}
+
+export class MissingContentError extends FileOperationError {
+    constructor() {
+        super(
+            'fileText must be provided for create command',
+            'No content provided for the file. Please specify the content to write.'
+        )
+    }
+}
+
+export class FileExistsWithSameContentError extends FileOperationError {
+    constructor() {
+        super(
+            'The file already exists with the same content',
+            'The file already exists with identical content. No changes were made.'
+        )
+    }
+}
+
+export class EmptyAppendContentError extends FileOperationError {
+    constructor() {
+        super(
+            'Content to append must not be empty',
+            'No content provided to append. Please specify the content to add to the file.'
+        )
+    }
+}
+
+// fsReplace specific errors
+export class EmptyDiffsError extends FileOperationError {
+    constructor() {
+        super('Diffs must not be empty', 'No changes specified. Please provide the content to replace.')
+    }
+}
+
+export class FileNotExistsError extends FileOperationError {
+    constructor() {
+        super(
+            'The provided path must exist in order to replace contents into it',
+            'The file does not exist. Please create the file first or check the path.'
+        )
+    }
+}
+
+export class TextNotFoundError extends FileOperationError {
+    constructor(text: string) {
+        super(
+            `No occurrences of "${text}" were found`,
+            'The text to replace was not found in the file. Please check your input.'
+        )
+    }
+}
+
+export class MultipleMatchesError extends FileOperationError {
+    constructor(text: string) {
+        super(
+            `Multiple occurrences of "${text}" were found when only 1 is expected`,
+            'Multiple instances of the text to replace were found. Please provide more context to identify the specific text to replace.'
+        )
+    }
+}
+
+/**
+ * Maps a standard Error to the appropriate FileOperationError type
+ * @param error The original error
+ * @returns A FileOperationError with customer-facing message
+ */
+export function createFileOperationError(error: Error): FileOperationError {
+    const message = error.message
+
+    // Common file system errors
+    if (message.includes('ENOENT') || message.includes('no such file or directory')) {
+        return new DirectoryNotFoundError(message)
+    }
+    if (message.includes('EACCES') || message.includes('permission denied')) {
+        return new PermissionDeniedError(message)
+    }
+    if (message.includes('EISDIR')) {
+        return new IsDirectoryError(message)
+    }
+    if (message.includes('ENOSPC')) {
+        return new NoSpaceError(message)
+    }
+    if (message.includes('EMFILE') || message.includes('ENFILE')) {
+        return new TooManyOpenFilesError(message)
+    }
+
+    // fsWrite specific errors
+    if (message === 'Path must not be empty') {
+        return new EmptyPathError()
+    }
+    if (message === 'fileText must be provided for create command') {
+        return new MissingContentError()
+    }
+    if (message === 'The file already exists with the same content') {
+        return new FileExistsWithSameContentError()
+    }
+    if (message === 'Content to append must not be empty') {
+        return new EmptyAppendContentError()
+    }
+
+    // fsReplace specific errors
+    if (message === 'Diffs must not be empty') {
+        return new EmptyDiffsError()
+    }
+    if (message === 'The provided path must exist in order to replace contents into it') {
+        return new FileNotExistsError()
+    }
+
+    // Pattern matching for errors with dynamic content
+    const noOccurrencesMatch = message.match(/No occurrences of "(.+)" were found/)
+    if (noOccurrencesMatch) {
+        return new TextNotFoundError(noOccurrencesMatch[1])
+    }
+
+    const multipleOccurrencesMatch = message.match(/Multiple occurrences of "(.+)" were found/)
+    if (multipleOccurrencesMatch) {
+        return new MultipleMatchesError(multipleOccurrencesMatch[1])
+    }
+
+    // Default fallback - wrap the original error with the same message
+    return new FileOperationError(message, message)
+}
+
+/**
+ * Maps an error to a customer-facing message
+ * @param error The original error (can be any type)
+ * @returns A customer-facing error message
+ */
+export function getCustomerFacingErrorMessage(error: unknown): string {
+    if (error instanceof FileOperationError) {
+        return error.customerMessage
+    }
+
+    if (error instanceof Error) {
+        return createFileOperationError(error).customerMessage
+    }
+
+    return String(error)
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsReplace.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsReplace.ts
@@ -1,4 +1,5 @@
 import { CommandValidation, ExplanatoryParams, InvokeOutput, requiresPathAcceptance } from './toolShared'
+import { EmptyPathError, EmptyDiffsError, FileNotExistsError, TextNotFoundError, MultipleMatchesError } from '../errors'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
 import * as os from 'os'
@@ -31,15 +32,15 @@ export class FsReplace {
 
     public async validate(params: FsReplaceParams): Promise<void> {
         if (!params.path) {
-            throw new Error('Path must not be empty')
+            throw new EmptyPathError()
         }
         if (!params.diffs || params.diffs.length === 0) {
-            throw new Error('Diffs must not be empty')
+            throw new EmptyDiffsError()
         }
         const sanitizedPath = sanitize(params.path)
         const fileExists = await this.workspace.fs.exists(sanitizedPath)
         if (!fileExists) {
-            throw new Error('The provided path must exist in order to replace contents into it')
+            throw new FileNotExistsError()
         }
     }
 
@@ -145,13 +146,13 @@ const getReplaceContent = (params: ReplaceParams, fileContent: string) => {
         const startIndex = fileContent.indexOf(normalizedOldStr)
 
         if (startIndex === -1) {
-            throw new Error(`No occurrences of "${diff.oldStr}" were found`)
+            throw new TextNotFoundError(diff.oldStr)
         }
 
         // Check for multiple occurrences
         const secondIndex = fileContent.indexOf(normalizedOldStr, startIndex + 1)
         if (secondIndex !== -1) {
-            throw new Error(`Multiple occurrences of "${diff.oldStr}" were found when only 1 is expected`)
+            throw new MultipleMatchesError(diff.oldStr)
         }
 
         // Perform the replacement using string operations instead of regex


### PR DESCRIPTION
## Problem

File operation errors should be visible.

## Solution

- Map file operation errors to user-friendly error messages
- Surface error message to the error status description so that it appears on hover

<img width="512" alt="image" src="https://github.com/user-attachments/assets/6acba2d5-6bb0-46e0-9b09-cf4d92673f0a" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
