### PR TITLE
fix: fsReplace should not be available in pair-programmer off mode

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -3319,7 +3319,7 @@ export class AgenticChatController implements ChatHandlers {
         )
 
         McpManager.instance.setToolNameMapping(tempMapping)
-        const writeToolNames = new Set(['fsWrite', 'executeBash'])
+        const writeToolNames = new Set(['fsWrite', 'executeBash', 'fsReplace'])
         const restrictedToolNames = new Set([...mcpToolSpecNames, ...writeToolNames])
 
         const readOnlyTools = allTools.filter(tool => {


### PR DESCRIPTION
## Problem
Agentic mode off was also writing to files
## Solution
fsReplace should also be considered a write tool and should not be available in pair-programmer off mode
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
