### PR TITLE
fix(amazonq): return empty if nep auto trigger is not triggered

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -484,6 +484,10 @@ export const CodewhispererServerFactory =
                                 ...(editPredictionAutoTriggerResult.shouldTrigger && editsEnabled ? [['EDITS']] : []),
                             ]
 
+                            if (predictionTypes.length === 0) {
+                                return EMPTY_RESULT
+                            }
+
                             // Step 1: Recent Edits context
                             const supplementalContextItemsForEdits =
                                 supplementalContextFromEdits?.supplementalContextItems || []


### PR DESCRIPTION
## Problem
empty prediction type will case 4xx error

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
