### PR TITLE
feat(chat-client): add built-in tool permission and enable auto-approve

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.test.ts
@@ -42,6 +42,7 @@ describe('McpEventHandler error handling', () => {
             },
             agent: {
                 getTools: sinon.stub().returns([]),
+                getBuiltInToolNames: sinon.stub().returns([]),
             },
             lsp: {},
             telemetry: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -220,7 +220,7 @@ export class McpEventHandler {
 
         // Return the result in the expected format
         const header = {
-            title: 'MCP Servers',
+            title: 'MCP Servers and Built-in Tools',
             description: "Add MCP servers to extend Q's capabilities.",
             // only  show error on list mcp server page if unable to read mcp.json file
             status: configLoadErrors
@@ -269,7 +269,7 @@ export class McpEventHandler {
         return {
             id,
             header: {
-                title: 'MCP Servers',
+                title: 'MCP Servers and Built-in Tools',
                 status: {},
                 description: `Add MCP servers to extend Q's capabilities.`,
                 actions: [],

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -124,38 +124,39 @@ export class McpEventHandler {
         // Transform server configs into DetailedListItem objects
         const activeItems: DetailedListItem[] = []
         const disabledItems: DetailedListItem[] = []
-        const builtInItems: DetailedListItem[] = []
 
         // Get built-in tools programmatically
         const allTools = this.#features.agent.getTools({ format: 'bedrock' })
-        const mcpToolNames = new Set(mcpManager.getAllTools().map(tool => tool.toolName))
+        const builtInToolNames = new Set(this.#features.agent.getBuiltInToolNames())
         const builtInTools = allTools
-            .filter(tool => !mcpToolNames.has(tool.toolSpecification.name))
+            .filter(tool => {
+                return builtInToolNames.has(tool.toolSpecification.name)
+            })
             .map(tool => ({
                 name: tool.toolSpecification.name,
                 description: tool.toolSpecification.description || `${tool.toolSpecification.name} tool`,
             }))
 
         // Add built-in tools as a server in the active items
-        // activeItems.push({
-        //     title: 'Built-in',
-        //     description: `${builtInTools.length} tools`,
-        //     children: [
-        //         {
-        //             groupName: 'serverInformation',
-        //             children: [
-        //                 {
-        //                     title: 'status',
-        //                     description: 'ENABLED',
-        //                 },
-        //                 {
-        //                     title: 'toolcount',
-        //                     description: `${builtInTools.length}`,
-        //                 },
-        //             ],
-        //         },
-        //     ],
-        // })
+        activeItems.push({
+            title: 'Built-in',
+            description: `${builtInTools.length} tools`,
+            children: [
+                {
+                    groupName: 'serverInformation',
+                    children: [
+                        {
+                            title: 'status',
+                            description: 'ENABLED',
+                        },
+                        {
+                            title: 'toolcount',
+                            description: `${builtInTools.length}`,
+                        },
+                    ],
+                },
+            ],
+        })
 
         Array.from(mcpManagerServerConfigs.entries()).forEach(([serverName, config]) => {
             const toolsWithPermissions = mcpManager.getAllToolsWithPermissions(serverName)
@@ -727,13 +728,13 @@ export class McpEventHandler {
         if (serverName === 'Built-in') {
             // Handle Built-in server specially
             const allTools = this.#features.agent.getTools({ format: 'bedrock' })
-            const mcpToolNames = new Set(McpManager.instance.getAllTools().map(tool => tool.toolName))
+            const builtInToolNames = new Set(this.#features.agent.getBuiltInToolNames())
             const builtInTools = allTools
-                .filter(tool => !mcpToolNames.has(tool.toolSpecification.name))
+                .filter(tool => {
+                    return builtInToolNames.has(tool.toolSpecification.name)
+                })
                 .map(tool => {
-                    // Set default permission based on tool name
-                    const permission = 'alwaysAllow'
-
+                    const permission = McpManager.instance.getToolPerm(serverName, tool.toolSpecification.name)
                     return {
                         tool: {
                             toolName: tool.toolSpecification.name,
@@ -750,6 +751,7 @@ export class McpEventHandler {
                 header: {
                     title: serverName,
                     status: serverStatusError || {},
+                    description: 'TOOLS',
                     actions: [],
                 },
                 list: [],
@@ -949,7 +951,8 @@ export class McpEventHandler {
             const toolName = item.tool.toolName
             const currentPermission = this.#getCurrentPermission(item.permission)
             // For Built-in server, use a special function that doesn't include the 'Deny' option
-            const permissionOptions = this.#buildPermissionOptions(item.permission)
+            let permissionOptions = this.#buildPermissionOptions(item.permission)
+            if (serverName === 'Built-in') permissionOptions = this.#buildBuiltInPermissionOptions(item.permission)
 
             filterOptions.push({
                 type: 'select',
@@ -1001,25 +1004,25 @@ export class McpEventHandler {
     /**
      * Builds permission options for Built-in tools (no 'Disable' option)
      */
-    // #buildBuiltInPermissionOptions(currentPermission: string) {
-    //     const permissionOptions: PermissionOption[] = []
+    #buildBuiltInPermissionOptions(currentPermission: string) {
+        const permissionOptions: PermissionOption[] = []
 
-    //     if (currentPermission !== 'alwaysAllow') {
-    //         permissionOptions.push({
-    //             label: 'Always run',
-    //             value: 'alwaysAllow',
-    //         })
-    //     }
+        if (currentPermission !== 'alwaysAllow') {
+            permissionOptions.push({
+                label: 'Always Allow',
+                value: 'alwaysAllow',
+            })
+        }
 
-    //     if (currentPermission !== 'ask') {
-    //         permissionOptions.push({
-    //             label: 'Ask to run',
-    //             value: 'ask',
-    //         })
-    //     }
+        if (currentPermission !== 'ask') {
+            permissionOptions.push({
+                label: 'Ask',
+                value: 'ask',
+            })
+        }
 
-    //     return permissionOptions
-    // }
+        return permissionOptions
+    }
 
     /**
      * Handles MCP permission change events to update the pending permission config without applying changes
@@ -1078,23 +1081,25 @@ export class McpEventHandler {
             await McpManager.instance.updateServerPermission(serverName, permission)
             this.#emitMCPConfigEvent()
 
-            // Get server config to emit telemetry
-            const serverConfig = McpManager.instance.getAllServerConfigs().get(serverName)
-            if (serverConfig) {
-                // Emit server initialize event after permission change
-                this.#telemetryController?.emitMCPServerInitializeEvent({
-                    source: 'updatePermission',
-                    command: serverConfig.command,
-                    enabled: true,
-                    numTools: McpManager.instance.getAllToolsWithPermissions(serverName).length,
-                    scope:
-                        serverConfig?.__configPath__ ===
-                        getGlobalMcpConfigPath(this.#features.workspace.fs.getUserHomeDir())
-                            ? 'global'
-                            : 'workspace',
-                    transportType: 'stdio',
-                    languageServerVersion: this.#features.runtime.serverInfo.version,
-                })
+            // Get server config to emit telemetry (skip for Built-in server)
+            if (serverName !== 'Built-in') {
+                const serverConfig = McpManager.instance.getAllServerConfigs().get(serverName)
+                if (serverConfig) {
+                    // Emit server initialize event after permission change
+                    this.#telemetryController?.emitMCPServerInitializeEvent({
+                        source: 'updatePermission',
+                        command: serverConfig.command,
+                        enabled: true,
+                        numTools: McpManager.instance.getAllToolsWithPermissions(serverName).length,
+                        scope:
+                            serverConfig?.__configPath__ ===
+                            getGlobalMcpConfigPath(this.#features.workspace.fs.getUserHomeDir())
+                                ? 'global'
+                                : 'workspace',
+                        transportType: 'stdio',
+                        languageServerVersion: this.#features.runtime.serverInfo.version,
+                    })
+                }
             }
 
             // Clear the pending permission config after applying


### PR DESCRIPTION
## Problem

Agent keeps asking for permissions create friction for vibe coding

## Solution

Add built-in tools permissions so that users can control which tools can run without asking for permission

## Screenshots
<img width="564" alt="Screenshot 2025-06-19 at 3 37 39 PM" src="https://github.com/user-attachments/assets/e62e0e61-3368-4a66-9af1-5e6fc0442172" />


https://github.com/user-attachments/assets/a2ae9380-56e7-4f37-8c8e-c834b336d0b6


https://github.com/user-attachments/assets/06dcc41a-fb6d-44ad-818d-69429f3b9313

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
