### PR TITLE
fix(amazonq): fix to add grep to read only commands

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -52,6 +52,7 @@ export const commandCategories = new Map<string, CommandCategory>([
     ['diff', CommandCategory.ReadOnly],
     ['head', CommandCategory.ReadOnly],
     ['tail', CommandCategory.ReadOnly],
+    ['grep', CommandCategory.ReadOnly],
 
     // Mutable commands
     ['chmod', CommandCategory.Mutate],


### PR DESCRIPTION
## Problem
Grep search command is not present in readonly commands prompting repeasted permission breaking user experience.

## Solution
- updated the read only commands list to include grep

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
