### PR TITLE
fix: ide mapping for VS/Eclipse for send telemetry API

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/telemetryUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetryUtils.test.ts
@@ -180,8 +180,8 @@ describe('makeUserContextObject', () => {
         const clientNames = [
             'AmazonQ-For-VSCode',
             'Amazon Q For JetBrains',
-            'AmazonQ-For-Eclipse',
-            'AWS-Toolkit-For-VisualStudio',
+            'Amazon Q For Eclipse',
+            'AWS Toolkit For VisualStudio',
         ]
 
         clientNames.forEach(clientName => {

--- a/server/aws-lsp-codewhisperer/src/shared/telemetryUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetryUtils.test.ts
@@ -196,10 +196,10 @@ describe('makeUserContextObject', () => {
                 case 'Amazon Q For JetBrains':
                     assert.strictEqual(result?.ideCategory, 'JETBRAINS')
                     break
-                case 'AmazonQ-For-Eclipse':
+                case 'Amazon Q For Eclipse':
                     assert.strictEqual(result?.ideCategory, 'ECLIPSE')
                     break
-                case 'AWS-Toolkit-For-VisualStudio':
+                case 'AWS Toolkit For VisualStudio':
                     assert.strictEqual(result?.ideCategory, 'VISUAL_STUDIO')
                     break
                 default:

--- a/server/aws-lsp-codewhisperer/src/shared/telemetryUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetryUtils.ts
@@ -50,8 +50,8 @@ const IDE_CATEGORY_MAP: { [key: string]: IdeCategory } = {
     // TODO: VSCode key needs to change for getting the correct coefficient value for inline
     'AmazonQ-For-VSCode': 'VSCODE',
     'Amazon Q For JetBrains': 'JETBRAINS',
-    'AmazonQ-For-Eclipse': 'ECLIPSE',
-    'AWS-Toolkit-For-VisualStudio': 'VISUAL_STUDIO',
+    'Amazon Q For Eclipse': 'ECLIPSE',
+    'AWS Toolkit For VisualStudio': 'VISUAL_STUDIO',
 }
 
 const mapClientNameToIdeCategory = (clientName: string): string | undefined => {


### PR DESCRIPTION
## Problem
IDE mapping for STE API is incorrect based on what Visual Studio and Eclipse sends. [Visual Studio'](https://github.com/aws/aws-toolkit-common/blob/a0f5c9f5e5a99294d41a87662e68bf69400be4f5/telemetry/service/service-model.json#L47)s and[ Eclipse](https://github.com/aws/amazon-q-eclipse/blob/3f9a056fc813caa6c0e74cb0a2dc2aae514f6100/plugin/codegen-resources/service-2.json#L66) is defined in the telemetry module which does not match the values used in the mapping.
## Solution
This change fixes it to match expected values sent by the clients.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
