### PR TITLE
fix: use absolute file path for shell

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -358,9 +358,10 @@ export class ExecuteBash {
         cancellationToken?: CancellationToken,
         updates?: WritableStream
     ): Promise<InvokeOutput> {
+        // use absoluate file path
         const { shellName, shellFlag } = IS_WINDOWS_PLATFORM
-            ? { shellName: 'cmd.exe', shellFlag: '/c' }
-            : { shellName: 'bash', shellFlag: '-c' }
+            ? { shellName: 'C:\\Windows\\System32\\cmd.exe', shellFlag: '/c' }
+            : { shellName: '/bin/bash', shellFlag: '-c' }
         this.logging.info(`Invoking ${shellName} command: "${params.command}" in cwd: "${params.cwd}"`)
 
         return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
## Notes
- Use absolute file path when invoking shell

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
