### PR TITLE
fix: intermediate file card does not have border

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1135,7 +1135,7 @@ export const createMynahUi = (
             buttons: processedButtons,
             fileList,
             // file diffs in the header need space
-            fullWidth: message.type === 'tool' && message.header?.buttons ? true : undefined,
+            fullWidth: message.type === 'tool' && includeHeader ? true : undefined,
             padding,
             contentHorizontalAlignment,
             wrapCodes: message.type === 'tool',


### PR DESCRIPTION
## Problem

Intermediate file cards are not rendered correctly with a border because `fullWidth` is not set correctly.

## Solution

Before:
<img width="566" alt="image" src="https://github.com/user-attachments/assets/5bf2a658-3a97-4821-920e-ea7af60249e2" />


After:
<img width="570" alt="image" src="https://github.com/user-attachments/assets/f0f24287-7215-497f-898e-24b6df1d2870" />



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
