### PR TITLE
fix: do not auto trigger when there is immediate right context for VSC/JB

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.test.ts
@@ -111,7 +111,7 @@ describe('Auto Trigger', async () => {
                 ide: 'VSCODE',
             })
 
-            const result = autoTrigger(params)
+            const result = autoTrigger(params, console)
             assert.strictEqual(result.shouldTrigger, false)
         })
 
@@ -120,7 +120,7 @@ describe('Auto Trigger', async () => {
                 fileContext: createBasicFileContext('console.', ' log()'),
             })
 
-            const result = autoTrigger(params)
+            const result = autoTrigger(params, console)
             assert.strictEqual(result.shouldTrigger, true)
         })
 
@@ -129,7 +129,7 @@ describe('Auto Trigger', async () => {
                 fileContext: createBasicFileContext('console.', '  '),
             })
 
-            const result = autoTrigger(params)
+            const result = autoTrigger(params, console)
             assert.strictEqual(result.shouldTrigger, true)
         })
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.test.ts
@@ -1,8 +1,28 @@
 import assert = require('assert')
 import { FileContext } from '../../../shared/codeWhispererService'
-import { triggerType } from './autoTrigger'
+import { autoTrigger, triggerType } from './autoTrigger'
 
 describe('Auto Trigger', async () => {
+    const createBasicFileContext = (left: string = '', right: string = ''): FileContext => ({
+        filename: 'test.ts',
+        leftFileContent: left,
+        rightFileContent: right,
+        programmingLanguage: {
+            languageName: 'typescript',
+        },
+    })
+
+    const createBasicParams = (overrides = {}) => ({
+        fileContext: createBasicFileContext(),
+        char: 'a',
+        triggerType: 'Classifier',
+        os: 'Windows',
+        previousDecision: 'Accept',
+        ide: 'VSCODE',
+        lineNum: 1,
+        ...overrides,
+    })
+
     describe('Get Trigger Type', async () => {
         const HELLO_WORLD_IN_CSHARP = `class HelloWorld
 {
@@ -81,6 +101,36 @@ describe('Auto Trigger', async () => {
             }
             const trigger = triggerType(fileContext)
             assert.equal(trigger, 'Classifier')
+        })
+    })
+
+    describe('Right Context should trigger validation', () => {
+        it('should not trigger when there is immediate right context in VSCode', () => {
+            const params = createBasicParams({
+                fileContext: createBasicFileContext('console.', 'log()'),
+                ide: 'VSCODE',
+            })
+
+            const result = autoTrigger(params)
+            assert.strictEqual(result.shouldTrigger, false)
+        })
+
+        it('should not trigger when right context starts with space', () => {
+            const params = createBasicParams({
+                fileContext: createBasicFileContext('console.', ' log()'),
+            })
+
+            const result = autoTrigger(params)
+            assert.strictEqual(result.shouldTrigger, true)
+        })
+
+        it('should trigger when right context is just space', () => {
+            const params = createBasicParams({
+                fileContext: createBasicFileContext('console.', '  '),
+            })
+
+            const result = autoTrigger(params)
+            assert.strictEqual(result.shouldTrigger, true)
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -423,15 +423,18 @@ export const CodewhispererServerFactory =
                     if (initializeParams !== undefined) {
                         ideCategory = getIdeCategory(initializeParams)
                     }
-                    const autoTriggerResult = autoTrigger({
-                        fileContext, // The left/right file context and programming language
-                        lineNum: params.position.line, // the line number of the invocation, this is the line of the cursor
-                        char: triggerCharacter, // Add the character just inserted, if any, before the invication position
-                        ide: ideCategory ?? '',
-                        os: '', // TODO: We should get this in a platform-agnostic way (i.e., compatible with the browser)
-                        previousDecision, // The last decision by the user on the previous invocation
-                        triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
-                    })
+                    const autoTriggerResult = autoTrigger(
+                        {
+                            fileContext, // The left/right file context and programming language
+                            lineNum: params.position.line, // the line number of the invocation, this is the line of the cursor
+                            char: triggerCharacter, // Add the character just inserted, if any, before the invication position
+                            ide: ideCategory ?? '',
+                            os: '', // TODO: We should get this in a platform-agnostic way (i.e., compatible with the browser)
+                            previousDecision, // The last decision by the user on the previous invocation
+                            triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
+                        },
+                        logging
+                    )
 
                     if (
                         isAutomaticLspTriggerKind &&


### PR DESCRIPTION

## Problem

In the non-Flare auto trigger for VSC and JB, we do not auto trigger when there is immediate right context.
But when switch to Flare, we are triggering. 
See https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/keyStrokeHandler.ts#L102

This causes API request to increase a lot.


## Solution

Do not auto trigger when there is immediate right context.

We are not changing Eclipse and VS because these products were using the Flare auto trigger to begin with. Changing this affects user experience

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
