### PR TITLE
fix(amazonq): updated the stopping message to a better string for new…

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -158,7 +158,7 @@ export const handleChatPrompt = (
         mynahUi.addChatItem(tabId, {
             type: ChatItemType.DIRECTIVE,
             messageId: 'stopped' + Date.now(),
-            body: 'Earlier request was cancelled. Processing your new request below instead.',
+            body: 'You stopped your current work and asked me to work on the following task instead.',
         })
 
         // Reset loading state

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -158,7 +158,7 @@ export const handleChatPrompt = (
         mynahUi.addChatItem(tabId, {
             type: ChatItemType.DIRECTIVE,
             messageId: 'stopped' + Date.now(),
-            body: 'You stopped your current work, please provide additional examples or ask another question.',
+            body: 'Earlier request was cancelled. Processing your new request below instead.',
         })
 
         // Reset loading state


### PR DESCRIPTION
## Problem
We were currently posting the same string for both when we stop a query
1. through stop button
2. through a new chat

This gives wrong customer experience.

## Solution
Update the message for the new chat case.

![image](https://github.com/user-attachments/assets/9148db23-0269-48d1-8bea-b040c0545cf5)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
