### PR TITLE
feat(amazonq): read and validate the images as context

### DIFF
--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -32,6 +32,8 @@ import {
     CHAT_PROMPT_OPTION_ACKNOWLEDGED,
     STOP_CHAT_RESPONSE,
     OPEN_SETTINGS,
+    OPEN_FILE_DIALOG,
+    FILES_DROPPED,
 } from '@aws/chat-client-ui-types'
 import {
     BUTTON_CLICK_REQUEST_METHOD,
@@ -99,6 +101,9 @@ import {
     TabBarActionParams,
     TabChangeParams,
     TabRemoveParams,
+    OpenFileDialogParams,
+    OPEN_FILE_DIALOG_METHOD,
+    OpenFileDialogResult,
 } from '@aws/language-server-runtimes-types'
 import { MynahUIDataModel, MynahUITabStoreModel } from '@aws/mynah-ui'
 import { ServerMessage, TELEMETRY, TelemetryParams } from '../contracts/serverContracts'
@@ -224,6 +229,9 @@ export const createChat = (
                 break
             case MCP_SERVER_CLICK_REQUEST_METHOD:
                 mynahApi.mcpServerClick(message.params as McpServerClickResult)
+                break
+            case OPEN_FILE_DIALOG_METHOD:
+                mynahApi.addSelectedFilesToContext(message.params as OpenFileDialogResult)
                 break
             case GET_SERIALIZED_CHAT_REQUEST_METHOD:
                 mynahApi.getSerializedChat(message.requestId, message.params as GetSerializedChatParams)
@@ -476,6 +484,12 @@ export const createChat = (
         },
         onRemovePinnedContext: (params: PinnedContextParams) => {
             sendMessageToClient({ command: PINNED_CONTEXT_REMOVE_NOTIFICATION_METHOD, params })
+        },
+        onOpenFileDialogClick: (params: OpenFileDialogParams) => {
+            sendMessageToClient({ command: OPEN_FILE_DIALOG, params: params })
+        },
+        onFilesDropped: (params: { tabId: string; files: FileList; insertPosition: number }) => {
+            sendMessageToClient({ command: FILES_DROPPED, params: params })
         },
     }
 

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -37,6 +37,7 @@ import {
     ListRulesParams,
     ListMcpServersParams,
     McpServerClickParams,
+    OpenFileDialogParams,
     OpenTabResult,
     PinnedContextParams,
     PromptInputOptionChangeParams,
@@ -107,6 +108,8 @@ export interface OutboundChatApi {
     listRules(params: ListRulesParams): void
     onAddPinnedContext(params: PinnedContextParams): void
     onRemovePinnedContext(params: PinnedContextParams): void
+    onOpenFileDialogClick(params: OpenFileDialogParams): void
+    onFilesDropped(params: { tabId: string; files: FileList; insertPosition: number }): void
 }
 
 export class Messager {
@@ -279,5 +282,13 @@ export class Messager {
 
     onRemovePinnedContext = (params: PinnedContextParams) => {
         this.chatApi.onRemovePinnedContext(params)
+    }
+
+    onOpenFileDialogClick = (params: OpenFileDialogParams): void => {
+        this.chatApi.onOpenFileDialogClick(params)
+    }
+
+    onFilesDropped = (params: { tabId: string; files: FileList; insertPosition: number }): void => {
+        this.chatApi.onFilesDropped(params)
     }
 }

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -74,6 +74,8 @@ describe('MynahUI', () => {
             listRules: sinon.stub(),
             onAddPinnedContext: sinon.stub(),
             onRemovePinnedContext: sinon.stub(),
+            onOpenFileDialogClick: sinon.stub(),
+            onFilesDropped: sinon.stub(),
         }
 
         messager = new Messager(outboundChatApi)

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -30,6 +30,8 @@ import {
     ListMcpServersResult,
     McpServerClickResult,
     OPEN_WORKSPACE_INDEX_SETTINGS_BUTTON_ID,
+    OpenFileDialogParams,
+    OpenFileDialogResult,
     OpenTabParams,
     PinnedContextParams,
     RuleClickResult,
@@ -45,6 +47,8 @@ import {
     MynahUIProps,
     QuickActionCommand,
     ChatItemButton,
+    MynahIcons,
+    CustomQuickActionCommand,
 } from '@aws/mynah-ui'
 import { VoteParams } from '../contracts/telemetry'
 import { Messager } from './messager'
@@ -89,6 +93,7 @@ export interface InboundChatApi {
     mcpServerClick(params: McpServerClickResult): void
     getSerializedChat(requestId: string, params: GetSerializedChatParams): void
     createTabId(openTab?: boolean): string | undefined
+    addSelectedFilesToContext(params: OpenFileDialogParams): void
     sendPinnedContext(params: PinnedContextParams): void
 }
 
@@ -199,6 +204,71 @@ const initializeChatResponse = (mynahUi: MynahUI, tabId: string, userPrompt?: st
     // Create initial empty response
     mynahUi.addChatItem(tabId, {
         type: ChatItemType.ANSWER_STREAM,
+    })
+}
+
+// Add verification function for dropped files
+const verifyDroppedFiles = async (files: FileList): Promise<{ validFiles: File[]; errors: string[] }> => {
+    const supportedExtensions = [
+        // Images
+        'jpeg',
+        'png',
+        'gif',
+        'webp',
+    ]
+
+    const validFiles: File[] = []
+    const errors: string[] = []
+    for (let i = 0; i < files.length; i++) {
+        const file = files[i]
+        const fileName = file.name || 'Unknown file'
+        const extension = file.name.split('.').pop()?.toLowerCase()
+
+        if (!extension || !supportedExtensions.includes(extension)) {
+            errors.push(`${fileName}: File must be an image in JPEG, PNG, GIF, or WebP format.`)
+            continue
+        }
+        if (extension && supportedExtensions.includes(extension)) {
+            // Check file size (3.75MB = 3.75 * 1024 * 1024 bytes)
+            const maxSizeBytes = 3.75 * 1024 * 1024
+            if (file.size > maxSizeBytes) {
+                errors.push(`${fileName}: Image must be no more than 3.75MB in size.`)
+                continue // Skip files that are too large
+            }
+
+            // Check image dimensions
+            try {
+                const dimensions = await getImageDimensions(file)
+                if (dimensions.width > 8000 || dimensions.height > 8000) {
+                    errors.push(`${fileName}: Image must be no more than 8,000px in width or height.`)
+                    continue // Skip images that are too large
+                }
+            } catch (error) {
+                // If we can't read dimensions, skip the file
+                continue
+            }
+
+            validFiles.push(file)
+        }
+    }
+    return { validFiles, errors }
+}
+
+// Helper function to get image dimensions
+const getImageDimensions = (file: File): Promise<{ width: number; height: number }> => {
+    return new Promise((resolve, reject) => {
+        const img = new Image()
+        const objectUrl = URL.createObjectURL(file)
+
+        img.onload = () => {
+            URL.revokeObjectURL(objectUrl) // Clean up the object URL
+            resolve({ width: img.width, height: img.height })
+        }
+        img.onerror = () => {
+            URL.revokeObjectURL(objectUrl) // Clean up the object URL
+            reject(new Error('Failed to load image'))
+        }
+        img.src = objectUrl
     })
 }
 
@@ -441,6 +511,23 @@ export const createMynahUi = (
             }
         },
         onContextSelected: (contextItem, tabId) => {
+            if (contextItem.command === 'image') {
+                const imageContext = getImageContextCount(tabId)
+                if (imageContext >= 20) {
+                    mynahUi.notify({
+                        content: 'A maximum of 20 images can be added to a single message.',
+                        type: NotificationType.WARNING,
+                    })
+                    return false
+                }
+                const payload: OpenFileDialogParams = {
+                    tabId,
+                    fileType: contextItem.command as 'image' | '',
+                    insertPosition: 0,
+                }
+                messager.onOpenFileDialogClick(payload)
+                return false
+            }
             if (contextItem.id === ContextPrompt.CreateItemId) {
                 mynahUi.showCustomForm(
                     tabId,
@@ -565,6 +652,83 @@ export const createMynahUi = (
         onStopChatResponse: tabId => {
             messager.onStopChatResponse(tabId)
         },
+        onOpenFileDialogClick: (tabId, fileType, insertPosition) => {
+            const imageContext = getImageContextCount(tabId)
+            if (imageContext >= 20) {
+                mynahUi.notify({
+                    content: 'A maximum of 20 images can be added to a single message.',
+                    type: NotificationType.WARNING,
+                })
+                return
+            }
+            const payload: OpenFileDialogParams = {
+                tabId,
+                fileType: fileType as 'image' | '',
+                insertPosition,
+            }
+            messager.onOpenFileDialogClick(payload)
+        },
+        onFilesDropped: async (tabId: string, files: FileList, insertPosition: number) => {
+            const imageContextCount = getImageContextCount(tabId)
+            if (imageContextCount >= 20) {
+                mynahUi.notify({
+                    content: 'A maximum of 20 images can be added to a single message.',
+                    type: NotificationType.WARNING,
+                })
+                return
+            }
+            // Verify dropped files and add valid ones to context
+            const { validFiles, errors } = await verifyDroppedFiles(files)
+            if (validFiles.length > 0) {
+                // Calculate how many files we can actually add
+                const availableSlots = 20 - imageContextCount
+                const filesToAdd = validFiles.slice(0, availableSlots)
+                const filesExceeded = validFiles.length - availableSlots
+
+                // Add error message if we exceed the limit
+                if (filesExceeded > 0) {
+                    errors.push(`A maximum of 20 images can be added to a single message.`)
+                }
+
+                const commands: CustomQuickActionCommand[] = await Promise.all(
+                    filesToAdd.map(async (file: File) => {
+                        const fileName = file.name || 'Unknown file'
+                        const filePath = file.name || ''
+
+                        // Determine file type and appropriate icon
+                        const fileExtension = filePath.split('.').pop()?.toLowerCase() || ''
+                        const isImage = ['jpeg', 'png', 'gif', 'webp'].includes(fileExtension)
+
+                        let icon = MynahIcons.FILE
+                        if (isImage) {
+                            icon = MynahIcons.IMAGE
+                        }
+
+                        const arrayBuffer = await file.arrayBuffer()
+                        const bytes = new Uint8Array(arrayBuffer)
+
+                        return {
+                            command: fileName,
+                            description: filePath,
+                            route: [filePath],
+                            label: 'image',
+                            icon: icon,
+                            content: bytes,
+                        }
+                    })
+                )
+
+                // Add valid files to context commands
+                mynahUi.addCustomContextToPrompt(tabId, commands, insertPosition)
+            }
+            const uniqueErrors = [...new Set(errors)]
+            for (const error of uniqueErrors) {
+                mynahUi.notify({
+                    content: error,
+                    type: NotificationType.WARNING,
+                })
+            }
+        },
     }
 
     const mynahUiProps: MynahUIProps = {
@@ -673,6 +837,20 @@ export const createMynahUi = (
                 ),
             },
         }
+    }
+
+    const getImageContextCount = (tabId: string) => {
+        const imageContextInPrompt =
+            mynahUi
+                .getTabData(tabId)
+                ?.getStore()
+                ?.customContextCommand?.filter(cm => cm.label === 'image').length || 0
+        const imageContextInPin =
+            mynahUi
+                .getTabData(tabId)
+                ?.getStore()
+                ?.promptTopBarContextItems?.filter(cm => cm.label === 'image').length || 0
+        return imageContextInPrompt + imageContextInPin
     }
 
     const addChatResponse = (chatResult: ChatResult, tabId: string, isPartialResult: boolean) => {
@@ -1287,6 +1465,31 @@ ${params.message}`,
         })
     }
 
+    const addSelectedFilesToContext = (params: OpenFileDialogResult) => {
+        if (params.errorMessage) {
+            mynahUi.notify({
+                content: params.errorMessage,
+                type: NotificationType.ERROR,
+            })
+            return
+        }
+        const commands: QuickActionCommand[] = []
+        for (const filePath of params.filePaths) {
+            const fileName = filePath.split('/').pop() || filePath
+            if (params.fileType === 'image') {
+                commands.push({
+                    command: fileName,
+                    description: filePath,
+                    label: 'image',
+                    route: [filePath],
+                    icon: MynahIcons.IMAGE,
+                })
+            }
+        }
+
+        mynahUi.addCustomContextToPrompt(params.tabId, commands, params.insertPosition)
+    }
+
     const chatHistoryList = new ChatHistoryList(mynahUi, messager)
     const listConversations = (params: ListConversationsResult) => {
         chatHistoryList.show(params)
@@ -1393,6 +1596,7 @@ ${params.message}`,
         getSerializedChat: getSerializedChat,
         createTabId: createTabId,
         ruleClicked: ruleClicked,
+        addSelectedFilesToContext: addSelectedFilesToContext,
     }
 
     return [mynahUi, api]

--- a/chat-client/src/client/withAdapter.ts
+++ b/chat-client/src/client/withAdapter.ts
@@ -124,6 +124,22 @@ export const withAdapter = (
             return defaultEventHandler.onContextSelected?.(contextItem, tabId, eventId) ?? false
         },
 
+        onOpenFileDialogClick(tabId, fileType, insertPosition) {
+            if (chatClientAdapter.isSupportedTab(tabId)) {
+                return customEventHandler.onOpenFileDialogClick?.(tabId, fileType, insertPosition) ?? false
+            }
+
+            return defaultEventHandler.onOpenFileDialogClick?.(tabId, fileType, insertPosition) ?? false
+        },
+
+        onFilesDropped(tabId, fileList, insertPosition) {
+            if (chatClientAdapter.isSupportedTab(tabId)) {
+                return customEventHandler.onFilesDropped?.(tabId, fileList, insertPosition) ?? false
+            }
+
+            return defaultEventHandler.onFilesDropped?.(tabId, fileList, insertPosition) ?? false
+        },
+
         onFormLinkClick(link, mouseEvent, eventId) {
             // Always delegate onFormLinkClick to adapter, if handled exists, since it's not tied to specific tabId
             if (customEventHandler.onFormLinkClick) {

--- a/chat-client/src/contracts/chatClientAdapter.ts
+++ b/chat-client/src/contracts/chatClientAdapter.ts
@@ -38,6 +38,8 @@ export interface ChatEventHandler
         | 'onPromptInputOptionChange'
         | 'onPromptInputButtonClick'
         | 'onMessageDismiss'
+        | 'onOpenFileDialogClick'
+        | 'onFilesDropped'
         | 'onPromptTopBarItemAdded'
         | 'onPromptTopBarItemRemoved'
         | 'onPromptTopBarButtonClick'

--- a/chat-client/src/contracts/serverContracts.ts
+++ b/chat-client/src/contracts/serverContracts.ts
@@ -39,6 +39,8 @@ import {
     GetSerializedChatResult,
     PROMPT_INPUT_OPTION_CHANGE_METHOD,
     BUTTON_CLICK_REQUEST_METHOD,
+    OPEN_FILE_DIALOG_METHOD,
+    OpenFileDialogParams,
     RULE_CLICK_REQUEST_METHOD,
     RuleClickParams,
     ListRulesParams,
@@ -78,6 +80,7 @@ export type ServerMessageCommand =
     | typeof RULE_CLICK_REQUEST_METHOD
     | typeof PINNED_CONTEXT_ADD_NOTIFICATION_METHOD
     | typeof PINNED_CONTEXT_REMOVE_NOTIFICATION_METHOD
+    | typeof OPEN_FILE_DIALOG_METHOD
 
 export interface ServerMessage {
     command: ServerMessageCommand
@@ -113,3 +116,4 @@ export type ServerMessageParams =
     | RuleClickParams
     | ListRulesParams
     | PinnedContextParams
+    | OpenFileDialogParams

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
             "dependencies": {
                 "@aws/language-server-runtimes": "^0.2.98",
                 "@smithy/types": "4.2.0",
+                "image-size": "^2.0.2",
                 "typescript": "^5.8.2"
             },
             "devDependencies": {
@@ -16803,6 +16804,18 @@
             },
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/image-size": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+            "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+            "license": "MIT",
+            "bin": {
+                "image-size": "bin/image-size.js"
+            },
+            "engines": {
+                "node": ">=16.x"
             }
         },
         "node_modules/immediate": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.98",
         "@smithy/types": "4.2.0",
+        "image-size": "^2.0.2",
         "typescript": "^5.8.2"
     },
     "devDependencies": {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -37,6 +37,8 @@ import {
     MessageType,
     ExecuteCommandParams,
     FollowUpClickParams,
+    OpenFileDialogParams,
+    OpenFileDialogResult,
 } from '@aws/language-server-runtimes/protocol'
 import {
     ApplyWorkspaceEditParams,
@@ -162,7 +164,10 @@ import {
     PaidTierMode,
     qProName,
 } from '../paidTier/paidTier'
+import { ImageBlock, ImageFormat } from '@aws/codewhisperer-streaming-client'
+import { ContextCommand } from '@aws/language-server-runtimes/protocol'
 import { Message as DbMessage, messageToStreamingMessage } from './tools/chatDb/util'
+import imageSize from 'image-size'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -426,6 +431,94 @@ export class AgenticChatController implements ChatHandlers {
         }
     }
 
+    async onOpenFileDialog(params: OpenFileDialogParams, token: CancellationToken): Promise<OpenFileDialogResult> {
+        if (params.fileType === 'image') {
+            const supportedExtensions = ['jpeg', 'png', 'gif', 'webp']
+            const maxSizeBytes = 3.75 * 1024 * 1024
+            const maxDimension = 8000
+
+            // 1. Prompt user for file selection
+            const result = await this.#features.lsp.window.showOpenDialog({
+                canSelectFiles: true,
+                canSelectFolders: false,
+                canSelectMany: false,
+                filters: { 'Image Files': ['*.jpeg', '*.png', '*.gif', '*.webp'] },
+            })
+
+            if (!result.uris || result.uris.length === 0) {
+                return {
+                    tabId: params.tabId,
+                    filePaths: [],
+                    fileType: params.fileType,
+                    insertPosition: params.insertPosition,
+                    errorMessage: 'No file selected.',
+                }
+            }
+
+            const validFilePaths: string[] = []
+            let errorMessage: string | undefined
+            for (const filePath of result.uris) {
+                // Extract filename from the URI for error messages
+                const fileName = filePath.split('/').pop() || ''
+
+                const extension = filePath.split('.').pop()?.toLowerCase() || ''
+                // 2. File type check
+                if (!supportedExtensions.includes(extension)) {
+                    errorMessage = `${fileName}: File must be an image in JPEG, PNG, GIF, or WebP format.`
+                    continue
+                }
+                const sanitizedPath = filePath.startsWith('file://') ? filePath.substring(7) : filePath[0]
+
+                // 3. File size check
+                const size = await this.#features.workspace.fs.getFileSize(sanitizedPath)
+                if (size.size > maxSizeBytes) {
+                    errorMessage = `${fileName}: Image must be no more than 3.75MB in size.`
+                    continue
+                }
+                // 4. Image dimension check
+                const fileContent = await this.#features.workspace.fs.readFile(sanitizedPath, {
+                    encoding: 'binary',
+                })
+                const imageBuffer = Buffer.from(fileContent, 'binary')
+                const { width = 0, height = 0 } = imageSize(imageBuffer)
+                if (width > maxDimension) {
+                    errorMessage = `${fileName}: Image must be no more than 8,000px in width.`
+                    continue
+                }
+                if (height > maxDimension) {
+                    errorMessage = `${fileName}: Image must be no more than 8,000px in height.`
+                    continue
+                }
+                // Passed all checks
+                validFilePaths.push(filePath)
+            }
+
+            if (validFilePaths.length === 0) {
+                return {
+                    tabId: params.tabId,
+                    filePaths: [],
+                    fileType: params.fileType,
+                    insertPosition: params.insertPosition,
+                    errorMessage: errorMessage || 'No valid image selected.',
+                }
+            }
+
+            // All valid files
+            return {
+                tabId: params.tabId,
+                filePaths: validFilePaths,
+                fileType: params.fileType,
+                insertPosition: params.insertPosition,
+            }
+        }
+        return {
+            tabId: params.tabId,
+            filePaths: [],
+            fileType: params.fileType,
+            insertPosition: params.insertPosition,
+        }
+    }
+
     async onCreatePrompt(params: CreatePromptParams): Promise<void> {
         if (params.isRule) {
             let workspaceFolders = workspaceUtils.getWorkspaceFolderPaths(this.#features.workspace)
@@ -572,13 +665,17 @@ export class AgenticChatController implements ChatHandlers {
                 triggerContext.documentReference =
                     this.#additionalContextProvider.getFileListFromContext(additionalContext)
             }
+
+            const customContext = await this.#additionalContextProvider.getImageBlocksFromContext(params.context)
+
             // Get the initial request input
             const initialRequestInput = await this.#prepareRequestInput(
                 params,
                 session,
                 triggerContext,
                 additionalContext,
-                chatResultStream
+                chatResultStream,
+                customContext
             )
 
             // Generate a unique ID for this prompt
@@ -654,10 +751,55 @@ export class AgenticChatController implements ChatHandlers {
         session: ChatSessionService,
         triggerContext: TriggerContext,
         additionalContext: AdditionalContentEntryAddition[],
-        chatResultStream: AgenticChatResultStream
+        chatResultStream: AgenticChatResultStream,
+        customContext: ImageBlock[]
     ): Promise<GenerateAssistantResponseCommandInput> {
         this.#debug('Preparing request input')
         const profileArn = AmazonQTokenServiceManager.getInstance().getActiveProfileArn()
+
+        // Handle image context if present
+        let imageBlocks: ImageBlock[] = []
+        if (params.context) {
+            for (const context of params.context as ContextCommand[]) {
+                if (
+                    context.label !== undefined &&
+                    context.label === 'image' &&
+                    context.route &&
+                    context.route.length > 0
+                ) {
+                    try {
+                        // sanitize the image path to remove  'file://' if it's a prefix
+                        const imagePath = context.route[0].startsWith('file://')
+                            ? context.route[0].substring(7)
+                            : context.route[0]
+                        // Read image file
+                        const fileContent = await this.#features.workspace.fs.readFile(imagePath, {
+                            encoding: 'binary',
+                        })
+                        const imageBuffer = Buffer.from(fileContent, 'binary')
+                        const imageBytes = new Uint8Array(imageBuffer)
+
+                        // Get image format from file extension
+                        const format = imagePath.split('.').pop()?.toLowerCase() || 'png'
+                        if (!['png', 'jpeg', 'gif', 'webp'].includes(format)) {
+                            this.#features.logging.warn(`Unsupported image format: ${format}`)
+                            continue
+                        }
+
+                        // Add image block
+                        imageBlocks.push({
+                            format: format as ImageFormat,
+                            source: {
+                                bytes: imageBytes,
+                            },
+                        })
+                    } catch (err) {
+                        this.#features.logging.error(`Failed to read image file: ${err}`)
+                    }
+                }
+            }
+        }
+
         const requestInput = await this.#triggerContext.getChatParamsFromTrigger(
             params,
             triggerContext,
@@ -668,7 +810,8 @@ export class AgenticChatController implements ChatHandlers {
             [],
             this.#getTools(session),
             additionalContext,
-            session.modelId
+            session.modelId,
+            customContext
         )
 
         return requestInput

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/addtionalContextProvider.ts
@@ -28,6 +28,7 @@ import {
 import { LocalProjectContextController } from '../../../shared/localProjectContextController'
 import { Features } from '../../types'
 import { ChatDatabase } from '../tools/chatDb/chatDb'
+import { ImageBlock, ImageFormat } from '@aws/codewhisperer-streaming-client'
 
 export const ACTIVE_EDITOR_CONTEXT_ID = 'active-editor'
 
@@ -350,6 +351,66 @@ export class AdditionalContextProvider {
                 showRules: workspaceUtils.getWorkspaceFolderPaths(this.features.workspace).length > 0,
             })
         }
+    }
+
+    /**
+     * Extracts image blocks from a context array, reading image files and returning them as ImageBlock objects.
+     * @param contextArr The context array to extract image blocks from.
+     */
+    public async getImageBlocksFromContext(contextArr?: ContextCommand[]): Promise<ImageBlock[]> {
+        const imageBlocks: ImageBlock[] = []
+        if (contextArr) {
+            for (const context of contextArr) {
+                if (
+                    context.label !== undefined &&
+                    context.label === 'image' &&
+                    context.route &&
+                    context.route.length > 0
+                ) {
+                    try {
+                        // sanitize the image path to remove  'file://' if it's a prefix
+                        const imagePath = context.route[0].startsWith('file://')
+                            ? context.route[0].substring(7)
+                            : context.route[0]
+                        // Read image file
+
+                        // Get image format from file extension
+                        const format = imagePath.split('.').pop()?.toLowerCase() || ''
+                        if (!['png', 'jpeg', 'gif', 'webp'].includes(format)) {
+                            this.features.logging.warn(`Unsupported image format: ${format}`)
+                            continue
+                        }
+
+                        if ('content' in context && context.content) {
+                            imageBlocks.push({
+                                format: format as ImageFormat,
+                                source: {
+                                    bytes: new Uint8Array(Object.values(context.content)),
+                                },
+                            })
+                            continue
+                        }
+
+                        const fileContent = await this.features.workspace.fs.readFile(imagePath, {
+                            encoding: 'binary',
+                        })
+                        const imageBuffer = Buffer.from(fileContent, 'binary')
+                        const imageBytes = new Uint8Array(imageBuffer)
+
+                        // Add image block
+                        imageBlocks.push({
+                            format: format as ImageFormat,
+                            source: {
+                                bytes: imageBytes,
+                            },
+                        })
+                    } catch (err) {
+                        this.features.logging.error(`Failed to read image file: ${err}`)
+                    }
+                }
+            }
+        }
+        return imageBlocks
     }
 
     async getRulesFolders(tabId: string): Promise<RulesFolder[]> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -13,6 +13,7 @@ import {
     ContentType,
     ProgrammingLanguage,
     EnvState,
+    ImageBlock,
 } from '@aws/codewhisperer-streaming-client'
 import {
     BedrockTools,
@@ -109,7 +110,8 @@ export class AgenticChatTriggerContext {
         history: ChatMessage[] = [],
         tools: BedrockTools = [],
         additionalContent?: AdditionalContentEntryAddition[],
-        modelId?: string
+        modelId?: string,
+        customContext?: ImageBlock[]
     ): Promise<GenerateAssistantResponseCommandInput> {
         const { prompt } = params
         const workspaceFolders = workspaceUtils.getWorkspaceFolderPaths(this.#workspace).slice(0, maxWorkspaceFolders)
@@ -149,6 +151,12 @@ export class AgenticChatTriggerContext {
         triggerContext.documentReference = triggerContext.documentReference
             ? mergeFileLists(triggerContext.documentReference, workspaceFileList)
             : workspaceFileList
+
+        let imageContext: ImageBlock[] = []
+        if (customContext && customContext.length > 0) {
+            imageContext = customContext
+        }
+
         // Process additionalContent items if present
         if (additionalContent) {
             for (const item of additionalContent) {
@@ -223,6 +231,7 @@ export class AgenticChatTriggerContext {
                         userIntent: triggerContext.userIntent,
                         origin: 'IDE',
                         modelId,
+                        images: imageContext,
                     },
                 },
                 customizationArn,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -142,12 +142,27 @@ export class ContextCommandsProvider implements Disposable {
             description: 'Add a saved prompt to context',
             icon: 'magic',
         }
+
+        const imageCmdGroup: ContextCommand = {
+            command: 'image',
+            description: 'Add a image to context',
+            icon: 'image',
+            placeholder: 'Select an image file',
+        }
         const workspaceCmd = {
             command: '@workspace',
             id: '@workspace',
             description: 'Reference all code in workspace',
         }
-        const commands = [workspaceCmd, activeFileCmd, folderCmdGroup, fileCmdGroup, codeCmdGroup, promptCmdGroup]
+        const commands = [
+            workspaceCmd,
+            activeFileCmd,
+            folderCmdGroup,
+            fileCmdGroup,
+            codeCmdGroup,
+            promptCmdGroup,
+            imageCmdGroup,
+        ]
         const allCommands: ContextCommandGroup[] = [
             {
                 commands: commands,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -123,6 +123,11 @@ export const QAgenticChatServer =
             return chatController.onChatPrompt(params, token)
         })
 
+        chat.onOpenFileDialog((params, token) => {
+            logging.log("Open File System")
+            return chatController.onOpenFileDialog(params, token)
+        })
+
         chat.onInlineChatPrompt((...params) => {
             logging.log('Received inline chat prompt')
             return chatController.onInlineChatPrompt(...params)

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -18,6 +18,8 @@ import {
     McpServerClickParams,
     McpServerClickResult,
     RequestHandler,
+    OpenFileDialogParams,
+    OpenFileDialogResult,
 } from '@aws/language-server-runtimes/protocol'
 import {
     CancellationToken,
@@ -596,5 +598,53 @@ export class ChatController implements ChatHandlers {
 
     #log(...messages: string[]) {
         this.#features.logging.log(messages.join(' '))
+    }
+
+    async onOpenFileDialog(params: OpenFileDialogParams, token: CancellationToken): Promise<OpenFileDialogResult> {
+        if (params.fileType === 'image') {
+            try {
+                const fileTypes = ['jpg', 'jpeg', 'png', 'gif', 'svg', 'webp']
+                const filters = { 'Image Files': fileTypes.map(ext => `*.${ext}`) }
+
+                const result = await this.#features.lsp.window.showOpenDialog({
+                    canSelectFiles: true,
+                    canSelectFolders: false,
+                    canSelectMany: false,
+                    filters,
+                })
+
+                if (result.uris && result.uris.length > 0) {
+                    return {
+                        tabId: params.tabId,
+                        filePaths: result.uris,
+                        fileType: params.fileType,
+                        insertPosition: params.insertPosition,
+                    }
+                } else {
+                    return {
+                        tabId: params.tabId,
+                        filePaths: [],
+                        fileType: params.fileType,
+                        insertPosition: params.insertPosition,
+                    }
+                }
+            } catch (error) {
+                this.#log('Error opening file dialog:', error instanceof Error ? error.message : String(error))
+                return {
+                    tabId: params.tabId,
+                    filePaths: [],
+                    errorMessage: 'Failed to open file dialog',
+                    fileType: params.fileType,
+                    insertPosition: params.insertPosition,
+                }
+            }
+        }
+        return {
+            tabId: params.tabId,
+            filePaths: [],
+            errorMessage: 'File type not supported',
+            fileType: params.fileType,
+            insertPosition: params.insertPosition,
+        }
     }
 }


### PR DESCRIPTION
## Problem
Enable adding images as context
## Solution

1. Adding images from file dialog flow:
 * onOpenFileDialog(Chat client outbound) -> OpenFileDialog (Language-severs-runtime) -> language server -> lsp.window.showOpenDialog -> extension's API
 * extension API -> language server -> OpenFileDialogResult (Language-severs-runtime) -> updatePrompt (Chat client inbound)
 2. Adding images from drag & drop
3. Verification and error messages:
    *  Size restriction: “Image must be no more than 3.75MB in size.”
    *  Width restriction: “Image must be no more than 8,000px in width.”
    *  Height restriction: “Image must be no more than 8,000px in height.”
    *  File type restriction: “File must be an image in JPEG, PNG, GIF, or WebP format.”
    *  File count restriction: “A maximum of 20 images can be added to a single message.”

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
