### PR TITLE
fix(amazonq): additional checks for binary and credential files

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
@@ -5,6 +5,8 @@ import { ExecuteBash } from './executeBash'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
+import * as fs from 'fs'
+import * as path from 'path'
 
 describe('ExecuteBash Tool', () => {
     let features: TestFeatures
@@ -119,5 +121,149 @@ describe('ExecuteBash Tool', () => {
             false,
             'A command without any path-like token should not require acceptance'
         )
+    })
+
+    describe('isLikelyCredentialFile', () => {
+        let execBash: ExecuteBash
+
+        beforeEach(() => {
+            execBash = new ExecuteBash(features)
+        })
+
+        it('should identify credential files by name', () => {
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/credentials.json'), true)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/secret_key.txt'), true)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/auth_token'), true)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/password.txt'), true)
+        })
+
+        it('should identify credential files by extension', () => {
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/certificate.pem'), true)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/private.key'), true)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/cert.crt'), true)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/keystore.p12'), true)
+        })
+
+        it('should identify credential-related config files', () => {
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/.aws/config'), true)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/.ssh/id_rsa'), true)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/config.json'), true)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/.env'), true)
+        })
+
+        it('should not identify non-credential files', () => {
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/document.txt'), false)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/image.png'), false)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/script.js'), false)
+            assert.equal((execBash as any).isLikelyCredentialFile('/path/to/data.csv'), false)
+        })
+    })
+
+    describe('isLikelyBinaryFile', () => {
+        let execBash: ExecuteBash
+
+        beforeEach(() => {
+            execBash = new ExecuteBash(features)
+        })
+
+        describe('on Windows', () => {
+            // Save original platform
+            const originalPlatform = process.platform
+
+            before(() => {
+                // Mock Windows platform
+                Object.defineProperty(process, 'platform', { value: 'win32' })
+            })
+
+            after(() => {
+                // Restore original platform
+                Object.defineProperty(process, 'platform', { value: originalPlatform })
+            })
+
+            it('should identify Windows executable extensions', () => {
+                // Create a simple mock implementation
+                const isLikelyBinaryFileMock = function (filePath: string): boolean {
+                    const ext = path.extname(filePath).toLowerCase()
+                    return ['.exe', '.dll', '.bat', '.cmd'].includes(ext)
+                }
+
+                // Replace the method with our mock
+                sinon.replace(execBash as any, 'isLikelyBinaryFile', isLikelyBinaryFileMock)
+
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/program.exe'), true)
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/library.dll'), true)
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/script.bat'), true)
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/command.cmd'), true)
+            })
+
+            it('should not identify non-executable extensions on Windows', () => {
+                // Create a simple mock implementation
+                const isLikelyBinaryFileMock = function (filePath: string): boolean {
+                    const ext = path.extname(filePath).toLowerCase()
+                    return ['.exe', '.dll', '.bat', '.cmd'].includes(ext)
+                }
+
+                // Replace the method with our mock
+                sinon.replace(execBash as any, 'isLikelyBinaryFile', isLikelyBinaryFileMock)
+
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/document.txt'), false)
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/script.js'), false)
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/data.csv'), false)
+            })
+        })
+
+        describe('on Unix', () => {
+            // Save original platform
+            const originalPlatform = process.platform
+
+            before(() => {
+                // Mock Unix platform
+                Object.defineProperty(process, 'platform', { value: 'darwin' })
+            })
+
+            after(() => {
+                // Restore original platform
+                Object.defineProperty(process, 'platform', { value: originalPlatform })
+            })
+
+            it('should identify files with execute permissions', () => {
+                const mockStats = {
+                    isFile: () => true,
+                    mode: 0o755, // rwxr-xr-x
+                } as fs.Stats
+
+                sinon.stub(fs, 'statSync').returns(mockStats)
+
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/executable'), true)
+            })
+
+            it('should not identify files without execute permissions', () => {
+                const mockStats = {
+                    isFile: () => true,
+                    mode: 0o644, // rw-r--r--
+                } as fs.Stats
+
+                sinon.stub(fs, 'statSync').returns(mockStats)
+
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/non-executable'), false)
+            })
+
+            it('should not identify non-existent files', () => {
+                sinon.stub(fs, 'statSync').throws(new Error('File not found'))
+
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/non-existent-file'), false)
+            })
+
+            it('should not identify directories', () => {
+                const mockStats = {
+                    isFile: () => false,
+                    mode: 0o755, // rwxr-xr-x
+                } as fs.Stats
+
+                sinon.stub(fs, 'statSync').returns(mockStats)
+
+                assert.equal((execBash as any).isLikelyBinaryFile('/path/to/directory'), false)
+            })
+        })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -7,9 +7,11 @@ import { CancellationError, processUtils, workspaceUtils } from '@aws/lsp-core'
 import { CancellationToken } from 'vscode-languageserver'
 import { ChildProcess, ChildProcessOptions } from '@aws/lsp-core/out/util/processUtils'
 // eslint-disable-next-line import/no-nodejs-modules
-import { isAbsolute, join } from 'path' // Safe to import on web since this is part of path-browserify
+import { isAbsolute, join, extname } from 'path' // Safe to import on web since this is part of path-browserify
 import { Features } from '../../types'
 import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
+// eslint-disable-next-line import/no-nodejs-modules
+import { existsSync, statSync } from 'fs'
 
 export enum CommandCategory {
     ReadOnly,
@@ -109,6 +111,9 @@ export const lineCount: number = 1024
 export const destructiveCommandWarningMessage = 'WARNING: Potentially destructive command detected:\n\n'
 export const mutateCommandWarningMessage = 'Mutation command:\n\n'
 export const outOfWorkspaceWarningmessage = 'Execution out of workspace scope:\n\n'
+export const credentialFileWarningMessage =
+    'WARNING: Command involves credential files that require secure permissions:\n\n'
+export const binaryFileWarningMessage = 'WARNING: Command involves binary files that require secure permissions:\n\n'
 
 /**
  * Parameters for executing a command on the system shell.
@@ -242,6 +247,34 @@ export class ExecuteBash {
                             continue
                         }
 
+                        // Check if this is a credential file that needs protection
+                        try {
+                            if (existsSync(fullPath) && statSync(fullPath).isFile()) {
+                                // Check for credential files
+                                if (this.isLikelyCredentialFile(fullPath)) {
+                                    this.logging.info(`Detected credential file in command: ${fullPath}`)
+                                    return {
+                                        requiresAcceptance: true,
+                                        warning: credentialFileWarningMessage,
+                                        commandCategory: CommandCategory.Mutate,
+                                    }
+                                }
+
+                                // Check for binary files
+                                if (this.isLikelyBinaryFile(fullPath)) {
+                                    this.logging.info(`Detected binary file in command: ${fullPath}`)
+                                    return {
+                                        requiresAcceptance: true,
+                                        warning: binaryFileWarningMessage,
+                                        commandCategory: CommandCategory.Mutate,
+                                    }
+                                }
+                            }
+                        } catch (err) {
+                            // Ignore errors for files that don't exist or can't be accessed
+                            this.logging.debug(`Error checking file ${fullPath}: ${(err as Error).message}`)
+                        }
+
                         const isInWorkspace = workspaceUtils.isInWorkspace(
                             getWorkspaceFolderPaths(this.workspace),
                             fullPath
@@ -352,7 +385,71 @@ export class ExecuteBash {
         }
     }
 
-    // TODO: generalize cancellation logic for tools.
+    // Static patterns for faster lookups - defined once, used many times
+    private static readonly CREDENTIAL_PATTERNS = new Set([
+        'credential',
+        'secret',
+        'token',
+        'password',
+        'key',
+        'cert',
+        'auth',
+        '.aws',
+        '.ssh',
+        '.pgp',
+        '.gpg',
+        '.pem',
+        '.crt',
+        '.key',
+        '.p12',
+        '.pfx',
+        'config.json',
+        'settings.json',
+        '.env',
+        '.npmrc',
+        '.yarnrc',
+    ])
+
+    private static readonly BINARY_EXTENSIONS_WINDOWS = new Set(['.exe', '.dll', '.bat', '.cmd'])
+
+    /**
+     * Efficiently checks if a file is likely to contain credentials based on name or extension
+     * @param filePath Path to check
+     * @returns true if the file likely contains credentials
+     */
+    private isLikelyCredentialFile(filePath: string): boolean {
+        const fileName = filePath.toLowerCase()
+
+        // Fast check using Set for O(1) lookups instead of array iteration
+        for (const pattern of ExecuteBash.CREDENTIAL_PATTERNS) {
+            if (fileName.includes(pattern)) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    /**
+     * Efficiently checks if a file is a binary executable
+     * @param filePath Path to check
+     * @returns true if the file is likely a binary executable
+     */
+    private isLikelyBinaryFile(filePath: string): boolean {
+        if (IS_WINDOWS_PLATFORM) {
+            const ext = extname(filePath).toLowerCase()
+            return ExecuteBash.BINARY_EXTENSIONS_WINDOWS.has(ext)
+        }
+
+        try {
+            // Check if file exists and is executable
+            const stats = statSync(filePath)
+            return stats.isFile() && (stats.mode & 0o111) !== 0 // Check if any execute bit is set
+        } catch {
+            return false
+        }
+    }
+
     public async invoke(
         params: ExecuteBashParams,
         cancellationToken?: CancellationToken,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -445,11 +445,13 @@ export class ExecuteBash {
             // Check if file exists and is executable
             const stats = statSync(filePath)
             return stats.isFile() && (stats.mode & 0o111) !== 0 // Check if any execute bit is set
-        } catch {
+        } catch (error) {
+            this.logging.debug(`Failed to check if file is binary: ${filePath}, error: ${(error as Error).message}`)
             return false
         }
     }
 
+    // TODO: generalize cancellation logic for tools.
     public async invoke(
         params: ExecuteBashParams,
         cancellationToken?: CancellationToken,


### PR DESCRIPTION
## Problem
Trust mode/auto-approve mode in execute bash tool needs additional security measure.

## Solution
- additional checks for binary and credential files

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
