### PR TITLE
feat: passing partialResultToken to onInlineCompletionHandler result for EDITS

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -805,6 +805,7 @@ export const CodewhispererServerFactory =
                         })
                         .filter(item => item.insertText !== ''),
                     sessionId: session.id,
+                    partialResultToken: suggestionResponse.responseContext.nextToken,
                 }
             }
         }


### PR DESCRIPTION
## Problem

passing partialResultToken to onInlineCompletionHandler result for EDITS

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
