### PR TITLE
fix: move ignore walk from app/package.json to server/package.json

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -29,8 +29,7 @@
         "stream-http": "^3.2.0",
         "vscode-languageserver": "^9.0.1",
         "wdio": "^6.0.1",
-        "webpack-dev-server": "^5.2.0",
-        "ignore-walk": "^7.0.0"
+        "webpack-dev-server": "^5.2.0"
     },
     "devDependencies": {
         "@wdio/cli": "^9.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,6 @@
                 "cross-spawn": "^7.0.6",
                 "crypto-browserify": "^3.12.1",
                 "https-browserify": "^1.0.0",
-                "ignore-walk": "^7.0.0",
                 "os-browserify": "^0.3.0",
                 "path-browserify": "^1.0.1",
                 "process": "^0.11.10",
@@ -16799,6 +16798,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-7.0.0.tgz",
             "integrity": "sha512-T4gbf83A4NH95zvhVYZc+qWocBBGlpzUXLPGurJggw/WIOwicfXJChLDP/iBZnN5WqROSu5Bm3hhle4z8a8YGQ==",
+            "dev": true,
             "dependencies": {
                 "minimatch": "^9.0.0"
             },
@@ -27363,6 +27363,7 @@
                 "assert": "^2.1.0",
                 "c8": "^10.1.2",
                 "copyfiles": "^2.4.1",
+                "ignore-walk": "^7.0.0",
                 "mock-fs": "^5.2.0",
                 "sinon": "^19.0.2",
                 "ts-loader": "^9.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
             "devDependencies": {
                 "@commitlint/cli": "^19.8.0",
                 "@commitlint/config-conventional": "^19.8.0",
+                "@types/ignore-walk": "^4.0.3",
                 "@types/node": "^22.9.0",
                 "@typescript-eslint/eslint-plugin": "^8.32.1",
                 "@typescript-eslint/parser": "^8.32.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "devDependencies": {
         "@commitlint/cli": "^19.8.0",
         "@commitlint/config-conventional": "^19.8.0",
+        "@types/ignore-walk": "^4.0.3",
         "@types/node": "^22.9.0",
         "@typescript-eslint/eslint-plugin": "^8.32.1",
         "@typescript-eslint/parser": "^8.32.1",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -72,6 +72,7 @@
         "@types/archiver": "^6.0.2",
         "@types/diff": "^7.0.2",
         "@types/ignore-walk": "^4.0.3",
+        "ignore-walk": "^7.0.0",
         "@types/local-indexing": "file:./types/types-local-indexing-1.1.0.tgz",
         "@types/lokijs": "^1.5.14",
         "@types/uuid": "^9.0.8",


### PR DESCRIPTION
## Problem

The internal build failed because package.json and package-lock.json is not in sync. 

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
