### PR TITLE
feat(chat-client): add stringOverrides to createChat config

### DIFF
--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -108,7 +108,7 @@ import {
     OPEN_FILE_DIALOG_METHOD,
     OpenFileDialogResult,
 } from '@aws/language-server-runtimes-types'
-import { MynahUIDataModel, MynahUITabStoreModel } from '@aws/mynah-ui'
+import { ConfigTexts, MynahUIDataModel, MynahUITabStoreModel } from '@aws/mynah-ui'
 import { ServerMessage, TELEMETRY, TelemetryParams } from '../contracts/serverContracts'
 import { Messager, OutboundChatApi } from './messager'
 import { InboundChatApi, createMynahUi } from './mynahUi'
@@ -131,6 +131,7 @@ type ChatClientConfig = Pick<MynahUIDataModel, 'quickActionCommands'> & {
     pairProgrammingAcknowledged?: boolean
     agenticMode?: boolean
     modelSelectionEnabled?: boolean
+    stringOverrides?: Partial<ConfigTexts>
 }
 
 export const createChat = (
@@ -537,7 +538,8 @@ export const createChat = (
         config?.pairProgrammingAcknowledged ?? false,
         chatClientAdapter,
         featureConfig,
-        !!config?.agenticMode
+        !!config?.agenticMode,
+        config?.stringOverrides
     )
 
     mynahApi = api

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -7,6 +7,7 @@ import {
     handleChatPrompt,
     DEFAULT_HELP_PROMPT,
     handlePromptInputChange,
+    uiComponentsTexts,
 } from './mynahUi'
 import { Messager, OutboundChatApi } from './messager'
 import { TabFactory } from './tabs/tabFactory'
@@ -15,6 +16,7 @@ import { ChatClientAdapter } from '../contracts/chatClientAdapter'
 import { ChatMessage, ListAvailableModelsResult } from '@aws/language-server-runtimes-types'
 import { ChatHistory } from './features/history'
 import { pairProgrammingModeOn, pairProgrammingModeOff } from './texts/pairProgramming'
+import { strictEqual } from 'assert'
 
 describe('MynahUI', () => {
     let messager: Messager
@@ -568,6 +570,38 @@ describe('MynahUI', () => {
                     },
                 ],
             })
+        })
+    })
+
+    describe('stringOverrides', () => {
+        it('should apply string overrides to config texts', () => {
+            const stringOverrides = {
+                spinnerText: 'Custom loading message...',
+                stopGenerating: 'Custom stop text',
+                showMore: 'Custom show more text',
+            }
+
+            const messager = new Messager(outboundChatApi)
+            const tabFactory = new TabFactory({})
+            const [customMynahUi] = createMynahUi(
+                messager,
+                tabFactory,
+                true,
+                true,
+                undefined,
+                undefined,
+                true,
+                stringOverrides
+            )
+
+            // Access the config texts from the instance
+            const configTexts = (customMynahUi as any).props.config.texts
+
+            // Verify that string overrides were applied and defaults are preserved
+            strictEqual(configTexts.spinnerText, 'Custom loading message...')
+            strictEqual(configTexts.stopGenerating, 'Custom stop text')
+            strictEqual(configTexts.showMore, 'Custom show more text')
+            strictEqual(configTexts.clickFileToViewDiff, uiComponentsTexts.clickFileToViewDiff)
         })
     })
 })

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1693,7 +1693,7 @@ const DEFAULT_TEST_PROMPT = `You are Amazon Q. Start with a warm greeting, then 
 
 const DEFAULT_DEV_PROMPT = `You are Amazon Q. Start with a warm greeting, then ask the user to specify what kind of help they need in code development. Present common questions asked (like Creating a new project, Adding a new feature, Modifying your files). Keep the question brief and friendly. Don't make assumptions about existing content or context. Wait for their response before providing specific guidance.`
 
-const uiComponentsTexts = {
+export const uiComponentsTexts = {
     mainTitle: 'Amazon Q (Preview)',
     copy: 'Copy',
     insertAtCursorLabel: 'Insert at cursor',

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -50,6 +50,7 @@ import {
     ChatItemButton,
     MynahIcons,
     CustomQuickActionCommand,
+    ConfigTexts,
 } from '@aws/mynah-ui'
 import { VoteParams } from '../contracts/telemetry'
 import { Messager } from './messager'
@@ -310,7 +311,8 @@ export const createMynahUi = (
     pairProgrammingCardAcknowledged: boolean,
     customChatClientAdapter?: ChatClientAdapter,
     featureConfig?: Map<string, any>,
-    agenticMode?: boolean
+    agenticMode?: boolean,
+    stringOverrides?: Partial<ConfigTexts>
 ): [MynahUI, InboundChatApi] => {
     let disclaimerCardActive = !disclaimerAcknowledged
     let programmingModeCardActive = !pairProgrammingCardAcknowledged
@@ -804,6 +806,7 @@ export const createMynahUi = (
                 // Fallback to original texts in non-agentic chat mode
                 stopGenerating: agenticMode ? uiComponentsTexts.stopGenerating : 'Stop generating',
                 spinnerText: agenticMode ? uiComponentsTexts.spinnerText : 'Generating your answer...',
+                ...stringOverrides,
             },
             // Total model context window limit 600k.
             // 500k for user input, 100k for context, history, system prompt.


### PR DESCRIPTION
## Problem
Clients need a way to override Mynah-UI strings. For example, a "workspace" in one IDE might be called a "project" in another IDE. Or when displaying keyboard shortcut hints, an IDE might want to display `Alt Enter` instead of `⌥ Enter`.

## Solution
Add an optional `stringOverrides` property to ChatClientConfig. This allows clients to override Mynah-UI [ConfigTexts](https://github.com/aws/mynah-ui/blob/aabb08d924a27ba19a0db3b01c3e3e371e7f6226/src/static.ts#L726) by passing in strings to createChat.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
