### PR TITLE
fix: setting shouldDisplayMessage to false for /agents

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -798,18 +798,17 @@ export class AgenticChatController implements ChatHandlers {
                     // Only skip adding message to history, continue executing to avoid unexpected stop for the conversation
                     this.#debug('Skipping adding user message to history - cancelled by user')
                 } else {
-                    // Adding a conditional check to not add /test, /doc and /dev prompts to history.
-                    if (!currentMessage.userInputMessage?.content?.startsWith('You are Amazon Q')) {
-                        this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier, {
-                            body: currentMessage.userInputMessage?.content ?? '',
-                            type: 'prompt' as any,
-                            userIntent: currentMessage.userInputMessage?.userIntent,
-                            origin: currentMessage.userInputMessage?.origin,
-                            userInputMessageContext: currentMessage.userInputMessage?.userInputMessageContext,
-                            shouldDisplayMessage: shouldDisplayMessage,
-                            timestamp: new Date(),
-                        })
-                    }
+                    this.#chatHistoryDb.addMessage(tabId, 'cwc', conversationIdentifier, {
+                        body: currentMessage.userInputMessage?.content ?? '',
+                        type: 'prompt' as any,
+                        userIntent: currentMessage.userInputMessage?.userIntent,
+                        origin: currentMessage.userInputMessage?.origin,
+                        userInputMessageContext: currentMessage.userInputMessage?.userInputMessageContext,
+                        shouldDisplayMessage:
+                            shouldDisplayMessage &&
+                            !currentMessage.userInputMessage?.content?.startsWith('You are Amazon Q'),
+                        timestamp: new Date(),
+                    })
                 }
             }
             shouldDisplayMessage = true


### PR DESCRIPTION
## Problem
- Prompt is being displayed in the history for the /agents.
## Solution
- Setting shouldDisplayMessage to false for /agents requests.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
