### PR TITLE
fix: include toolSpec count for history trimming

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -617,8 +617,12 @@ export class ChatDatabase {
         const currentUserInputCharacterCount = this.calculateMessagesCharacterCount([
             chatMessageToMessage(newUserMessage),
         ])
-        this.#features.logging.debug(`Current user message characters: ${currentUserInputCharacterCount}`)
-        const maxHistoryCharacterSize = Math.max(0, MaxOverallCharacters - currentUserInputCharacterCount)
+        const currentInputToolSpecCount = this.calculateToolSpecCharacterCount(newUserMessage)
+        const currentUserInputCount = currentUserInputCharacterCount + currentInputToolSpecCount
+        this.#features.logging.debug(
+            `Current user message characters input: ${currentUserInputCharacterCount} + toolSpec: ${currentInputToolSpecCount}`
+        )
+        const maxHistoryCharacterSize = Math.max(0, MaxOverallCharacters - currentUserInputCount)
         this.#features.logging.debug(`Current remaining character budget: ${maxHistoryCharacterSize}`)
         while (totalCharacters > maxHistoryCharacterSize && messages.length > 2) {
             // Find the next valid user message to start from
@@ -638,6 +642,20 @@ export class ChatDatabase {
             this.#features.logging.debug(`Current history characters: ${totalCharacters}`)
         }
         return messages
+    }
+
+    private calculateToolSpecCharacterCount(currentMessage: ChatMessage): number {
+        let count = 0
+        if (currentMessage.userInputMessage?.userInputMessageContext?.tools) {
+            try {
+                for (const tool of currentMessage.userInputMessage?.userInputMessageContext?.tools) {
+                    count += JSON.stringify(tool).length
+                }
+            } catch (e) {
+                this.#features.logging.error(`Error counting tools: ${String(e)}`)
+            }
+        }
+        return count
     }
 
     private calculateMessagesCharacterCount(allMessages: Message[]): number {


### PR DESCRIPTION
## Problem
- ToolSpec is not included in the character count when we decide to trim the history. With MCP, the toolSpec can be large and cause Input to exceed context window

## Solution
- Include toolSpec character count for history trimming

```
2025-06-26 16:12:17.211 [info] [2025-06-26T23:12:17.206Z] Current history characters: 435
2025-06-26 16:12:17.212 [info] [2025-06-26T23:12:17.206Z] Current user message characters input: 98 + toolSpec: 5082
2025-06-26 16:12:17.213 [info] [2025-06-26T23:12:17.206Z] Current remaining character budget: 564820
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
