### PR TITLE
fix: ci build packaging

### DIFF
--- a/.github/workflows/create-agent-standalone.yml
+++ b/.github/workflows/create-agent-standalone.yml
@@ -38,10 +38,12 @@ jobs:
                   for platform in "${platforms[@]}"; do
                     echo "Preparing artifacts for $platform"
                     mkdir -p "_artifacts/$platform"
-                    unzip _artifacts/$platform.zip -d _artifacts/$platform
+
+                    cp "app/aws-lsp-codewhisperer-runtimes/build/archives/shared/clients.zip" "_artifacts/$platform/"
+                    cp "app/aws-lsp-codewhisperer-runtimes/build/archives/agent-standalone/$platform/servers.zip" "_artifacts/$platform/"
                   done
                   mkdir -p "_artifacts/clients"
-                  unzip _artifacts/clients.zip -d _artifacts/clients
+                  unzip "app/aws-lsp-codewhisperer-runtimes/build/archives/shared/clients.zip" -d _artifacts/clients
 
             # GitHub Actions zips the archive, so we upload the folder used to
             # produce clients.zip. Otherwise we have a clients.zip artifact


### PR DESCRIPTION

Fixes a bug in #1842 that prevents CI from packaging artifacts.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
