### PR TITLE
fix: undefined path causing the loop to break

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1363,30 +1363,33 @@ export class AgenticChatController implements ChatHandlers {
                 if ((toolUse.name === 'fsWrite' || toolUse.name === 'fsReplace') && toolUse.toolUseId) {
                     const existingCard = chatResultStream.getMessageBlockId(toolUse.toolUseId)
                     const fsParam = toolUse.input as unknown as FsWriteParams | FsReplaceParams
-                    const fileName = path.basename(fsParam.path)
-                    const errorResult = {
-                        type: 'tool',
-                        messageId: toolUse.toolUseId,
-                        header: {
-                            fileList: {
-                                filePaths: [fileName],
-                                details: {
-                                    [fileName]: {
-                                        description: fsParam.path,
+                    if (fsParam.path) {
+                        const fileName = path.basename(fsParam.path)
+                        const errorResult = {
+                            type: 'tool',
+                            messageId: toolUse.toolUseId,
+                            header: {
+                                fileList: {
+                                    filePaths: [fileName],
+                                    details: {
+                                        [fileName]: {
+                                            description: fsParam.path,
+                                        },
                                     },
                                 },
+                                status: {
+                                    status: 'error',
+                                    icon: 'error',
+                                    text: 'Error',
+                                },
                             },
-                            status: {
-                                status: 'error',
-                                icon: 'error',
-                                text: 'Error',
-                            },
-                        },
-                    } as ChatResult
-                    if (existingCard) {
-                        await chatResultStream.overwriteResultBlock(errorResult, existingCard)
-                    } else {
-                        await chatResultStream.writeResultBlock(errorResult)
+                        } as ChatResult
+
+                        if (existingCard) {
+                            await chatResultStream.overwriteResultBlock(errorResult, existingCard)
+                        } else {
+                            await chatResultStream.writeResultBlock(errorResult)
+                        }
                     }
                 } else if (toolUse.name === 'executeBash' && toolUse.toolUseId) {
                     const existingCard = chatResultStream.getMessageBlockId(toolUse.toolUseId)


### PR DESCRIPTION
## Problem
- When path from toolUseInput is undefined, the loop breaks and we see this error

```
{
  "code": "ERR_INVALID_ARG_TYPE",
  "name": "TypeError",
  "message": "The \"path\" argument must be of type string. Received undefined"
}
```

## Solution
- Handle the undefined case to allow LLM to recover

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
