### PR TITLE
fix(amazonq): make workspace context server upload dependency chunks sequentially

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyEventBundler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyEventBundler.ts
@@ -21,9 +21,9 @@ export class DependencyEventBundler {
     }
 
     /**
-     * Start the bundler process
-     * Bundler process will process all the events in the queue every 500ms
-     * and concatenate all the paths within the same language and workspaceFolder
+     * Starts the dependency event bundler that processes the eventQueue every 500ms.
+     * Skips execution if previous work hasn't finished to prevent concurrent processing.
+     * Groups events by language and workspaceFolder, then processes them as batches.
      */
     public startDependencyEventBundler() {
         this.eventBundlerInterval = setInterval(async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/JSTSDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/JSTSDependencyHandler.ts
@@ -2,7 +2,6 @@ import { BaseDependencyInfo, Dependency, LanguageDependencyHandler } from './Lan
 import * as path from 'path'
 import * as fs from 'fs'
 import { WorkspaceFolder } from '@aws/language-server-runtimes/server-interface'
-import { FileMetadata } from '../../artifactManager'
 import { DependencyWatcher } from './DependencyWatcher'
 
 interface JSTSDependencyInfo extends BaseDependencyInfo {
@@ -185,12 +184,11 @@ export class JSTSDependencyHandler extends LanguageDependencyHandler<JSTSDepende
                 const callBackDependencyUpdate = async (events: string[]) => {
                     this.logging.log(`Change detected in ${packageJsonPath}`)
                     const updatedDependencyMap = this.generateDependencyMap(jstsDependencyInfo)
-                    let zips: FileMetadata[] = await this.compareAndUpdateDependencyMap(
+                    await this.compareAndUpdateDependencyMap(
                         jstsDependencyInfo.workspaceFolder,
                         updatedDependencyMap,
                         true
                     )
-                    this.emitDependencyChange(jstsDependencyInfo.workspaceFolder, zips)
                 }
                 const watcher = new DependencyWatcher(
                     packageJsonPath,

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/JavaDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/JavaDependencyHandler.ts
@@ -2,7 +2,6 @@ import { BaseDependencyInfo, Dependency, LanguageDependencyHandler } from './Lan
 import * as path from 'path'
 import * as fs from 'fs'
 import * as xml2js from 'xml2js'
-import { FileMetadata } from '../../artifactManager'
 import { WorkspaceFolder } from '@aws/language-server-runtimes/server-interface'
 import { DependencyWatcher } from './DependencyWatcher'
 
@@ -93,12 +92,11 @@ export class JavaDependencyHandler extends LanguageDependencyHandler<JavaDepende
                 const callBackDependencyUpdate = async (events: string[]) => {
                     this.logging.log(`Change detected in ${dotClasspathPath}`)
                     const updatedDependencyMap = this.generateDependencyMap(javaDependencyInfo)
-                    let zips: FileMetadata[] = await this.compareAndUpdateDependencyMap(
+                    await this.compareAndUpdateDependencyMap(
                         javaDependencyInfo.workspaceFolder,
                         updatedDependencyMap,
                         true
                     )
-                    this.emitDependencyChange(javaDependencyInfo.workspaceFolder, zips)
                 }
                 const watcher = new DependencyWatcher(
                     dotClasspathPath,

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/PythonDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/PythonDependencyHandler.ts
@@ -2,7 +2,6 @@ import { BaseDependencyInfo, Dependency, LanguageDependencyHandler } from './Lan
 import { WorkspaceFolder } from '@aws/language-server-runtimes/server-interface'
 import * as path from 'path'
 import * as fs from 'fs'
-import { FileMetadata } from '../../artifactManager'
 import { resolveSymlink, isDirectory } from '../../util'
 import { DependencyWatcher } from './DependencyWatcher'
 
@@ -123,12 +122,11 @@ export class PythonDependencyHandler extends LanguageDependencyHandler<PythonDep
                                 this.handlePackageChange(sitePackagesPath, fileName, updatedDependencyMap)
                             }
                         }
-                        let zips: FileMetadata[] = await this.compareAndUpdateDependencyMap(
+                        await this.compareAndUpdateDependencyMap(
                             pythonDependencyInfo.workspaceFolder,
                             updatedDependencyMap,
                             true
                         )
-                        this.emitDependencyChange(pythonDependencyInfo.workspaceFolder, zips)
                     } // end of callback function
 
                     const watcher = new DependencyWatcher(


### PR DESCRIPTION
## Problem

The current workspace context server dependency upload logic has two key performance issues:
1. **Memory inefficiency**: During dependency discovery, all chunked zip files are collected into a single array before upload, causing them to remain in memory simultaneously (up to 8GB before compression) and preventing individual garbage collection.
2. **Upload concurrency spikes**: While compression is sequential, uploads run concurrently across workspace folders and languages, creating traffic spikes to the backend.

## Solution

Refactor from EventEmitter to callback-based approach in LanguageDependencyHandler:
1. **Immediate processing**: Process individual zip files via callback instead of batching, enabling immediate garbage collection after each upload.
2. **Sequential uploads:** Make the callback return a promise that's awaited before generating the next zip, eliminating upload concurrency issues.

This approach reduces memory footprint as well as provides smoother, more predictable backend traffic patterns.

### Testing

Tested the change on a local machine successfully:
<img width="1394" alt="image" src="https://github.com/user-attachments/assets/991f45e9-2311-463f-b36a-dbfb0573fa18" />

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
