### PR TITLE
fix(amazonq): fix the order of publishing the chat stop ack message

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -146,7 +146,32 @@ export const handleChatPrompt = (
     agenticMode?: boolean
 ) => {
     let userPrompt = prompt.escapedPrompt
-    messager.onStopChatResponse(tabId)
+
+    // Check if there's an ongoing request
+    const isLoading = mynahUi.getTabData(tabId)?.getStore()?.loadingChat
+
+    if (isLoading) {
+        // Stop the current response
+        messager.onStopChatResponse(tabId)
+
+        // Add cancellation message BEFORE showing the new prompt
+        mynahUi.addChatItem(tabId, {
+            type: ChatItemType.DIRECTIVE,
+            messageId: 'stopped' + Date.now(),
+            body: 'You stopped your current work, please provide additional examples or ask another question.',
+        })
+
+        // Reset loading state
+        mynahUi.updateStore(tabId, {
+            loadingChat: false,
+            cancelButtonWhenLoading: true,
+            promptInputDisabledState: false,
+        })
+    } else {
+        // If no ongoing request, just send the stop signal
+        messager.onStopChatResponse(tabId)
+    }
+
     if (prompt.command) {
         // Temporary solution to handle clear quick actions on the client side
         if (prompt.command === '/clear') {
@@ -564,6 +589,20 @@ export const createMynahUi = (
         },
         onStopChatResponse: tabId => {
             messager.onStopChatResponse(tabId)
+
+            // Add cancellation message when stop button is clicked
+            mynahUi.addChatItem(tabId, {
+                type: ChatItemType.DIRECTIVE,
+                messageId: 'stopped' + Date.now(),
+                body: 'You stopped your current work, please provide additional examples or ask another question.',
+            })
+
+            // Reset loading state
+            mynahUi.updateStore(tabId, {
+                loadingChat: false,
+                cancelButtonWhenLoading: true,
+                promptInputDisabledState: false,
+            })
         },
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -554,11 +554,6 @@ export class AgenticChatController implements ChatHandlers {
                 // Then update UI to inform the user
                 await this.#showUndoAllIfRequired(chatResultStream, session)
                 await chatResultStream.updateOngoingProgressResult('Canceled')
-                await this.#getChatResultStream(params.partialResultToken).writeResultBlock({
-                    type: 'directive',
-                    messageId: 'stopped' + uuid(),
-                    body: 'You stopped your current work, please provide additional examples or ask another question.',
-                })
 
                 // Finally, send telemetry/metrics
                 this.#telemetryController.emitInteractWithAgenticChat(


### PR DESCRIPTION
## Problem
We were printing the chat processing stopped acknowledging message in the wrong order where it was coming after the new message. 

## Solution
We moved the message publication to the mynah.ts file so that we can handle it at source and hence we dont publish it after the message is published.

![image](https://github.com/user-attachments/assets/c1d47c89-6159-43ce-90cd-d3cd7d40b483)
![image](https://github.com/user-attachments/assets/1eea379b-1d1d-44a8-8d19-c36c780f3e39)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
