### PR TITLE
revert: adding streakLength back for UserTriggerDecisionEvent

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -589,7 +589,8 @@ export const CodewhispererServerFactory =
                         }
                         // Emit user trigger decision at session close time for active session
                         sessionManager.discardSession(currentSession)
-                        const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(false) : 0
+                        // TODO add streakLength back once the model is updated
+                        // const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(false) : 0
                         await emitUserTriggerDecisionTelemetry(
                             telemetry,
                             telemetryService,
@@ -598,8 +599,7 @@ export const CodewhispererServerFactory =
                             0,
                             0,
                             [],
-                            [],
-                            streakLength
+                            []
                         )
                     }
 
@@ -703,17 +703,13 @@ export const CodewhispererServerFactory =
             if (session.discardInflightSessionOnNewInvocation) {
                 session.discardInflightSessionOnNewInvocation = false
                 sessionManager.discardSession(session)
-                const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(false) : 0
+                // TODO add streakLength back once the model is updated
+                // const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(false) : 0
                 await emitUserTriggerDecisionTelemetry(
                     telemetry,
                     telemetryService,
                     session,
-                    timeSinceLastUserModification,
-                    0,
-                    0,
-                    [],
-                    [],
-                    streakLength
+                    timeSinceLastUserModification
                 )
             }
 
@@ -997,7 +993,8 @@ export const CodewhispererServerFactory =
 
             // Always emit user trigger decision at session close
             sessionManager.closeSession(session)
-            const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(isAccepted) : 0
+            // TODO add streakLength back once the model is updated
+            // const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(isAccepted) : 0
             await emitUserTriggerDecisionTelemetry(
                 telemetry,
                 telemetryService,
@@ -1006,8 +1003,7 @@ export const CodewhispererServerFactory =
                 addedCharactersForEditSuggestion.length,
                 deletedCharactersForEditSuggestion.length,
                 addedDiagnostics,
-                removedDiagnostics,
-                streakLength
+                removedDiagnostics
             )
         }
 

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -276,7 +276,6 @@ describe('TelemetryService', () => {
                     deletedCharacterCount: undefined,
                     addedIdeDiagnostics: undefined,
                     removedIdeDiagnostics: undefined,
-                    streakLength: 0,
                 },
             },
             optOutPreference: 'OPTIN',

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -271,7 +271,8 @@ export class TelemetryService {
             deletedCharacterCount: deletedCharacterCount,
             addedIdeDiagnostics: addedIdeDiagnostics,
             removedIdeDiagnostics: removedIdeDiagnostics,
-            streakLength: streakLength ?? 0,
+            // TODO add streakLength back once the model is updated
+            // streakLength: streakLength,
         }
         return this.invokeSendTelemetryEvent({
             userTriggerDecisionEvent: event,


### PR DESCRIPTION
## Problem

This reverts commit 7052132a5198944ef05ddbf857d622ba518e71da as telemetry event is broken.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
