### PR TITLE
fix(amazonq): handle undefined paths gracefully and retry

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/utils/pathValidation.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/utils/pathValidation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs'
+import * as assert from 'assert'
+import sinon from 'ts-sinon'
+import { validatePathBasic, validatePathExists, validatePaths } from './pathValidation'
+
+describe('Path Validation Utilities', () => {
+    let fsExistsSyncStub: sinon.SinonStub
+
+    beforeEach(() => {
+        fsExistsSyncStub = sinon.stub(fs, 'existsSync')
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('validatePathBasic', () => {
+        it('should not throw error for valid path', () => {
+            assert.doesNotThrow(() => validatePathBasic('/valid/path'))
+        })
+
+        it('should throw error for empty path', () => {
+            assert.throws(() => validatePathBasic(''), /Path cannot be empty./)
+        })
+
+        it('should throw error for path with only whitespace', () => {
+            assert.throws(() => validatePathBasic('   '), /Path cannot be empty./)
+        })
+
+        it('should throw error for undefined path', () => {
+            assert.throws(() => validatePathBasic(undefined as unknown as string), /Path cannot be empty./)
+        })
+    })
+
+    describe('validatePathExists', () => {
+        it('should not throw error when path exists', () => {
+            fsExistsSyncStub.returns(true)
+            assert.doesNotThrow(() => validatePathExists('/existing/path'))
+            sinon.assert.calledWith(fsExistsSyncStub, '/existing/path')
+        })
+
+        it('should throw error when path does not exist', () => {
+            fsExistsSyncStub.returns(false)
+            assert.throws(
+                () => validatePathExists('/non-existing/path'),
+                /Path "\/non-existing\/path" does not exist or cannot be accessed./
+            )
+            sinon.assert.calledWith(fsExistsSyncStub, '/non-existing/path')
+        })
+
+        it('should throw error for empty path before checking existence', () => {
+            assert.throws(() => validatePathExists(''), /Path cannot be empty./)
+            sinon.assert.notCalled(fsExistsSyncStub)
+        })
+    })
+
+    describe('validatePaths', () => {
+        it('should not throw error for valid array of paths', () => {
+            fsExistsSyncStub.returns(true)
+            const paths = ['/path1', '/path2', '/path3']
+            assert.doesNotThrow(() => validatePaths(paths))
+            sinon.assert.callCount(fsExistsSyncStub, 3)
+        })
+
+        it('should throw error for empty array', () => {
+            assert.throws(() => validatePaths([]), /Paths array cannot be empty./)
+            sinon.assert.notCalled(fsExistsSyncStub)
+        })
+
+        it('should throw error for undefined array', () => {
+            assert.throws(() => validatePaths(undefined), /Paths array cannot be empty./)
+            sinon.assert.notCalled(fsExistsSyncStub)
+        })
+
+        it('should throw error if any path in array does not exist', () => {
+            fsExistsSyncStub.onFirstCall().returns(true) // First path exists
+            fsExistsSyncStub.onSecondCall().returns(false) // Second path doesn't exist
+            fsExistsSyncStub.onThirdCall().returns(true) // Third path exists
+
+            const paths = ['/path1', '/non-existing/path', '/path3']
+            assert.throws(
+                () => validatePaths(paths),
+                /Path "\/non-existing\/path" does not exist or cannot be accessed./
+            )
+            sinon.assert.callCount(fsExistsSyncStub, 2) // Should stop at the first failing path
+        })
+
+        it('should throw error if any path in array is empty', () => {
+            fsExistsSyncStub.returns(true)
+            const paths = ['/path1', '', '/path3']
+            assert.throws(() => validatePaths(paths), /Path cannot be empty./)
+            sinon.assert.callCount(fsExistsSyncStub, 1) // Should stop at the first failing path
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/utils/pathValidation.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/utils/pathValidation.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs'
+
+/**
+ * Path validation utilities (synchronous only)
+ */
+
+/**
+ * Validates that a path is not empty or undefined
+ * @param path Path to validate
+ * @throws Error if path is empty or undefined
+ */
+export function validatePathBasic(path: string): void {
+    if (!path || path.trim().length === 0) {
+        throw new Error('Path cannot be empty.')
+    }
+}
+
+/**
+ * Synchronously validates that a path exists
+ * @param path Path to validate
+ * @throws Error if path does not exist
+ */
+export function validatePathExists(path: string): void {
+    validatePathBasic(path)
+    if (!fs.existsSync(path)) {
+        throw new Error(`Path "${path}" does not exist or cannot be accessed.`)
+    }
+}
+
+/**
+ * Validates that an array of paths is not empty and all paths exist
+ * @param paths Array of paths to validate
+ * @throws Error if paths array is empty or if any path is invalid
+ */
+export function validatePaths(paths: string[] | undefined): void {
+    if (!paths || paths.length === 0) {
+        throw new Error('Paths array cannot be empty.')
+    }
+
+    for (const path of paths) {
+        validatePathExists(path)
+    }
+}


### PR DESCRIPTION
## Problem
Sometime due to different reasons if LLM gave us undefined paths our tools would not perform correctly as we would start to ask for permissions for out of workspace access for them.

## Solution
Added check for filePath and used the existing retry mechanism to retry with LLM.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
