### PR TITLE
fix(amazonq): prevent WCS matching workspaceFolder with only prefix

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/util.ts
@@ -21,7 +21,9 @@ export const findWorkspaceRootFolder = (
 
     const matchingFolder = sortedFolders.find(folder => {
         const parsedFolderUri = URI.parse(folder.uri)
-        return parsedFileUri.path.startsWith(parsedFolderUri.path)
+        // Paths are normalized to use forward slashes in the .path property regardless of the underlying OS
+        const folderPath = parsedFolderUri.path.endsWith('/') ? parsedFolderUri.path : parsedFolderUri.path + '/'
+        return parsedFileUri.path.startsWith(folderPath)
     })
 
     return matchingFolder


### PR DESCRIPTION
## Problem

We observed that if there is a workspace folder like `file:///someFolder` and an event for a file like `file:///someFolderAndSuffix/file.txt`, the workspace folder will be wrongly matched by the `findWorkspaceRootFolder()` function.

## Solution

Added a forward slash at the end of the `workspaceFolder` path when checking whether a file belongs to a workspace folder. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
