### PR TITLE
fix(amazonq): add files created by fsWrite tool to @Files list

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fsWrite.ts
@@ -2,6 +2,8 @@ import { CommandValidation, ExplanatoryParams, InvokeOutput, requiresPathAccepta
 import { EmptyPathError, MissingContentError, FileExistsWithSameContentError, EmptyAppendContentError } from '../errors'
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
 import { sanitize } from '@aws/lsp-core/out/util/path'
+import { LocalProjectContextController } from '../../../shared/localProjectContextController'
+import { URI } from 'vscode-uri'
 
 interface BaseParams extends ExplanatoryParams {
     path: string
@@ -99,6 +101,12 @@ export class FsWrite {
     private async handleCreate(params: CreateParams, sanitizedPath: string): Promise<void> {
         const content = params.fileText
         await this.workspace.fs.writeFile(sanitizedPath, content)
+
+        // Add created file to @Files list
+        void LocalProjectContextController.getInstance().then(controller => {
+            const filePath = URI.file(sanitizedPath).fsPath
+            return controller.updateIndexAndContextCommand([filePath], true)
+        })
     }
 
     private async handleAppend(params: AppendParams, sanitizedPath: string): Promise<void> {


### PR DESCRIPTION
## Problem
Files created by Q (using fsWrite tool) were not being added to the `@Files` context list.

## Solution
When fsWrite tool creates a file, add it to the `@Files` context list.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
