### PR TITLE
fix(amazonq): init mcp servers in batch of 5

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -794,48 +794,35 @@ describe('concurrent server initialization', () => {
         } catch {}
     })
 
-    it('initializes multiple servers concurrently', async () => {
-        // Create multiple server configs
-        const cfg1: MCPServerConfig = {
-            command: 'server1',
-            args: [],
-            env: {},
-            timeout: 0,
-            __configPath__: 'config1.json',
-        }
-
-        const cfg2: MCPServerConfig = {
-            command: 'server2',
-            args: [],
-            env: {},
-            timeout: 0,
-            __configPath__: 'config2.json',
-        }
-
-        const cfg3: MCPServerConfig = {
-            command: 'server3',
-            args: [],
-            env: {},
-            timeout: 0,
-            __configPath__: 'config3.json',
+    it('initializes multiple servers concurrently with a limit of 5', async () => {
+        // Create 7 server configs to test batching (more than the MAX_CONCURRENT_SERVERS of 5)
+        const serverConfigs: Record<string, MCPServerConfig> = {}
+        for (let i = 1; i <= 7; i++) {
+            serverConfigs[`server${i}`] = {
+                command: `server${i}`,
+                args: [],
+                env: {},
+                timeout: 0,
+                __configPath__: `config${i}.json`,
+            }
         }
 
         // Set up the loadMcpServerConfigs stub to return multiple servers
+        const serversMap = new Map(Object.entries(serverConfigs))
         loadStub = sinon.stub(mcpUtils, 'loadMcpServerConfigs').resolves({
-            servers: new Map([
-                ['server1', cfg1],
-                ['server2', cfg2],
-                ['server3', cfg3],
-            ]),
+            servers: serversMap,
             serverNameMapping: new Map(),
             errors: new Map(),
         })
 
         // Create a controlled stub for initOneServer that resolves after a delay
-        // This helps verify that servers are initialized concurrently
-        const initPromises: Promise<void>[] = []
+        // This helps verify that servers are initialized in batches
         const initStartTimes: Record<string, number> = {}
         const initEndTimes: Record<string, number> = {}
+        const batchAssignments: Record<string, number> = {} // Track which batch each server is in
+
+        // Spy on the debug logging to capture batch information
+        const debugSpy = sinon.spy(fakeLogging, 'debug')
 
         initOneServerStub = sinon
             .stub(McpManager.prototype as any, 'initOneServer' as keyof McpManager)
@@ -844,7 +831,7 @@ describe('concurrent server initialization', () => {
                 initStartTimes[serverName] = Date.now()
 
                 // Create a promise that resolves after a short delay
-                const promise = new Promise<void>(resolve => {
+                return new Promise<void>(resolve => {
                     setTimeout(() => {
                         // Set up the server state as the original method would
                         this.clients.set(serverName, new Client({ name: `mcp-client-${serverName}`, version: '1.0.0' }))
@@ -860,51 +847,72 @@ describe('concurrent server initialization', () => {
                         resolve()
                     }, 50) // Small delay to simulate async initialization
                 })
-
-                initPromises.push(promise)
-                return promise
             })
 
         // Initialize the McpManager
-        const mgr = await McpManager.init(['config1.json', 'config2.json', 'config3.json'], [], features)
+        const mgr = await McpManager.init(['config1.json'], [], features)
 
-        // Verify that Promise.all was called with an array of promises
+        // Verify that Promise.all was called at least twice (once for each batch)
         expect(promiseAllSpy.called).to.be.true
-
-        // At least one of the calls to Promise.all should have our 3 initialization promises
-        let foundInitCall = false
-        for (const call of promiseAllSpy.getCalls()) {
-            const args = call.args[0]
-            if (Array.isArray(args) && args.length === 3) {
-                foundInitCall = true
-                break
-            }
-        }
-        expect(foundInitCall).to.be.true
+        expect(promiseAllSpy.callCount).to.be.at.least(2) // At least 2 batches for 7 servers with max 5 per batch
 
         // Verify that initOneServer was called for each server
-        expect(initOneServerStub.callCount).to.equal(3)
-        expect(initOneServerStub.calledWith('server1', cfg1)).to.be.true
-        expect(initOneServerStub.calledWith('server2', cfg2)).to.be.true
-        expect(initOneServerStub.calledWith('server3', cfg3)).to.be.true
+        expect(initOneServerStub.callCount).to.equal(7)
+        for (let i = 1; i <= 7; i++) {
+            expect(initOneServerStub.calledWith(`server${i}`, serverConfigs[`server${i}`])).to.be.true
+        }
 
         // Verify that all servers were initialized
         const serverStates = mgr.getAllServerStates()
-        expect(serverStates.get('server1')?.status).to.equal('ENABLED')
-        expect(serverStates.get('server2')?.status).to.equal('ENABLED')
-        expect(serverStates.get('server3')?.status).to.equal('ENABLED')
+        for (let i = 1; i <= 7; i++) {
+            expect(serverStates.get(`server${i}`)?.status).to.equal('ENABLED')
+        }
 
-        // Verify that all servers were initialized concurrently
-        // This is done by checking that the initialization of the second and third servers
-        // started before the first one completed
-        const server1Start = initStartTimes['server1']
-        const server2Start = initStartTimes['server2']
-        const server3Start = initStartTimes['server3']
-        const server1End = initEndTimes['server1']
+        // Verify that debug logging shows batch processing
+        expect(debugSpy.called).to.be.true
 
-        // All servers should have started initialization before any of them completed
-        expect(server2Start).to.be.lessThan(server1End)
-        expect(server3Start).to.be.lessThan(server1End)
+        // Instead of checking individual calls, convert the entire debug log to a string
+        // This avoids TypeScript errors with array access
+        let debugLogString = ''
+
+        // Safely collect all debug messages into a single string
+        debugSpy.getCalls().forEach(call => {
+            try {
+                if (call && call.args) {
+                    // Convert all arguments to string and concatenate
+                    for (let i = 0; i < call.args.length; i++) {
+                        debugLogString += String(call.args[i] || '') + ' '
+                    }
+                }
+            } catch (e) {
+                // Ignore any errors during string conversion
+            }
+        })
+
+        // Now check if the combined log contains our expected phrases
+        const batchLogFound =
+            debugLogString.indexOf('initializing batch of') >= 0 && debugLogString.indexOf('of 7') >= 0
+        expect(batchLogFound).to.be.true
+
+        // Verify that Promise.all was called with the correct batch sizes
+        let firstBatchFound = false
+        let secondBatchFound = false
+
+        for (const call of promiseAllSpy.getCalls()) {
+            if (call.args && call.args.length > 0) {
+                const args = call.args[0]
+                if (Array.isArray(args)) {
+                    if (args.length === 5) {
+                        firstBatchFound = true
+                    } else if (args.length === 2) {
+                        secondBatchFound = true
+                    }
+                }
+            }
+        }
+
+        expect(firstBatchFound).to.be.true // First batch should have 5 servers
+        expect(secondBatchFound).to.be.true // Second batch should have 2 servers
     })
 })
 


### PR DESCRIPTION
## Problem
- Init all MCP servers in parallel could slow down plugin initialization if there are high number of MCPs as Promise.all() itself doesn't have a built-in limit
## Solution
-  Process servers init in batches of 5 at a time

## Test/Demo
- before

https://github.com/user-attachments/assets/df3dc75a-ccda-418c-b0f9-f15f596548d5

- after

https://github.com/user-attachments/assets/2fdb9fde-1119-4f48-93ca-5b5ea2067cf3




<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
