### PR TITLE
fix: adding files on windows properly triggers reindexing

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
@@ -80,7 +80,7 @@ export const LocalProjectContextServer =
 
         lsp.workspace.onDidCreateFiles(async event => {
             try {
-                const filePaths = event.files.map(file => URI.parse(file.uri).fsPath)
+                const filePaths = event.files.map(file => URI.file(file.uri).fsPath)
                 await localProjectContextController.updateIndexAndContextCommand(filePaths, true)
             } catch (error) {
                 logging.error(`Error handling create event: ${error}`)
@@ -89,7 +89,7 @@ export const LocalProjectContextServer =
 
         lsp.workspace.onDidDeleteFiles(async event => {
             try {
-                const filePaths = event.files.map(file => URI.parse(file.uri).fsPath)
+                const filePaths = event.files.map(file => URI.file(file.uri).fsPath)
                 await localProjectContextController.updateIndexAndContextCommand(filePaths, false)
             } catch (error) {
                 logging.error(`Error handling delete event: ${error}`)
@@ -98,8 +98,8 @@ export const LocalProjectContextServer =
 
         lsp.workspace.onDidRenameFiles(async event => {
             try {
-                const oldPaths = event.files.map(file => URI.parse(file.oldUri).fsPath)
-                const newPaths = event.files.map(file => URI.parse(file.newUri).fsPath)
+                const oldPaths = event.files.map(file => URI.file(file.oldUri).fsPath)
+                const newPaths = event.files.map(file => URI.file(file.newUri).fsPath)
 
                 await localProjectContextController.updateIndexAndContextCommand(oldPaths, false)
                 await localProjectContextController.updateIndexAndContextCommand(newPaths, true)
@@ -110,7 +110,7 @@ export const LocalProjectContextServer =
 
         lsp.onDidSaveTextDocument(async event => {
             try {
-                const filePaths = [URI.parse(event.textDocument.uri).fsPath]
+                const filePaths = [URI.file(event.textDocument.uri).fsPath]
                 await localProjectContextController.updateIndex(filePaths, 'update')
             } catch (error) {
                 logging.error(`Error handling save event: ${error}`)


### PR DESCRIPTION
## Problem
- When adding, deleting, or renaming a file on Windows, it does not properly retrigger indexing and therefore, the context list is not updated accordingly. This means that a user won't be able to reference `@fileName` after creating a file in the IDE (i.e. File -> New File). 

## Solution
- Use `URI.file()` instead of `URI.parse()` as `URI.file()` preserves the Windows drive letter 
    - On Mac
        - URI.parse(): `/Users/chungjac/repos/tempFolder/abc.py`
        -  URI.file(): `/Users/chungjac/repos/tempFolder/abc.py`
    - On Windows         
        - URI.parse(): `\\Users\\chungjac\\repos\\tempFolder\\abc.py`
        -  URI.file(): `c:\\Users\\chungjac\\repos\\tempFolder\\abc.py `
-  Now on windows, a user will be able to reference `@fileName` after creating a file in the IDE (i.e. File -> New File)

## Note
- Separate known issue:
    - When a file in workspace is added or removed outside the IDE (i.e. creating or deleting a file in Finder), the LSP does not know about it so no reindexing takes place








<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
