### PR TITLE
fix: remove disclaimer message from chat window

### DIFF
--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -120,8 +120,6 @@ import { modelSelectionForRegion } from './texts/modelSelection'
 const getDefaultTabConfig = (agenticMode?: boolean) => {
     return {
         tabTitle: 'Chat',
-        promptInputInfo:
-            'Amazon Q Developer uses generative AI. You may need to verify responses. See the [AWS Responsible AI Policy](https://aws.amazon.com/machine-learning/responsible-ai/policy/).',
         promptInputPlaceholder: `Ask a question. Use${agenticMode ? ' @ to add context,' : ''} / for quick actions`,
     }
 }


### PR DESCRIPTION
## Problem
- we don't want the disclaimer message at the bottom, as we already have a popup warning when user tries Q for the first time
<img width="529" height="1412" alt="old" src="https://github.com/user-attachments/assets/81a6f3b9-ea22-44d9-bc2c-a99d0a81318a" />




## Solution
- removing disclaimer message at the bottom


<img width="528" height="1411" alt="new" src="https://github.com/user-attachments/assets/86cdf1d3-2e6a-4774-b749-473a0f6a9fc2" />



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
