### PR TITLE
fix(amazonq): save one unnecessary listWorkspaceMetadata call

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
@@ -138,16 +138,6 @@ export class WorkspaceFolderManager {
     }
 
     async processNewWorkspaceFolders(folders: WorkspaceFolder[]) {
-        // Check if user is opted in before trying to process any files
-        const { optOut } = await this.listWorkspaceMetadata()
-        if (optOut) {
-            this.logging.log('User is opted out, clearing resources and starting opt-out monitor')
-            this.isOptedOut = true
-            await this.clearAllWorkspaceResources()
-            await this.startOptOutMonitor()
-            return
-        }
-
         // Wait for remote workspace id
         await this.waitForRemoteWorkspaceId()
 


### PR DESCRIPTION
## Problem

While auditing the API usage for the recent goal to reduce the call volume to backend `ListWorkspaceMetadata` API, we noticed that there is one unnecessary `listWorkspaceMetadata` call within `processNewWorkspaceFolders()`, whose original purpose is to detect user server-side opt-out behavior and has been covered by `listWorkspaceMetadata` invocation within `checkRemoteWorkspaceStatusAndReact()`.

We should delegate the user server-side opt-out detection to the same place (`continuousMonitorInterval`) and avoid this unnecessary call.

## Solution

Avoid calling `listWorkspaceMetadata` within `processNewWorkspaceFolders()`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
