### PR TITLE
fix(amazonq): add image context to chat history

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -541,6 +541,7 @@ describe('AgenticChatController', () => {
                 {
                     userInputMessage: {
                         content: 'Previous question',
+                        images: [],
                         origin: 'IDE',
                         userInputMessageContext: { toolResults: [] },
                         userIntent: undefined,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2951,6 +2951,7 @@ export class AgenticChatController implements ChatHandlers {
                 useRelevantDocuments: false,
             }
 
+        // Clear images to avoid passing them again in follow-up toolUse/toolResult loops, as it is may confuse the model
         updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.images = []
 
         for (const toolResult of toolResults) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -67,7 +67,6 @@ import {
     ListAvailableModelsResult,
     OpenFileDialogParams,
     OpenFileDialogResult,
-    ContextCommand,
 } from '@aws/language-server-runtimes/protocol'
 import {
     ApplyWorkspaceEditParams,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2921,6 +2921,8 @@ export class AgenticChatController implements ChatHandlers {
                 useRelevantDocuments: false,
             }
 
+        updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.images = []
+
         for (const toolResult of toolResults) {
             this.#debug(`ToolResult: ${JSON.stringify(toolResult)}`)
             updatedRequestInput.conversationState!.currentMessage!.userInputMessage!.userInputMessageContext!.toolResults.push(

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -817,12 +817,6 @@ export class AgenticChatController implements ChatHandlers {
                 params.context,
                 params.tabId
             )
-            // Add image context to triggerContext.documentReference for transparency
-            await this.#additionalContextProvider.appendCustomContextToTriggerContext(
-                triggerContext,
-                params.context,
-                params.tabId
-            )
 
             let finalResult
             if (params.prompt.command === QuickAction.Compact) {
@@ -870,7 +864,7 @@ export class AgenticChatController implements ChatHandlers {
                     session.conversationId,
                     token,
                     triggerContext.documentReference,
-                    additionalContext.filter(item => item.pinned)
+                    additionalContext
                 )
             }
 
@@ -1145,13 +1139,15 @@ export class AgenticChatController implements ChatHandlers {
         conversationIdentifier?: string,
         token?: CancellationToken,
         documentReference?: FileList,
-        pinnedContext?: AdditionalContentEntryAddition[]
+        additionalContext?: AdditionalContentEntryAddition[]
     ): Promise<Result<AgenticChatResultWithMetadata, string>> {
         let currentRequestInput = { ...initialRequestInput }
         let finalResult: Result<AgenticChatResultWithMetadata, string> | null = null
         let iterationCount = 0
         let shouldDisplayMessage = true
         let currentRequestCount = 0
+        const pinnedContext = additionalContext?.filter(item => item.pinned)
+
         metric.recordStart()
         this.logSystemInformation()
         while (true) {
@@ -1168,7 +1164,7 @@ export class AgenticChatController implements ChatHandlers {
                 throw new CancellationError('user')
             }
 
-            this.truncateRequest(currentRequestInput, pinnedContext)
+            this.truncateRequest(currentRequestInput, additionalContext)
             const currentMessage = currentRequestInput.conversationState?.currentMessage
             const conversationId = conversationIdentifier ?? ''
             if (!currentMessage || !conversationId) {
@@ -1478,7 +1474,7 @@ export class AgenticChatController implements ChatHandlers {
      * Returns the remaining character budget for chat history.
      * @param request
      */
-    truncateRequest(request: ChatCommandInput, pinnedContext?: AdditionalContentEntryAddition[]): number {
+    truncateRequest(request: ChatCommandInput, additionalContext?: AdditionalContentEntryAddition[]): number {
         // TODO: Confirm if this limit applies to SendMessage and rename this constant
         let remainingCharacterBudget = GENERATE_ASSISTANT_RESPONSE_INPUT_LIMIT
         if (!request?.conversationState?.currentMessage?.userInputMessage) {
@@ -1499,40 +1495,72 @@ export class AgenticChatController implements ChatHandlers {
             }
         }
 
-        // 2. try to fit @context into budget
-        let truncatedRelevantDocuments = []
+        // 2. try to fit @context and images into budget together
+        const docs =
+            request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.editorState
+                ?.relevantDocuments ?? []
+        const images = request.conversationState.currentMessage.userInputMessage.images ?? []
+
+        // Combine docs and images, preserving the order from additionalContext
+        let combined
+        if (additionalContext && additionalContext.length > 0) {
+            let docIdx = 0
+            let imageIdx = 0
+            combined = additionalContext
+                .map(entry => {
+                    if (entry.type === 'image') {
+                        return { type: 'image', value: images[imageIdx++] }
+                    } else {
+                        return { type: 'doc', value: docs[docIdx++] }
+                    }
+                })
+                .filter(item => item.value !== undefined)
+        } else {
+            combined = [
+                ...docs.map(d => ({ type: 'doc', value: d })),
+                ...images.map(i => ({ type: 'image', value: i })),
+            ]
+        }
+
+        const truncatedDocs: typeof docs = []
+        const truncatedImages: typeof images = []
+        for (const item of combined) {
+            let itemLength = 0
+            if (item.type === 'doc') {
+                itemLength = (item.value as any)?.text?.length || 0
+                if (remainingCharacterBudget >= itemLength) {
+                    truncatedDocs.push(item.value as (typeof docs)[number])
+                    remainingCharacterBudget -= itemLength
+                }
+            } else if (item.type === 'image') {
+                // Type guard: only call on ImageBlock
+                if (item.value && typeof item.value === 'object' && 'format' in item.value && 'source' in item.value) {
+                    itemLength = estimateCharacterCountFromImageBlock(item.value)
+                    if (remainingCharacterBudget >= itemLength) {
+                        truncatedImages.push(item.value as (typeof images)[number])
+                        remainingCharacterBudget -= itemLength
+                    }
+                }
+            }
+        }
+
+        // Assign truncated lists back to request
         if (
             request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.editorState
                 ?.relevantDocuments
         ) {
-            for (const relevantDoc of request.conversationState.currentMessage.userInputMessage.userInputMessageContext
-                ?.editorState?.relevantDocuments) {
-                const docLength = relevantDoc?.text?.length || 0
-                if (remainingCharacterBudget > docLength) {
-                    truncatedRelevantDocuments.push(relevantDoc)
-                    remainingCharacterBudget = remainingCharacterBudget - docLength
-                }
-            }
             request.conversationState.currentMessage.userInputMessage.userInputMessageContext.editorState.relevantDocuments =
-                truncatedRelevantDocuments
+                truncatedDocs
         }
 
-        // 3. try to fit images into budget
         if (
             request.conversationState.currentMessage.userInputMessage.images !== undefined &&
             request.conversationState.currentMessage.userInputMessage.images.length > 0
         ) {
-            const truncatedImageBlocks: ImageBlock[] = []
-            for (const imageBlock of request.conversationState.currentMessage.userInputMessage.images) {
-                const imageCharCount = estimateCharacterCountFromImageBlock(imageBlock)
-                if (remainingCharacterBudget > imageCharCount) {
-                    truncatedImageBlocks.push(imageBlock)
-                    remainingCharacterBudget = remainingCharacterBudget - imageCharCount
-                }
-            }
-            request.conversationState.currentMessage.userInputMessage.images = truncatedImageBlocks
+            request.conversationState.currentMessage.userInputMessage.images = truncatedImages
         }
-        // 4. try to fit current file context
+
+        // 3. try to fit current file context
         let truncatedCurrentDocument = undefined
         if (request.conversationState.currentMessage.userInputMessage.userInputMessageContext?.editorState?.document) {
             const docLength =
@@ -1548,7 +1576,9 @@ export class AgenticChatController implements ChatHandlers {
                 truncatedCurrentDocument
         }
 
-        // 5. try to fit pinned context into budget
+        const pinnedContext = additionalContext?.filter(item => item.pinned)
+
+        // 4. try to fit pinned context into budget
         if (pinnedContext && pinnedContext.length > 0) {
             remainingCharacterBudget = this.truncatePinnedContext(remainingCharacterBudget, pinnedContext)
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -213,6 +213,11 @@ export class AgenticChatTriggerContext {
         // Add @context in prompt to relevantDocuments
         if (additionalContent) {
             for (const item of additionalContent.filter(item => !item.pinned)) {
+                // image context does not come from workspace, skip
+                if (item.type === 'image') {
+                    continue
+                }
+
                 // Determine programming language from file extension or type
                 let programmingLanguage: ProgrammingLanguage | undefined = undefined
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -800,7 +800,7 @@ export class ChatDatabase {
         let toolUsesCount = 0
         let toolResultsCount = 0
         let editorStateCount = 0
-        let imageTokenCount = 0
+        let imageCharCount = 0
 
         for (const message of allMessages) {
             // Count characters of all message text
@@ -838,7 +838,7 @@ export class ChatDatabase {
                 try {
                     for (const image of message.images) {
                         let imageTokenInCharacter = estimateCharacterCountFromImageBlock(image)
-                        imageTokenCount += imageTokenInCharacter
+                        imageCharCount += imageTokenInCharacter
                     }
                 } catch (e) {
                     this.#features.logging.error(`Error counting images: ${String(e)}`)
@@ -846,9 +846,9 @@ export class ChatDatabase {
             }
         }
 
-        const totalCount = bodyCount + toolUsesCount + toolResultsCount + editorStateCount + imageTokenCount
+        const totalCount = bodyCount + toolUsesCount + toolResultsCount + editorStateCount + imageCharCount
         this.#features.logging.debug(
-            `Messages characters: body: ${bodyCount} + toolUses: ${toolUsesCount} + toolResults: ${toolResultsCount} + editorState: ${editorStateCount} + imageTokenCount: ${imageTokenCount} = total: ${totalCount}`
+            `Messages characters: body: ${bodyCount} + toolUses: ${toolUsesCount} + toolResults: ${toolResultsCount} + editorState: ${editorStateCount} + imageTokenCount: ${imageCharCount} = total: ${totalCount}`
         )
         return totalCount
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -800,6 +800,7 @@ export class ChatDatabase {
         let toolUsesCount = 0
         let toolResultsCount = 0
         let editorStateCount = 0
+        let imageTokenCount = 0
 
         for (const message of allMessages) {
             // Count characters of all message text
@@ -837,7 +838,7 @@ export class ChatDatabase {
                 try {
                     for (const image of message.images) {
                         let imageTokenInCharacter = estimateCharacterCountFromImageBlock(image)
-                        bodyCount += imageTokenInCharacter
+                        imageTokenCount += imageTokenInCharacter
                     }
                 } catch (e) {
                     this.#features.logging.error(`Error counting images: ${String(e)}`)
@@ -845,9 +846,9 @@ export class ChatDatabase {
             }
         }
 
-        const totalCount = bodyCount + toolUsesCount + toolResultsCount + editorStateCount
+        const totalCount = bodyCount + toolUsesCount + toolResultsCount + editorStateCount + imageTokenCount
         this.#features.logging.debug(
-            `Messages characters: body: ${bodyCount} + toolUses: ${toolUsesCount} + toolResults: ${toolResultsCount} + editorState: ${editorStateCount} = total: ${totalCount}`
+            `Messages characters: body: ${bodyCount} + toolUses: ${toolUsesCount} + toolResults: ${toolResultsCount} + editorState: ${editorStateCount} + imageTokenCount: ${imageTokenCount} = total: ${totalCount}`
         )
         return totalCount
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -837,7 +837,7 @@ export class ChatDatabase {
                 try {
                     for (const image of message.images) {
                         let imageTokenInCharacter = estimateCharacterCountFromImageBlock(image)
-                        count += imageTokenInCharacter
+                        bodyCount += imageTokenInCharacter
                     }
                 } catch (e) {
                     this.#features.logging.error(`Error counting images: ${String(e)}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -848,7 +848,7 @@ export class ChatDatabase {
 
         const totalCount = bodyCount + toolUsesCount + toolResultsCount + editorStateCount + imageCharCount
         this.#features.logging.debug(
-            `Messages characters: body: ${bodyCount} + toolUses: ${toolUsesCount} + toolResults: ${toolResultsCount} + editorState: ${editorStateCount} + imageTokenCount: ${imageCharCount} = total: ${totalCount}`
+            `Messages characters: body: ${bodyCount} + toolUses: ${toolUsesCount} + toolResults: ${toolResultsCount} + editorState: ${editorStateCount} + imageCharCount: ${imageCharCount} = total: ${totalCount}`
         )
         return totalCount
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -848,7 +848,7 @@ export class ChatDatabase {
 
         const totalCount = bodyCount + toolUsesCount + toolResultsCount + editorStateCount + imageCharCount
         this.#features.logging.debug(
-            `Messages characters: body: ${bodyCount} + toolUses: ${toolUsesCount} + toolResults: ${toolResultsCount} + editorState: ${editorStateCount} + imageCharCount: ${imageCharCount} = total: ${totalCount}`
+            `Messages characters: body: ${bodyCount} + toolUses: ${toolUsesCount} + toolResults: ${toolResultsCount} + editorState: ${editorStateCount} + images: ${imageCharCount} = total: ${totalCount}`
         )
         return totalCount
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -23,6 +23,7 @@ import {
     getSha256WorkspaceId,
     getMd5WorkspaceId,
     MessagesWithCharacterCount,
+    estimateCharacterCountFromImageBlock,
 } from './util'
 import * as crypto from 'crypto'
 import * as path from 'path'
@@ -829,6 +830,17 @@ export class ChatDatabase {
                     editorStateCount += JSON.stringify(message.userInputMessageContext?.editorState).length
                 } catch (e) {
                     this.#features.logging.error(`Error counting editorState: ${String(e)}`)
+                }
+            }
+
+            if (message.images) {
+                try {
+                    for (const image of message.images) {
+                        let imageTokenInCharacter = estimateCharacterCountFromImageBlock(image)
+                        count += imageTokenInCharacter
+                    }
+                } catch (e) {
+                    this.#features.logging.error(`Error counting images: ${String(e)}`)
                 }
             }
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
@@ -645,7 +645,7 @@ describe('Image Block Utilities', () => {
             }
 
             const result = estimateCharacterCountFromImageBlock(imageBlock)
-            // 1MB * 1100 tokens/MB * 3 chars/token = 3,300,000 characters
+            // (1,000,000 / 1,000,000) * 1100 * 3 = 3300 characters
             assert.strictEqual(result, 3300)
         })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.test.ts
@@ -39,6 +39,7 @@ describe('ChatDb Utilities', () => {
             assert.deepStrictEqual(result, {
                 userInputMessage: {
                     content: 'Hello',
+                    images: [],
                     userInputMessageContext: {},
                     userIntent: undefined,
                     origin: 'IDE',
@@ -645,7 +646,7 @@ describe('Image Block Utilities', () => {
 
             const result = estimateCharacterCountFromImageBlock(imageBlock)
             // 1MB * 1100 tokens/MB * 3 chars/token = 3,300,000 characters
-            assert.strictEqual(result, 3300000)
+            assert.strictEqual(result, 3300)
         })
 
         it('should return 0 for image without bytes', () => {
@@ -682,7 +683,9 @@ describe('Image Block Utilities', () => {
 
             const result = estimateCharacterCountFromImageBlock(imageBlock)
             // 0.001MB * 1100 tokens/MB * 3 chars/token = 3.3 characters
-            assert.strictEqual(result, 3.3)
+            const EPSILON = 1e-6
+            // avoid using strict equality for floating point numbers
+            assert(Math.abs(result - 3.3) < EPSILON)
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
@@ -20,6 +20,7 @@ import {
     ToolUse,
     UserInputMessage,
     AssistantResponseMessage,
+    ImageBlock,
 } from '@amzn/codewhisperer-streaming'
 import { Workspace } from '@aws/language-server-runtimes/server-interface'
 import { activeFileCmd } from '../../context/additionalContextProvider'
@@ -104,6 +105,7 @@ export type Message = {
     toolUses?: ToolUse[]
     timestamp?: Date
     shouldDisplayMessage?: boolean
+    images?: ImageBlock[]
 }
 
 /**
@@ -146,6 +148,7 @@ export function messageToStreamingMessage(msg: Message): StreamingMessage {
                   userIntent: msg.userIntent,
                   origin: msg.origin || 'IDE',
                   userInputMessageContext: msg.userInputMessageContext || {},
+                  images: msg.images || [],
               },
           }
 }
@@ -458,4 +461,20 @@ export function getMd5WorkspaceId(filePath: string): string {
 
 export function getSha256WorkspaceId(filePath: string): string {
     return crypto.createHash('sha256').update(filePath).digest('hex')
+}
+
+/**
+ * Estimates the number of characters that an image binary would represent in a text context.
+ * The estimation is based on the image's byte size, converting bytes to megabytes, then estimating tokens (using 1100 tokens per MB),
+ * and finally converting tokens to characters (assuming 1 token ≈ 3 characters).
+ *
+ * @param image The ImageBlock object containing the image data (expects image.source.bytes to be a Buffer or Uint8Array).
+ * @returns The estimated number of characters that the image would represent.
+ */
+export function estimateCharacterCountFromImageBlock(image: ImageBlock): number {
+    let imagesBytesLen = image.source?.bytes?.byteLength ?? 0
+    // Convert bytes to MB and estimate tokens (using 1100 tokens per MB as middle ground)
+    const imageTokens = (imagesBytesLen / 1000000) * 1100
+    // Each token is 3 characters
+    return imageTokens * 3
 }


### PR DESCRIPTION
## Problem
The image context is not added to history, as a result, if customer ask follow-up questions, the model does not know the previous chat context

## Solution
Add image context to history

https://github.com/user-attachments/assets/a0f3d3fa-6b45-49cb-b67f-51aaa19d4b5b





<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
