### PR TITLE
fix(amazonq): fix to add upper limit validation for tool description

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -120,7 +120,7 @@ export const McpToolsServer: Server = ({ credentialsProvider, workspace, logging
             agent.addTool(
                 {
                     name: namespaced,
-                    description: def.description?.trim() || 'undefined',
+                    description: (def.description?.trim() || 'undefined').substring(0, 10240),
                     inputSchema: def.inputSchema,
                 },
                 input => tool.invoke(input)


### PR DESCRIPTION
## Problem
Service validation fails for descriptions crossing 10240 characters. This causes chat wise failures if we add an MCP tools with longer description than limit.

## Solution
- Added upper limit validation for tool description in initialization.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
