### PR TITLE
feat(amazonq): update workspace context server A/B testing filter

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -176,7 +176,10 @@ export const WorkspaceContextServer = (): Server => features => {
             logging.log(`${JSON.stringify(result)}`)
             abTestingEnabled =
                 result.featureEvaluations?.some(
-                    feature => feature.feature === 'ServiceSideWorkspaceContext' && feature.variation === 'TREATMENT'
+                    feature =>
+                        (feature.feature === 'ServiceSideWorkspaceContext' ||
+                            feature.feature === 'BuilderIdServiceSideProjectContext') &&
+                        feature.variation === 'TREATMENT'
                 ) ?? false
             logging.info(`A/B testing enabled: ${abTestingEnabled}`)
             abTestingEvaluated = true

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -23,6 +23,7 @@ import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/A
 import { FileUploadJobManager, FileUploadJobType } from './fileUploadJobManager'
 import { DependencyEventBundler } from './dependency/dependencyEventBundler'
 import ignore = require('ignore')
+import { INTERNAL_USER_START_URL } from '../../shared/constants'
 
 const Q_CONTEXT_CONFIGURATION_SECTION = 'aws.q.workspaceContext'
 
@@ -165,22 +166,30 @@ export const WorkspaceContextServer = (): Server => features => {
         }
 
         try {
-            const clientParams = safeGet(lsp.getClientInitializeParams())
-            const userContext = makeUserContextObject(clientParams, runtime.platform, 'CodeWhisperer') ?? {
-                ideCategory: 'VSCODE',
-                operatingSystem: 'MAC',
-                product: 'CodeWhisperer',
+            const startUrl = credentialsProvider.getConnectionMetadata()?.sso?.startUrl
+            if (startUrl && startUrl.includes(INTERNAL_USER_START_URL)) {
+                // Overriding abTestingEnabled to true for all internal users
+                abTestingEnabled = true
+            } else {
+                const clientParams = safeGet(lsp.getClientInitializeParams())
+                const userContext = makeUserContextObject(clientParams, runtime.platform, 'CodeWhisperer') ?? {
+                    ideCategory: 'VSCODE',
+                    operatingSystem: 'MAC',
+                    product: 'CodeWhisperer',
+                }
+
+                const result = await amazonQServiceManager
+                    .getCodewhispererService()
+                    .listFeatureEvaluations({ userContext })
+                logging.log(`${JSON.stringify(result)}`)
+                abTestingEnabled =
+                    result.featureEvaluations?.some(
+                        feature =>
+                            feature.feature === 'BuilderIdServiceSideProjectContext' &&
+                            feature.variation === 'TREATMENT'
+                    ) ?? false
             }
 
-            const result = await amazonQServiceManager.getCodewhispererService().listFeatureEvaluations({ userContext })
-            logging.log(`${JSON.stringify(result)}`)
-            abTestingEnabled =
-                result.featureEvaluations?.some(
-                    feature =>
-                        (feature.feature === 'ServiceSideWorkspaceContext' ||
-                            feature.feature === 'BuilderIdServiceSideProjectContext') &&
-                        feature.variation === 'TREATMENT'
-                ) ?? false
             logging.info(`A/B testing enabled: ${abTestingEnabled}`)
             abTestingEvaluated = true
         } catch (error: any) {

--- a/server/aws-lsp-codewhisperer/src/shared/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/constants.ts
@@ -2,6 +2,7 @@ export const MISSING_BEARER_TOKEN_ERROR = 'credentialsProvider does not have bea
 export const INVALID_TOKEN = 'The bearer token included in the request is invalid.'
 export const GENERIC_UNAUTHORIZED_ERROR = 'User is not authorized to make this call'
 export const BUILDER_ID_START_URL = 'https://view.awsapps.com/start'
+export const INTERNAL_USER_START_URL = 'https://amzn.awsapps.com/start'
 export const DEFAULT_AWS_Q_ENDPOINT_URL = 'https://codewhisperer.us-east-1.amazonaws.com/'
 export const DEFAULT_AWS_Q_REGION = 'us-east-1'
 


### PR DESCRIPTION
## Problem

We are starting a new A/B testing experiment called `BuilderIdServiceSideProjectContext` for BuilderID users.

Also, we are going to switch all internal users to another experiment that needs workspace context server enabled.

## Solution

Allow `BuilderIdServiceSideProjectContext` for WCS A/B testing.

Set WCS `abTestingEnabled` to true for all internal users.

### Testing

Tested locally with my Amazon internal user credentials and verified it works.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
