### PR TITLE
chore: bump runtimes

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -15,7 +15,7 @@
         "local-build": "node scripts/local-build.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.98"
+        "@aws/language-server-runtimes": "^0.2.102"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.40",
-        "@aws/language-server-runtimes-types": "^0.1.42",
+        "@aws/language-server-runtimes-types": "^0.1.43",
         "@aws/mynah-ui": "^4.35.6"
     },
     "devDependencies": {

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -347,7 +347,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.40",
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "server/**"
             ],
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@smithy/types": "4.2.0",
                 "typescript": "^5.8.2"
             },
@@ -44,7 +44,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -81,7 +81,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -114,7 +114,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -122,7 +122,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -142,7 +142,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -184,7 +184,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -204,7 +204,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -226,7 +226,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.98"
+                "@aws/language-server-runtimes": "^0.2.102"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -247,7 +247,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.40",
-                "@aws/language-server-runtimes-types": "^0.1.42",
+                "@aws/language-server-runtimes-types": "^0.1.43",
                 "@aws/mynah-ui": "^4.35.6"
             },
             "devDependencies": {
@@ -270,7 +270,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.40",
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -3807,12 +3807,12 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.101",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.101.tgz",
-            "integrity": "sha512-LYmRa2t05B6KUbrrxFeFZ9EDslmjXD1th1MamJoi0tQx5VS5Ikc6rsN9PR9wdnX4sH6ZvYTtddtNh2zr8MbbHw==",
+            "version": "0.2.102",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.102.tgz",
+            "integrity": "sha512-O68zmXClLP6mtKxh0fzGKYW3MwgFCTkAgL32WKzOWLwD6gMc5CaVRrNsZ2cabkAudf2laTeWeSDZJZsiQ0hCfA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.42",
+                "@aws/language-server-runtimes-types": "^0.1.43",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/api-logs": "^0.200.0",
                 "@opentelemetry/core": "^2.0.0",
@@ -3839,9 +3839,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.42",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.42.tgz",
-            "integrity": "sha512-zwlF5vfH7jCvlVrkAynmO8uTMWxrIDDRvTmN+aOHminVy84qnG6qYLd+TFjmdeLKoH+fMInYQ+chJXPdOjb+rA==",
+            "version": "0.1.43",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.43.tgz",
+            "integrity": "sha512-qXaAGkiJ1hldF+Ynu6ZBXS18s47UOnbZEHxKiGRrBlBX2L75ih/4yasj8ITgshqS5Kx5JMntu+8vpc0CkGV6jA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
@@ -24137,7 +24137,7 @@
             "version": "0.1.14",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-core": "^0.0.10"
             },
             "devDependencies": {
@@ -24209,7 +24209,7 @@
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.40",
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-core": "^0.0.10",
                 "@modelcontextprotocol/sdk": "^1.9.0",
                 "@smithy/node-http-handler": "^2.5.0",
@@ -24341,7 +24341,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-core": "^0.0.10",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -24386,7 +24386,7 @@
             "version": "0.1.14",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-core": "^0.0.10",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -24403,7 +24403,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-core": "^0.0.10",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -24444,7 +24444,7 @@
             "version": "0.0.14",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -24477,7 +24477,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "@aws/lsp-core": "^0.0.10",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -24491,7 +24491,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -24502,7 +24502,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.101",
+                "@aws/language-server-runtimes": "^0.2.102",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "package": "npm run compile && npm run package --workspaces --if-present"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@smithy/types": "4.2.0",
         "typescript": "^5.8.2"
     },

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-core": "^0.0.10"
     },
     "peerDependencies": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -36,7 +36,7 @@
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.40",
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-core": "^0.0.10",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -197,6 +197,7 @@ type ChatHandlers = Omit<
     | 'onPinnedContextAdd'
     | 'onPinnedContextRemove'
     | 'onOpenFileDialog'
+    | 'onListAvailableModels'
 >
 
 export class AgenticChatController implements ChatHandlers {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -83,6 +83,7 @@ type ChatHandlers = Omit<
     | 'onPinnedContextAdd'
     | 'onPinnedContextRemove'
     | 'onOpenFileDialog'
+    | 'onListAvailableModels'
 >
 
 export class ChatController implements ChatHandlers {

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-core": "^0.0.10",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -26,7 +26,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-core": "^0.0.10",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -22,7 +22,7 @@
         "coverage:report": "c8 report --reporter=html --reporter=text"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-core": "^0.0.10",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "@aws/lsp-core": "^0.0.10",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -13,7 +13,7 @@
         "coverage:report": "c8 report --reporter=html --reporter=text"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.101",
+        "@aws/language-server-runtimes": "^0.2.102",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem

New version of `@aws/language-server-runtimes` is available

## Solution

Bump to 0.2.102

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
