### PR TITLE
fix(amazonq): fix to include explanation field in mcp tools schema

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1172,6 +1172,19 @@ export class AgenticChatController implements ChatHandlers {
                     default:
                         // Get original server and tool names from the mapping
                         const originalNames = McpManager.instance.getOriginalToolNames(toolUse.name)
+
+                        // Remove explanation field from toolUse.input for MCP tools
+                        // many MCP servers do not support explanation field and it will break the tool if this is altered
+                        if (
+                            originalNames &&
+                            toolUse.input &&
+                            typeof toolUse.input === 'object' &&
+                            'explanation' in toolUse.input
+                        ) {
+                            const { explanation, ...inputWithoutExplanation } = toolUse.input as any
+                            toolUse.input = inputWithoutExplanation
+                        }
+
                         if (originalNames) {
                             const { serverName, toolName } = originalNames
                             const def = McpManager.instance

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -117,11 +117,24 @@ export const McpToolsServer: Server = ({ credentialsProvider, workspace, logging
             )
             const tool = new McpTool({ logging, workspace, lsp }, def)
 
+            // Add explanation field to input schema
+            const inputSchemaWithExplanation = {
+                ...def.inputSchema,
+                properties: {
+                    ...def.inputSchema.properties,
+                    explanation: {
+                        type: 'string',
+                        description:
+                            'One sentence explanation as to why this tool is being used, and how it contributes to the goal.',
+                    },
+                },
+            }
+
             agent.addTool(
                 {
                     name: namespaced,
                     description: def.description?.trim() || 'undefined',
-                    inputSchema: def.inputSchema,
+                    inputSchema: inputSchemaWithExplanation,
                 },
                 input => tool.invoke(input)
             )


### PR DESCRIPTION
## Problem
Many MCP servers do not allow custom fields in tool schema like `explanation` which we use to add a directive message for tool executions. The  mcp tools are breaking and initialization is failing due to this.

## Solution
- Added explanation back to tool schema.
- removed it right before user facing messages with parameters and tool execution.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
