### PR TITLE
fix(amazonq): show active file in context transparency list

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -675,10 +675,6 @@ export class AgenticChatController implements ChatHandlers {
             // Combine additional context with active file and get file list to display at top of response
             const contextItems = [...additionalContext, ...activeFile]
             triggerContext.documentReference = this.#additionalContextProvider.getFileListFromContext(contextItems)
-            if (additionalContext.length) {
-                triggerContext.documentReference =
-                    this.#additionalContextProvider.getFileListFromContext(additionalContext)
-            }
 
             const customContext = await this.#additionalContextProvider.getImageBlocksFromContext(
                 params.context,


### PR DESCRIPTION
## Problem
This [PR](https://github.com/aws/language-servers/pull/1716#discussion_r2180174999) introduced a regression which broke the [fix](https://github.com/aws/language-servers/pull/1762) to display active file in context transparency list.


## Solution
Remove unnecessary code block which overrode triggerContext.documentReference initialized in the previous line
Add unit test to prevent another regression.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
