### PR TITLE
fix: add workspace folder to the relativePath

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -34,6 +34,7 @@ import { languageByExtension } from '../../../shared/languageDetection'
 import { AgenticChatResultStream } from '../agenticChatResultStream'
 import { ContextInfo, mergeFileLists, mergeRelevantTextDocuments } from './contextUtils'
 import { WorkspaceFolderManager } from '../../workspaceContext/workspaceFolderManager'
+import { getRelativePathWithWorkspaceFolder } from '../../workspaceContext/util'
 
 export interface TriggerContext extends Partial<DocumentContext> {
     userIntent?: UserIntent
@@ -172,11 +173,14 @@ export class AgenticChatTriggerContext {
                           : item.type === 'code'
                             ? ContentType.CODE
                             : undefined
+                const workspaceFolder = this.#workspace.getWorkspaceFolder(URI.file(item.path).toString())
                 // Create the relevant text document
                 const relevantTextDocument: RelevantTextDocumentAddition = {
                     text: item.innerContext,
                     path: item.path,
-                    relativeFilePath: item.relativePath,
+                    relativeFilePath: workspaceFolder
+                        ? getRelativePathWithWorkspaceFolder(workspaceFolder, item.path)
+                        : item.relativePath,
                     programmingLanguage: programmingLanguage,
                     type: filteredType,
                     startLine: item.startLine ?? -1,

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentContext.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentContext.test.ts
@@ -32,9 +32,14 @@ describe('DocumentContext', () => {
                 workspace: mockWorkspace,
                 characterLimits: 19,
             })
+
+            let relativeFilePath = 'workspace/test.ts'
+            if (process.platform === 'win32') {
+                relativeFilePath = 'workspace\\test.ts'
+            }
             const expected: DocumentContext = {
                 programmingLanguage: { languageName: 'typescript' },
-                relativeFilePath: 'test.ts',
+                relativeFilePath: relativeFilePath,
                 text: "console.log('test')",
                 hasCodeSnippet: true,
                 totalEditorCharacters: mockTypescriptCodeBlock.length,
@@ -75,9 +80,13 @@ describe('DocumentContext', () => {
                 workspace: mockWorkspace,
                 characterLimits: 19,
             })
+            let relativeFilePath = 'workspace/test.ts'
+            if (process.platform === 'win32') {
+                relativeFilePath = 'workspace\\test.ts'
+            }
             const expected: DocumentContext = {
                 programmingLanguage: { languageName: 'typescript' },
-                relativeFilePath: 'test.ts',
+                relativeFilePath: relativeFilePath,
                 text: "console.log('test')",
                 hasCodeSnippet: true,
                 totalEditorCharacters: mockTypescriptCodeBlock.length,
@@ -123,9 +132,14 @@ describe('DocumentContext', () => {
         const testGoFilePath = 'file://mock/workspace/test.go'
         const mockDocument = TextDocument.create(testGoFilePath, 'go', 1, mockGoCodeBLock)
 
+        let relativeFilePath = 'workspace/test.go'
+        if (process.platform === 'win32') {
+            relativeFilePath = 'workspace\\test.go'
+        }
+
         const expectedResult: DocumentContext = {
             programmingLanguage: { languageName: 'go' },
-            relativeFilePath: 'test.go',
+            relativeFilePath: relativeFilePath,
             text: 'fmt.Println("test")',
             totalEditorCharacters: mockGoCodeBLock.length,
             hasCodeSnippet: true,

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/documentContext.ts
@@ -4,8 +4,7 @@ import { Range, TextDocument } from 'vscode-languageserver-textdocument'
 import { getLanguageId } from '../../../shared/languageDetection'
 import { Features } from '../../types'
 import { getExtendedCodeBlockRange, getSelectionWithinExtendedRange } from './utils'
-import path = require('path')
-import { URI } from 'vscode-uri'
+import { getRelativePathWithUri, getRelativePathWithWorkspaceFolder } from '../../workspaceContext/util'
 
 export type DocumentContext = CwsprTextDocument & {
     cursorState?: EditorState['cursorState']
@@ -52,7 +51,12 @@ export class DocumentContextExtractor {
 
         const workspaceFolder = this.#workspace?.getWorkspaceFolder?.(document.uri)
 
-        const relativePath = this.getRelativePath(document)
+        let relativePath
+        if (workspaceFolder) {
+            relativePath = getRelativePathWithWorkspaceFolder(workspaceFolder, document.uri)
+        } else {
+            relativePath = getRelativePathWithUri(document.uri, workspaceFolder)
+        }
 
         const languageId = getLanguageId(document)
 
@@ -65,14 +69,5 @@ export class DocumentContextExtractor {
             totalEditorCharacters: document.getText().length,
             workspaceFolder,
         }
-    }
-
-    private getRelativePath(document: TextDocument): string {
-        const documentUri = URI.parse(document.uri)
-        const workspaceFolder = this.#workspace?.getWorkspaceFolder?.(document.uri)
-        const workspaceUri = workspaceFolder?.uri
-        const workspaceRoot = workspaceUri ? URI.parse(workspaceUri).fsPath : process.cwd()
-        const absolutePath = documentUri.fsPath
-        return path.relative(workspaceRoot, absolutePath)
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/util.ts
@@ -80,3 +80,20 @@ export const getRelativePath = (workspaceFolder: WorkspaceFolder, filePath: stri
     const fileUri = URI.parse(filePath)
     return path.relative(workspaceUri.path, fileUri.path)
 }
+
+export const getRelativePathWithUri = (uri: string, workspaceFolder?: WorkspaceFolder | null): string => {
+    const documentUri = URI.parse(uri)
+    const workspaceUri = workspaceFolder?.uri
+    const workspaceRoot = workspaceUri ? URI.parse(workspaceUri).fsPath : process.cwd()
+    const absolutePath = documentUri.fsPath
+    return path.relative(workspaceRoot, absolutePath)
+}
+
+// Include workspace folder name to disambiguate files when there are multiple workspace folders
+export const getRelativePathWithWorkspaceFolder = (workspaceFolder: WorkspaceFolder, filePath: string): string => {
+    const workspaceUri = URI.parse(workspaceFolder.uri)
+    const fileUri = URI.parse(filePath)
+    const relativePath = path.relative(workspaceUri.path, fileUri.path)
+    const workspaceFolderName = path.basename(workspaceUri.path)
+    return path.join(workspaceFolderName, relativePath)
+}


### PR DESCRIPTION
## Problem
- When there are multiple workspace folders, the model needs to guess which folder is the relativePath for

## Solution
- add workspace folder to the relativePath so that model knows the correct full path without guessing

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
