### PR TITLE
feat(amazonq): migrating / agents to q agentic chat

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.40",
         "@aws/language-server-runtimes-types": "^0.1.42",
-        "@aws/mynah-ui": "^4.35.6"
+        "@aws/mynah-ui": "^4.35.7"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -270,6 +270,11 @@ export const createChat = (
                     tabFactory.setInfoMessages((message.params as ChatOptionsUpdateParams).chatNotifications)
                 }
 
+                // Enable reroute FIRST before processing other options
+                if ((params as any)?.reroute) {
+                    tabFactory.enableReroute()
+                }
+
                 if (params?.quickActions?.quickActionsCommandGroups) {
                     const quickActionCommandGroups = params.quickActions.quickActionsCommandGroups.map(group => ({
                         ...group,

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -226,10 +226,10 @@ export const handleChatPrompt = (
             let defaultPrompt = userPrompt
             switch (prompt.command) {
                 case '/dev':
-                    defaultPrompt = 'Help me with code development' //TODO: Change the /dev prompt
+                    defaultPrompt = DEFAULT_DEV_PROMPT
                     break
                 case '/test':
-                    defaultPrompt = 'Help me generate unit tests'
+                    defaultPrompt = DEFAULT_TEST_PROMPT
                     break
                 case '/doc':
                     defaultPrompt = DEFAULT_DOC_PROMPT
@@ -1513,7 +1513,11 @@ const ACTIVE_EDITOR_CONTEXT_ID = 'active-editor'
 
 export const DEFAULT_HELP_PROMPT = 'What can Amazon Q help me with?'
 
-export const DEFAULT_DOC_PROMPT = `You are a Amazon Q. Start with a warm greeting, then ask the user to specify what kind of documentation they need. Present common documentation types (like API docs, README, user guides, developer guides, or configuration guides) as clear options. Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
+const DEFAULT_DOC_PROMPT = `You are a Amazon Q. Start with a warm greeting, then ask the user to specify what kind of documentation they need. Present common documentation types (like API docs, README, user guides, developer guides, or configuration guides) as clear options. Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
+
+const DEFAULT_TEST_PROMPT = `Help me generate unit tests`
+
+const DEFAULT_DEV_PROMPT = `You are a Amazon Q. Start with a warm greeting, then ask the user to specify what kind of help they need in code development. Present common questions asked (like Creating a new project, Adding a new feature, Modifying your files). Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
 
 const uiComponentsTexts = {
     mainTitle: 'Amazon Q (Preview)',

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1515,7 +1515,7 @@ export const DEFAULT_HELP_PROMPT = 'What can Amazon Q help me with?'
 
 const DEFAULT_DOC_PROMPT = `You are a Amazon Q. Start with a warm greeting, then ask the user to specify what kind of documentation they need. Present common documentation types (like API docs, README, user guides, developer guides, or configuration guides) as clear options. Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
 
-const DEFAULT_TEST_PROMPT = `Help me generate unit tests`
+const DEFAULT_TEST_PROMPT = `You are a Amazon Q. Start with a warm greeting, then help me generate unit tests`
 
 const DEFAULT_DEV_PROMPT = `You are a Amazon Q. Start with a warm greeting, then ask the user to specify what kind of help they need in code development. Present common questions asked (like Creating a new project, Adding a new feature, Modifying your files). Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
 

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -62,7 +62,12 @@ import {
     toMynahIcon,
 } from './utils'
 import { ChatHistory, ChatHistoryList } from './features/history'
-import { pairProgrammingModeOff, pairProgrammingModeOn, programmerModeCard } from './texts/pairProgramming'
+import {
+    pairProgrammingModeOff,
+    pairProgrammingModeOn,
+    programmerModeCard,
+    createRerouteCard,
+} from './texts/pairProgramming'
 import { ContextRule, RulesList } from './features/rules'
 import { getModelSelectionChatItem, modelUnavailableBanner, modelThrottledBanner } from './texts/modelSelection'
 import {
@@ -143,7 +148,8 @@ export const handleChatPrompt = (
     messager: Messager,
     triggerType?: TriggerType,
     _eventId?: string,
-    agenticMode?: boolean
+    agenticMode?: boolean,
+    tabFactory?: TabFactory
 ) => {
     let userPrompt = prompt.escapedPrompt
 
@@ -172,7 +178,14 @@ export const handleChatPrompt = (
         messager.onStopChatResponse(tabId)
     }
 
-    if (prompt.command) {
+    const isReroutedCommand =
+        agenticMode &&
+        tabFactory?.isRerouteEnabled() &&
+        prompt.command &&
+        ['/dev', '/test', '/doc'].includes(prompt.command)
+
+    if (prompt.command && !isReroutedCommand) {
+        // Handle non-rerouted commands (/clear, /help, /transform, /review) as quick actions
         // Temporary solution to handle clear quick actions on the client side
         if (prompt.command === '/clear') {
             mynahUi.updateStore(tabId, {
@@ -193,12 +206,60 @@ export const handleChatPrompt = (
             return
         }
     } else {
-        // Send chat prompt to server
-        const context = prompt.context?.map(c => (typeof c === 'string' ? { command: c } : c))
-        messager.onChatPrompt({ prompt, tabId, context }, triggerType)
+        // Go agentic chat workflow when:
+        // 1. Regular prompts without commands
+        // 2. Rerouted commands (/dev, /test, /doc) when feature flag: reroute is enabled
+
+        // Special handling for /doc command - always send fixed prompt for fixed response
+        if (isReroutedCommand && prompt.command === '/doc') {
+            const context = prompt.context?.map(c => (typeof c === 'string' ? { command: c } : c))
+            messager.onChatPrompt(
+                {
+                    prompt: { ...prompt, escapedPrompt: DEFAULT_DOC_PROMPT, prompt: DEFAULT_DOC_PROMPT },
+                    tabId,
+                    context,
+                },
+                triggerType
+            )
+        } else if (isReroutedCommand && (!userPrompt || userPrompt.trim() === '')) {
+            // For /dev and /test commands, provide meaningful defaults if no additional text
+            let defaultPrompt = userPrompt
+            switch (prompt.command) {
+                case '/dev':
+                    defaultPrompt = 'Help me with code development' //TODO: Change the /dev prompt
+                    break
+                case '/test':
+                    defaultPrompt = 'Help me generate unit tests'
+                    break
+                case '/doc':
+                    defaultPrompt = DEFAULT_DOC_PROMPT
+                    break
+            }
+
+            // Send the updated prompt with default text to server
+            const context = prompt.context?.map(c => (typeof c === 'string' ? { command: c } : c))
+            messager.onChatPrompt(
+                {
+                    prompt: { ...prompt, escapedPrompt: defaultPrompt, prompt: defaultPrompt },
+                    tabId,
+                    context,
+                },
+                triggerType
+            )
+        } else {
+            const context = prompt.context?.map(c => (typeof c === 'string' ? { command: c } : c))
+            messager.onChatPrompt({ prompt, tabId, context }, triggerType)
+        }
     }
 
-    initializeChatResponse(mynahUi, tabId, userPrompt, agenticMode)
+    // For /doc command, don't show any prompt in UI
+    const displayPrompt = isReroutedCommand && prompt.command === '/doc' ? '' : userPrompt
+    initializeChatResponse(mynahUi, tabId, displayPrompt, agenticMode)
+
+    // If this is a rerouted command AND reroute feature is enabled, show the reroute card after the prompt
+    if (isReroutedCommand && tabFactory?.isRerouteEnabled() && prompt.command) {
+        mynahUi.addChatItem(tabId, createRerouteCard(prompt.command))
+    }
 }
 
 const initializeChatResponse = (mynahUi: MynahUI, tabId: string, userPrompt?: string, agenticMode?: boolean) => {
@@ -284,7 +345,8 @@ export const createMynahUi = (
                     messager,
                     'click',
                     eventId,
-                    agenticMode
+                    agenticMode,
+                    tabFactory
                 )
 
                 const payload: FollowUpClickParams = {
@@ -296,7 +358,7 @@ export const createMynahUi = (
             }
         },
         onChatPrompt(tabId, prompt, eventId) {
-            handleChatPrompt(mynahUi, tabId, prompt, messager, 'click', eventId, agenticMode)
+            handleChatPrompt(mynahUi, tabId, prompt, messager, 'click', eventId, agenticMode, tabFactory)
         },
         onReady: () => {
             messager.onUiReady()
@@ -309,6 +371,9 @@ export const createMynahUi = (
             const defaultTabBarData = tabFactory.getDefaultTabData()
             const defaultTabConfig: Partial<MynahUIDataModel> = {
                 quickActionCommands: defaultTabBarData.quickActionCommands,
+                ...(tabFactory.isRerouteEnabled()
+                    ? { quickActionCommandsHeader: defaultTabBarData.quickActionCommandsHeader }
+                    : {}),
                 tabBarButtons: defaultTabBarData.tabBarButtons,
                 contextCommands: [
                     ...(contextCommandGroups || []),
@@ -639,7 +704,7 @@ export const createMynahUi = (
     const mynahUiRef = { mynahUI: undefined as MynahUI | undefined }
     if (customChatClientAdapter) {
         // Attach routing to custom adapter top of default message handlers
-        chatEventHandlers = withAdapter(chatEventHandlers, mynahUiRef, customChatClientAdapter)
+        chatEventHandlers = withAdapter(chatEventHandlers, mynahUiRef, customChatClientAdapter, tabFactory)
     }
 
     const mynahUi = new MynahUI({
@@ -1228,7 +1293,7 @@ export const createMynahUi = (
         ].join('')
         const chatPrompt: ChatPrompt = { prompt: body, escapedPrompt: body }
 
-        handleChatPrompt(mynahUi, tabId, chatPrompt, messager, params.triggerType, undefined, agenticMode)
+        handleChatPrompt(mynahUi, tabId, chatPrompt, messager, params.triggerType, undefined, agenticMode, tabFactory)
     }
 
     const showError = (params: ErrorParams) => {
@@ -1447,6 +1512,9 @@ ${params.message}`,
 const ACTIVE_EDITOR_CONTEXT_ID = 'active-editor'
 
 export const DEFAULT_HELP_PROMPT = 'What can Amazon Q help me with?'
+
+export const DEFAULT_DOC_PROMPT = `You are a Amazon Q. Start with a warm greeting, then ask the user to specify what kind of documentation they need. Present common documentation types (like API docs, README, user guides, developer guides, or configuration guides) as clear options. Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
+
 const uiComponentsTexts = {
     mainTitle: 'Amazon Q (Preview)',
     copy: 'Copy',

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1513,11 +1513,11 @@ const ACTIVE_EDITOR_CONTEXT_ID = 'active-editor'
 
 export const DEFAULT_HELP_PROMPT = 'What can Amazon Q help me with?'
 
-const DEFAULT_DOC_PROMPT = `You are a Amazon Q. Start with a warm greeting, then ask the user to specify what kind of documentation they need. Present common documentation types (like API docs, README, user guides, developer guides, or configuration guides) as clear options. Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
+const DEFAULT_DOC_PROMPT = `You are Amazon Q. Start with a warm greeting, then ask the user to specify what kind of documentation they need. Present common documentation types (like API docs, README, user guides, developer guides, or configuration guides) as clear options. Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
 
-const DEFAULT_TEST_PROMPT = `You are a Amazon Q. Start with a warm greeting, then help me generate unit tests`
+const DEFAULT_TEST_PROMPT = `You are Amazon Q. Start with a warm greeting, then help me generate unit tests`
 
-const DEFAULT_DEV_PROMPT = `You are a Amazon Q. Start with a warm greeting, then ask the user to specify what kind of help they need in code development. Present common questions asked (like Creating a new project, Adding a new feature, Modifying your files). Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
+const DEFAULT_DEV_PROMPT = `You are Amazon Q. Start with a warm greeting, then ask the user to specify what kind of help they need in code development. Present common questions asked (like Creating a new project, Adding a new feature, Modifying your files). Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
 
 const uiComponentsTexts = {
     mainTitle: 'Amazon Q (Preview)',

--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -139,7 +139,7 @@ export class TabFactory {
                               "You can now ask Q directly in the chat to generate code, documentation, and unit tests. You don't need to explicitly use /dev, /test, or /doc",
                       } as QuickActionCommandsHeader,
                   }
-                : { quickActionCommandsHeader: {} }),
+                : {}),
         }
 
         tabData.tabBarButtons = this.getTabBarButtons()

--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -4,6 +4,7 @@ import {
     MynahIcons,
     MynahUIDataModel,
     QuickActionCommandGroup,
+    QuickActionCommandsHeader,
     TabBarMainAction,
 } from '@aws/mynah-ui'
 import { disclaimerCard } from '../texts/disclaimer'
@@ -24,6 +25,7 @@ export class TabFactory {
     private agenticMode: boolean = false
     private mcp: boolean = false
     private modelSelectionEnabled: boolean = false
+    private reroute: boolean = false
     initialTabId: string
 
     public static generateUniqueId() {
@@ -111,10 +113,33 @@ export class TabFactory {
         this.modelSelectionEnabled = true
     }
 
+    public enableReroute() {
+        this.reroute = true
+    }
+
+    public isRerouteEnabled(): boolean {
+        return this.reroute
+    }
+
     public getDefaultTabData(): DefaultTabData {
         const tabData = {
             ...this.defaultTabData,
-            ...(this.quickActionCommands ? { quickActionCommands: this.quickActionCommands } : {}),
+            ...(this.quickActionCommands
+                ? {
+                      quickActionCommands: this.quickActionCommands,
+                  }
+                : {}),
+            ...(this.reroute
+                ? {
+                      quickActionCommandsHeader: {
+                          status: 'warning',
+                          icon: MynahIcons.INFO,
+                          title: 'Q Developer agentic capabilities',
+                          description:
+                              "You can now ask Q directly in the chat to generate code, documentation, and unit tests. You don't need to explicitly use /dev, /test, or /doc",
+                      } as QuickActionCommandsHeader,
+                  }
+                : { quickActionCommandsHeader: {} }),
         }
 
         tabData.tabBarButtons = this.getTabBarButtons()

--- a/chat-client/src/client/texts/pairProgramming.ts
+++ b/chat-client/src/client/texts/pairProgramming.ts
@@ -1,4 +1,4 @@
-import { ChatItem, ChatItemFormItem, ChatItemType } from '@aws/mynah-ui'
+import { ChatItem, ChatItemFormItem, ChatItemType, MynahIcons } from '@aws/mynah-ui'
 
 export const programmerModeCard: ChatItem = {
     type: ChatItemType.ANSWER,
@@ -35,4 +35,60 @@ export const pairProgrammingModeOff: ChatItem = {
     contentHorizontalAlignment: 'center',
     fullWidth: true,
     body: 'Agentic coding - OFF',
+}
+
+export const testRerouteCard: ChatItem = {
+    type: ChatItemType.ANSWER,
+    border: true,
+    header: {
+        padding: true,
+        iconForegroundStatus: 'warning',
+        icon: MynahIcons.INFO,
+        body: 'You can now ask to generate unit tests directly in the chat.',
+    },
+    body: `You don't need to explicitly use /test. We've redirected your request to chat.
+Ask me to do things like:
+• Add unit tests for highlighted functions in my active file
+• Generate tests for null and empty inputs in my project`,
+}
+
+export const docRerouteCard: ChatItem = {
+    type: ChatItemType.ANSWER,
+    border: true,
+    header: {
+        padding: true,
+        iconForegroundStatus: 'warning',
+        icon: MynahIcons.INFO,
+        body: 'You can now ask to generate documentation directly in the chat.',
+    },
+    body: `You don't need to explicitly use /doc. We've redirected your request to chat.`,
+}
+
+export const devRerouteCard: ChatItem = {
+    type: ChatItemType.ANSWER,
+    border: true,
+    header: {
+        padding: true,
+        iconForegroundStatus: 'warning',
+        icon: MynahIcons.INFO,
+        body: 'You can now ask to generate code directly in the chat.',
+    },
+    body: `You don't need to explicitly use /dev. We've redirected your request to chat.
+Ask me to do things like:
+1. Create a project
+2. Add a feature
+3. Modify your files`,
+}
+
+export const createRerouteCard = (command: string): ChatItem => {
+    switch (command) {
+        case '/test':
+            return testRerouteCard
+        case '/doc':
+            return docRerouteCard
+        case '/dev':
+            return devRerouteCard
+        default:
+            return devRerouteCard // Default fallback
+    }
 }

--- a/chat-client/src/client/withAdapter.test.ts
+++ b/chat-client/src/client/withAdapter.test.ts
@@ -5,6 +5,7 @@ import { withAdapter } from './withAdapter'
 import { ChatClientAdapter, ChatEventHandler } from '../contracts/chatClientAdapter'
 import { MynahUI, MynahUIProps, RelevancyVoteType } from '@aws/mynah-ui'
 import { disclaimerAcknowledgeButtonId } from './texts/disclaimer'
+import { TabFactory } from './tabs/tabFactory'
 
 describe('withAdapter', () => {
     let defaultEventHandlers: ChatEventHandler
@@ -12,6 +13,7 @@ describe('withAdapter', () => {
     let chatClientAdapter: ChatClientAdapter
     let customEventHandlers: ChatEventHandler
     let mynahUiPropsWithAdapter: MynahUIProps
+    let tabFactory: TabFactory
 
     beforeEach(() => {
         // Set up base MynahUIProps with stub methods
@@ -102,8 +104,13 @@ describe('withAdapter', () => {
             handleQuickAction: sinon.stub(),
         }
 
+        // Set up tab factory
+        tabFactory = {
+            isRerouteEnabled: sinon.stub().returns(false),
+        } as unknown as TabFactory
+
         // Create the enhanced props
-        mynahUiPropsWithAdapter = withAdapter(defaultEventHandlers, mynahUIRef, chatClientAdapter)
+        mynahUiPropsWithAdapter = withAdapter(defaultEventHandlers, mynahUIRef, chatClientAdapter, tabFactory)
     })
 
     afterEach(() => {
@@ -159,7 +166,7 @@ describe('withAdapter', () => {
         }
 
         assert.throws(() => {
-            withAdapter(defaultEventHandlers, mynahUIRef, invalidAdapter)
+            withAdapter(defaultEventHandlers, mynahUIRef, invalidAdapter, tabFactory)
         }, new Error('Custom ChatEventHandler is not defined'))
     })
 
@@ -564,7 +571,8 @@ describe('withAdapter', () => {
                     // @ts-ignore
                     {
                         createChatEventHandler: () => ({}),
-                    }
+                    },
+                    tabFactory
                 )
 
                 const customOnFormLinkClickHandler = customEventHandlers.onFileActionClick

--- a/chat-client/src/client/withAdapter.ts
+++ b/chat-client/src/client/withAdapter.ts
@@ -77,13 +77,12 @@ export const withAdapter = (
 
             // Only /review and /transform commands for chatClientAdapter handling
             // Let /dev, /test, /doc use default event handler routing(agentic chat)
-            if (!tabFactory.isRerouteEnabled()) {
-                if (prompt.command && chatClientAdapter.isSupportedQuickAction(prompt.command)) {
-                    chatClientAdapter.handleQuickAction(prompt, tabId, eventId)
-                    return
-                }
-            } else {
-                if (prompt.command && ['/review', '/transform'].includes(prompt.command)) {
+            if (prompt.command) {
+                const shouldHandleQuickAction = !tabFactory.isRerouteEnabled()
+                    ? chatClientAdapter.isSupportedQuickAction(prompt.command)
+                    : ['/review', '/transform'].includes(prompt.command)
+
+                if (shouldHandleQuickAction) {
                     chatClientAdapter.handleQuickAction(prompt, tabId, eventId)
                     return
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,7 +248,7 @@
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.40",
                 "@aws/language-server-runtimes-types": "^0.1.42",
-                "@aws/mynah-ui": "^4.35.6"
+                "@aws/mynah-ui": "^4.35.7"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -3972,7 +3972,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.35.6",
+            "version": "4.35.7",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.35.7.tgz",
+            "integrity": "sha512-Bcfb3cVEQkzu0Zsq7938b6GYy6vha/+M6euaPLhjYIvs8FnoCgom9bqLxtUFdnQRUVdd9zUX/Yvz1bAlYebJ4g==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -774,7 +774,7 @@ export class AgenticChatController implements ChatHandlers {
                     this.#debug('Skipping adding user message to history - cancelled by user')
                 } else {
                     // Adding a conditional check to not add /test, /doc and /dev prompts to history.
-                    if (!currentMessage.userInputMessage?.content?.startsWith('You are a Amazon Q')) {
+                    if (!currentMessage.userInputMessage?.content?.startsWith('You are Amazon Q')) {
                         this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier, {
                             body: currentMessage.userInputMessage?.content ?? '',
                             type: 'prompt' as any,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -773,15 +773,18 @@ export class AgenticChatController implements ChatHandlers {
                     // Only skip adding message to history, continue executing to avoid unexpected stop for the conversation
                     this.#debug('Skipping adding user message to history - cancelled by user')
                 } else {
-                    this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier, {
-                        body: currentMessage.userInputMessage?.content ?? '',
-                        type: 'prompt' as any,
-                        userIntent: currentMessage.userInputMessage?.userIntent,
-                        origin: currentMessage.userInputMessage?.origin,
-                        userInputMessageContext: currentMessage.userInputMessage?.userInputMessageContext,
-                        shouldDisplayMessage: shouldDisplayMessage,
-                        timestamp: new Date(),
-                    })
+                    // Adding a conditional check to not add /test, /doc and /dev prompts to history.
+                    if (!currentMessage.userInputMessage?.content?.startsWith('You are a Amazon Q')) {
+                        this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier, {
+                            body: currentMessage.userInputMessage?.content ?? '',
+                            type: 'prompt' as any,
+                            userIntent: currentMessage.userInputMessage?.userIntent,
+                            origin: currentMessage.userInputMessage?.origin,
+                            userInputMessageContext: currentMessage.userInputMessage?.userInputMessageContext,
+                            shouldDisplayMessage: shouldDisplayMessage,
+                            timestamp: new Date(),
+                        })
+                    }
                 }
             }
             shouldDisplayMessage = true

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -17,7 +17,15 @@ import { AmazonQWorkspaceConfig } from '../../shared/amazonQServiceManager/confi
 import { TabBarController } from './tabBarController'
 import { AmazonQServiceInitializationError } from '../../shared/amazonQServiceManager/errors'
 import { isUsingIAMAuth, safeGet, enabledModelSelection } from '../../shared/utils'
-import { enabledMCP, enabledReroute } from './tools/mcp/mcpUtils'
+import { enabledMCP } from './tools/mcp/mcpUtils'
+import { QClientCapabilities } from '../configuration/qConfigurationServer'
+
+export function enabledReroute(params: InitializeParams | undefined): boolean {
+    const qCapabilities = params?.initializationOptions?.aws?.awsClientCapabilities?.q as
+        | QClientCapabilities
+        | undefined
+    return qCapabilities?.reroute || false
+}
 
 export const QAgenticChatServer =
     // prettier-ignore

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -17,7 +17,7 @@ import { AmazonQWorkspaceConfig } from '../../shared/amazonQServiceManager/confi
 import { TabBarController } from './tabBarController'
 import { AmazonQServiceInitializationError } from '../../shared/amazonQServiceManager/errors'
 import { isUsingIAMAuth, safeGet, enabledModelSelection } from '../../shared/utils'
-import { enabledMCP } from './tools/mcp/mcpUtils'
+import { enabledMCP, enabledReroute } from './tools/mcp/mcpUtils'
 
 export const QAgenticChatServer =
     // prettier-ignore
@@ -32,6 +32,8 @@ export const QAgenticChatServer =
         let chatSessionManagementService: ChatSessionManagementService
 
         lsp.addInitializer((params: InitializeParams) => {
+            const rerouteEnabled = enabledReroute(params)
+
             return {
                 capabilities: {
                     executeCommandProvider: {
@@ -53,7 +55,8 @@ export const QAgenticChatServer =
                         // we should set it as true for current VSC and VS clients
                         modelSelection: true,
                         history: true,
-                        export: TabBarController.enableChatExport(params)
+                        export: TabBarController.enableChatExport(params),
+                        reroute: rerouteEnabled
                     },
                 },
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -494,7 +494,7 @@ export class ChatDatabase {
             const tabTitle =
                 (message.type === 'prompt' && message.shouldDisplayMessage !== false && message.body.trim().length > 0
                     ? message.body
-                    : tabData?.title) || 'Amazon Q Chat'
+                    : tabData?.title) || 'Amazon Q Chat Agent' // Show default message in place of IDE-to-LLM prompts for generating test/documentation/development content
             message = this.formatChatHistoryMessage(message)
             if (tabData) {
                 this.#features.logging.log(`Updating existing tab with historyId=${historyId}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -322,6 +322,13 @@ export function enabledMCP(params: InitializeParams | undefined): boolean {
     return qCapabilities?.mcp || false
 }
 
+export function enabledReroute(params: InitializeParams | undefined): boolean {
+    const qCapabilities = params?.initializationOptions?.aws?.awsClientCapabilities?.q as
+        | QClientCapabilities
+        | undefined
+    return qCapabilities?.reroute || false
+}
+
 /**
  * Sanitizes a name by:
  * 1. Returning the original if it matches the regex and doesn't contain namespace delimiter(__)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -322,13 +322,6 @@ export function enabledMCP(params: InitializeParams | undefined): boolean {
     return qCapabilities?.mcp || false
 }
 
-export function enabledReroute(params: InitializeParams | undefined): boolean {
-    const qCapabilities = params?.initializationOptions?.aws?.awsClientCapabilities?.q as
-        | QClientCapabilities
-        | undefined
-    return qCapabilities?.reroute || false
-}
-
 /**
  * Sanitizes a name by:
  * 1. Returning the original if it matches the regex and doesn't contain namespace delimiter(__)

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -40,6 +40,7 @@ export interface QClientCapabilities {
     customizationsWithMetadata?: boolean
     mcp?: boolean
     modelSelection?: boolean
+    reroute?: boolean
 }
 
 type QConfigurationResponse =


### PR DESCRIPTION
## Notes:
- Q IDE is transitioning its /test, /dev, and /doc agents to use the new Q Agentic chat capabilities, while /review and /transform agents will continue using the original mechanisms.


https://github.com/user-attachments/assets/d43c585b-6fad-4749-b0d0-b422c778bc01


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
