### PR TITLE
fix: `/` shown in rules list on windows

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -690,9 +690,12 @@ export class AgenticChatController implements ChatHandlers {
                 params.tabId,
                 params.context
             )
-            // Add active file to context list if it exists
+            // Add active file to context list if it's not already there
             const activeFile =
-                triggerContext.text && triggerContext.relativeFilePath && triggerContext.activeFilePath
+                triggerContext.text &&
+                triggerContext.relativeFilePath &&
+                triggerContext.activeFilePath &&
+                !additionalContext.map(item => item.path).includes(triggerContext.activeFilePath)
                     ? [
                           {
                               name: path.basename(triggerContext.relativeFilePath),

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -695,7 +695,7 @@ export class AgenticChatController implements ChatHandlers {
                 triggerContext.text &&
                 triggerContext.relativeFilePath &&
                 triggerContext.activeFilePath &&
-                !additionalContext.map(item => item.path).includes(triggerContext.activeFilePath)
+                !additionalContext.some(item => item.path === triggerContext.activeFilePath)
                     ? [
                           {
                               name: path.basename(triggerContext.relativeFilePath),

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
@@ -177,7 +177,8 @@ export class AdditionalContextProvider {
         if (prompt.filePath.endsWith(promptFileExtension)) {
             if (
                 pathUtils.isInDirectory(path.join('.amazonq', 'rules'), prompt.relativePath) ||
-                path.basename(prompt.relativePath) === 'AmazonQ.md'
+                path.basename(prompt.relativePath) === 'AmazonQ.md' ||
+                path.basename(prompt.relativePath) === 'README.md'
             ) {
                 return 'rule'
             } else if (pathUtils.isInDirectory(getUserPromptsDirectory(), prompt.filePath)) {
@@ -616,7 +617,11 @@ export class AdditionalContextProvider {
                 // Root files will use the workspace folder name
                 // Subdir files will use workspace folder name + subdir
                 const workspaceFolderName = path.basename(rule.workspaceFolder)
-                folderName = dirPath === '.' ? workspaceFolderName : `${workspaceFolderName}/${dirPath}`
+                folderName =
+                    dirPath === '.'
+                        ? workspaceFolderName
+                        : // Escape backslashes since folderName is displayed in innerHTML
+                          path.join(workspaceFolderName, dirPath).replace(/\\/g, '\\\\')
             }
 
             // Get or create the folder's rule list


### PR DESCRIPTION
## Problem
This PR fixes 2 bugs:
- If a file is active file and also added in pinned context, it may show up in Context dropdown twice
- If a multi-root workspace is open on windows, rules folder path shows `/` instead of `\` 

## Solution
- Don't add active file to Context dropdown if file is already in list
- Properly use path.join when constructing path, making sure to escape `\` 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
