### PR TITLE
fix(amazonq): nep trigger detection should use file uri but filename is used

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/editPredictionAutoTrigger.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/editPredictionAutoTrigger.ts
@@ -50,7 +50,7 @@ export const editPredictionAutoTrigger = ({
     // 1. Check required conditions
     // 1.1 Recent Edit Detection [NEEDED]
     const hasRecentEdit = recentEdits?.hasRecentEditInLine(
-        fileContext.filename,
+        fileContext.fileUri,
         lineNum,
         config.recentEditThresholdMs,
         config.editAdjacentLineRange

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/tracker/codeEditTracker.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/tracker/codeEditTracker.ts
@@ -536,11 +536,15 @@ export class RecentEditTracker implements Disposable {
     }
 
     public hasRecentEditInLine(
-        documentUri: string,
+        documentUri: string | undefined,
         lineNum: number,
         timeThresholdMs: number = 20000,
         lineRange: number = 5
     ): boolean {
+        if (!documentUri) {
+            return false
+        }
+
         // Check if we have snapshots for this document
         const snapshots = this.snapshots.get(documentUri)
         if (!snapshots || snapshots.length === 0) {


### PR DESCRIPTION
## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
