### PR TITLE
fix: adding files on VSC windows properly triggers reindexing

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/localProjectContext/localProjectContextServer.ts
@@ -17,6 +17,7 @@ export const LocalProjectContextServer =
         let telemetryService: TelemetryService
 
         let localProjectContextEnabled: boolean = false
+        let VSCWindowsOverride: boolean = false
 
         lsp.addInitializer((params: InitializeParams) => {
             const workspaceFolders = workspace.getAllWorkspaceFolders() || params.workspaceFolders
@@ -25,6 +26,11 @@ export const LocalProjectContextServer =
                 workspaceFolders,
                 logging
             )
+            // Context: Adding, deleting, renaming files within the VSC IDE on windows does not properly trigger reindexing. All other IDE/OS combinations work
+            // For all IDE/OS combination except VSC on Windows, using URI.parse() works
+            // For VSC on Windows, using URI.parse() chops off the windows drive letter, so need to use URI.file() to preserve it
+            // Temporary solution until further investigation is done on how the pathing works:
+            VSCWindowsOverride = params.clientInfo?.name === 'vscode' && process.platform === 'win32'
 
             const supportedFilePatterns = Object.keys(languageByExtension).map(ext => `**/*${ext}`)
 
@@ -85,7 +91,9 @@ export const LocalProjectContextServer =
 
         lsp.workspace.onDidCreateFiles(async event => {
             try {
-                const filePaths = event.files.map(file => URI.parse(file.uri).fsPath)
+                const filePaths = VSCWindowsOverride
+                    ? event.files.map(file => URI.file(file.uri).fsPath)
+                    : event.files.map(file => URI.parse(file.uri).fsPath)
                 await localProjectContextController.updateIndexAndContextCommand(filePaths, true)
             } catch (error) {
                 logging.error(`Error handling create event: ${error}`)
@@ -94,7 +102,9 @@ export const LocalProjectContextServer =
 
         lsp.workspace.onDidDeleteFiles(async event => {
             try {
-                const filePaths = event.files.map(file => URI.parse(file.uri).fsPath)
+                const filePaths = VSCWindowsOverride
+                    ? event.files.map(file => URI.file(file.uri).fsPath)
+                    : event.files.map(file => URI.parse(file.uri).fsPath)
                 await localProjectContextController.updateIndexAndContextCommand(filePaths, false)
             } catch (error) {
                 logging.error(`Error handling delete event: ${error}`)
@@ -103,8 +113,12 @@ export const LocalProjectContextServer =
 
         lsp.workspace.onDidRenameFiles(async event => {
             try {
-                const oldPaths = event.files.map(file => URI.parse(file.oldUri).fsPath)
-                const newPaths = event.files.map(file => URI.parse(file.newUri).fsPath)
+                const oldPaths = VSCWindowsOverride
+                    ? event.files.map(file => URI.file(file.oldUri).fsPath)
+                    : event.files.map(file => URI.parse(file.newUri).fsPath)
+                const newPaths = VSCWindowsOverride
+                    ? event.files.map(file => URI.file(file.oldUri).fsPath)
+                    : event.files.map(file => URI.parse(file.newUri).fsPath)
 
                 await localProjectContextController.updateIndexAndContextCommand(oldPaths, false)
                 await localProjectContextController.updateIndexAndContextCommand(newPaths, true)
@@ -115,7 +129,9 @@ export const LocalProjectContextServer =
 
         lsp.onDidSaveTextDocument(async event => {
             try {
-                const filePaths = [URI.parse(event.textDocument.uri).fsPath]
+                const filePaths = VSCWindowsOverride
+                    ? [URI.file(event.textDocument.uri).fsPath]
+                    : [URI.parse(event.textDocument.uri).fsPath]
                 await localProjectContextController.updateIndex(filePaths, 'update')
             } catch (error) {
                 logging.error(`Error handling save event: ${error}`)


### PR DESCRIPTION
## Problem / Context
- Adding, deleting, renaming files within the VSC IDE specifically on Windows does not properly trigger reindexing. All other IDE/OS combinations work
- For all IDE/OS combination except VSC on Windows, using URI.parse() works
- For VSC on Windows, using URI.parse() chops off the Windows drive letter, so need to use URI.file() to preserve it
- Discussed with the team and this is only a temporary solution until further investigation is done on how the pathing works

## Solution
- If we are specifically on VSC on Windows, we use URI.file() instead of URI.parse()
- We understand that flare is IDE agnostic. We are doing this temporary solution for a time-sensitive customer ticket, until we can go back and investigate the longer term solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
