### PR TITLE
fix: pull client info from initialization options and not top level

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -271,7 +271,9 @@ export class AgenticChatController implements ChatHandlers {
             this.#features.lsp
         )
         this.#mcpEventHandler = new McpEventHandler(features, telemetryService)
-        this.#origin = getOriginFromClientInfo(this.#features.lsp.getClientInitializeParams()?.clientInfo?.name)
+        this.#origin = getOriginFromClientInfo(
+            this.#features.lsp.getClientInitializeParams()?.initializationOptions?.aws?.clientInfo?.extension?.name
+        )
     }
 
     async onExecuteCommand(params: ExecuteCommandParams, _token: CancellationToken): Promise<any> {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -134,7 +134,9 @@ export class ChatSessionService {
         this.#serviceManager = serviceManager
         this.#lsp = lsp
         this.#logging = logging
-        this.#origin = getOriginFromClientInfo(this.#lsp?.getClientInitializeParams()?.clientInfo?.name)
+        this.#origin = getOriginFromClientInfo(
+            this.#lsp?.getClientInitializeParams()?.initializationOptions?.aws?.clientInfo?.extension?.name
+        )
     }
 
     public async sendMessage(request: SendMessageCommandInput): Promise<SendMessageCommandOutput> {


### PR DESCRIPTION
## Problem
In previous PR pulled client info from top level parameter: https://github.com/aws/language-servers/commit/a1c33d1d7e2bbea693a6d8a9885491c1815f7f62


## Solution
Fixing this to pull from initialization options and keep it consistent with VS Code toolkit: https://github.com/aws/aws-toolkit-vscode/blob/master/packages/amazonq/src/lsp/client.ts#L151

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
