### PR TITLE
fix(amazonq): include tsx and jsx files in workspace context server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/languageDetection.ts
@@ -296,7 +296,7 @@ export function getCodeWhispererLanguageIdFromPath(filePath: string): Codewhispe
 
     for (const [extension, languageId] of Object.entries(languageByExtension)) {
         if (filePath.endsWith(extension)) {
-            return languageId
+            return getRuntimeLanguage(languageId)
         }
     }
 


### PR DESCRIPTION
## Problem

Data plane requests coming to RuntimeService have normalized language field (e.g. recognizing `tsx` files as `typescript`), so those files are accepted correctly in the backend.

However, workspace context server is not normalizing the language type when checking files, which makes those files being ignored:

https://github.com/aws/language-servers/blob/233c7d7c86d0be3960175a9fcbff594665581515/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts#L21

## Solution

Normalize language type when workspace context server checking whether a file should be included or not.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
