### PR TITLE
fix(amazonq): replacing image's large binary in log

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -929,7 +929,7 @@ export class AgenticChatController implements ChatHandlers {
             // Phase 3: Request Execution
             // Note: these logs are very noisy, but contain information redacted on the backend.
             this.#debug(
-                `generateAssistantResponse/SendMessage Request: ${JSON.stringify(currentRequestInput, undefined, 2)}`
+                `generateAssistantResponse/SendMessage Request: ${JSON.stringify(currentRequestInput, this.#imageReplacer, 2)}`
             )
             const response = await session.getChatResponse(currentRequestInput)
             if (response.$metadata.requestId) {
@@ -3761,5 +3761,14 @@ export class AgenticChatController implements ChatHandlers {
 
     #debug(...messages: string[]) {
         this.#features.logging.debug(messages.join(' '))
+    }
+
+    // Helper function to sanitize the 'images' field for logging by replacing large binary data (e.g., Uint8Array) with a concise summary.
+    // This prevents logs from being overwhelmed by raw byte arrays and keeps log output readable.
+    #imageReplacer(key: string, value: any) {
+        if (key === 'bytes' && value && typeof value.length === 'number') {
+            return `[Uint8Array, length: ${value.length}]`
+        }
+        return value
     }
 }


### PR DESCRIPTION
## Problem
logging of images field of the request is very noisy
```
...
"images": [
          {
            "format": "png",
            "source": {
              "bytes": {
                "0": 137,
                "1": 80,
                "2": 78,
                "3": 71,
                "4": 13,
                "5": 10,
                "6": 26,
                "7": 10,
                "8": 0,
                "9": 0,
                "10": 0,
                "11": 13,
                "12": 73,
                "13": 72,
                "14": 68,
                "15": 82,
                "16": 0,
                "17": 0,
                "18": 0,
                "19": 253,
                "20": 0,
                "21": 0,
                "22": 0,
                "23": 168,
...
```
## Solution
sanitize the 'images' field for logging by replacing large binary data (e.g., Uint8Array) with a concise summary

```
..        ],
          "envState": {
            "operatingSystem": "macos"
          }
        },
        "origin": "IDE",
        "modelId": "CLAUDE_SONNET_4_20250514_V1_0",
        "images": [
          {
            "format": "png",
            "source": {
              "bytes": "[Uint8Array, length: 43176]"
            }
          }
        ]
      }
    },
    "history": []
...
```

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
