### PR TITLE
fix: Disable Concurrent inline completion handler

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
@@ -2065,8 +2065,8 @@ describe('CodeWhisperer Server', () => {
                 expectedSessionData
             )
         })
-
-        it('should discard inflight session on new request when cached session is in REQUESTING state on subsequent requests', async () => {
+        // we decided to temporarily stop concurrent trigger and disable such logic
+        it.skip('should discard inflight session on new request when cached session is in REQUESTING state on subsequent requests', async () => {
             const getCompletionsResponses = await Promise.all([
                 features.doInlineCompletionWithReferences(
                     {
@@ -2128,7 +2128,7 @@ describe('CodeWhisperer Server', () => {
             )
         })
 
-        it('should record all sessions that were created in session log', async () => {
+        it.skip('should record all sessions that were created in session log', async () => {
             // Start 3 session, 2 will be cancelled inflight
             await Promise.all([
                 features.doInlineCompletionWithReferences(

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
@@ -2128,6 +2128,46 @@ describe('CodeWhisperer Server', () => {
             )
         })
 
+        it('should block inflight session on new request when cached session is in REQUESTING state on subsequent requests', async () => {
+            const getCompletionsResponses = await Promise.all([
+                features.doInlineCompletionWithReferences(
+                    {
+                        textDocument: { uri: SOME_FILE.uri },
+                        position: AUTO_TRIGGER_POSITION,
+                        context: { triggerKind: InlineCompletionTriggerKind.Automatic },
+                    },
+                    CancellationToken.None
+                ),
+                features.doInlineCompletionWithReferences(
+                    {
+                        textDocument: { uri: SOME_FILE.uri },
+                        position: AUTO_TRIGGER_POSITION,
+                        context: { triggerKind: InlineCompletionTriggerKind.Automatic },
+                    },
+                    CancellationToken.None
+                ),
+                features.doInlineCompletionWithReferences(
+                    {
+                        textDocument: { uri: SOME_FILE.uri },
+                        position: AUTO_TRIGGER_POSITION,
+                        context: { triggerKind: InlineCompletionTriggerKind.Automatic },
+                    },
+                    CancellationToken.None
+                ),
+            ])
+
+            // 3 requests were processed by server, but only first should return results
+            const EXPECTED_COMPLETION_RESPONSES = [
+                { sessionId: SESSION_IDS_LOG[0], items: EXPECTED_RESULT.items, partialResultToken: undefined }, // First session wins
+                { sessionId: '', items: [] },
+                { sessionId: '', items: [] },
+            ]
+            // Only last request must return completion items
+            assert.deepEqual(getCompletionsResponses, EXPECTED_COMPLETION_RESPONSES)
+
+            assert.equal(sessionManagerSpy.createSession.callCount, 1)
+        })
+
         it.skip('should record all sessions that were created in session log', async () => {
             // Start 3 session, 2 will be cancelled inflight
             await Promise.all([

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -673,7 +673,7 @@ export const CodewhispererServerFactory =
                     }
                     try {
                         const suggestionResponse = await codeWhispererService.generateSuggestions(generateCompletionReq)
-                        return processSuggestionResponse(suggestionResponse, newSession, true, selectionRange)
+                        return await processSuggestionResponse(suggestionResponse, newSession, true, selectionRange)
                     } catch (error) {
                         return handleSuggestionsErrors(error as Error, newSession)
                     }

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -338,27 +338,41 @@ export const CodewhispererServerFactory =
         const cursorTracker = CursorTracker.getInstance()
         const rejectedEditTracker = RejectedEditTracker.getInstance(logging, DEFAULT_REJECTED_EDIT_TRACKER_CONFIG)
         let editsEnabled = false
+        let isOnInlineCompletionHandlerInProgress = false
 
         const onInlineCompletionHandler = async (
             params: InlineCompletionWithReferencesParams,
             token: CancellationToken
         ): Promise<InlineCompletionListWithReferences> => {
-            // On every new completion request close current inflight session.
-            const currentSession = sessionManager.getCurrentSession()
-            if (currentSession && currentSession.state == 'REQUESTING' && !params.partialResultToken) {
-                currentSession.discardInflightSessionOnNewInvocation = true
+            // this handle should not run concurrently because
+            // 1. it would create a high volume of traffic, causing throttling
+            // 2. it is not designed to handle concurrent changes to these state variables.
+            // when one handler is at the API call stage, it has not yet update the session state
+            // but another request can start, causing the state to be incorrect.
+            if (isOnInlineCompletionHandlerInProgress) {
+                logging.log(`Skip concurrent inline completion`)
+                return EMPTY_RESULT
             }
+            isOnInlineCompletionHandlerInProgress = true
 
-            if (cursorTracker) {
-                cursorTracker.trackPosition(params.textDocument.uri, params.position)
-            }
+            try {
+                // On every new completion request close current inflight session.
+                const currentSession = sessionManager.getCurrentSession()
+                if (currentSession && currentSession.state == 'REQUESTING' && !params.partialResultToken) {
+                    // this REQUESTING state only happens when the session is initialized, which is rare
+                    currentSession.discardInflightSessionOnNewInvocation = true
+                }
 
-            return workspace.getTextDocument(params.textDocument.uri).then(async textDocument => {
+                if (cursorTracker) {
+                    cursorTracker.trackPosition(params.textDocument.uri, params.position)
+                }
+                const textDocument = await workspace.getTextDocument(params.textDocument.uri)
+
                 const codeWhispererService = amazonQServiceManager.getCodewhispererService()
                 if (params.partialResultToken && currentSession) {
                     // subsequent paginated requests for current session
-                    return codeWhispererService
-                        .generateSuggestions({
+                    try {
+                        const suggestionResponse = await codeWhispererService.generateSuggestions({
                             ...currentSession.requestContext,
                             fileContext: {
                                 ...currentSession.requestContext.fileContext,
@@ -371,17 +385,15 @@ export const CodewhispererServerFactory =
                             },
                             nextToken: `${params.partialResultToken}`,
                         })
-                        .then(async suggestionResponse => {
-                            return await processSuggestionResponse(
-                                suggestionResponse,
-                                currentSession,
-                                false,
-                                params.context.selectedCompletionInfo?.range
-                            )
-                        })
-                        .catch(error => {
-                            return handleSuggestionsErrors(error, currentSession)
-                        })
+                        return await processSuggestionResponse(
+                            suggestionResponse,
+                            currentSession,
+                            false,
+                            params.context.selectedCompletionInfo?.range
+                        )
+                    } catch (error) {
+                        return handleSuggestionsErrors(error as Error, currentSession)
+                    }
                 } else {
                     // request for new session
                     if (!textDocument) {
@@ -659,17 +671,16 @@ export const CodewhispererServerFactory =
                         },
                         ...(workspaceId ? { workspaceId: workspaceId } : {}),
                     }
-
-                    return codeWhispererService
-                        .generateSuggestions(generateCompletionReq)
-                        .then(async suggestionResponse => {
-                            return processSuggestionResponse(suggestionResponse, newSession, true, selectionRange)
-                        })
-                        .catch(err => {
-                            return handleSuggestionsErrors(err, newSession)
-                        })
+                    try {
+                        const suggestionResponse = await codeWhispererService.generateSuggestions(generateCompletionReq)
+                        return processSuggestionResponse(suggestionResponse, newSession, true, selectionRange)
+                    } catch (error) {
+                        return handleSuggestionsErrors(error as Error, newSession)
+                    }
                 }
-            })
+            } finally {
+                isOnInlineCompletionHandlerInProgress = false
+            }
         }
 
         const processSuggestionResponse = async (

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
@@ -1266,8 +1266,9 @@ describe('Telemetry', () => {
             })
         })
 
+        // we are blocking subsequent completion request as long as inflight is running
         describe('Case 4. Inflight session is closed by subsequent completion request', function () {
-            it('should emit Discard user trigger decision event when REQUESTING session is closed before becoming ACTIVE', async () => {
+            it.skip('should emit Discard user trigger decision event when REQUESTING session is closed before becoming ACTIVE', async () => {
                 // Chain requests in a callbacks
                 let concurrentCount = 0
                 let requests: Promise<InlineCompletionListWithReferences>[] = []


### PR DESCRIPTION
## Problem

After we migrated inline completion to Flare, we are seeing a 30%+ throttling rate for inline APIs. This rate had been very high for Eclipse since Feb 2025. The server side throttling is 1TPS. 

As user types in the IDE, the `onInlineCompletionHandler` will be invoked per user typing, but this function is not designed to properly handle concurrency. And in the old VSC/JB inline completion, we block such concurrent request, instead of keeping firing and discard the old request. 

As user types, the model is supposed to generate a suggestion that matches the user typeahead, which will get rendered. The previous in flight trigger should not be abandoned. 

## Solution

Block concurrent inline completion handler.


Eventually this needs integration test. To properly test this, we need to create a real in-flight API call. This entire file for some reason does not have a unit test at all. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
