### PR TITLE
telemetry: adding agenticCoding field to amazonq_addMessage metric

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -682,6 +682,9 @@ export class AgenticChatController implements ChatHandlers {
                     session.pairProgrammingMode,
                     session.getConversationType()
                 )
+                metric.setDimension('languageServerVersion', this.#features.runtime.serverInfo.version)
+                metric.setDimension('codewhispererCustomizationArn', this.#customizationArn)
+                metric.setDimension('enabled', session.pairProgrammingMode)
                 await this.#telemetryController.emitAddMessageMetric(params.tabId, metric.metric, 'Cancelled')
             })
             session.setConversationType('AgenticChat')
@@ -2483,6 +2486,8 @@ export class AgenticChatController implements ChatHandlers {
         const requestID = getRequestID(err) ?? ''
         metric.setDimension('cwsprChatResponseCode', getHttpStatusCode(err) ?? 0)
         metric.setDimension('languageServerVersion', this.#features.runtime.serverInfo.version)
+        metric.setDimension('codewhispererCustomizationArn', this.#customizationArn)
+        metric.setDimension('enabled', agenticCodingMode)
 
         metric.metric.requestIds = [requestID]
         metric.metric.cwsprChatMessageId = errorMessageId


### PR DESCRIPTION
## Problem
- Missing telemetry fields like agenticCoding fields in `amazonq_addMessage` if the result is `Failed` or `Cancelled`
## Solution
- Fixed this above issue.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
