### PR TITLE
fix: pinned `@Code` symbols do not persist between IDE sessions

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
@@ -3,13 +3,14 @@ import * as sinon from 'sinon'
 import { URI } from 'vscode-uri'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as assert from 'assert'
-import { AdditionalContextPrompt } from 'local-indexing'
+import { AdditionalContextPrompt, ContextCommandItem } from 'local-indexing'
 import { AdditionalContextProvider } from './additionalContextProvider'
-import { getUserPromptsDirectory } from './contextUtils'
+import { getInitialContextInfo, getUserPromptsDirectory } from './contextUtils'
 import { LocalProjectContextController } from '../../../shared/localProjectContextController'
 import { workspaceUtils } from '@aws/lsp-core'
 import { ChatDatabase } from '../tools/chatDb/chatDb'
 import { TriggerContext } from './agenticChatTriggerContext'
+import { expect } from 'chai'
 
 describe('AdditionalContextProvider', () => {
     let provider: AdditionalContextProvider
@@ -17,6 +18,7 @@ describe('AdditionalContextProvider', () => {
     let chatHistoryDb: ChatDatabase
     let fsExistsStub: sinon.SinonStub
     let getContextCommandPromptStub: sinon.SinonStub
+    let getContextCommandItemsStub: sinon.SinonStub
     let fsReadDirStub: sinon.SinonStub
     let localProjectContextControllerInstanceStub: sinon.SinonStub
 
@@ -27,7 +29,8 @@ describe('AdditionalContextProvider', () => {
         testFeatures.workspace.fs.exists = fsExistsStub
         testFeatures.workspace.fs.readdir = fsReadDirStub
         testFeatures.chat.sendPinnedContext = sinon.stub()
-        getContextCommandPromptStub = sinon.stub()
+        getContextCommandPromptStub = sinon.stub().returns([])
+        getContextCommandItemsStub = sinon.stub().returns([])
         chatHistoryDb = {
             getHistory: sinon.stub().returns([]),
             searchMessages: sinon.stub().returns([]),
@@ -49,6 +52,7 @@ describe('AdditionalContextProvider', () => {
         provider = new AdditionalContextProvider(testFeatures, chatHistoryDb)
         localProjectContextControllerInstanceStub = sinon.stub(LocalProjectContextController, 'getInstance').resolves({
             getContextCommandPrompt: getContextCommandPromptStub,
+            getContextCommandItems: getContextCommandItemsStub,
         } as unknown as LocalProjectContextController)
     })
 
@@ -498,6 +502,60 @@ describe('AdditionalContextProvider', () => {
                     id: path.join('/workspace', '.amazonq', 'rules', 'rule2.md'),
                 },
             ])
+        })
+
+        it('should update pinned code symbol IDs when they no longer match current index', async () => {
+            // Mock LocalProjectContextController.getInstance
+            getContextCommandItemsStub.returns([
+                {
+                    id: 'new-symbol-id',
+                    symbol: {
+                        name: 'calculateTotal',
+                        kind: 'Function',
+                        range: {
+                            start: { line: 9, column: 0 },
+                            end: { line: 19, column: 1 },
+                        },
+                    },
+                    workspaceFolder: '/workspace',
+                    relativePath: 'src/utils.ts',
+                    type: 'file',
+                },
+            ] as ContextCommandItem[])
+
+            // Create a trigger context
+            const triggerContext = {
+                workspaceFolder: { uri: '/workspace', name: 'workspace' },
+                contextInfo: getInitialContextInfo(),
+            }
+
+            // Mock pinned context with an outdated symbol ID
+            const pinnedContext = [
+                {
+                    id: 'old-symbol-id', // This ID no longer exists in the index
+                    command: 'calculateTotal',
+                    label: 'code',
+                    description: 'Function, workspace/src/utils.ts',
+                    route: ['/workspace', '/src/utils.ts'],
+                    pinned: true,
+                },
+            ]
+
+            // Mock chatDb.getPinnedContext to return our pinned context
+            ;(chatHistoryDb.getPinnedContext as sinon.SinonStub).returns(pinnedContext)
+
+            // Call getAdditionalContext
+            await provider.getAdditionalContext(triggerContext, 'tab1')
+
+            // Verify that LocalProjectContextController.getInstance was called
+            sinon.assert.called(localProjectContextControllerInstanceStub)
+
+            // Verify that getContextCommandPrompt was called with updated ID
+            const contextCommandPromptCall = getContextCommandPromptStub
+                .getCalls()
+                .find(call => call.args[0].some((item: ContextCommandItem) => item.id === 'new-symbol-id'))
+
+            expect(contextCommandPromptCall).to.exist
         })
 
         describe('convertPinnedContextToChatMessages', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -3,7 +3,7 @@ import { FSWatcher, watch } from 'chokidar'
 import { ContextCommand, ContextCommandGroup } from '@aws/language-server-runtimes/protocol'
 import { Disposable } from 'vscode-languageclient/node'
 import { Chat, Logging, Lsp, Workspace } from '@aws/language-server-runtimes/server-interface'
-import { getUserPromptsDirectory, promptFileExtension } from './contextUtils'
+import { getCodeSymbolDescription, getUserPromptsDirectory, promptFileExtension } from './contextUtils'
 import { ContextCommandItem } from 'local-indexing'
 import { LocalProjectContextController } from '../../../shared/localProjectContextController'
 import { URI } from 'vscode-uri'
@@ -193,7 +193,7 @@ export class ContextCommandsProvider implements Disposable {
                 codeCmds.push({
                     ...baseItem,
                     command: item.symbol.name,
-                    description: `${item.symbol.kind}, ${path.join(wsFolderName, item.relativePath)}, L${item.symbol.range.start.line + 1}-${item.symbol.range.end.line + 1}`,
+                    description: getCodeSymbolDescription(item, true),
                     label: 'code',
                     icon: 'code-block',
                 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextUtils.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 import { sanitizeFilename } from '@aws/lsp-core/out/util/text'
 import { RelevantTextDocumentAddition } from './agenticChatTriggerContext'
 import { FileDetails, FileList } from '@aws/language-server-runtimes/server-interface'
+import { ContextCommandItem } from 'local-indexing'
 export interface ContextInfo {
     pinnedContextCount: {
         fileContextCount: number
@@ -225,4 +226,34 @@ export function mergeFileLists(fileList1: FileList, fileList2: FileList): FileLi
         filePaths: mergedFilePaths,
         details: mergedDetails,
     }
+}
+
+/**
+ * Generates a description string for a code symbol with optional line numbers.
+ *
+ * @param item - The ContextCommandItem containing symbol and workspace information
+ * @param includeLineNumbers - Whether to include line number range in the description
+ * @returns A formatted string containing the symbol kind, path and optionally line numbers,
+ *          or empty string if no symbol exists
+ * @example
+ * // Without line numbers:
+ * // "Function, myProject/src/utils.ts"
+ *
+ * // With line numbers:
+ * // "Function, myProject/src/utils.ts, L10-L20"
+ */
+export function getCodeSymbolDescription(item: ContextCommandItem, includeLineNumbers?: boolean): string {
+    const wsFolderName = path.basename(item.workspaceFolder)
+
+    if (item.symbol) {
+        const symbolKind = item.symbol.kind
+        const symbolPath = path.join(wsFolderName, item.relativePath)
+        const symbolLineNumbers = `L${item.symbol.range.start.line + 1}-${item.symbol.range.end.line + 1}`
+        const parts = [symbolKind, symbolPath]
+        if (includeLineNumbers) {
+            parts.push(symbolLineNumbers)
+        }
+        return parts.join(', ')
+    }
+    return ''
 }


### PR DESCRIPTION
## Problem

When a workspace is re-indexed, code symbols receive new IDs, causing pinned code symbols to become "orphaned" and no longer reference the correct code elements. This happens because:

1. The local project indexing system assigns new unique IDs to code symbols during each indexing session
2. Pinned code symbols store references to these IDs, which become invalid after re-indexing
3. There was no mechanism to reconnect pinned symbols to their newly indexed counterparts
4. This resulted in users losing their pinned code context after workspace re-indexing operations

## Solution

Implemented a robust symbol matching mechanism that preserves pinned code symbols across workspace re-indexing:

1. Added a new getCodeSymbolDescription() utility function in contextUtils.ts that:
   • Generates consistent descriptions for code symbols with or without line numbers
   • Creates a stable identifier based on symbol kind, name, and file path

2. Enhanced AdditionalContextProvider to handle code symbol ID mismatches by:
   • Detecting when a pinned symbol's ID no longer exists in the current index
   • Extracting the symbol's name, filepath, and kind (without line numbers)
   • Searching for a matching symbol in the current index with the same attributes
   • Updating the pinned symbol's ID to reference the newly indexed equivalent

3. Standardized symbol description formatting across the codebase:
   • Updated ContextCommandsProvider to use the new utility function
   • Ensured consistent formatting between pinned symbols and newly indexed symbols

4. Added comprehensive test coverage:
   • Unit tests for the new getCodeSymbolDescription() utility function
   • Unit test for the symbol ID matching mechanism
   • Tests for various edge cases like different workspace folder names and symbol kinds

This change ensures that users' pinned code symbols persist across workspace re-indexing operations, providing a more reliable and consistent experience when 
using code context in Amazon Q chat sessions.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
