### PR TITLE
fix(amazonq): add jitter for websocket client re-connections

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/client.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/client.ts
@@ -82,7 +82,9 @@ export class WebSocketClient {
         // Apply exponential backoff for both unclean closures and failed reconnection attempts
         if (this.reconnectAttempts < this.maxReconnectAttempts) {
             this.reconnectAttempts++
-            const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 30000)
+            const baseDelay = Math.min(1000 * Math.pow(2, this.reconnectAttempts), 30000)
+            const jitter = Math.random() * 5000 // jitter of 0 ~ 5000 milliseconds
+            const delay = baseDelay + jitter
             this.logging.log(
                 `WebSocket will attempt reconnection ${this.reconnectAttempts}/${this.maxReconnectAttempts} in ${delay}s`
             )


### PR DESCRIPTION
## Problem

We need to prevent the thundering herd problem when there is a network issue or backend issue causing a large amount of WebSocket clients disconnected.

## Solution

Introduce randomness into the timing of retries to avoid simultaneous requests to re-establish WebSocket connection.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
