### PR TITLE
fix(amazonq): fix grammar mistake in image context list

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -148,7 +148,7 @@ export class ContextCommandsProvider implements Disposable {
 
         const imageCmdGroup: ContextCommand = {
             command: 'Image',
-            description: 'Add a image to context',
+            description: 'Add image to context',
             icon: 'image',
             placeholder: 'Select an image file',
         }


### PR DESCRIPTION
## Problem
There's grammar mistake in the context list 
<img width="613" alt="Screenshot 2025-07-07 at 1 13 13 PM" src="https://github.com/user-attachments/assets/2cc523c4-7b94-4bc4-b8ff-a7b95a8e4940" />

## Solution
Fix the grammar mistake
<img width="305" alt="Screenshot 2025-07-07 at 1 15 19 PM" src="https://github.com/user-attachments/assets/2ed77cc0-991f-415c-9ab4-3c6bd41e4c58" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
