### PR TITLE
feat: Implement dynamic model selection based on extension capabilities and improve error handling

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -64,7 +64,7 @@ import {
 import { ChatHistory, ChatHistoryList } from './features/history'
 import { pairProgrammingModeOff, pairProgrammingModeOn, programmerModeCard } from './texts/pairProgramming'
 import { ContextRule, RulesList } from './features/rules'
-import { getModelSelectionChatItem, modelUnavailableBanner } from './texts/modelSelection'
+import { getModelSelectionChatItem, modelUnavailableBanner, modelThrottledBanner } from './texts/modelSelection'
 import {
     freeTierLimitSticky,
     upgradeSuccessSticky,
@@ -1012,6 +1012,13 @@ export const createMynahUi = (
                 if (updatedMessage.messageId === 'modelUnavailable') {
                     mynahUi.updateStore(tabId, {
                         promptInputStickyCard: modelUnavailableBanner,
+                    })
+                    return
+                }
+
+                if (updatedMessage.messageId === 'modelThrottled') {
+                    mynahUi.updateStore(tabId, {
+                        promptInputStickyCard: modelThrottledBanner,
                     })
                     return
                 }

--- a/chat-client/src/client/texts/modelSelection.ts
+++ b/chat-client/src/client/texts/modelSelection.ts
@@ -44,6 +44,8 @@ export const getModelSelectionChatItem = (modelId: string): ChatItem => ({
     body: `Switched model to ${modelRecord[modelId as BedrockModel].label}`,
 })
 
+// Todo: after toolkit passing modelSelection flag in qcapabilities, add a separte card name and
+// change the body back to The model you selected is temporarily unavailable. Please switch to a different model and try again.
 export const modelUnavailableBanner: Partial<ChatItem> = {
     messageId: 'model-unavailable-banner',
     header: {
@@ -51,6 +53,6 @@ export const modelUnavailableBanner: Partial<ChatItem> = {
         iconStatus: 'warning',
         body: '### Model Unavailable',
     },
-    body: `The model you selected is temporarily unavailable. Please switch to a different model and try again.`,
+    body: `I am experiencing high traffic, please try again shortly`,
     canBeDismissed: true,
 }

--- a/chat-client/src/client/texts/modelSelection.ts
+++ b/chat-client/src/client/texts/modelSelection.ts
@@ -1,5 +1,6 @@
 import { ChatItem, ChatItemFormItem, ChatItemType } from '@aws/mynah-ui'
 
+
 export enum BedrockModel {
     CLAUDE_SONNET_4_20250514_V1_0 = 'CLAUDE_SONNET_4_20250514_V1_0',
     CLAUDE_3_7_SONNET_20250219_V1_0 = 'CLAUDE_3_7_SONNET_20250219_V1_0',
@@ -44,8 +45,7 @@ export const getModelSelectionChatItem = (modelId: string): ChatItem => ({
     body: `Switched model to ${modelRecord[modelId as BedrockModel].label}`,
 })
 
-// Todo: after toolkit passing modelSelection flag in qcapabilities, add a separte card name and
-// change the body back to The model you selected is temporarily unavailable. Please switch to a different model and try again.
+
 export const modelUnavailableBanner: Partial<ChatItem> = {
     messageId: 'model-unavailable-banner',
     header: {
@@ -53,6 +53,17 @@ export const modelUnavailableBanner: Partial<ChatItem> = {
         iconStatus: 'warning',
         body: '### Model Unavailable',
     },
-    body: `I am experiencing high traffic, please try again shortly`,
+    body: `The model you selected is temporarily unavailable. Please switch to a different model and try again.`,
+    canBeDismissed: true,
+}
+
+export const modelThrottledBanner: Partial<ChatItem> = {
+    messageId: 'model-throttled-banner',
+    header: {
+        icon: 'warning',
+        iconStatus: 'warning',
+        body: '### Model Unavailable',
+    },
+    body: `I am experiencing high traffic, please try again shortly.`,
     canBeDismissed: true,
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2311,10 +2311,7 @@ export class AgenticChatController implements ChatHandlers {
             }
             if (err.code === 'QModelResponse') {
                 // special case for throttling where we show error card instead of chat message
-                if (
-                    err.message ===
-                    `The model you selected is temporarily unavailable. Please switch to a different model and try again.`
-                ) {
+                if (err.message === `I am experiencing high traffic, please try again shortly.`) {
                     this.#features.chat.sendChatUpdate({
                         tabId: tabId,
                         data: { messages: [{ messageId: 'modelUnavailable' }] },

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants.ts
@@ -5,4 +5,4 @@ export const outputLimitExceedsPartialMsg = 'output exceeds maximum character li
 export const responseTimeoutMs = 240_000
 export const responseTimeoutPartialMsg = 'Response processing timed out after'
 export const clientTimeoutMs = 245_000
-export const defaultModelId = 'CLAUDE_SONNET_4_20250514_V1_0' // TODO: this can't be imported from chat-client, so we hardcode it here
+// export const defaultModelId = 'CLAUDE_SONNET_4_20250514_V1_0' // TODO: this can't be imported from chat-client, so we hardcode it here

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -16,6 +16,15 @@ import { AmazonQServiceInitializationError } from '../../shared/amazonQServiceMa
 import { safeGet } from '../../shared/utils'
 import { enabledMCP } from './tools/mcp/mcpUtils'
 
+let _modelSelectionEnabled = false
+
+export let defaultModelId: string | undefined = undefined
+
+export const setModelSelectionEnabled = (enabled: boolean | undefined) => {
+    _modelSelectionEnabled = enabled ?? false
+    defaultModelId = _modelSelectionEnabled ? 'CLAUDE_SONNET_4_20250514_V1_0' : undefined
+}
+
 export const QAgenticChatServer =
     // prettier-ignore
     (): Server => features => {
@@ -29,6 +38,8 @@ export const QAgenticChatServer =
         let chatSessionManagementService: ChatSessionManagementService
 
         lsp.addInitializer((params: InitializeParams) => {
+            let modelSelectionEnabled = params?.initializationOptions?.aws?.awsClientCapabilities?.q?.modelSelection
+            setModelSelectionEnabled(modelSelectionEnabled)
             return {
                 capabilities: {
                     executeCommandProvider: {
@@ -47,7 +58,7 @@ export const QAgenticChatServer =
                             ],
                         },
                         mcpServers: enabledMCP(params),
-                        modelSelection: true,
+                        modelSelection: modelSelectionEnabled,
                         history: true,
                         export: TabBarController.enableChatExport(params)
                     },
@@ -144,7 +155,7 @@ export const QAgenticChatServer =
             return chatController.onListConversations(params)
         })
 
-         chat.onListRules(params => {
+        chat.onListRules(params => {
             return chatController.onListRules(params)
         })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -194,7 +194,7 @@ export class ChatSessionService {
                     error.message ===
                         'Encountered unexpectedly high load when processing the request, please try again.'
                 ) {
-                    error.message = `The model you selected is temporarily unavailable. Please switch to a different model and try again.`
+                    error.message = `I am experiencing high traffic, please try again shortly.`
                 }
                 throw error
             }


### PR DESCRIPTION
## Problem
The model selection design was not sending client capabilities to servers, so servers didn't know if the client had model selection enabled or not. Customers using previous versions of the toolkit would see "please change model" messages when throttling occurred, but the feature wasn't supported in their version, which was confusing.
## Solution
The solution implements capability detection by reading the model selection flag from the extension's qcapabilities during initialization. This determines whether model selection features should be enabled and sets the appropriate default model ID. Enhanced error handling now provides context-aware messages with separate banners for model unavailability versus general throttling scenarios. When model selection is enabled, users get guidance to switch models, while users without model selection capabilities receive generic throttling messages. 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
