### PR TITLE
feat(amazonq): added full system information to the logs

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -5,6 +5,7 @@
 
 import * as crypto from 'crypto'
 import * as path from 'path'
+import * as os from 'os'
 import {
     ChatTriggerType,
     Origin,
@@ -247,6 +248,26 @@ export class AgenticChatController implements ChatHandlers {
         const toolUseId = toolUse.toolUseId!
         // Return plain toolUseId for executeBash, add "_permission" suffix for all other tools
         return toolUse.name === 'executeBash' || toolType === 'executeBash' ? toolUseId : `${toolUseId}_permission`
+    }
+
+    /**
+     * Logs system information that can be helpful for debugging customer issues
+     */
+    private logSystemInformation(): void {
+        const clientInfo = this.#features.lsp.getClientInitializeParams()?.clientInfo
+        const systemInfo = {
+            languageServerVersion: this.#features.runtime.serverInfo.version ?? 'unknown',
+            clientName: clientInfo?.name ?? 'unknown',
+            clientVersion: clientInfo?.version ?? 'unknown',
+            OS: os.platform(),
+            OSVersion: os.release(),
+            ComputeEnv: process.env.COMPUTE_ENV ?? 'unknown',
+            extensionVersion:
+                this.#features.lsp.getClientInitializeParams()?.initializationOptions?.aws?.clientInfo?.extension
+                    ?.version,
+        }
+
+        this.#features.logging.info(`System Information: ${JSON.stringify(systemInfo)}`)
     }
 
     constructor(
@@ -851,7 +872,7 @@ export class AgenticChatController implements ChatHandlers {
         let iterationCount = 0
         let shouldDisplayMessage = true
         metric.recordStart()
-
+        this.logSystemInformation()
         while (true) {
             iterationCount++
             this.#debug(`Agent loop iteration ${iterationCount} for conversation id:`, conversationIdentifier || '')


### PR DESCRIPTION
## Problem
Currently, We didn't have the full system information in logs and were asking users to collect it when submitting tickets.

## Solution
Added the system information to the logs.

System Information: {"languageServerVersion":"0.1.0","clientName":"vscode","clientVersion":"1.101.2","OS":"darwin","OSVersion":"24.5.0","ComputeEnv":"unknown","extensionVersion":"testPluginVersion"}

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
