### PR TITLE
fix: adjust vs code auto trigger coefficients

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/coefficients.json
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/coefficients.json
@@ -388,7 +388,7 @@
     },
 
     "ideCoefficient": {
-        "VSCODE": -0.13566,
+        "VSCODE": -0.1905,
         "JETBRAINS": 0.0,
         "ECLIPSE": 0.0,
         "VISUAL_STUDIO": 0.0


### PR DESCRIPTION
## Problem

The VS Code coefficient should be -0.1905. See https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/classifierTrigger.ts#L77

With the -0.13566, we will be making more auto triggers

## Solution

Revert the VSC coefficient to the previous one.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
