### PR TITLE
fix(amazonq): change to use promptStickyCard to show image verificati…

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -777,13 +777,21 @@ export const createMynahUi = (
                 // Add valid files to context commands
                 mynahUi.addCustomContextToPrompt(tabId, commands, insertPosition)
             }
-            const uniqueErrors = [...new Set(errors)]
-            for (const error of uniqueErrors) {
-                mynahUi.notify({
-                    content: error,
-                    type: NotificationType.WARNING,
-                })
+
+            const imageVerificationBanner: Partial<ChatItem> = {
+                messageId: 'image-verification-banner',
+                header: {
+                    icon: 'warning',
+                    iconStatus: 'warning',
+                    body: '### Invalid Image',
+                },
+                body: `${errors.join('\n')}`,
+                canBeDismissed: true,
             }
+
+            mynahUi.updateStore(tabId, {
+                promptInputStickyCard: imageVerificationBanner,
+            })
         },
     }
 


### PR DESCRIPTION
…on notification

## Problem
all errors are displayed near the top of the chat view and it's very easy to miss.

<img width="404" height="535" alt="Screenshot 2025-07-15 at 8 47 54 PM" src="https://github.com/user-attachments/assets/45af8a61-5ab5-47ff-a7f5-f83d896a7842" />

## Solution

change to use promptStickyCard which is closer to prompt input to show

<img width="522" height="779" alt="Screenshot 2025-07-15 at 8 48 53 PM" src="https://github.com/user-attachments/assets/818a4c79-fe9f-410e-a8d9-e00f0e19eafb" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
