### PR TITLE
feat(amazonq): allow opt-out for workspace context server

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
@@ -124,7 +124,12 @@ export class ArtifactManager {
         return zipFileMetadata
     }
 
-    async removeWorkspaceFolders(workspaceFolders: WorkspaceFolder[]): Promise<void> {
+    dispose(): void {
+        this.filesByWorkspaceFolderAndLanguage.clear()
+        this.workspaceFolders = []
+    }
+
+    removeWorkspaceFolders(workspaceFolders: WorkspaceFolder[]): void {
         workspaceFolders.forEach(workspaceToRemove => {
             // Find the matching workspace folder by URI
             let folderToDelete: WorkspaceFolder | undefined

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyDiscoverer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyDiscoverer.ts
@@ -137,6 +137,7 @@ export class DependencyDiscoverer {
     async reSyncDependenciesToS3(folders: WorkspaceFolder[]) {
         Atomics.store(this.dependencyUploadedSizeSum, 0, 0)
         for (const dependencyHandler of this.dependencyHandlerRegistry) {
+            dependencyHandler.markAllDependenciesAsUnZipped()
             await dependencyHandler.zipDependencyMap(folders)
         }
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/LanguageDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/LanguageDependencyHandler.ts
@@ -353,4 +353,12 @@ export abstract class LanguageDependencyHandler<T extends BaseDependencyInfo> {
     protected isDependencyZipped(dependencyName: string, workspaceFolder: WorkspaceFolder): boolean | undefined {
         return this.dependencyMap.get(workspaceFolder)?.get(dependencyName)?.zipped
     }
+
+    markAllDependenciesAsUnZipped(): void {
+        this.dependencyMap.forEach(correspondingDependencyMap => {
+            correspondingDependencyMap.forEach(dependency => {
+                dependency.zipped = false
+            })
+        })
+    }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/fileUploadJobManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/fileUploadJobManager.ts
@@ -157,6 +157,8 @@ export class FileUploadJobManager {
     }
 
     public dispose(): void {
-        clearInterval(this.jobConsumerInterval)
+        if (this.jobConsumerInterval) {
+            clearInterval(this.jobConsumerInterval)
+        }
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.test.ts
@@ -2,14 +2,13 @@ import { InitializeParams, Server } from '@aws/language-server-runtimes/server-i
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import sinon from 'ts-sinon'
 import { WorkspaceContextServer } from './workspaceContextServer'
-import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 
 describe('WorkspaceContext Server', () => {
     let features: TestFeatures
     let server: Server
     let disposeServer: () => void
 
-    before(() => {
+    beforeEach(() => {
         features = new TestFeatures()
         server = WorkspaceContextServer()
         disposeServer = server(features)
@@ -43,6 +42,151 @@ describe('WorkspaceContext Server', () => {
 
             // Verify that a warning was logged (indicating the workspaceIdentifier was generated)
             sinon.assert.calledWith(features.logging.warn, sinon.match(/No workspaceIdentifier set/))
+        })
+    })
+
+    describe('UpdateConfiguration', () => {
+        it('should opt in for VSCode extension with server-sideContext enabled', async () => {
+            features.lsp.getClientInitializeParams.returns({
+                initializationOptions: {
+                    aws: {
+                        clientInfo: {
+                            name: 'AmazonQ-For-VSCode',
+                            version: '0.0.1',
+                            extension: {
+                                name: 'AmazonQ-For-VSCode',
+                                version: '0.0.1',
+                            },
+                        },
+                    },
+                },
+            } as InitializeParams)
+
+            features.lsp.workspace.getConfiguration.withArgs('amazonQ').resolves({
+                'server-sideContext': true,
+            })
+
+            await features.initialize(server)
+            await features.doChangeConfiguration()
+
+            sinon.assert.calledWith(features.logging.log, sinon.match(/Workspace context server opt-in flag is: true/))
+        })
+
+        it('should opt out for VSCode extension with server-sideContext disabled', async () => {
+            features.lsp.getClientInitializeParams.returns({
+                initializationOptions: {
+                    aws: {
+                        clientInfo: {
+                            name: 'AmazonQ-For-VSCode',
+                            version: '0.0.1',
+                            extension: {
+                                name: 'AmazonQ-For-VSCode',
+                                version: '0.0.1',
+                            },
+                        },
+                    },
+                },
+            } as InitializeParams)
+
+            features.lsp.workspace.getConfiguration.withArgs('amazonQ').resolves({
+                'server-sideContext': false,
+            })
+
+            await features.initialize(server)
+            await features.doChangeConfiguration()
+
+            sinon.assert.calledWith(features.logging.log, sinon.match(/Workspace context server opt-in flag is: false/))
+        })
+
+        it('should opt in for VSCode extension with server-sideContext missing for internal & BuilderID users', async () => {
+            features.lsp.getClientInitializeParams.returns({
+                initializationOptions: {
+                    aws: {
+                        clientInfo: {
+                            name: 'AmazonQ-For-VSCode',
+                            version: '0.0.1',
+                            extension: {
+                                name: 'AmazonQ-For-VSCode',
+                                version: '0.0.1',
+                            },
+                        },
+                    },
+                },
+            } as InitializeParams)
+
+            features.lsp.workspace.getConfiguration.withArgs('amazonQ').resolves({})
+            await features.initialize(server)
+
+            // Internal users
+            features.credentialsProvider.getConnectionMetadata.returns({
+                sso: {
+                    startUrl: 'https://amzn.awsapps.com/start',
+                },
+            })
+            await features.doChangeConfiguration()
+            sinon.assert.calledWith(features.logging.log, sinon.match(/Workspace context server opt-in flag is: true/))
+
+            // BuilderID users
+            sinon.restore()
+            features.credentialsProvider.getConnectionMetadata.returns({
+                sso: {
+                    startUrl: 'https://view.awsapps.com/start',
+                },
+            })
+            await features.doChangeConfiguration()
+            sinon.assert.calledWith(features.logging.log, sinon.match(/Workspace context server opt-in flag is: true/))
+        })
+
+        it('should opt in for JetBrains extension with server-sideContext enabled', async () => {
+            features.lsp.getClientInitializeParams.returns({
+                initializationOptions: {
+                    aws: {
+                        clientInfo: {
+                            name: 'Amazon Q For JetBrains',
+                            version: '0.0.1',
+                            extension: {
+                                name: 'Amazon Q For JetBrains',
+                                version: '0.0.1',
+                            },
+                        },
+                    },
+                },
+            } as InitializeParams)
+
+            features.lsp.workspace.getConfiguration.withArgs('aws.codeWhisperer').resolves({
+                workspaceContext: true,
+            })
+
+            await features.initialize(server)
+            await features.doChangeConfiguration()
+
+            sinon.assert.calledWith(features.logging.log, sinon.match(/Workspace context server opt-in flag is: true/))
+        })
+
+        it('should opt out for JetBrains extension with server-sideContext disabled', async () => {
+            features.lsp.getClientInitializeParams.returns({
+                initializationOptions: {
+                    aws: {
+                        clientInfo: {
+                            name: 'Amazon Q For JetBrains',
+                            version: '0.0.1',
+                            extension: {
+                                name: 'Amazon Q For JetBrains',
+                                version: '0.0.1',
+                            },
+                        },
+                    },
+                },
+            } as InitializeParams)
+
+            features.lsp.workspace.getConfiguration.withArgs('aws.codeWhisperer').resolves({
+                workspaceContext: false,
+            })
+
+            await features.initialize(server)
+            await features.doChangeConfiguration()
+
+            sinon.assert.calledWith(features.logging.log, sinon.match(/Workspace context server opt-in flag is: false/))
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -147,13 +147,16 @@ export const WorkspaceContextServer = (): Server => features => {
                 workspaceContextConfig = workspaceContextConfig || configJetBrains['workspaceContext']
             }
 
-            // TODO, removing client side opt in temporarily
-            isOptedIn = true
-            // isOptedIn = workspaceContextConfig === true
+            isOptedIn = workspaceContextConfig === true
+            logging.log(`Workspace context server opt-in flag is: ${workspaceContextConfig}`)
 
             if (!isOptedIn) {
                 isWorkflowInitialized = false
+                fileUploadJobManager?.dispose()
+                dependencyEventBundler?.dispose()
                 await workspaceFolderManager.clearAllWorkspaceResources()
+                // Delete remote workspace when user chooses to opt-out
+                await workspaceFolderManager.deleteRemoteWorkspace()
             }
         } catch (error) {
             logging.error(`Error in getConfiguration: ${error}`)
@@ -304,6 +307,8 @@ export const WorkspaceContextServer = (): Server => features => {
                     if (isWorkflowInitialized) {
                         // If user is not logged in but the workflow is marked as initialized, it means user was logged in and is now logged out
                         // In this case, clear the resources and stop the monitoring
+                        fileUploadJobManager?.dispose()
+                        dependencyEventBundler?.dispose()
                         await workspaceFolderManager.clearAllWorkspaceResources()
                     }
                     isWorkflowInitialized = false

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
@@ -204,7 +204,6 @@ export class WorkspaceFolderManager {
     async clearAllWorkspaceResources() {
         this.stopContinuousMonitoring()
         this.stopMessageQueueConsumer()
-        this.resetRemoteWorkspaceId()
         this.workspaceState.webSocketClient?.destroyClient()
         this.dependencyDiscoverer.dispose()
     }
@@ -640,14 +639,19 @@ export class WorkspaceFolderManager {
         }
     }
 
-    // TODO, this function is unused at the moment
-    private async deleteWorkspace(workspaceId: string) {
+    public async deleteRemoteWorkspace() {
+        const workspaceId = this.workspaceState.workspaceId
+        this.resetRemoteWorkspaceId()
         try {
+            if (!workspaceId) {
+                this.logging.warn(`No remote workspaceId found, skipping workspace deletion`)
+                return
+            }
             if (isLoggedInUsingBearerToken(this.credentialsProvider)) {
                 await this.serviceManager.getCodewhispererService().deleteWorkspace({
                     workspaceId: workspaceId,
                 })
-                this.logging.log(`Workspace (${workspaceId}) deleted successfully`)
+                this.logging.log(`Remote workspace (${workspaceId}) deleted successfully`)
             } else {
                 this.logging.log(`Skipping workspace (${workspaceId}) deletion because user is not logged in`)
             }


### PR DESCRIPTION
## Problem

In order to open workspace context server to all users, we need to support both client-side opt-out (controlled by individual users in IDE) and server-side opt-out (controlled by users' administrator in AWS console).

## Solution

Add the support for both client-side opt-out and server-side opt-out and react to status switches from one to another.

## Testing

Tested the following scenarios locally, with:
- An Amazon internal user identity and a Pro Tier user identity
- An Amazon Q extension on VSCode and an Amazon Q extension on JetBrains

**Client-side Opt-in Tests**

| Scenario | Behavior |
| - | - |
| *New Flare Code & Extension without Checkbox* | |
| Amazon Internal User / BuilderID User | Treated the same as client-side opted-in|
| Pro Tier User | Treated the same as client-side opted-out |
| *New Flare Code & Extension with Checkbox (All users)* | |
| IDE window open without previous opt-in settings | Default as client-side opted-in |
| IDE window open with opt-in checkbox checked | Workspace context server creates a remote workspace and reacts to events |
| IDE window open with opt-in checkbox unchecked | Workspace context server neither creates a remote workspace nor reacts to events |
| IDE opt-in checkbox switch from opted-in to opted-out | After the switch, workspace context server stops reacting to events and calls DeleteWorkspace API to delete the remote workspace |
| IDE opt-in checkbox switch from opted-out to opted-in | After the switch, workspace context server creates a remote workspace and starts reacting to events |

**Server-side Opt-in Tests (with client-side opted-in)**

| Scenario | Behavior |
| - | - |
| User's administrator opted-in | Workspace context server creates a remote workspace and reacts to events, probing server-side opt-in status every 30 minutes |
| User's administrator opted-out | Workspace context server neither creates a remote workspace nor reacts to events, probing server-side opt-in status every 30 minutes |
| User's administrator switch from opted-in to opted-out | After the switch, workspace context server stops reacting to events |
| User's administrator switch from opted-out to opted-in | After the switch, workspace context server creates a remote workspace and starts reacting to events |

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
