### PR TITLE
chore(amazonq): manual trigger should always assign Completions prediction type

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -446,7 +446,6 @@ export const CodewhispererServerFactory =
 
                     // Get supplemental context from recent edits if available.
                     let supplementalContextFromEdits = undefined
-                    let predictionTypes = [['COMPLETIONS']]
 
                     // supplementalContext available only via token authentication
                     const supplementalContextPromise =
@@ -478,6 +477,24 @@ export const CodewhispererServerFactory =
                         ]
 
                         if (editsEnabled) {
+                            const predictionTypes: string[][] = []
+
+                            /**
+                             * Manual trigger - should always have 'Completions'
+                             * Auto trigger
+                             *  - Classifier - should have 'Completions' when classifier evalualte to true given the editor's states
+                             *  - Others - should always have 'Completions'
+                             */
+                            if (
+                                !isAutomaticLspTriggerKind ||
+                                (isAutomaticLspTriggerKind && codewhispererAutoTriggerType !== 'Classifier') ||
+                                (isAutomaticLspTriggerKind &&
+                                    codewhispererAutoTriggerType === 'Classifier' &&
+                                    autoTriggerResult.shouldTrigger)
+                            ) {
+                                predictionTypes.push(['COMPLETIONS'])
+                            }
+
                             // Step 0: Determine if we have "Rcent Edit context"
                             if (recentEditTracker) {
                                 supplementalContextFromEdits =
@@ -491,10 +508,10 @@ export const CodewhispererServerFactory =
                                 cursorHistory: cursorTracker,
                                 recentEdits: recentEditTracker,
                             })
-                            predictionTypes = [
-                                ...(autoTriggerResult.shouldTrigger ? [['COMPLETIONS']] : []),
-                                ...(editPredictionAutoTriggerResult.shouldTrigger && editsEnabled ? [['EDITS']] : []),
-                            ]
+
+                            if (editPredictionAutoTriggerResult.shouldTrigger) {
+                                predictionTypes.push(['EDITS'])
+                            }
 
                             if (predictionTypes.length === 0) {
                                 return EMPTY_RESULT


### PR DESCRIPTION


## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
