### PR TITLE
feat: make origin a configurable parameter and pass it to downstream …

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -66,6 +66,7 @@ import {
 import { McpManager } from './tools/mcp/mcpManager'
 import { AgenticChatResultStream } from './agenticChatResultStream'
 import { AgenticChatError } from './errors'
+import * as sharedUtils from '../../shared/utils'
 
 describe('AgenticChatController', () => {
     let mcpInstanceStub: sinon.SinonStub
@@ -2626,7 +2627,6 @@ ${' '.repeat(8)}}
             // Create chat session management service with IAM service manager
             iamChatSessionManagementService = ChatSessionManagementService.getInstance()
             iamChatSessionManagementService.withAmazonQServiceManager(iamServiceManager)
-
             // Create controller with IAM service manager
             iamChatController = new AgenticChatController(
                 iamChatSessionManagementService,
@@ -2688,6 +2688,32 @@ ${' '.repeat(8)}}
             sinon.assert.called(sendMessageStub)
             const request = sendMessageStub.firstCall.args[0]
             assert.strictEqual(request.source, 'IDE')
+        })
+
+        it('sets source to origin from client info when using IAM service manager', async () => {
+            // Stub getOriginFromClientInfo to return a specific value
+            const getOriginFromClientInfoStub = sinon
+                .stub(sharedUtils, 'getOriginFromClientInfo')
+                .returns('MD_IDE' as any)
+            // Create a session
+            iamChatController.onTabAdd({ tabId: mockTabId })
+
+            // Reset the sendMessage stub to track new calls
+            sendMessageStub.resetHistory()
+
+            // Make a chat request
+            await iamChatController.onChatPrompt(
+                { tabId: mockTabId, prompt: { prompt: 'Hello' } },
+                mockCancellationToken
+            )
+            // Verify getOriginFromClientInfo was called
+            sinon.assert.calledOnce(getOriginFromClientInfoStub)
+            // Verify sendMessage was called with source set to IDE
+            sinon.assert.called(sendMessageStub)
+            const request = sendMessageStub.firstCall.args[0]
+            assert.strictEqual(request.source, 'MD_IDE')
+            // Restore the stub
+            getOriginFromClientInfoStub.restore()
         })
 
         it('does not call onManageSubscription with IAM service manager', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -7,6 +7,7 @@ import * as crypto from 'crypto'
 import * as path from 'path'
 import {
     ChatTriggerType,
+    Origin,
     ToolResult,
     ToolResultContentBlock,
     ToolResultStatus,
@@ -95,6 +96,7 @@ import {
     isUsageLimitError,
     isNullish,
     enabledModelSelection,
+    getOriginFromClientInfo,
 } from '../../shared/utils'
 import { HELP_MESSAGE, loadingMessage } from '../chat/constants'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
@@ -215,6 +217,7 @@ export class AgenticChatController implements ChatHandlers {
     #toolUseLatencies: Array<{ toolName: string; toolUseId: string; latency: number }> = []
     #mcpEventHandler: McpEventHandler
     #paidTierMode: PaidTierMode | undefined
+    #origin: Origin
 
     // latency metrics
     #llmRequestStartTime: number = 0
@@ -268,6 +271,7 @@ export class AgenticChatController implements ChatHandlers {
             this.#features.lsp
         )
         this.#mcpEventHandler = new McpEventHandler(features, telemetryService)
+        this.#origin = getOriginFromClientInfo(this.#features.lsp.getClientInitializeParams()?.clientInfo?.name)
     }
 
     async onExecuteCommand(params: ExecuteCommandParams, _token: CancellationToken): Promise<any> {
@@ -675,7 +679,8 @@ export class AgenticChatController implements ChatHandlers {
             [],
             this.#getTools(session),
             additionalContext,
-            session.modelId
+            session.modelId,
+            this.#origin
         )
         return requestInput
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -12,6 +12,7 @@ import {
     ContentType,
     ProgrammingLanguage,
     EnvState,
+    Origin,
 } from '@aws/codewhisperer-streaming-client'
 import {
     BedrockTools,
@@ -124,7 +125,8 @@ export class AgenticChatTriggerContext {
         history: ChatMessage[] = [],
         tools: BedrockTools = [],
         additionalContent?: AdditionalContentEntryAddition[],
-        modelId?: string
+        modelId?: string,
+        origin?: Origin
     ): Promise<ChatCommandInput> {
         const { prompt } = params
         const workspaceFolders = workspaceUtils.getWorkspaceFolderPaths(this.#workspace).slice(0, maxWorkspaceFolders)
@@ -239,7 +241,7 @@ export class AgenticChatTriggerContext {
                                       envState: this.#mapPlatformToEnvState(process.platform),
                                   },
                         userIntent: triggerContext.userIntent,
-                        origin: 'IDE',
+                        origin: origin ? origin : 'IDE',
                         modelId,
                     },
                 },

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.test.ts
@@ -6,6 +6,8 @@ import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/A
 import { StreamingClientServiceToken, StreamingClientServiceIAM } from '../../shared/streamingClientService'
 import { AmazonQBaseServiceManager } from '../../shared/amazonQServiceManager/BaseAmazonQServiceManager'
 import { AmazonQIAMServiceManager } from '../../shared/amazonQServiceManager/AmazonQIAMServiceManager'
+import * as sharedUtils from '../../shared/utils'
+import { Utils } from 'vscode-uri'
 
 describe('Chat Session Service', () => {
     let abortStub: sinon.SinonStub<any, any>
@@ -351,6 +353,47 @@ describe('Chat Session Service', () => {
             sinon.assert.calledOnce(codeWhispererStreamingClientIAM.sendMessage)
             const actualRequest = codeWhispererStreamingClientIAM.sendMessage.firstCall.args[0]
             assert.strictEqual(actualRequest.source, 'IDE')
+        })
+
+        it('calls getOriginFromClientInfo and uses returned origin in SendMessage request', async () => {
+            // Stub getOriginFromClientInfo to return a specific value
+            const getOriginFromClientInfoStub = sinon
+                .stub(sharedUtils, 'getOriginFromClientInfo')
+                .returns('MD_IDE' as any)
+
+            const codeWhispererStreamingClientIAM = stubInterface<StreamingClientServiceIAM>()
+            codeWhispererStreamingClientIAM.sendMessage.callsFake(() => Promise.resolve(mockRequestResponse))
+
+            const amazonQServiceManagerIAM = stubInterface<AmazonQIAMServiceManager>()
+            amazonQServiceManagerIAM.getStreamingClient.returns(codeWhispererStreamingClientIAM)
+
+            // Set prototype to make instanceof check work
+            Object.setPrototypeOf(codeWhispererStreamingClientIAM, StreamingClientServiceIAM.prototype)
+            Object.setPrototypeOf(amazonQServiceManagerIAM, AmazonQIAMServiceManager.prototype)
+
+            const chatSessionServiceIAM = new ChatSessionService(amazonQServiceManagerIAM)
+
+            // Create a request without source property
+            const request = {
+                conversationState: {
+                    chatTriggerType: ChatTriggerType.MANUAL,
+                    currentMessage: { userInputMessage: { content: 'test' } },
+                },
+            }
+
+            // Call getChatResponse
+            await chatSessionServiceIAM.getChatResponse(request)
+
+            // Verify getOriginFromClientInfo was called
+            sinon.assert.calledOnce(getOriginFromClientInfoStub)
+
+            // Verify that sendMessage was called with source set to the value from getOriginFromClientInfo
+            sinon.assert.calledOnce(codeWhispererStreamingClientIAM.sendMessage)
+            const actualRequest = codeWhispererStreamingClientIAM.sendMessage.firstCall.args[0]
+            assert.strictEqual(actualRequest.source, 'MD_IDE')
+
+            // Restore the stub
+            getOriginFromClientInfoStub.restore()
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -3,6 +3,7 @@ import {
     CodeWhispererStreamingServiceException,
     GenerateAssistantResponseCommandInput,
     GenerateAssistantResponseCommandOutput,
+    Origin,
     SendMessageCommand,
     ToolUse,
 } from '@aws/codewhisperer-streaming-client'
@@ -26,7 +27,7 @@ import { AmazonQBaseServiceManager } from '../../shared/amazonQServiceManager/Ba
 import { loggingUtils } from '@aws/lsp-core'
 import { Logging } from '@aws/language-server-runtimes/server-interface'
 import { Features } from '../types'
-import { getRequestID, isUsageLimitError } from '../../shared/utils'
+import { getOriginFromClientInfo, getRequestID, isUsageLimitError } from '../../shared/utils'
 import { enabledModelSelection } from '../../shared/utils'
 
 export type ChatSessionServiceConfig = CodeWhispererStreamingClientConfig
@@ -56,6 +57,7 @@ export class ChatSessionService {
     #approvedPaths: Set<string> = new Set<string>()
     #serviceManager?: AmazonQBaseServiceManager
     #logging?: Logging
+    #origin?: Origin
 
     public getConversationType(): string {
         return this.#conversationType
@@ -132,6 +134,7 @@ export class ChatSessionService {
         this.#serviceManager = serviceManager
         this.#lsp = lsp
         this.#logging = logging
+        this.#origin = getOriginFromClientInfo(this.#lsp?.getClientInitializeParams()?.clientInfo?.name)
     }
 
     public async sendMessage(request: SendMessageCommandInput): Promise<SendMessageCommandOutput> {
@@ -228,7 +231,9 @@ export class ChatSessionService {
         } else if (client instanceof StreamingClientServiceIAM) {
             try {
                 // @ts-ignore
-                request.source = 'IDE'
+                // SendMessageStreaming checks for origin from request source
+                // https://code.amazon.com/packages/AWSVectorConsolasRuntimeService/blobs/ac917609a28dbcb6757a8427bcc585a42fd15bf2/--/src/com/amazon/aws/vector/consolas/runtimeservice/activity/SendMessageStreamingActivity.java#L246
+                request.source = this.#origin ? this.#origin : 'IDE'
                 return await client.sendMessage(request, this.#abortController)
             } catch (e) {
                 // Log the error using the logging property if available, otherwise fall back to console.error

--- a/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
@@ -24,6 +24,7 @@ import {
     safeGet,
     getFileExtensionName,
     listFilesWithGitignore,
+    getOriginFromClientInfo,
 } from './utils'
 import { promises as fsPromises } from 'fs'
 
@@ -68,6 +69,28 @@ describe('getBearerTokenFromProvider', () => {
             Error,
             'credentialsProvider does not have bearer token credentials'
         )
+    })
+})
+
+describe('getOriginFromClientInfo', () => {
+    it('returns MD_IDE for SMUS client name', () => {
+        const result = getOriginFromClientInfo('AmazonQ-For-SMUS-IDE-1.0.0')
+        assert.strictEqual(result, 'MD_IDE')
+    })
+
+    it('returns IDE for non-SMUS client name', () => {
+        const result = getOriginFromClientInfo('VSCode-Extension')
+        assert.strictEqual(result, 'IDE')
+    })
+
+    it('returns IDE for undefined client name', () => {
+        const result = getOriginFromClientInfo(undefined)
+        assert.strictEqual(result, 'IDE')
+    })
+
+    it('returns IDE for empty string client name', () => {
+        const result = getOriginFromClientInfo('')
+        assert.strictEqual(result, 'IDE')
     })
 })
 

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -17,6 +17,7 @@ import {
 } from './constants'
 import {
     CodeWhispererStreamingServiceException,
+    Origin,
     ServiceQuotaExceededException,
     ThrottlingException,
     ThrottlingExceptionReason,
@@ -382,6 +383,13 @@ export function getIAMCredentialsFromProvider(credentialsProvider: CredentialsPr
         secretAccessKey: credentials.secretAccessKey,
         sessionToken: credentials.sessionToken,
     }
+}
+
+export function getOriginFromClientInfo(clientName: string | undefined): Origin {
+    if (clientName?.startsWith('AmazonQ-For-SMUS-IDE')) {
+        return 'MD_IDE'
+    }
+    return 'IDE'
 }
 
 export function isUsingIAMAuth(): boolean {


### PR DESCRIPTION
…calls

## Problem
Today, the origin passed to Q is hardcoded as IDE.  

## Solution
This PR makes this configurable through the client info passed during initialization and defaults ro IDE.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
