### PR TITLE
chore: produce agentic chat license attribution

### DIFF
--- a/.github/workflows/create-agent-standalone.yml
+++ b/.github/workflows/create-agent-standalone.yml
@@ -28,7 +28,9 @@ jobs:
               run: npm run compile
 
             - name: Generate agent standalone
-              run: npm run ci:generate:agent-standalone -w app/aws-lsp-codewhisperer-runtimes
+              run: |
+                  npm run ci:generate:agent-standalone -w app/aws-lsp-codewhisperer-runtimes
+                  npm run ci:generate:agentic:attribution
 
             # We "flatten" out each clients.zip-servers.zip pairing so that the
             # downloadable artifacts are nicely organized, one per platform.
@@ -89,4 +91,11 @@ jobs:
               with:
                   name: win-x64
                   path: _artifacts/win-x64/
+                  if-no-files-found: error
+
+            - name: Upload THIRD_PARTY_LICENSES
+              uses: actions/upload-artifact@v4
+              with:
+                  name: THIRD_PARTY_LICENSES
+                  path: attribution/THIRD_PARTY_LICENSES
                   if-no-files-found: error

--- a/.github/workflows/create-agentic-github-prerelease.yml
+++ b/.github/workflows/create-agentic-github-prerelease.yml
@@ -131,6 +131,9 @@ jobs:
                   # clients.zip : just pick one of the platforms, they're all the same file
                   cp downloaded-artifacts/linux-x64/clients.zip _release-artifacts/clients.zip
 
+                  # THIRD_PARTY_LICENSES : unzip it from the artifact
+                  unzip -o downloaded-artifacts/THIRD_PARTY_LICENSES.zip -d _release-artifacts/
+
             # Manifest assigned to the GitHub release will only ever contain one version,
             # which points to the assets uploaded to the release (the latest commit).
             - name: Create Artifact Manifest

--- a/app/aws-lsp-codewhisperer-runtimes/scripts/create-repo-manifest.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/scripts/create-repo-manifest.ts
@@ -118,7 +118,7 @@ export async function updateManifest(
         versions: [],
     }
 
-    const licensesURL = 'placeholder'
+    const licensesURL = getGitHubReleaseDownloadUrl('THIRD_PARTY_LICENSES')
     const newEntry = generateNewEntry({
         version: {
             server: serverVersion,

--- a/app/aws-lsp-codewhisperer-runtimes/scripts/download-node.sh
+++ b/app/aws-lsp-codewhisperer-runtimes/scripts/download-node.sh
@@ -73,7 +73,7 @@ echo "License file has been updated in $LICENSE_FILE"
 LICENSE_TEXT=$(cat "$LICENSE_FILE")
 
 # Update the attribution overrides file
-ATTRIBUTION_FILE="build/node-assets/attribution-overrides.json"
+ATTRIBUTION_FILE="../../attribution/overrides.json"
 
 # Create attribution file with empty JSON object if it doesn't exist
 if [ ! -f "$ATTRIBUTION_FILE" ]; then
@@ -84,9 +84,12 @@ fi
 # Update version and licenseText fields using jq
 # jq also escapes text by default
 jq --indent 4 \
+   --arg name "Node.js" \
    --arg version "$NODE_SEMVER" \
-   --arg license "$LICENSE_TEXT" \
-   '.node.version = $version | .node.licenseText = $license' \
+   --arg licenseText "$LICENSE_TEXT" \
+   --arg url "https://github.com/nodejs/node" \
+   --arg license "MIT" \
+   '.node.name = $name | .node.version = $version | .node.url = $url | .node.license = $license | .node.licenseText = $licenseText' \
    "$ATTRIBUTION_FILE" > "$ATTRIBUTION_FILE.tmp" && mv "$ATTRIBUTION_FILE.tmp" "$ATTRIBUTION_FILE"
 echo "Successfully updated Node.js version and license in $ATTRIBUTION_FILE"
 

--- a/app/aws-lsp-codewhisperer-runtimes/src/scripts/copy-node-assets.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/src/scripts/copy-node-assets.ts
@@ -41,7 +41,7 @@ async function copyWindowsAssets() {
 }
 
 async function copyLinuxAndMacAssets() {
-    const overridesContent = await fsPromises.readFile('build/node-assets/attribution-overrides.json', 'utf8')
+    const overridesContent = await fsPromises.readFile('../../attribution/overrides.json', 'utf8')
     const version = JSON.parse(overridesContent).node.version
     const nodeAssetsRoot = 'build/node-assets'
     const linuxX64 = `node-v${version}-linux-x64`

--- a/attribution/overrides.json
+++ b/attribution/overrides.json
@@ -1,0 +1,15 @@
+{
+    "file-description": "Used by generate-attribution in script/generate-attribution.sh",
+    "@aws/language-server-runtimes": {
+        "ignore": true
+    },
+    "@aws/lsp-codewhisperer": {
+        "ignore": true
+    },
+    "@aws/lsp-core": {
+        "ignore": true
+    },
+    "caniuse-lite": {
+        "ignore": true
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,9 @@
                 "eslint-plugin-import": "^2.29.1",
                 "eslint-plugin-unused-imports": "^4.1.4",
                 "husky": "^9.1.7",
+                "license-checker": "^25.0.1",
                 "node-loader": "^2.1.0",
+                "oss-attribution-generator": "^1.7.1",
                 "prettier": "^3.3.3",
                 "pretty-quick": "^4.0.0",
                 "shx": "^0.3.4",
@@ -228,7 +230,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.104"
+                "@aws/language-server-runtimes": "^0.2.105"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -10413,6 +10415,12 @@
                 "node": ">=16.5.0"
             }
         },
+        "node_modules/abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
+        },
         "node_modules/abort-controller": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -10861,6 +10869,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/array-find-index": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+            "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -10971,6 +10988,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+            "dev": true
         },
         "node_modules/asn1.js": {
             "version": "4.10.1",
@@ -11517,6 +11540,12 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true
+        },
         "node_modules/bn.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
@@ -11555,6 +11584,110 @@
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "dev": true
+        },
+        "node_modules/bower": {
+            "version": "1.8.14",
+            "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.14.tgz",
+            "integrity": "sha512-8Rq058FD91q9Nwthyhw0la9fzpBz0iwZTrt51LWl+w+PnJgZk9J+5wp3nibsJcIUPglMYXr4NRBaR+TUj0OkBQ==",
+            "dev": true,
+            "bin": {
+                "bower": "bin/bower"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/bower-json": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.8.4.tgz",
+            "integrity": "sha512-mMKghvq9ivbuzSsY5nrOLnDtZIJMUCpysqbGaGW3mj88JAcuSi8ZAzIt34vNZjohy0aR9VXLwgPTZGnBX2Vpjg==",
+            "dev": true,
+            "dependencies": {
+                "deep-extend": "^0.5.1",
+                "ends-with": "^0.2.0",
+                "ext-list": "^2.0.0",
+                "graceful-fs": "^4.1.3",
+                "intersect": "^1.0.1",
+                "sort-keys-length": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/bower-json/node_modules/deep-extend": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+            "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+            "dev": true,
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/bower-license": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/bower-license/-/bower-license-0.4.4.tgz",
+            "integrity": "sha512-zkDh1GlJkXNFNdlw/JVjihbYsLw5aJhnZnEMMSXLuFKxhJaz+SGFJDOfhBiPZxrASsQCEohuU9EPYdUj1X3GwA==",
+            "dev": true,
+            "dependencies": {
+                "bower-json": "~0.4.0",
+                "npm-license": "~0.3.3",
+                "package-license": "~0.1.1",
+                "raptor-args": "~1.0.1",
+                "treeify": "~1.0.1",
+                "underscore": "~1.5.2"
+            },
+            "bin": {
+                "bower-license": "bin/bower-license"
+            }
+        },
+        "node_modules/bower-license/node_modules/bower-json": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+            "integrity": "sha512-CiCTvl2OndArvZjWYvaOuQWI/fjeaBz8wPLF8MWadHT+ULaBDqtQIOYqQFsxtzUFw6E206960mlZfiUuR1PPBg==",
+            "dev": true,
+            "dependencies": {
+                "deep-extend": "~0.2.5",
+                "graceful-fs": "~2.0.0",
+                "intersect": "~0.0.3"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/bower-license/node_modules/deep-extend": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+            "integrity": "sha512-t2N+4ihO7YgydJOUI47I6GdXpONJ+jUZmYeTNiifALaEduiCja1mKcq3tuSp0RhA9mMfxdMN3YskpwB7puMAtw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
+        "node_modules/bower-license/node_modules/graceful-fs": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+            "integrity": "sha512-hcj/NTUWv+C3MbqrVb9F+aH6lvTwEHJdx2foBxlrVq5h6zE8Bfu4pv4CAAqbDcZrw/9Ak5lsRXlY9Ao8/F0Tuw==",
+            "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/bower-license/node_modules/intersect": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz",
+            "integrity": "sha512-Bp/mSG9dsq/eOMk2Q7DyjKxY62TTU2RvNvycjXHhi5TjrA72H+I3c5+1nAOAqtENcrQvCb5NDlsoPWJ4Bh01SA==",
+            "dev": true
+        },
+        "node_modules/bower-license/node_modules/treeify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.0.1.tgz",
+            "integrity": "sha512-i3MKN4nGEOuVAcd7s5MtAc2+QBExwcaRT/6/CzUSYVYwzM58bJ3H3wwCPu2PEAGjVPHjfIC/MPaXsxPGUk07cg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            }
         },
         "node_modules/bowser": {
             "version": "2.11.0",
@@ -13241,6 +13374,16 @@
                 }
             }
         },
+        "node_modules/debuglog": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/decamelize": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
@@ -13512,6 +13655,16 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+        },
+        "node_modules/dezalgo": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+            "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+            "dev": true,
+            "dependencies": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            }
         },
         "node_modules/diff": {
             "version": "7.0.0",
@@ -13922,6 +14075,15 @@
             "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
             "dependencies": {
                 "once": "^1.4.0"
+            }
+        },
+        "node_modules/ends-with": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
+            "integrity": "sha512-lRppY4dK3VkqBdR242sKcAJeYc8Gf/DhoX9AWvWI2RzccmLnqBQfwm2k4oSDv5MPDjUqawCauXhZkyWxkVhRsg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/enhanced-resolve": {
@@ -15175,6 +15337,18 @@
                 "express": ">= 4.11"
             }
         },
+        "node_modules/ext-list": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+            "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+            "dev": true,
+            "dependencies": {
+                "mime-db": "^1.28.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/external-editor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -15648,6 +15822,86 @@
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
             "license": "MIT"
+        },
+        "node_modules/fs-jetpack": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-0.12.0.tgz",
+            "integrity": "sha512-Xhuoorec62B9LwumWmlcPD9/pussEmpHa4Udyhuu2w0fLZ2sI8AJQ2ZDpkkMpcvDbybOiahZaCmGwAl7yPvbTg==",
+            "dev": true,
+            "dependencies": {
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.1",
+                "q": "^1.0.1",
+                "rimraf": "^2.2.8"
+            }
+        },
+        "node_modules/fs-jetpack/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/fs-jetpack/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/fs-jetpack/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/fs-jetpack/node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/fs-jetpack/node_modules/rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            }
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -16159,6 +16413,30 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
             "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
+        },
+        "node_modules/has-ansi": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+            "integrity": "sha512-1YsTg1fk2/6JToQhtZkArMkurq8UoWU1Qe0aR3VUHjgij4nOylSWLWAtBXoZ4/dXOmugfLGm1c+QhuD0JyedFA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^0.2.0"
+            },
+            "bin": {
+                "has-ansi": "cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/has-ansi/node_modules/ansi-regex": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+            "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
@@ -16864,6 +17142,21 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/intersect": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/intersect/-/intersect-1.0.1.tgz",
+            "integrity": "sha512-qsc720yevCO+4NydrJWgEWKccAQwTOvj2m73O/VBA6iUL2HGZJ9XqBiyraNrBXX/W1IAjdpXdRZk24sq8TzBRg==",
+            "dev": true
+        },
+        "node_modules/invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/ip-address": {
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -17404,6 +17697,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
+            "dev": true
+        },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -17460,6 +17759,24 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/is2": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/is2/-/is2-0.0.11.tgz",
+            "integrity": "sha512-d3CswkUZ7i1wxhbRanVqfUsVRQXZrDC7iALpPg4I5IJdL9nbJSJQBjOMk0hhyO+B5H8a1LQKgn7n1uX4ZF9I8w==",
+            "dev": true,
+            "dependencies": {
+                "deep-is": "0.1.2"
+            },
+            "engines": {
+                "node": ">=v0.6.0"
+            }
+        },
+        "node_modules/is2/node_modules/deep-is": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.2.tgz",
+            "integrity": "sha512-+ykBpFL44/E8TlSBn0kDHZ1+IseXxUu/Om3bS2nqNscaeYWzxx54R9CewU6pLrsXLmEeTRZsGMTQIHfSUEEcUw==",
+            "dev": true
         },
         "node_modules/isarray": {
             "version": "1.0.0",
@@ -19049,6 +19366,18 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "node_modules/lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
+            "dev": true,
+            "dependencies": {
+                "invert-kv": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -19071,6 +19400,128 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/license-checker": {
+            "version": "25.0.1",
+            "resolved": "https://registry.npmjs.org/license-checker/-/license-checker-25.0.1.tgz",
+            "integrity": "sha512-mET5AIwl7MR2IAKYYoVBBpV0OnkKQ1xGj2IMMeEFIs42QAkEVjRtFZGWmQ28WeU7MP779iAgOaOy93Mn44mn6g==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^2.4.1",
+                "debug": "^3.1.0",
+                "mkdirp": "^0.5.1",
+                "nopt": "^4.0.1",
+                "read-installed": "~4.0.3",
+                "semver": "^5.5.0",
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-satisfies": "^4.0.0",
+                "treeify": "^1.1.0"
+            },
+            "bin": {
+                "license-checker": "bin/license-checker"
+            }
+        },
+        "node_modules/license-checker/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/license-checker/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/license-checker/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/license-checker/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
+        "node_modules/license-checker/node_modules/debug": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+            "dev": true,
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/license-checker/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/license-checker/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/license-checker/node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/license-checker/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/license-checker/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/lie": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -19084,6 +19535,55 @@
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
+        },
+        "node_modules/load-json-file": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/load-json-file/node_modules/parse-json": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
+            "dev": true,
+            "dependencies": {
+                "error-ex": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/load-json-file/node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/load-json-file/node_modules/strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
+            "dev": true,
+            "dependencies": {
+                "is-utf8": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/loader-runner": {
             "version": "4.3.0",
@@ -20072,6 +20572,25 @@
             "integrity": "sha512-6kM8CLXvuW5crTxsAtva2YLrRrDaiTIkIePWs9moLHqbFWT94WpNFjwS/5dfLfECg5i/lkmw3aoqVidxt23TEQ==",
             "license": "MIT"
         },
+        "node_modules/nopt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+            "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+            "dev": true,
+            "dependencies": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            }
+        },
+        "node_modules/nopt-usage": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/nopt-usage/-/nopt-usage-0.1.0.tgz",
+            "integrity": "sha512-Tg2sISrWBbSsCRqpEMmdxn3KZfacrd0N2NYpZQIq0MHxGHMjwzYlxeB9pVIom/g7CBK28atDUQsTlOfG0wOsNA==",
+            "dev": true
+        },
         "node_modules/normalize-package-data": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
@@ -20116,6 +20635,70 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/npm-license": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/npm-license/-/npm-license-0.3.3.tgz",
+            "integrity": "sha512-NxvqmkWieR7fFwzUu1bLky75flVrxTB+Le/C/opOChFaF04o+kl6ng3FW9b51ce8rVdw6ma9rsvpu6Uok5eg/g==",
+            "dev": true,
+            "dependencies": {
+                "mkdirp": "~0.5.0",
+                "nopt": "~3.0.1",
+                "nopt-usage": "^0.1.0",
+                "package-license": "~0.1.1",
+                "pkginfo": "^0.3.0",
+                "read-installed": "~4.0.3",
+                "treeify": "~1.0.1",
+                "underscore": "~1.4.4"
+            },
+            "bin": {
+                "npm-license": "bin/npm-license"
+            }
+        },
+        "node_modules/npm-license/node_modules/mkdirp": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.6"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/npm-license/node_modules/nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
+            "dev": true,
+            "dependencies": {
+                "abbrev": "1"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            }
+        },
+        "node_modules/npm-license/node_modules/treeify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.0.1.tgz",
+            "integrity": "sha512-i3MKN4nGEOuVAcd7s5MtAc2+QBExwcaRT/6/CzUSYVYwzM58bJ3H3wwCPu2PEAGjVPHjfIC/MPaXsxPGUk07cg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/npm-license/node_modules/underscore": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+            "integrity": "sha512-ZqGrAgaqqZM7LGRzNjLnw5elevWb5M8LEoDMadxIW3OWbcv72wMMgKdwOKpd5Fqxe8choLD8HN3iSj3TUh/giQ==",
+            "dev": true
+        },
+        "node_modules/npm-normalize-package-bin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+            "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+            "dev": true
         },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
@@ -20375,6 +20958,27 @@
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
             "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A=="
         },
+        "node_modules/os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/os-locale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
+            "dev": true,
+            "dependencies": {
+                "lcid": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/os-proxy-config": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/os-proxy-config/-/os-proxy-config-1.1.2.tgz",
@@ -20392,6 +20996,480 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "deprecated": "This package is no longer supported.",
+            "dev": true,
+            "dependencies": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
+        },
+        "node_modules/oss-attribution-generator": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/oss-attribution-generator/-/oss-attribution-generator-1.7.1.tgz",
+            "integrity": "sha512-ReLf/UJ3z3ZEhzW6XD4HswUIoUgEUVq8I+amX12DqFwcEYhw8HGGhn2mrk7afqXuT+4AZiPDEhwDXtZSgtnOeA==",
+            "dev": true,
+            "dependencies": {
+                "bluebird": "^3.5.0",
+                "bower": "^1.8.0",
+                "bower-json": "^0.8.1",
+                "bower-license": "^0.4.4",
+                "fs-jetpack": "^0.12.0",
+                "license-checker": "^13.0.3",
+                "lodash": "^4.17.4",
+                "spdx-licenses": "^0.0.3",
+                "taim": "^1.0.2",
+                "yargs": "^7.0.2"
+            },
+            "bin": {
+                "generate-attribution": "index.js"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/ansi-regex": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+            "integrity": "sha512-sGwIGMjhYdW26/IhwK2gkWWI8DRCVO6uj3hYgHT+zD+QL1pa37tM3ujhyfcJIYSbsxp7Gxhy7zrRW/1AHm4BmA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/ansi-styles": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+            "integrity": "sha512-f2PKUkN5QngiSemowa6Mrk9MPCdtFiOSmibjZ+j1qhLGHHYsqZwmBMRF3IRMVXo8sybDqx2fJl2d/8OphBoWkA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/camelcase": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/chalk": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+            "integrity": "sha512-bIKA54hP8iZhyDT81TOsJiQvR1gW+ZYSXFaZUAvoD4wCHdbHY2actmpTE4x344ZlFqHbvoxKOaESULTZN2gstg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^1.1.0",
+                "escape-string-regexp": "^1.0.0",
+                "has-ansi": "^0.1.0",
+                "strip-ansi": "^0.3.0",
+                "supports-color": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/cliui": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/cliui/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/cliui/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/find-up": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
+            "dev": true,
+            "dependencies": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/get-caller-file": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "dev": true
+        },
+        "node_modules/oss-attribution-generator/node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true
+        },
+        "node_modules/oss-attribution-generator/node_modules/is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+            "dev": true,
+            "dependencies": {
+                "number-is-nan": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/license-checker": {
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/license-checker/-/license-checker-13.1.0.tgz",
+            "integrity": "sha512-0sqnOzLkYYSZKzR3IO7q/1Drksin6IH1nlUgXE61ycWvF807UmFHV1fSDf6fGw5woQ0On/Gmh1YvVZ2jYMjUwQ==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "~0.5.1",
+                "debug": "^2.2.0",
+                "mkdirp": "^0.3.5",
+                "nopt": "^2.2.0",
+                "read-installed": "~4.0.3",
+                "semver": "^5.3.0",
+                "spdx": "^0.5.1",
+                "spdx-correct": "^2.0.3",
+                "spdx-satisfies": "^0.1.3",
+                "treeify": "^1.0.1"
+            },
+            "bin": {
+                "license-checker": "bin/license-checker"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/mkdirp": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+            "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
+            "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+            "dev": true
+        },
+        "node_modules/oss-attribution-generator/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true
+        },
+        "node_modules/oss-attribution-generator/node_modules/nopt": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+            "integrity": "sha512-gIOTA/uJuhPwFqp+spY7VQ1satbnGlD+iQVZxI18K6hs8Evq4sX81Ml7BB5byP/LsbR2yBVtmvdEmhi7evJ6Aw==",
+            "dev": true,
+            "dependencies": {
+                "abbrev": "1"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/path-exists": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+            "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
+            "dev": true,
+            "dependencies": {
+                "pinkie-promise": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/read-pkg": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+            "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
+            "dev": true,
+            "dependencies": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/read-pkg-up": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
+            "dev": true,
+            "dependencies": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/spdx-compare": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-0.1.2.tgz",
+            "integrity": "sha512-Wc1aAqOHvP0e9H6Q6Ie56rGc9Mn00xmhqiB1BaKfMsBpJw/BPp6FLkuKxLcubHXIXwAKTTyvA2E74aPUv8OA8A==",
+            "dev": true,
+            "dependencies": {
+                "spdx-expression-parse": "^1.0.0",
+                "spdx-ranges": "^1.0.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/spdx-compare/node_modules/spdx-expression-parse": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+            "integrity": "sha512-xMXXC4eLKaIskvZm89nZi/MstVv1UtGk3nJz9BBKjreMVyoWisWFKfboH+kJS97+wUyBLpO/8ghV9M5VvrwwrA==",
+            "dev": true
+        },
+        "node_modules/oss-attribution-generator/node_modules/spdx-correct": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-2.0.4.tgz",
+            "integrity": "sha512-c+4gPpt9YDhz7cHlz5UrsHzxxRi4ksclxnEEKsuGT9JdwSC+ZNmsGbYRzzgxyZaBYpcWnlu+4lPcdLKx4DOCmA==",
+            "dev": true,
+            "dependencies": {
+                "spdx-expression-parse": "^2.0.1",
+                "spdx-license-ids": "^2.0.1"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/spdx-expression-parse": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-2.0.2.tgz",
+            "integrity": "sha512-oFxOkWCfFS0ltNp0H66gXlU4NF6bxg7RkoTYR0413t+yTY9zyj+AIWsjtN8dcVp6703ijDYBWBIARlJ7DkyP9Q==",
+            "dev": true,
+            "dependencies": {
+                "spdx-exceptions": "^2.0.0",
+                "spdx-license-ids": "^2.0.1"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/spdx-license-ids": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-2.0.1.tgz",
+            "integrity": "sha512-3RF4t5oYLlynWVIsKsmmGVM0obnTBK8ElS+2XSwRIYdf1U12aT8jS8MVHv1BH/tKrUKckogK5qJt/T+IMQZlAg==",
+            "dev": true
+        },
+        "node_modules/oss-attribution-generator/node_modules/spdx-ranges": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-1.0.1.tgz",
+            "integrity": "sha512-re78PYmpAkAqL63aWC+Xnf2GOhOP37uldGWCslThw+NHKuOSPmLATVfNFyetdjyF6F9yHxn5/XzvFHH6CHFjJA==",
+            "dev": true
+        },
+        "node_modules/oss-attribution-generator/node_modules/spdx-satisfies": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-0.1.3.tgz",
+            "integrity": "sha512-SdspT8Tv3RyHlH8pESd/rWEXII4Ho3sRr9KYeGAUbhVF+Z8loYdcMg8taog1551DMwHcdV/FK725lEANTehPhg==",
+            "dev": true,
+            "dependencies": {
+                "spdx-compare": "^0.1.2",
+                "spdx-expression-parse": "^1.0.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/spdx-satisfies/node_modules/spdx-expression-parse": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+            "integrity": "sha512-xMXXC4eLKaIskvZm89nZi/MstVv1UtGk3nJz9BBKjreMVyoWisWFKfboH+kJS97+wUyBLpO/8ghV9M5VvrwwrA==",
+            "dev": true
+        },
+        "node_modules/oss-attribution-generator/node_modules/string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+            "dev": true,
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/string-width/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/string-width/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/strip-ansi": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+            "integrity": "sha512-DerhZL7j6i6/nEnVG0qViKXI0OKouvvpsAiaj7c+LfqZZZxdwZtv8+UiA/w4VUJpT8UzX0pR1dcHOii1GbmruQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^0.2.1"
+            },
+            "bin": {
+                "strip-ansi": "cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/supports-color": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+            "integrity": "sha512-tdCZ28MnM7k7cJDJc7Eq80A9CsRFAAOZUy41npOZCs++qSjfIy7o5Rh46CBk+Dk5FbKJ33X3Tqg4YrV07N5RaA==",
+            "dev": true,
+            "bin": {
+                "supports-color": "cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/y18n": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+            "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+            "dev": true
+        },
+        "node_modules/oss-attribution-generator/node_modules/yargs": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.2.tgz",
+            "integrity": "sha512-ZEjj/dQYQy0Zx0lgLMLR8QuaqTihnxirir7EwUHp1Axq4e3+k8jXU5K0VLbNvedv1f4EWtBonDIZm0NUr+jCcA==",
+            "dev": true,
+            "dependencies": {
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^5.0.1"
+            }
+        },
+        "node_modules/oss-attribution-generator/node_modules/yargs-parser": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.1.tgz",
+            "integrity": "sha512-wpav5XYiddjXxirPoCTUPbqM0PXvJ9hiBMvuJgInvo4/lAOTZzUprArw17q2O1P2+GHhbBr18/iQwjL5Z9BqfA==",
+            "dev": true,
+            "dependencies": {
+                "camelcase": "^3.0.0",
+                "object.assign": "^4.1.0"
             }
         },
         "node_modules/own-keys": {
@@ -20537,6 +21615,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+        },
+        "node_modules/package-license": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/package-license/-/package-license-0.1.2.tgz",
+            "integrity": "sha512-Q5zmx+M9ZJneMpYS6MlYL77gqeMYWuyErXMnQ/83WCztmYQD7Z0U9XGLvX9OKFFXwRj2NzdzlM0y9Jzcww2O1Q==",
+            "dev": true
         },
         "node_modules/pako": {
             "version": "1.0.11",
@@ -20772,6 +21856,29 @@
                 "node": ">=16"
             }
         },
+        "node_modules/path-type": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+            "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-type/node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/path/node_modules/inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -20874,6 +21981,27 @@
             "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+            "dev": true,
+            "dependencies": {
+                "pinkie": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/pino": {
@@ -21090,6 +22218,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pkginfo": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+            "integrity": "sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -21200,6 +22337,15 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/pretty-hrtime": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+            "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/pretty-ms": {
@@ -21437,6 +22583,17 @@
                 }
             ]
         },
+        "node_modules/q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+            "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6.0",
+                "teleport": ">=0.2.0"
+            }
+        },
         "node_modules/qs": {
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -21508,6 +22665,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/ramda": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.18.0.tgz",
+            "integrity": "sha512-bSgBktaZE0uDH5KmMpbizsxSNcw9MumqtouUVUrxHZSunm+WdDc/UlzwWFtgqMfngX7TZ12d9QsyWkYK7OoJSw==",
+            "dev": true
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -21532,6 +22695,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/raptor-args": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/raptor-args/-/raptor-args-1.0.3.tgz",
+            "integrity": "sha512-dxcvspDOzYGTF4lonon711avlxvcX5s/XTqNNGSaz59cy4Tik+Z6jDFDSVGpAaOL71cc01kc3u3AdxgPIKG+RQ==",
+            "dev": true
         },
         "node_modules/raw-body": {
             "version": "3.0.0",
@@ -21582,6 +22751,116 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true
+        },
+        "node_modules/read-installed": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+            "integrity": "sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==",
+            "deprecated": "This package is no longer supported.",
+            "dev": true,
+            "dependencies": {
+                "debuglog": "^1.0.1",
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "slide": "~1.1.3",
+                "util-extend": "^1.0.1"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.2"
+            }
+        },
+        "node_modules/read-installed/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/read-package-json": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
+            "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
+            "deprecated": "This package is no longer supported. Please use @npmcli/package-json instead.",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "normalize-package-data": "^2.0.0",
+                "npm-normalize-package-bin": "^1.0.0"
+            }
+        },
+        "node_modules/read-package-json/node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/read-package-json/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/read-package-json/node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+            "dev": true
+        },
+        "node_modules/read-package-json/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/read-package-json/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/read-package-json/node_modules/semver": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
         },
         "node_modules/read-pkg": {
             "version": "8.1.0",
@@ -21789,6 +23068,19 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/readdir-scoped-modules": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+            "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+            "deprecated": "This functionality has been moved to @npmcli/fs",
+            "dev": true,
+            "dependencies": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
             }
         },
         "node_modules/readdirp": {
@@ -21999,6 +23291,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
+            "dev": true
         },
         "node_modules/requires-port": {
             "version": "1.0.0",
@@ -23075,6 +24373,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/slide": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+            "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -23140,6 +24447,39 @@
                 "atomic-sleep": "^1.0.0"
             }
         },
+        "node_modules/sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
+            "dev": true,
+            "dependencies": {
+                "is-plain-obj": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sort-keys-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+            "integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
+            "dev": true,
+            "dependencies": {
+                "sort-keys": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sort-keys/node_modules/is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -23183,6 +24523,28 @@
                 }
             ]
         },
+        "node_modules/spdx": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/spdx/-/spdx-0.5.2.tgz",
+            "integrity": "sha512-WQbfCQT2uKLsDllnO9ItpcGUiiF1O/ZvBGCyqFZRg122HgiZubpwpZiM7BkmH19HC3XR3Z+DFMGJNzXSPebG8A==",
+            "deprecated": "see spdx-expression-parse, spdx-satisfies, &c.",
+            "dev": true,
+            "dependencies": {
+                "spdx-exceptions": "^1.0.0",
+                "spdx-license-ids": "^1.0.0"
+            }
+        },
+        "node_modules/spdx-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+            "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+            "dev": true,
+            "dependencies": {
+                "array-find-index": "^1.0.2",
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-ranges": "^2.0.0"
+            }
+        },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -23213,6 +24575,54 @@
             "version": "3.0.21",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
             "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+            "dev": true
+        },
+        "node_modules/spdx-licenses": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/spdx-licenses/-/spdx-licenses-0.0.3.tgz",
+            "integrity": "sha512-T9bEF+Q2ugCCyFp3c9t5ROjLFGTNxDJBobjK5muQlEM5ATKRDwjprTOwpwbrc/+WcBzHvPck/roTMfC9YHWbCQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "0.7.4",
+                "is2": "0.0.11"
+            }
+        },
+        "node_modules/spdx-licenses/node_modules/debug": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+            "integrity": "sha512-EohAb3+DSHSGx8carOSKJe8G0ayV5/i609OD0J2orCkuyae7SyZSz2aoLmQF2s0Pj5gITDebwPH7GFBlqOUQ1Q==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/spdx-ranges": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
+            "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
+            "dev": true
+        },
+        "node_modules/spdx-satisfies": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.1.tgz",
+            "integrity": "sha512-WVzZ/cXAzoNmjCWiEluEA3BjHp5tiUmmhn9MK+X0tBbR9sOqtC6UQwmgCNrAIZvNlMuBUYAaHYfb2oqlF9SwKA==",
+            "dev": true,
+            "dependencies": {
+                "spdx-compare": "^1.0.0",
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-ranges": "^2.0.0"
+            }
+        },
+        "node_modules/spdx/node_modules/spdx-exceptions": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.5.tgz",
+            "integrity": "sha512-gJ2SzvQuUNno1/G6sDRHP2CN+Hfi+weHY9E+kTvB8zxH/CTkhazfYazuZcwhXtwWbDKl5CAJ1fBbqAgpkd8CCQ==",
+            "dev": true
+        },
+        "node_modules/spdx/node_modules/spdx-license-ids": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+            "integrity": "sha512-qIBFhkh6ILCWNeWEe3ODFPKDYhPJrZpqdNCI2Z+w9lNdH5hoVEkfRLLbRfoIi8fb4xRYmpEOaaMH4G2pwYp/iQ==",
             "dev": true
         },
         "node_modules/spdy": {
@@ -23626,6 +25036,93 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
+        "node_modules/taim": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/taim/-/taim-1.1.0.tgz",
+            "integrity": "sha512-NvqllOkhHKSG6llRKhrRLIzXHnbfyfTdcObDGIEqea9098ierzuowZyYAuHHf+JbpOhfKSisbe2bIVuA2nEaRA==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^1.1.1",
+                "pretty-hrtime": "^1.0.0",
+                "ramda": "0.18.x"
+            }
+        },
+        "node_modules/taim/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/taim/node_modules/ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/taim/node_modules/chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/taim/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/taim/node_modules/has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/taim/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/taim/node_modules/supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/tapable": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
@@ -24012,6 +25509,15 @@
             },
             "peerDependencies": {
                 "tslib": "2"
+            }
+        },
+        "node_modules/treeify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+            "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6"
             }
         },
         "node_modules/ts-api-utils": {
@@ -24660,6 +26166,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/underscore": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
+            "integrity": "sha512-yejOFsRnTJs0N9CK5Apzf6maDO2djxGoLLrlZlvGs2o9ZQuhIhDL18rtFyy4FBIbOkzA6+4hDgXbgz5EvDQCXQ==",
+            "dev": true
+        },
         "node_modules/undici": {
             "version": "6.21.3",
             "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
@@ -24811,6 +26323,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+        },
+        "node_modules/util-extend": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+            "integrity": "sha512-mLs5zAK+ctllYBj+iAQvlDCwoxU/WDOUaJkcFudeiAX6OajC6BKXJUa9a+tbtkC11dz2Ufb7h0lyvIOVn4LADA==",
+            "dev": true
         },
         "node_modules/utila": {
             "version": "0.4.0",
@@ -26060,6 +27578,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/which-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ==",
+            "dev": true
         },
         "node_modules/which-pm-runs": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "test:coverage": "npm run compile && npm run test:coverage --workspaces --if-present",
         "coverage:report": "c8 report --reporter=html --reporter=text",
         "coverage:check": "c8 check-coverage --lines 70 --functions 70 --branches 70 --statements 70",
-        "package": "npm run compile && npm run package --workspaces --if-present"
+        "package": "npm run compile && npm run package --workspaces --if-present",
+        "ci:generate:agentic:attribution": "ts-node ./script/prepare-agentic-attribution-dependencies.ts && ./script/generate-agentic-attribution.sh && git restore package.json"
     },
     "dependencies": {
         "@aws/language-server-runtimes": "^0.2.105",
@@ -52,7 +53,9 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-unused-imports": "^4.1.4",
         "husky": "^9.1.7",
+        "license-checker": "^25.0.1",
         "node-loader": "^2.1.0",
+        "oss-attribution-generator": "^1.7.1",
         "prettier": "^3.3.3",
         "pretty-quick": "^4.0.0",
         "shx": "^0.3.4",

--- a/script/generate-agentic-attribution.sh
+++ b/script/generate-agentic-attribution.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# This script performs license checks and compiles a license attribution file 
+# for the agentic chat bundle.
+# It requires prepare-attribution-dependencies.ts to run first, in order to 
+# handle multiple packages from this monorepo.
+# 
+# To use, call npm run ci:generate:agentic:attribution
+
+set -euo pipefail
+
+#----------------------------------------
+# Perform license checks
+#----------------------------------------
+
+EXCLUDED_PACKAGES=("@amzn/monorepo-language-servers" "@aws/lsp-codewhisperer" "@aws/lsp-core" "@amzn/dexp-runtime-server-build-configuration" "caniuse-lite" "pako")
+EXCLUDED_LICENSES="MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,0BSD,Python-2.0,BlueOak-1.0.0"
+
+process_packages() {
+  local output="$1"
+  IFS=$'\n'
+
+  for line in $output; do
+    # Extract package_name from "package_name@1.0.0"
+    if [[ "$line" =~ ^├─\ (.+)@ ]]; then
+      package_name="${BASH_REMATCH[1]}"
+
+      if [[ ! "${EXCLUDED_PACKAGES[*]}" =~ "${package_name}" ]]; then
+        echo "License for package '$package_name'  is either not pre-approved or package is not in the excluded package list."
+        exit 1
+      fi
+    fi
+  done
+
+  IFS=$' \t\n'
+}
+
+LICENSE_CHECK_RESULT=$(npx license-checker --production --exclude $EXCLUDED_LICENSES)
+process_packages "$LICENSE_CHECK_RESULT"
+
+#----------------------------------------
+# Generate attribution file
+#----------------------------------------
+
+# The attribution folder is where overrides.json is, which influences generate-attribution behavior.
+ATTRIBUTION_FOLDER="attribution"
+mkdir -p $ATTRIBUTION_FOLDER
+
+(npx generate-attribution --outputDir $ATTRIBUTION_FOLDER)>/dev/null
+
+ATTRIBUTION_HEADER="The Amazon aws-lsp-codewhisperer bundle includes the following third-party software/licensing:\n\n"
+(echo -e $ATTRIBUTION_HEADER && cat "$ATTRIBUTION_FOLDER/attribution.txt") > "$ATTRIBUTION_FOLDER/THIRD_PARTY_LICENSES"
+
+echo "Third party attribution: $ATTRIBUTION_FOLDER/THIRD_PARTY_LICENSES"
+
+rm $ATTRIBUTION_FOLDER/attribution.txt
+rm $ATTRIBUTION_FOLDER/licenseInfos.json
+
+echo "Attribution generation completed."

--- a/script/prepare-agentic-attribution-dependencies.ts
+++ b/script/prepare-agentic-attribution-dependencies.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env ts-node
+
+/**
+ * This script is used by CI to gather package.json dependencies that should be
+ * included in the license attribution.
+ *
+ * It is a hack -- the tooling used to gather licenses is not compatible with
+ * monorepo workspaces.
+ *
+ * As long as 'npm install' has been run, the root node_modules folder will contain
+ * the dependency packages for the full workspace. We then add dependency entries
+ * to the root package.json from agentic chat related workspace packages (which
+ * then have a valid reference to content in node_modules).
+ *
+ * This script is intended to be run just prior to generate-agentic-attribution.sh.
+ * It mutates package.json, but the intention is to run this in CI, and discard the mutation.
+ *
+ * To properly use this script, call npm run ci:generate:agentic:attribution
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+interface PackageJson {
+    dependencies?: Record<string, string>
+    [key: string]: any
+}
+
+/**
+ * The packages in this monorepo that we want to accumulate dependencies from
+ */
+const TARGET_PACKAGE_FILES = [
+    'app/aws-lsp-codewhisperer-runtimes/package.json',
+    'chat-client/package.json',
+    'core/aws-lsp-core/package.json',
+    'server/aws-lsp-codewhisperer/package.json',
+    'server/aws-lsp-identity/package.json',
+]
+
+const ROOT_PACKAGE_JSON = './package.json'
+
+function readPackageJson(filePath: string): PackageJson {
+    try {
+        const content = fs.readFileSync(filePath, 'utf8')
+        return JSON.parse(content)
+    } catch (error) {
+        console.error(`Error reading ${filePath}:`, error)
+        throw error
+    }
+}
+
+function writePackageJson(filePath: string, packageJson: PackageJson): void {
+    try {
+        const content = JSON.stringify(packageJson, null, 2) + '\n'
+        fs.writeFileSync(filePath, content, 'utf8')
+    } catch (error) {
+        console.error(`Error writing ${filePath}:`, error)
+        throw error
+    }
+}
+
+function gatherDependencies(): void {
+    console.log('Gathering dependencies from target packages...')
+
+    // Read root package.json
+    const rootPackage = readPackageJson(ROOT_PACKAGE_JSON)
+
+    // Ensure dependencies section exists
+    if (!rootPackage.dependencies) {
+        rootPackage.dependencies = {}
+    }
+
+    let addedCount = 0
+    let skippedCount = 0
+
+    // Process each target package.json file
+    for (const targetFile of TARGET_PACKAGE_FILES) {
+        const fullPath = path.resolve(targetFile)
+
+        if (!fs.existsSync(fullPath)) {
+            console.warn(`Warning: ${targetFile} does not exist, skipping...`)
+            continue
+        }
+
+        console.log(`Processing ${targetFile}...`)
+        const targetPackage = readPackageJson(fullPath)
+
+        // Add non-duplicate entries to the root package.json dependencies from
+        // the currently loaded package.json.
+        if (targetPackage.dependencies) {
+            for (const [depName, depVersion] of Object.entries(targetPackage.dependencies)) {
+                if (rootPackage.dependencies[depName]) {
+                    console.log(`  Skipping ${depName} (already exists in root)`)
+                    skippedCount++
+                } else {
+                    console.log(`  Adding ${depName}@${depVersion}`)
+                    rootPackage.dependencies[depName] = depVersion
+                    addedCount++
+                }
+            }
+        } else {
+            console.log(`  No dependencies found in ${targetFile}`)
+        }
+    }
+
+    // Write updated root package.json
+    writePackageJson(ROOT_PACKAGE_JSON, rootPackage)
+
+    console.log(`\nCompleted: ${addedCount} dependencies added, ${skippedCount} skipped`)
+}
+
+if (require.main === module) {
+    gatherDependencies()
+}


### PR DESCRIPTION

This change produces a third party license attribution for the agentic chat builds. It also attaches it to the GitHub releases that are produced.

The script (generate-agentic-attribution.sh) to produce the manifest has been sourced from the internal repo DEXPRuntimeServerBuildConfiguration (attribution.sh) with minor alterations. This avoided building the script from scratch.



## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
