### PR TITLE
chore: automate creation of release candidate branches

### DIFF
--- a/.github/workflows/create-agent-standalone.yml
+++ b/.github/workflows/create-agent-standalone.yml
@@ -2,7 +2,7 @@ name: Create agent-standalone bundles
 
 on:
     push:
-        branches: [main, feature/*]
+        branches: [main, feature/*, release/agentic/*]
 
 jobs:
     build:
@@ -12,6 +12,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
+                  ref: ${{ github.ref }}
                   lfs: true
 
             - name: Setup Node.js
@@ -36,10 +37,11 @@ jobs:
                   platforms=("linux-arm64" "linux-x64" "mac-arm64" "mac-x64" "win-x64")
                   for platform in "${platforms[@]}"; do
                     echo "Preparing artifacts for $platform"
-                    mkdir -p "artifacts/$platform"
-                    cp "app/aws-lsp-codewhisperer-runtimes/build/archives/shared/clients.zip" "artifacts/$platform/"
-                    cp "app/aws-lsp-codewhisperer-runtimes/build/archives/agent-standalone/$platform/servers.zip" "artifacts/$platform/"
+                    mkdir -p "_artifacts/$platform"
+                    unzip _artifacts/$platform.zip -d _artifacts/$platform
                   done
+                  mkdir -p "_artifacts/clients"
+                  unzip _artifacts/clients.zip -d _artifacts/clients
 
             # GitHub Actions zips the archive, so we upload the folder used to
             # produce clients.zip. Otherwise we have a clients.zip artifact
@@ -49,40 +51,40 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: clients
-                  path: app/aws-lsp-codewhisperer-runtimes/build/private/bundle/client
+                  path: _artifacts/clients/
                   if-no-files-found: error
 
             - name: Upload linux-arm64
               uses: actions/upload-artifact@v4
               with:
                   name: linux-arm64
-                  path: artifacts/linux-arm64/
+                  path: _artifacts/linux-arm64/
                   if-no-files-found: error
 
             - name: Upload linux-x64
               uses: actions/upload-artifact@v4
               with:
                   name: linux-x64
-                  path: artifacts/linux-x64/
+                  path: _artifacts/linux-x64/
                   if-no-files-found: error
 
             - name: Upload mac-arm64
               uses: actions/upload-artifact@v4
               with:
                   name: mac-arm64
-                  path: artifacts/mac-arm64/
+                  path: _artifacts/mac-arm64/
                   if-no-files-found: error
 
             - name: Upload mac-x64
               uses: actions/upload-artifact@v4
               with:
                   name: mac-x64
-                  path: artifacts/mac-x64/
+                  path: _artifacts/mac-x64/
                   if-no-files-found: error
 
             - name: Upload win-x64
               uses: actions/upload-artifact@v4
               with:
                   name: win-x64
-                  path: artifacts/win-x64/
+                  path: _artifacts/win-x64/
                   if-no-files-found: error

--- a/.github/workflows/create-release-candidate-branch.yml
+++ b/.github/workflows/create-release-candidate-branch.yml
@@ -1,0 +1,116 @@
+﻿name: Set up a new Release Candidate
+
+on:
+    workflow_dispatch:
+        inputs:
+            versionIncrement:
+                description: 'Release Version Increment'
+                default: 'Minor'
+                required: true
+                type: choice
+                options:
+                    - Major
+                    - Minor
+                    - Patch
+                    - Custom
+            customVersion:
+                description: "Custom Release Version (only used if release increment is 'Custom') - Format: 1.2.3"
+                default: ''
+                required: false
+                type: string
+            commitId:
+                description: 'The commit Id to produce a release candidate with'
+                default: ''
+                required: true
+                type: string
+
+jobs:
+    setupRcBranch:
+        name: Set up a Release Candidate Branch
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Sync code
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ inputs.commitId }}
+                  # Use RELEASE_CANDIDATE_BRANCH_CREATION_PAT to ensure workflow triggering works
+                  token: ${{ secrets.RELEASE_CANDIDATE_BRANCH_CREATION_PAT }}
+                  persist-credentials: true
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+                  cache: 'npm'
+
+            - name: Calculate Release Version
+              id: release-version
+              env:
+                  VERSION_FILE: app/aws-lsp-codewhisperer-runtimes/src/version.json
+              run: |
+                  customVersion="${{ inputs.customVersion }}"
+                  versionIncrement="${{ inputs.versionIncrement }}"
+
+                  # Read current version
+                  currentVersion=$(jq -r '.agenticChat' "$VERSION_FILE")
+
+                  if [[ "$versionIncrement" == "Custom" && -n "$customVersion" ]]; then
+                      newVersion="$customVersion"
+                  else
+                      # Parse current version
+                      IFS='.' read -r major minor patch <<< "$currentVersion"
+                      
+                      case "$versionIncrement" in
+                          "Major")
+                              major=$((major + 1))
+                              minor=0
+                              patch=0
+                              ;;
+                          "Minor")
+                              minor=$((minor + 1))
+                              patch=0
+                              ;;
+                          "Patch")
+                              patch=$((patch + 1))
+                              ;;
+                      esac
+                      
+                      newVersion="$major.$minor.$patch"
+                  fi
+
+                  # Update version.json
+                  jq --arg version "$newVersion" '.agenticChat = $version' "$VERSION_FILE" > tmp.json && mv tmp.json "$VERSION_FILE"
+
+                  # Set output only
+                  echo "RELEASE_VERSION=$newVersion" >> $GITHUB_OUTPUT
+
+                  git add "$VERSION_FILE"
+
+            - name: Create Release Candidate Branch
+              id: release-branch
+              env:
+                  RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+              run: |
+                  branch="release/agentic/$RELEASE_VERSION"
+                  git checkout -b "$branch"
+
+                  # Save the branch value as output only
+                  echo "BRANCH_NAME=$branch" >> $GITHUB_OUTPUT
+
+            - name: Commit and Push changes
+              env:
+                  BRANCH_NAME: ${{ steps.release-branch.outputs.BRANCH_NAME }}
+                  RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
+                  # We use the toolkit-automation account, basically something that
+                  # isn't the default GitHub Token, because you cannot chain actions with that.
+                  # In our case, after pushing a commit (below), we want create-agent-standalone.yml
+                  # to start automatically.
+                  REPO_PAT: ${{ secrets.RELEASE_CANDIDATE_BRANCH_CREATION_PAT }}
+              run: |
+                  git config --global user.email "<>"
+                  git config --global user.name "aws-toolkit-automation"
+                  # Configure git to use the PAT token for authentication
+                  git remote set-url origin "https://x-access-token:${REPO_PAT}@github.com/${{ github.repository }}.git"
+                  git commit -m "Bump agentic version: $RELEASE_VERSION"
+                  git push --set-upstream origin "$BRANCH_NAME"


### PR DESCRIPTION

This change builds on #1832 and #1827.

This change sets up a GitHub Action that will be used to create release candidate branches for agentic chat. Once we have a commit on the main branch that we want to use as a release candidate (aka "preprod" internally) build, the new GitHub Action will be run, which creates a release candidate branch, and increments the agentic chat version. Once the automation pushes the new commit into the new release candidate branch, the action from #1827 gets triggered, which produces the build. On completion of the build action, the action from #1832 gets triggered, which creates (or updates) a GitHub release.

Example, if agentic chat was versioned "1.2.3", and we initiate a release candidate using a minor version increment:
- the new version will become "1.3.0"
- a branch "release/agentic/1.3.0" will be created
- a commit will be pushed into that branch updating version.json (added in #1832)
- GitHub Actions will produce a GitHub release called "agentic-rc-1.3.0", which will contain downloadable builds
- the builds will be kept up to date with the latest commit from the release candidate branch

To support this change:
- create-agent-standalone.yml was updated to get invoked on pushes to `release/agentic/*` branches
- branch restrictions have been added to `release/agentic/*` branches
- a new secret `RELEASE_CANDIDATE_BRANCH_CREATION_PAT` was added to the repo, which is used by this Action, in order to ensure that our operations are able to trigger other GitHub actions

We won't use this automation until the internal pipelines have been set up to consume artifacts from the GitHub releases that these changes will produce.

Here's a quick sample of how the new Action will be run:
- you designate if the new agentic chat version is a (semver) major/minor/patch increment
  - alternatively, you can specify the full version, this is an escape hatch should a situation require it.
- you indicate what commit to seed the release candidate branch with

![image](https://github.com/user-attachments/assets/574b8cf5-d389-4069-848c-4abc3bb62f44)


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
