### PR TITLE
fix(amazonq): change the UI message from to out of workspace

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2010,7 +2010,7 @@ export class AgenticChatController implements ChatHandlers {
                 }
                 body = builtInPermission
                     ? `I need permission to modify files.\n\`${writeFilePath}\``
-                    : `I need permission to modify files in your workspace.\n\`${writeFilePath}\``
+                    : `I need permission to modify files outside of your workspace.\n\`${writeFilePath}\``
                 break
             }
 


### PR DESCRIPTION
## Problem
We were wrongly tagging the message as a file inside the workspace. It should have been outside of the workspace.

## Solution
Changed the message.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
