### PR TITLE
fix(amazonq): change the image filter used in open file dialog

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -454,7 +454,7 @@ export class AgenticChatController implements ChatHandlers {
         if (params.fileType === 'image') {
             // 1. Prompt user for file selection
             const supportedExtensions = DEFAULT_IMAGE_VERIFICATION_OPTIONS.supportedExtensions
-            const filters = { 'Image Files': supportedExtensions.map(ext => `*.${ext}`) }
+            const filters = { 'Image Files': supportedExtensions }
             const result = await this.#features.lsp.window.showOpenDialog({
                 canSelectFiles: true,
                 canSelectFolders: false,


### PR DESCRIPTION
## Problem

The Windows should takes filter like `'Images': ['jpeg', 'jpg', 'png', 'gif', 'webp'] `

## Solution
Not prefix the supported extensions with `*.`.


https://github.com/user-attachments/assets/c0641e28-07c0-415b-8bd2-e536993b1133



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
