### PR TITLE
fix: imagecontext image name bug, mutliple images in pinned context

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -767,6 +767,7 @@ export const createMynahUi = (
                             label: 'image',
                             icon: icon,
                             content: bytes,
+                            id: fileName,
                         }
                     })
                 )
@@ -1535,7 +1536,7 @@ ${params.message}`,
         }
         const commands: QuickActionCommand[] = []
         for (const filePath of params.filePaths) {
-            const fileName = filePath.split('/').pop() || filePath
+            const fileName = filePath.split(/[\\/]/).pop() || filePath
             if (params.fileType === 'image') {
                 commands.push({
                     command: fileName,
@@ -1543,6 +1544,7 @@ ${params.message}`,
                     label: 'image',
                     route: [filePath],
                     icon: MynahIcons.IMAGE,
+                    id: fileName,
                 })
             }
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -476,7 +476,7 @@ export class AgenticChatController implements ChatHandlers {
             let errorMessage: string | undefined
             for (const filePath of result.uris) {
                 // Extract filename from the URI for error messages
-                const fileName = filePath.split('/').pop() || ''
+                const fileName = path.basename(filePath) || ''
                 const sanitizedPath = sanitize(filePath)
 
                 // Get file size and content for verification


### PR DESCRIPTION
## Problem

During integration of Flare changes with Visual Studio, following bugs have been identified
- On windows, when we add an image using the options @image or @image: options, full file name is shown, we should only show file name.
- I was able to add only one image when I used @image context menu option, when I add another image, it does not show up in pinned context.
Images for the these bugs are below.

![image](https://github.com/user-attachments/assets/baf75858-60e3-40d4-8b78-95b70a1bd864)

## Solution
- After fixing these issues.
![image](https://github.com/user-attachments/assets/a028abfc-8ce8-4036-8f67-0c66e46f31de)

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
