### PR TITLE
fix: temporarily disable bad unit tests

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.test.ts
@@ -174,7 +174,7 @@ describe('StreamingClientService', () => {
             expect(streamingClientService['inflightRequests'].size).to.eq(0)
         })
 
-        it('aborts in flight generate assistant response requests with explicit abort controller', async () => {
+        it.skip('aborts in flight generate assistant response requests with explicit abort controller', async () => {
             const abort = sinon.stub()
             const signal = sinon.createStubInstance(AbortSignal)
 


### PR DESCRIPTION
## Problem
- Github CI takes 35min

## Solution
- This test has a resource leak, cause unhandled Promise rejection due to the usage of `AbortSignal`, temporarily disable it.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
