### PR TITLE
feat: add logic to merge with previous suggestions for EDITS

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/mergeRightUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/mergeRightUtils.test.ts
@@ -1,6 +1,18 @@
-import { getPrefixSuffixOverlap, truncateOverlapWithRightContext } from './mergeRightUtils'
-import { HELLO_WORLD_IN_CSHARP, HELLO_WORLD_WITH_WINDOWS_ENDING } from '../../shared/testUtils'
+import {
+    getPrefixOverlapLastIndex,
+    getPrefixSuffixOverlap,
+    mergeEditSuggestionsWithFileContext,
+    truncateOverlapWithRightContext,
+} from './mergeRightUtils'
+import {
+    HELLO_WORLD_IN_CSHARP,
+    HELLO_WORLD_WITH_WINDOWS_ENDING,
+    INCOMPLETE_HELLO_WORLD_IN_CSHARP,
+    SAMPLE_SESSION_DATA_WITH_EXTRA_LEFT_CONTENT,
+} from '../../shared/testUtils'
 import assert = require('assert')
+import { CodeWhispererSession } from './session/sessionManager'
+import { TextDocument } from '@aws/language-server-runtimes/server-interface'
 
 describe('Merge Right Utils', () => {
     const HELLO_WORLD = `Console.WriteLine("Hello World!");`
@@ -8,6 +20,15 @@ describe('Merge Right Utils', () => {
     it('get prefix suffix overlap works as expected', () => {
         const result = getPrefixSuffixOverlap('adwg31', '31ggrs')
         assert.deepEqual(result, '31')
+    })
+
+    it('get prefix prefix overlap index works as expected', () => {
+        const result1 = getPrefixOverlapLastIndex('static void', 'static')
+        assert.deepEqual(result1, 6)
+        const result2 = getPrefixOverlapLastIndex('static void', 'void')
+        assert.deepEqual(result2, 11)
+        const result3 = getPrefixOverlapLastIndex('static void', 'staic')
+        assert.deepEqual(result3, 3)
     })
 
     it('should return empty suggestion when right context equals line content ', () => {
@@ -61,5 +82,189 @@ describe('Merge Right Utils', () => {
             HELLO_WORLD_WITH_WINDOWS_ENDING.replaceAll('\r', '')
         )
         assert.deepEqual(result, '')
+    })
+})
+
+describe('mergeEditSuggestionsWithFileContext', function () {
+    const PREVIOUS_SESSION = new CodeWhispererSession(SAMPLE_SESSION_DATA_WITH_EXTRA_LEFT_CONTENT)
+    const SUGGESTION_CONTENT =
+        '--- file:///incomplete.cs\t1750894867455\n' +
+        '+++ file:///incomplete.cs\t1750894887671\n' +
+        '@@ -1,4 +1,9 @@\n' +
+        'class HelloWorld\n' +
+        '+{\n' +
+        '+        static void Main(string[] args)\n' +
+        '+    {\n' +
+        '+        Console.WriteLine(\"Hello World!\");\n' +
+        '+    }\n' +
+        '+}\n' +
+        '     \n' +
+        '}\n' +
+        '\\ No newline at end of file\n'
+
+    beforeEach(() => {
+        PREVIOUS_SESSION.suggestions = [{ content: SUGGESTION_CONTENT, itemId: 'itemId' }]
+    })
+
+    it('should return non-empty suggestion if user input matches prefix of the suggestion', () => {
+        const userEdit = '{'
+        const currentTextDocument = TextDocument.create(
+            'file:///incomplete.cs',
+            'csharp',
+            1,
+            INCOMPLETE_HELLO_WORLD_IN_CSHARP + userEdit
+        )
+        const fileContext = {
+            filename: currentTextDocument.uri,
+            programmingLanguage: { languageName: 'csharp' },
+            leftFileContent: INCOMPLETE_HELLO_WORLD_IN_CSHARP + userEdit,
+            rightFileContent: '',
+        }
+        const expectedNewDiff =
+            '@@ -1,2 +1,8 @@\n' +
+            ' class HelloWorld\n' +
+            '-' +
+            userEdit +
+            '\n' +
+            '\\ No newline at end of file\n' +
+            '+' +
+            userEdit +
+            '\n' +
+            '+        static void Main(string[] args)\n' +
+            '+    {\n' +
+            '+        Console.WriteLine("Hello World!");\n' +
+            '+    }\n' +
+            '+}\n' +
+            '+    \n' +
+            '\\ No newline at end of file\n'
+        const mergedSuggestions = mergeEditSuggestionsWithFileContext(
+            PREVIOUS_SESSION,
+            currentTextDocument,
+            fileContext
+        )
+        assert.deepEqual(mergedSuggestions.length, 1)
+        const insertText = (mergedSuggestions[0].insertText as string).split('\n').slice(2).join('\n')
+        assert.deepEqual(insertText, expectedNewDiff)
+    })
+
+    it('should return non-empty suggestion if user input contains extra white space prefix', () => {
+        const userEdit = '    {'
+        const currentTextDocument = TextDocument.create(
+            'file:///incomplete.cs',
+            'csharp',
+            1,
+            INCOMPLETE_HELLO_WORLD_IN_CSHARP + userEdit
+        )
+        const fileContext = {
+            filename: currentTextDocument.uri,
+            programmingLanguage: { languageName: 'csharp' },
+            leftFileContent: INCOMPLETE_HELLO_WORLD_IN_CSHARP + userEdit,
+            rightFileContent: '',
+        }
+        const expectedNewDiff =
+            '@@ -1,2 +1,8 @@\n' +
+            ' class HelloWorld\n' +
+            '-' +
+            userEdit +
+            '\n' +
+            '\\ No newline at end of file\n' +
+            '+' +
+            userEdit +
+            '\n' +
+            '+        static void Main(string[] args)\n' +
+            '+    {\n' +
+            '+        Console.WriteLine("Hello World!");\n' +
+            '+    }\n' +
+            '+}\n' +
+            '+    \n' +
+            '\\ No newline at end of file\n'
+        const mergedSuggestions = mergeEditSuggestionsWithFileContext(
+            PREVIOUS_SESSION,
+            currentTextDocument,
+            fileContext
+        )
+        assert.deepEqual(mergedSuggestions.length, 1)
+        const insertText = (mergedSuggestions[0].insertText as string).split('\n').slice(2).join('\n')
+        assert.deepEqual(insertText, expectedNewDiff)
+    })
+
+    it('should return empty suggestion if user input contains a deletion', () => {
+        const currentTextDocument = TextDocument.create(
+            'file:///incomplete.cs',
+            'csharp',
+            1,
+            INCOMPLETE_HELLO_WORLD_IN_CSHARP.substring(0, -3)
+        )
+        const fileContext = {
+            filename: currentTextDocument.uri,
+            programmingLanguage: { languageName: 'csharp' },
+            leftFileContent: INCOMPLETE_HELLO_WORLD_IN_CSHARP.substring(0, -3),
+            rightFileContent: '',
+        }
+        const mergedSuggestions = mergeEditSuggestionsWithFileContext(
+            PREVIOUS_SESSION,
+            currentTextDocument,
+            fileContext
+        )
+        assert.deepEqual(mergedSuggestions.length, 0)
+    })
+
+    it('should return empty suggestion if user input contains a line break', () => {
+        const userEdit = '\n'
+        const currentTextDocument = TextDocument.create(
+            'file:///incomplete.cs',
+            'csharp',
+            1,
+            INCOMPLETE_HELLO_WORLD_IN_CSHARP.substring(0, -3)
+        )
+        const fileContext = {
+            filename: currentTextDocument.uri,
+            programmingLanguage: { languageName: 'csharp' },
+            leftFileContent: INCOMPLETE_HELLO_WORLD_IN_CSHARP + userEdit,
+            rightFileContent: '',
+        }
+        const mergedSuggestions = mergeEditSuggestionsWithFileContext(
+            PREVIOUS_SESSION,
+            currentTextDocument,
+            fileContext
+        )
+        assert.deepEqual(mergedSuggestions.length, 0)
+    })
+
+    it('should return non-empty suggestion if user input matches a part of the suggestion', () => {
+        const userEdit = '{\n        void'
+        const currentTextDocument = TextDocument.create(
+            'file:///incomplete.cs',
+            'csharp',
+            1,
+            INCOMPLETE_HELLO_WORLD_IN_CSHARP + userEdit
+        )
+        const fileContext = {
+            filename: currentTextDocument.uri,
+            programmingLanguage: { languageName: 'csharp' },
+            leftFileContent: INCOMPLETE_HELLO_WORLD_IN_CSHARP + userEdit,
+            rightFileContent: '',
+        }
+        const expectedNewDiff =
+            '@@ -1,3 +1,8 @@\n' +
+            ' class HelloWorld\n' +
+            ' {\n' +
+            '-        void\n' +
+            '\\ No newline at end of file\n' +
+            '+        void Main(string[] args)\n' +
+            '+    {\n' +
+            '+        Console.WriteLine("Hello World!");\n' +
+            '+    }\n' +
+            '+}\n' +
+            '+    \n' +
+            '\\ No newline at end of file\n'
+        const mergedSuggestions = mergeEditSuggestionsWithFileContext(
+            PREVIOUS_SESSION,
+            currentTextDocument,
+            fileContext
+        )
+        assert.deepEqual(mergedSuggestions.length, 1)
+        const insertText = (mergedSuggestions[0].insertText as string).split('\n').slice(2).join('\n')
+        assert.deepEqual(insertText, expectedNewDiff)
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/mergeRightUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/mergeRightUtils.ts
@@ -1,3 +1,8 @@
+import { InlineCompletionItemWithReferences, TextDocument } from '@aws/language-server-runtimes/server-interface'
+import { CodeWhispererSession } from './session/sessionManager'
+import { applyUnifiedDiff, generateUnifiedDiffWithTimestamps } from './diffUtils'
+import { FileContext } from '../../shared/codeWhispererService'
+
 /**
  * Returns the longest overlap between the Suffix of firstString and Prefix of second string
  * getPrefixSuffixOverlap("adwg31", "31ggrs") = "31"
@@ -13,19 +18,115 @@ export function getPrefixSuffixOverlap(firstString: string, secondString: string
     return secondString.slice(0, i)
 }
 
-export function truncateOverlapWithRightContext(rightFileContent: string, suggestion: string): string {
+/**
+ * Returns the last index of the longest overlap between the first string and the second string
+ * @param targetString the target string
+ * @param searchString the search string
+ * @returns last index of the longest overlap between the first string and the second string
+ * @example getPrefixOverlapLastIndex("public static void", "static") = 13
+ */
+export function getPrefixOverlapLastIndex(targetString: string, searchString: string) {
+    let i = searchString.length
+    let idx = -1
+    while (i > 0) {
+        idx = targetString.indexOf(searchString.slice(0, i))
+        if (idx != -1) {
+            return idx + i
+        }
+        i--
+    }
+    return idx
+}
+
+export function truncateOverlapWithRightContext(
+    rightFileContent: string,
+    suggestion: string,
+    userEdit?: string
+): string {
     const trimmedSuggestion = suggestion.trim()
     // limit of 5000 for right context matching
     const rightContext = rightFileContent
         .substring(0, 5000)
         .replaceAll('\r\n', '\n')
         .replace(/^[^\S\n]+/, '') // remove leading tabs and whitespaces
-    const overlap = getPrefixSuffixOverlap(trimmedSuggestion, rightContext)
-    const overlapIndex = suggestion.lastIndexOf(overlap)
-    if (overlapIndex >= 0) {
-        const truncated = suggestion.slice(0, overlapIndex)
+    let prefixOverlapLastIndex = 0
+    if (userEdit) {
+        const trimmpedUserEdit = userEdit.trim()
+        prefixOverlapLastIndex = getPrefixOverlapLastIndex(trimmedSuggestion, trimmpedUserEdit)
+        if (prefixOverlapLastIndex == -1) {
+            return ''
+        }
+    }
+    const prefixSuffixOverlap = getPrefixSuffixOverlap(trimmedSuggestion, rightContext)
+    const prefixSuffixOverlapIndex = suggestion.lastIndexOf(prefixSuffixOverlap)
+    if (prefixSuffixOverlapIndex >= 0) {
+        const truncated = suggestion.slice(prefixOverlapLastIndex, prefixSuffixOverlapIndex)
         return truncated.trim().length ? truncated : ''
     } else {
         return suggestion
     }
+}
+
+/**
+ * Merge Edit suggestions with current file context.
+ * @param currentSession current session that contains previous suggestions
+ * @param currentTextDocument current text document
+ * @param currentFileContext current file context that contains the cursor position
+ * @returns InlineCompletionItemWithReferences[] with merged edit suggestions and new diff content in insertText field
+ */
+export function mergeEditSuggestionsWithFileContext(
+    currentSession: CodeWhispererSession,
+    currentTextDocument: TextDocument,
+    currentFileContext: FileContext
+): InlineCompletionItemWithReferences[] {
+    return currentSession.suggestions
+        .map(suggestion => {
+            // generate the previous suggested file content by applying previous suggestion to previous doc content
+            const previousTextDocument = currentSession.document
+            const suggestedFileContent = applyUnifiedDiff(previousTextDocument.getText(), suggestion.content)
+            const currentLeftFileContent = currentFileContext.leftFileContent
+            const currentRightFileContent = currentFileContext.rightFileContent
+            const previousLeftFileContent = currentSession.requestContext.fileContext.leftFileContent
+            const userEdit = currentLeftFileContent.substring(previousLeftFileContent.length)
+            // if the user moves the cursor backward, deletes some contents, or goes to the next line, discard the suggestion
+            if (previousLeftFileContent.length > currentLeftFileContent.length || userEdit.includes('\n')) {
+                return {
+                    insertText: '',
+                    isInlineEdit: true,
+                    itemId: suggestion.itemId,
+                }
+            }
+            // find the first overlap between the user input and the previous suggestion
+            const mergedRightContent = truncateOverlapWithRightContext(
+                currentRightFileContent,
+                suggestedFileContent,
+                userEdit
+            )
+            // if the merged right content is empty, discard the suggestion
+            if (!mergedRightContent) {
+                return {
+                    insertText: '',
+                    isInlineEdit: true,
+                    itemId: suggestion.itemId,
+                }
+            }
+            // generate new diff from the merged content
+            const newDiff = generateUnifiedDiffWithTimestamps(
+                currentTextDocument.uri,
+                currentSession.document.uri,
+                currentTextDocument.getText(),
+                currentLeftFileContent + mergedRightContent,
+                Date.now(),
+                Date.now()
+            )
+            suggestion.content = newDiff
+            currentSession.requestContext.fileContext = currentFileContext
+            currentSession.document = currentTextDocument
+            return {
+                insertText: newDiff,
+                isInlineEdit: true,
+                itemId: suggestion.itemId,
+            }
+        })
+        .filter(item => item.insertText !== '')
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
@@ -74,6 +74,7 @@ export class CodeWhispererSession {
     customizationArn?: string
     includeImportsWithSuggestions?: boolean
     codewhispererSuggestionImportCount: number = 0
+    suggestionType?: string
 
     constructor(data: SessionData) {
         this.id = this.generateSessionId()

--- a/server/aws-lsp-codewhisperer/src/shared/testUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/testUtils.ts
@@ -15,6 +15,7 @@ export const HELLO_WORLD_IN_CSHARP = `class HelloWorld
     }
 }`
 
+export const INCOMPLETE_HELLO_WORLD_IN_CSHARP = `class HelloWorld\n`
 export const SPECIAL_CHARACTER_HELLO_WORLD = `{class HelloWorld`
 
 export const HELLO_WORLD_WITH_WINDOWS_ENDING = HELLO_WORLD_IN_CSHARP.replaceAll('\n', '\r\n')
@@ -26,6 +27,12 @@ export const SOME_FILE_WITH_ALT_CASED_LANGUAGE_ID = TextDocument.create(
     'CSharp',
     1,
     HELLO_WORLD_IN_CSHARP
+)
+export const SOME_INCOMPLETE_FILE = TextDocument.create(
+    'file:///incomplete.cs',
+    'csharp',
+    1,
+    INCOMPLETE_HELLO_WORLD_IN_CSHARP
 )
 export const SOME_CLOSED_FILE = TextDocument.create('file:///closed.cs', 'csharp', 1, HELLO_WORLD_IN_CSHARP)
 export const SOME_UNSUPPORTED_FILE = TextDocument.create(
@@ -244,6 +251,25 @@ export const SAMPLE_SESSION_DATA: SessionData = {
             programmingLanguage: { languageName: 'csharp' },
             leftFileContent: '',
             rightFileContent: HELLO_WORLD_IN_CSHARP,
+        },
+        maxResults: 5,
+    },
+}
+
+export const SAMPLE_SESSION_DATA_WITH_EXTRA_LEFT_CONTENT: SessionData = {
+    document: SOME_INCOMPLETE_FILE,
+    startPosition: {
+        line: 1,
+        character: 0,
+    },
+    triggerType: 'OnDemand',
+    language: 'csharp',
+    requestContext: {
+        fileContext: {
+            filename: SOME_FILE.uri,
+            programmingLanguage: { languageName: 'csharp' },
+            leftFileContent: INCOMPLETE_HELLO_WORLD_IN_CSHARP,
+            rightFileContent: '',
         },
         maxResults: 5,
     },


### PR DESCRIPTION
## Problem

Currently all previous suggestions are discarded before generating new suggestions.

## Solution

add logic to merge with previous suggestions for EDITS

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
