### PR TITLE
fix(amazonq): remove the unnecessary new line after the chat shell co…

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -557,7 +557,10 @@ export class ExecuteBash {
 
     private static handleChunk(chunk: string, buffer: string[], writer?: WritableStreamDefaultWriter<any>) {
         try {
-            void writer?.write(chunk)
+            // Trim trailing newlines from the chunk before writing
+            const trimmedChunk = chunk.replace(/\r?\n$/, '')
+            void writer?.write(trimmedChunk)
+
             const lines = chunk.split(/\r?\n/)
             for (const line of lines) {
                 buffer.push(line)


### PR DESCRIPTION
## Problem
Currently Q was outputting an unnecessary newline after the command line output when a command ran and gave an output. 

## Solution
Removed the default newline at the end of command line outputs if any. 
From:
![image](https://github.com/user-attachments/assets/68633d8b-21a9-4875-863c-66b4a1ad605d)

To:
![image](https://github.com/user-attachments/assets/922f870d-2fd8-479e-858c-9bbe76b96a45)


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
