### PR TITLE
fix(amazonq): allow taking .jpg file as image context, add image cont…

### DIFF
--- a/chat-client/src/client/imageVerification.ts
+++ b/chat-client/src/client/imageVerification.ts
@@ -20,7 +20,7 @@ export interface ImageVerificationOptions {
 export const DEFAULT_IMAGE_VERIFICATION_OPTIONS: Required<ImageVerificationOptions> = {
     maxSizeBytes: 3.75 * 1024 * 1024, // 3.75MB
     maxDimension: 8000, // 8000px
-    supportedExtensions: ['jpeg', 'png', 'gif', 'webp'],
+    supportedExtensions: ['jpeg', 'jpg', 'png', 'gif', 'webp'],
 }
 
 /**

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -681,7 +681,12 @@ export class AgenticChatController implements ChatHandlers {
                 params.context,
                 params.tabId
             )
-
+            // Add image context to triggerContext.documentReference for transparency
+            await this.#additionalContextProvider.appendCustomContextToTriggerContext(
+                triggerContext,
+                params.context,
+                params.tabId
+            )
             // Get the initial request input
             const initialRequestInput = await this.#prepareRequestInput(
                 params,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
@@ -31,7 +31,8 @@ import { Features } from '../../types'
 import { ChatDatabase } from '../tools/chatDb/chatDb'
 import { ChatMessage, ImageBlock, ImageFormat } from '@amzn/codewhisperer-streaming'
 import { getRelativePathWithUri, getRelativePathWithWorkspaceFolder } from '../../workspaceContext/util'
-import { isSupportedImageExtension } from '../../../shared/imageVerification'
+import { isSupportedImageExtension, MAX_IMAGE_CONTEXT_COUNT } from '../../../shared/imageVerification'
+import { mergeFileLists } from './contextUtils'
 
 export const ACTIVE_EDITOR_CONTEXT_ID = 'active-editor'
 
@@ -401,6 +402,60 @@ export class AdditionalContextProvider {
     }
 
     /**
+     * Returns merged image context from params.context and DB, deduplicated and limited to 20 items.
+     */
+    private getMergedImageContext(contextArr?: ContextCommand[], tabId?: string): ContextCommand[] {
+        let mergedContext: ContextCommand[] = contextArr ? [...contextArr] : []
+        if (tabId) {
+            const pinnedContext = this.chatDb.getPinnedContext(tabId)
+            for (const pc of pinnedContext) {
+                if (
+                    pc.label === 'image' &&
+                    !mergedContext.some(c => c.label === 'image' && c.description === pc.description)
+                ) {
+                    mergedContext.push(pc)
+                }
+            }
+        }
+        return mergedContext.slice(0, MAX_IMAGE_CONTEXT_COUNT)
+    }
+
+    public async appendCustomContextToTriggerContext(
+        triggerContext: any,
+        contextArr?: ContextCommand[],
+        tabId?: string
+    ) {
+        const mergedContext = this.getMergedImageContext(contextArr, tabId)
+        if (mergedContext.length > 0) {
+            const imageFilePaths: string[] = []
+            const imageDetails: Record<string, FileDetails> = {}
+
+            for (const contextCommand of mergedContext) {
+                if (contextCommand.label === 'image' && contextCommand.route && contextCommand.route.length > 0) {
+                    let filePath = contextCommand.route[0]
+                    imageFilePaths.push(filePath)
+                    imageDetails[filePath] = {
+                        description: contextCommand.description || filePath,
+                        lineRanges: [{ first: -1, second: -1 }],
+                    }
+                }
+            }
+
+            if (imageFilePaths.length > 0) {
+                const imageFileList: FileList = {
+                    filePaths: imageFilePaths,
+                    details: imageDetails,
+                }
+                if (triggerContext.documentReference) {
+                    triggerContext.documentReference = mergeFileLists(triggerContext.documentReference, imageFileList)
+                } else {
+                    triggerContext.documentReference = imageFileList
+                }
+            }
+        }
+    }
+
+    /**
      * Extracts image blocks from a context array, reading image files and returning them as ImageBlock objects.
      * Optionally, appends pinned image context from chatDb for the given tabId.
      * @param contextArr The context array to extract image blocks from.
@@ -409,28 +464,19 @@ export class AdditionalContextProvider {
     public async getImageBlocksFromContext(contextArr?: ContextCommand[], tabId?: string): Promise<ImageBlock[]> {
         const imageBlocks: ImageBlock[] = []
 
-        // 1. Start with the provided contextArr or an empty array
-        let mergedContext: ContextCommand[] = contextArr ? [...contextArr] : []
+        // Use the helper to get merged and deduplicated image context
+        const mergedContext: ContextCommand[] = this.getMergedImageContext(contextArr, tabId)
 
-        // 2. If tabId is provided, append pinned image context from chatDb (avoid duplicates)
-        if (tabId) {
-            const pinnedContext = this.chatDb.getPinnedContext(tabId)
-            for (const pc of pinnedContext) {
-                if (pc.label === 'image' && !mergedContext.some(c => c.label === 'image' && c.id === pc.id)) {
-                    mergedContext.push(pc)
-                }
-            }
-        }
-
-        // 3. Limit mergedContext to 20 items
-        mergedContext = mergedContext.slice(0, 20)
-
-        // 4. Process all image contexts in mergedContext
+        // Process all image contexts in mergedContext
         for (const context of mergedContext) {
             if (context.label === 'image' && context.route && context.route.length > 0) {
                 try {
                     const imagePath = context.route[0]
-                    const format = imagePath.split('.').pop()?.toLowerCase() || ''
+                    let format = imagePath.split('.').pop()?.toLowerCase() || ''
+                    // Both .jpg and .jpeg files use the exact same JPEG compression algorithm and file structure.
+                    if (format === 'jpg') {
+                        format = 'jpeg'
+                    }
                     if (!isSupportedImageExtension(format)) {
                         this.features.logging.warn(`Unsupported image format: ${format}`)
                         continue

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
@@ -421,7 +421,7 @@ export class AdditionalContextProvider {
     }
 
     public async appendCustomContextToTriggerContext(
-        triggerContext: any,
+        triggerContext: TriggerContext,
         contextArr?: ContextCommand[],
         tabId?: string
     ) {

--- a/server/aws-lsp-codewhisperer/src/shared/imageVerification.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/imageVerification.ts
@@ -11,6 +11,8 @@ export interface ImageVerificationResult {
     errors: string[]
 }
 
+export const MAX_IMAGE_CONTEXT_COUNT = 20
+
 export interface ImageVerificationOptions {
     maxSizeBytes?: number
     maxDimension?: number
@@ -20,7 +22,7 @@ export interface ImageVerificationOptions {
 export const DEFAULT_IMAGE_VERIFICATION_OPTIONS: Required<ImageVerificationOptions> = {
     maxSizeBytes: 3.75 * 1024 * 1024, // 3.75MB
     maxDimension: 8000, // 8000px
-    supportedExtensions: ['jpeg', 'png', 'gif', 'webp'],
+    supportedExtensions: ['jpeg', 'jpg', 'png', 'gif', 'webp'],
 }
 
 /**


### PR DESCRIPTION
…ext used to transparency list

## Problem
In bug bash, found 2 issues
1) Images sent as context don't show up in context transparency list. All other items sent as context appear in Context dropdown at top of response
2) .JPG file is not accepted, .JPEG is

## Solution
1) Add image context to the trigger context, so the image contexts used can be rendered in ui
2) Both .jpg and .jpeg files use the exact same JPEG compression algorithm and file structure, so read a file as binary, we're getting the raw data, replace the format to 'jpeg' if it's originally 'jpg'.
<img width="596" alt="Screenshot 2025-07-02 at 1 25 18 AM" src="https://github.com/user-attachments/assets/eab76445-3e13-4699-a2a2-70ae1dc04495" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
