### PR TITLE
fix(amazonq): add slight delay to print chat string after card

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -590,19 +590,22 @@ export const createMynahUi = (
         onStopChatResponse: tabId => {
             messager.onStopChatResponse(tabId)
 
-            // Add cancellation message when stop button is clicked
-            mynahUi.addChatItem(tabId, {
-                type: ChatItemType.DIRECTIVE,
-                messageId: 'stopped' + Date.now(),
-                body: 'You stopped your current work, please provide additional examples or ask another question.',
-            })
-
             // Reset loading state
             mynahUi.updateStore(tabId, {
                 loadingChat: false,
                 cancelButtonWhenLoading: true,
                 promptInputDisabledState: false,
             })
+
+            // Add a small delay before adding the chat item
+            setTimeout(() => {
+                // Add cancellation message when stop button is clicked
+                mynahUi.addChatItem(tabId, {
+                    type: ChatItemType.DIRECTIVE,
+                    messageId: 'stopped' + Date.now(),
+                    body: 'You stopped your current work, please provide additional examples or ask another question.',
+                })
+            }, 500) // 500ms delay
         },
     }
 


### PR DESCRIPTION
## Problem
Text was coming in the chat before the UI card.
![image](https://github.com/user-attachments/assets/82138346-81a5-4c33-9857-59380575e333)


## Solution
Added slight delay to get it to come after. 

![image](https://github.com/user-attachments/assets/9afe3267-bbc3-4ffe-b33a-5f6239027fcf)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
