### PR TITLE
fix(amazonq): removed explanation field for mcp servers

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -117,24 +117,11 @@ export const McpToolsServer: Server = ({ credentialsProvider, workspace, logging
             )
             const tool = new McpTool({ logging, workspace, lsp }, def)
 
-            // Add explanation field to input schema
-            const inputSchemaWithExplanation = {
-                ...def.inputSchema,
-                properties: {
-                    ...def.inputSchema.properties,
-                    explanation: {
-                        type: 'string',
-                        description:
-                            'One sentence explanation as to why this tool is being used, and how it contributes to the goal.',
-                    },
-                },
-            }
-
             agent.addTool(
                 {
                     name: namespaced,
                     description: def.description?.trim() || 'undefined',
-                    inputSchema: inputSchemaWithExplanation,
+                    inputSchema: def.inputSchema,
                 },
                 input => tool.invoke(input)
             )


### PR DESCRIPTION
## Problem

Explanation field is causing failure for users running remote mcp using `npx`, as this field is getting blocked since it was an additonal field added by us.

## Solution
- Removed explanation field from tool input schema.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
