### PR TITLE
fix: fsReplace still available when agentic mode off

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -3327,7 +3327,7 @@ export class AgenticChatController implements ChatHandlers {
         )
 
         McpManager.instance.setToolNameMapping(tempMapping)
-        const writeToolNames = new Set(['fsWrite', 'executeBash'])
+        const writeToolNames = new Set(['fsWrite', 'fsReplace', 'executeBash'])
         const restrictedToolNames = new Set([...mcpToolSpecNames, ...writeToolNames])
 
         const readOnlyTools = allTools.filter(tool => {


### PR DESCRIPTION
## Problem
fsReplace tool is still available when agentic mode off. Which is not expected.
## Solution
Add fsReplace to writeTool Set

https://github.com/user-attachments/assets/6744385e-ee31-40da-b0aa-3cd442c5de4a


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
