### PR TITLE
refactor(amazonq): moved string literals to const file for code quality

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -17,6 +17,28 @@ import {
     ImageBlock,
 } from '@amzn/codewhisperer-streaming'
 import {
+    FS_READ,
+    FS_WRITE,
+    FS_REPLACE,
+    LIST_DIRECTORY,
+    GREP_SEARCH,
+    FILE_SEARCH,
+    EXECUTE_BASH,
+    Q_CODE_REVIEW,
+    BUTTON_RUN_SHELL_COMMAND,
+    BUTTON_REJECT_SHELL_COMMAND,
+    BUTTON_REJECT_MCP_TOOL,
+    BUTTON_ALLOW_TOOLS,
+    BUTTON_UNDO_CHANGES,
+    BUTTON_UNDO_ALL_CHANGES,
+    BUTTON_STOP_SHELL_COMMAND,
+    BUTTON_PAIDTIER_UPGRADE_Q_LEARNMORE,
+    BUTTON_PAIDTIER_UPGRADE_Q,
+    SUFFIX_PERMISSION,
+    SUFFIX_UNDOALL,
+    SUFFIX_EXPLANATION,
+} from './constants/toolConstants'
+import {
     SendMessageCommandInput,
     SendMessageCommandOutput,
     ChatCommandInput,
@@ -260,7 +282,9 @@ export class AgenticChatController implements ChatHandlers {
     #getMessageIdForToolUse(toolType: string | undefined, toolUse: ToolUse): string {
         const toolUseId = toolUse.toolUseId!
         // Return plain toolUseId for executeBash, add "_permission" suffix for all other tools
-        return toolUse.name === 'executeBash' || toolType === 'executeBash' ? toolUseId : `${toolUseId}_permission`
+        return toolUse.name === EXECUTE_BASH || toolType === EXECUTE_BASH
+            ? toolUseId
+            : `${toolUseId}${SUFFIX_PERMISSION}`
     }
 
     /**
@@ -335,18 +359,18 @@ export class AgenticChatController implements ChatHandlers {
         this.#log(`onButtonClick event with params: ${JSON.stringify(params)}`)
         const session = this.#chatSessionManagementService.getSession(params.tabId)
         if (
-            params.buttonId === 'run-shell-command' ||
-            params.buttonId === 'reject-shell-command' ||
-            params.buttonId === 'reject-mcp-tool' ||
-            params.buttonId === 'allow-tools'
+            params.buttonId === BUTTON_RUN_SHELL_COMMAND ||
+            params.buttonId === BUTTON_REJECT_SHELL_COMMAND ||
+            params.buttonId === BUTTON_REJECT_MCP_TOOL ||
+            params.buttonId === BUTTON_ALLOW_TOOLS
         ) {
             if (!session.data) {
                 return { success: false, failureReason: `could not find chat session for tab: ${params.tabId} ` }
             }
             // For 'allow-tools', remove suffix as permission card needs to be seperate from file list card
             const messageId =
-                params.buttonId === 'allow-tools' && params.messageId.endsWith('_permission')
-                    ? params.messageId.replace('_permission', '')
+                params.buttonId === BUTTON_ALLOW_TOOLS && params.messageId.endsWith(SUFFIX_PERMISSION)
+                    ? params.messageId.replace(SUFFIX_PERMISSION, '')
                     : params.messageId
 
             const handler = session.data.getDeferredToolExecution(messageId)
@@ -356,7 +380,7 @@ export class AgenticChatController implements ChatHandlers {
                     failureReason: `could not find deferred tool execution for message: ${messageId} `,
                 }
             }
-            params.buttonId === 'reject-shell-command' || params.buttonId === 'reject-mcp-tool'
+            params.buttonId === BUTTON_REJECT_SHELL_COMMAND || params.buttonId === BUTTON_REJECT_MCP_TOOL
                 ? (() => {
                       handler.reject(new ToolApprovalException('Command was rejected.', true))
                       this.#stoppedToolUses.add(messageId)
@@ -365,7 +389,7 @@ export class AgenticChatController implements ChatHandlers {
             return {
                 success: true,
             }
-        } else if (params.buttonId === 'undo-changes') {
+        } else if (params.buttonId === BUTTON_UNDO_CHANGES) {
             const toolUseId = params.messageId
             try {
                 await this.#undoFileChange(toolUseId, session.data)
@@ -384,21 +408,21 @@ export class AgenticChatController implements ChatHandlers {
             return {
                 success: true,
             }
-        } else if (params.buttonId === 'undo-all-changes') {
-            const toolUseId = params.messageId.replace('_undoall', '')
+        } else if (params.buttonId === BUTTON_UNDO_ALL_CHANGES) {
+            const toolUseId = params.messageId.replace(SUFFIX_UNDOALL, '')
             await this.#undoAllFileChanges(params.tabId, toolUseId, session.data)
             return {
                 success: true,
             }
-        } else if (params.buttonId === 'stop-shell-command') {
+        } else if (params.buttonId === BUTTON_STOP_SHELL_COMMAND) {
             this.#stoppedToolUses.add(params.messageId)
             await this.#renderStoppedShellCommand(params.tabId, params.messageId)
             return { success: true }
-        } else if (params.buttonId === 'paidtier-upgrade-q-learnmore') {
+        } else if (params.buttonId === BUTTON_PAIDTIER_UPGRADE_Q_LEARNMORE) {
             onPaidTierLearnMore(this.#features.lsp, this.#features.logging)
 
             return { success: true }
-        } else if (params.buttonId === 'paidtier-upgrade-q') {
+        } else if (params.buttonId === BUTTON_PAIDTIER_UPGRADE_Q) {
             await this.onManageSubscription(params.tabId)
 
             return { success: true }
@@ -432,7 +456,7 @@ export class AgenticChatController implements ChatHandlers {
             return
         }
         const fileList = cachedToolUse.chatResult?.header?.fileList
-        const button = cachedToolUse.chatResult?.header?.buttons?.filter(button => button.id !== 'undo-changes')
+        const button = cachedToolUse.chatResult?.header?.buttons?.filter(button => button.id !== BUTTON_UNDO_CHANGES)
 
         const updatedHeader = {
             ...cachedToolUse.chatResult?.header,
@@ -487,7 +511,7 @@ export class AgenticChatController implements ChatHandlers {
             return
         }
         for (const messageId of [...toUndo].reverse()) {
-            await this.onButtonClick({ buttonId: 'undo-changes', messageId, tabId })
+            await this.onButtonClick({ buttonId: BUTTON_UNDO_CHANGES, messageId, tabId })
         }
     }
 
@@ -1317,36 +1341,36 @@ export class AgenticChatController implements ChatHandlers {
                 await chatResultStream.removeResultBlockAndUpdateUI(progressPrefix + toolUse.toolUseId)
 
                 // fsRead and listDirectory write to an existing card and could show nothing in the current position
-                if (!['fsWrite', 'fsReplace', 'fsRead', 'listDirectory'].includes(toolUse.name)) {
+                if (![FS_WRITE, FS_REPLACE, FS_READ, LIST_DIRECTORY].includes(toolUse.name)) {
                     await this.#showUndoAllIfRequired(chatResultStream, session)
                 }
                 // fsWrite can take a long time, so we render fsWrite  Explanatory upon partial streaming responses.
-                if (toolUse.name !== 'fsWrite' && toolUse.name !== 'fsReplace') {
+                if (toolUse.name !== FS_WRITE && toolUse.name !== FS_REPLACE) {
                     const { explanation } = toolUse.input as unknown as ExplanatoryParams
                     if (explanation) {
                         await chatResultStream.writeResultBlock({
                             type: 'directive',
-                            messageId: toolUse.toolUseId + '_explanation',
+                            messageId: toolUse.toolUseId + SUFFIX_EXPLANATION,
                             body: explanation,
                         })
                     }
                 }
                 switch (toolUse.name) {
-                    case 'fsRead':
-                    case 'listDirectory':
-                    case 'grepSearch':
-                    case 'fileSearch':
-                    case 'fsWrite':
-                    case 'fsReplace':
-                    case 'executeBash': {
+                    case FS_READ:
+                    case LIST_DIRECTORY:
+                    case GREP_SEARCH:
+                    case FILE_SEARCH:
+                    case FS_WRITE:
+                    case FS_REPLACE:
+                    case EXECUTE_BASH: {
                         const toolMap = {
-                            fsRead: { Tool: FsRead },
-                            listDirectory: { Tool: ListDirectory },
-                            fsWrite: { Tool: FsWrite },
-                            fsReplace: { Tool: FsReplace },
-                            executeBash: { Tool: ExecuteBash },
-                            grepSearch: { Tool: GrepSearch },
-                            fileSearch: { Tool: FileSearch },
+                            [FS_READ]: { Tool: FsRead },
+                            [LIST_DIRECTORY]: { Tool: ListDirectory },
+                            [FS_WRITE]: { Tool: FsWrite },
+                            [FS_REPLACE]: { Tool: FsReplace },
+                            [EXECUTE_BASH]: { Tool: ExecuteBash },
+                            [GREP_SEARCH]: { Tool: GrepSearch },
+                            [FILE_SEARCH]: { Tool: FileSearch },
                         }
 
                         const { Tool } = toolMap[toolUse.name as keyof typeof toolMap]
@@ -1369,7 +1393,7 @@ export class AgenticChatController implements ChatHandlers {
                         // Honor built-in permission if available, otherwise use tool's requiresAcceptance
                         // const requiresAcceptance = builtInPermission || toolRequiresAcceptance
 
-                        if (requiresAcceptance || toolUse.name === 'executeBash') {
+                        if (requiresAcceptance || toolUse.name === EXECUTE_BASH) {
                             // for executeBash, we till send the confirmation message without action buttons
                             const confirmationResult = this.#processToolConfirmation(
                                 toolUse,
@@ -1378,7 +1402,7 @@ export class AgenticChatController implements ChatHandlers {
                                 commandCategory
                             )
                             cachedButtonBlockId = await chatResultStream.writeResultBlock(confirmationResult)
-                            const isExecuteBash = toolUse.name === 'executeBash'
+                            const isExecuteBash = toolUse.name === EXECUTE_BASH
                             if (isExecuteBash) {
                                 this.#telemetryController.emitInteractWithAgenticChat(
                                     'GeneratedCommand',
@@ -1476,7 +1500,7 @@ export class AgenticChatController implements ChatHandlers {
                         break
                 }
 
-                if (toolUse.name === 'fsWrite' || toolUse.name === 'fsReplace') {
+                if (toolUse.name === FS_WRITE || toolUse.name === FS_REPLACE) {
                     const input = toolUse.input as unknown as FsWriteParams | FsReplaceParams
                     const document = await this.#triggerContext.getTextDocumentFromPath(input.path, true, true)
 
@@ -1529,27 +1553,27 @@ export class AgenticChatController implements ChatHandlers {
                 })
 
                 switch (toolUse.name) {
-                    case 'fsRead':
-                    case 'listDirectory':
-                    case 'fileSearch':
+                    case FS_READ:
+                    case LIST_DIRECTORY:
+                    case FILE_SEARCH:
                         const initialListDirResult = this.#processReadOrListOrSearch(toolUse, chatResultStream)
                         if (initialListDirResult) {
                             await chatResultStream.writeResultBlock(initialListDirResult)
                         }
                         break
                     // no need to write tool result for listDir,fsRead,fileSearch into chat stream
-                    case 'executeBash':
+                    case EXECUTE_BASH:
                         // no need to write tool result for listDir and fsRead into chat stream
                         // executeBash will stream the output instead of waiting until the end
                         break
-                    case 'grepSearch':
+                    case GREP_SEARCH:
                         const grepSearchResult = this.#processGrepSearchResult(toolUse, result, chatResultStream)
                         if (grepSearchResult) {
                             await chatResultStream.writeResultBlock(grepSearchResult)
                         }
                         break
-                    case 'fsReplace':
-                    case 'fsWrite':
+                    case FS_REPLACE:
+                    case FS_WRITE:
                         const input = toolUse.input as unknown as FsWriteParams | FsReplaceParams
                         // Load from the filesystem instead of workspace.
                         // Workspace is likely out of date - when files
@@ -1657,13 +1681,13 @@ export class AgenticChatController implements ChatHandlers {
                     }
 
                     // Rethrow error for executeBash or any named tool
-                    if (toolUse.name === 'executeBash' || toolUse.name) {
+                    if (toolUse.name === EXECUTE_BASH || toolUse.name) {
                         throw err
                     }
                 }
 
                 // display fs write failure status in the UX of that file card
-                if ((toolUse.name === 'fsWrite' || toolUse.name === 'fsReplace') && toolUse.toolUseId) {
+                if ((toolUse.name === FS_WRITE || toolUse.name === FS_REPLACE) && toolUse.toolUseId) {
                     const existingCard = chatResultStream.getMessageBlockId(toolUse.toolUseId)
                     const fsParam = toolUse.input as unknown as FsWriteParams | FsReplaceParams
                     if (fsParam.path) {
@@ -1696,7 +1720,7 @@ export class AgenticChatController implements ChatHandlers {
                             await chatResultStream.writeResultBlock(errorResult)
                         }
                     }
-                } else if (toolUse.name === 'executeBash' && toolUse.toolUseId) {
+                } else if (toolUse.name === EXECUTE_BASH && toolUse.toolUseId) {
                     const existingCard = chatResultStream.getMessageBlockId(toolUse.toolUseId)
                     const command = (toolUse.input as unknown as ExecuteBashParams).command
                     const completedErrorResult = {
@@ -1757,10 +1781,10 @@ export class AgenticChatController implements ChatHandlers {
      * Updates the currentUndoAllId state in the session
      */
     #updateUndoAllState(toolUse: ToolUse, session: ChatSessionService) {
-        if (toolUse.name === 'fsRead' || toolUse.name === 'listDirectory') {
+        if (toolUse.name === FS_READ || toolUse.name === LIST_DIRECTORY) {
             return
         }
-        if (toolUse.name === 'fsWrite' || toolUse.name === 'fsReplace') {
+        if (toolUse.name === FS_WRITE || toolUse.name === FS_REPLACE) {
             if (session.currentUndoAllId === undefined) {
                 session.currentUndoAllId = toolUse.toolUseId
             }
@@ -1798,10 +1822,10 @@ export class AgenticChatController implements ChatHandlers {
 
         await chatResultStream.writeResultBlock({
             type: 'answer',
-            messageId: `${session.currentUndoAllId}_undoall`,
+            messageId: `${session.currentUndoAllId}${SUFFIX_UNDOALL}`,
             buttons: [
                 {
-                    id: 'undo-all-changes',
+                    id: BUTTON_UNDO_ALL_CHANGES,
                     text: 'Undo all changes',
                     icon: 'undo',
                     status: 'clear',
@@ -1834,11 +1858,11 @@ export class AgenticChatController implements ChatHandlers {
     #validateToolResult(toolUse: ToolUse, result: ToolResultContentBlock) {
         let maxToolResponseSize
         switch (toolUse.name) {
-            case 'fsRead':
-            case 'executeBash':
+            case FS_READ:
+            case EXECUTE_BASH:
                 // fsRead and executeBash already have truncation logic
                 return
-            case 'listDirectory':
+            case LIST_DIRECTORY:
                 maxToolResponseSize = 50_000
                 break
             default:
@@ -1901,7 +1925,7 @@ export class AgenticChatController implements ChatHandlers {
         if (toolUse.name === QCodeReview.toolName) {
             return this.#getToolOverWritableStream(chatResultStream, toolUse)
         }
-        if (toolUse.name !== 'executeBash') {
+        if (toolUse.name !== EXECUTE_BASH) {
             return
         }
 
@@ -1911,7 +1935,7 @@ export class AgenticChatController implements ChatHandlers {
 
         const initialHeader: ChatMessage['header'] = {
             body: 'shell',
-            buttons: [{ id: 'stop-shell-command', text: 'Stop', icon: 'stop' }],
+            buttons: [{ id: BUTTON_STOP_SHELL_COMMAND, text: 'Stop', icon: 'stop' }],
         }
 
         const completedHeader: ChatMessage['header'] = {
@@ -1972,7 +1996,7 @@ export class AgenticChatController implements ChatHandlers {
         const toolName = originalToolName ?? (toolType || toolUse.name)
 
         // Handle bash commands with special formatting
-        if (toolName === 'executeBash') {
+        if (toolName === EXECUTE_BASH) {
             return {
                 messageId: toolUse.toolUseId,
                 type: 'tool',
@@ -1988,7 +2012,7 @@ export class AgenticChatController implements ChatHandlers {
                                   text: 'Rejected',
                               },
                           }),
-                    buttons: isAccept ? [{ id: 'stop-shell-command', text: 'Stop', icon: 'stop' }] : [],
+                    buttons: isAccept ? [{ id: BUTTON_STOP_SHELL_COMMAND, text: 'Stop', icon: 'stop' }] : [],
                 },
             }
         }
@@ -2001,10 +2025,10 @@ export class AgenticChatController implements ChatHandlers {
         let body: string | undefined
 
         switch (toolName) {
-            case 'fsReplace':
-            case 'fsWrite':
-            case 'fsRead':
-            case 'listDirectory':
+            case FS_REPLACE:
+            case FS_WRITE:
+            case FS_READ:
+            case LIST_DIRECTORY:
                 header = {
                     body: undefined,
                     status: {
@@ -2015,7 +2039,7 @@ export class AgenticChatController implements ChatHandlers {
                 }
                 break
 
-            case 'fileSearch':
+            case FILE_SEARCH:
                 const searchPath = (toolUse.input as unknown as FileSearchParams).path
                 header = {
                     body: 'File Search',
@@ -2122,13 +2146,13 @@ export class AgenticChatController implements ChatHandlers {
 
         // Configure tool-specific UI elements
         switch (toolName) {
-            case 'executeBash': {
+            case EXECUTE_BASH: {
                 const commandString = (toolUse.input as unknown as ExecuteBashParams).command
                 buttons = requiresAcceptance
                     ? [
-                          { id: 'run-shell-command', text: 'Run', icon: 'play' },
+                          { id: BUTTON_RUN_SHELL_COMMAND, text: 'Run', icon: 'play' },
                           {
-                              id: 'reject-shell-command',
+                              id: BUTTON_REJECT_SHELL_COMMAND,
                               status: 'dimmed-clear' as Status,
                               text: 'Reject',
                               icon: 'cancel',
@@ -2167,14 +2191,14 @@ export class AgenticChatController implements ChatHandlers {
                 break
             }
 
-            case 'fsWrite': {
+            case FS_WRITE: {
                 const writeFilePath = (toolUse.input as unknown as FsWriteParams).path
 
                 // Validate the path using our synchronous utility
                 validatePathBasic(writeFilePath)
 
                 this.#debug(`Processing ${toolUse.name} for path: ${writeFilePath}`)
-                buttons = [{ id: 'allow-tools', text: 'Allow', icon: 'ok', status: 'clear' }]
+                buttons = [{ id: BUTTON_ALLOW_TOOLS, text: 'Allow', icon: 'ok', status: 'clear' }]
                 header = {
                     icon: 'warning',
                     iconForegroundStatus: 'warning',
@@ -2189,14 +2213,14 @@ export class AgenticChatController implements ChatHandlers {
                 break
             }
 
-            case 'fsReplace': {
+            case FS_REPLACE: {
                 const writeFilePath = (toolUse.input as unknown as FsReplaceParams).path
 
                 // For replace, we need to verify the file exists
                 validatePathExists(writeFilePath)
 
                 this.#debug(`Processing ${toolUse.name} for path: ${writeFilePath}`)
-                buttons = [{ id: 'allow-tools', text: 'Allow', icon: 'ok', status: 'clear' }]
+                buttons = [{ id: BUTTON_ALLOW_TOOLS, text: 'Allow', icon: 'ok', status: 'clear' }]
                 header = {
                     icon: 'warning',
                     iconForegroundStatus: 'warning',
@@ -2211,9 +2235,9 @@ export class AgenticChatController implements ChatHandlers {
                 break
             }
 
-            case 'fsRead':
-            case 'listDirectory': {
-                buttons = [{ id: 'allow-tools', text: 'Allow', icon: 'ok', status: 'clear' }]
+            case FS_READ:
+            case LIST_DIRECTORY: {
+                buttons = [{ id: BUTTON_ALLOW_TOOLS, text: 'Allow', icon: 'ok', status: 'clear' }]
                 header = {
                     icon: 'tools',
                     iconForegroundStatus: 'tools',
@@ -2223,7 +2247,7 @@ export class AgenticChatController implements ChatHandlers {
                     buttons,
                 }
 
-                if (toolName === 'fsRead') {
+                if (toolName === FS_READ) {
                     const paths = (toolUse.input as unknown as FsReadParams).paths
 
                     // Validate paths using our synchronous utility
@@ -2251,7 +2275,7 @@ export class AgenticChatController implements ChatHandlers {
 
             default: {
                 // — DEFAULT ⇒ MCP tools
-                buttons = [{ id: 'allow-tools', text: 'Allow', icon: 'ok', status: 'clear' }]
+                buttons = [{ id: BUTTON_ALLOW_TOOLS, text: 'Allow', icon: 'ok', status: 'clear' }]
                 header = {
                     icon: 'tools',
                     iconForegroundStatus: 'warning',
@@ -2271,7 +2295,7 @@ export class AgenticChatController implements ChatHandlers {
                 type: 'tool',
                 messageId: this.#getMessageIdForToolUse(toolType, toolUse),
                 header,
-                body: warning ? (toolName === 'executeBash' ? '' : '\n\n') + body : body,
+                body: warning ? (toolName === EXECUTE_BASH ? '' : '\n\n') + body : body,
             }
         } else {
             return {
@@ -2283,9 +2307,9 @@ export class AgenticChatController implements ChatHandlers {
                             icon: 'tools',
                             body: `${toolName}`,
                             buttons: [
-                                { id: 'allow-tools', text: 'Run', icon: 'play', status: 'clear' },
+                                { id: BUTTON_ALLOW_TOOLS, text: 'Run', icon: 'play', status: 'clear' },
                                 {
-                                    id: 'reject-mcp-tool',
+                                    id: BUTTON_REJECT_MCP_TOOL,
                                     text: 'Reject',
                                     icon: 'cancel',
                                     status: 'dimmed-clear' as Status,
@@ -2338,7 +2362,7 @@ export class AgenticChatController implements ChatHandlers {
                         },
                     },
                 },
-                buttons: [{ id: 'undo-changes', text: 'Undo', icon: 'undo' }],
+                buttons: [{ id: BUTTON_UNDO_CHANGES, text: 'Undo', icon: 'undo' }],
             },
         }
     }
@@ -2353,7 +2377,7 @@ export class AgenticChatController implements ChatHandlers {
             chatResultStream.setMessageIdToUpdateForTool(toolUse.name!, messageIdToUpdate)
         }
         let currentPaths = []
-        if (toolUse.name === 'fsRead') {
+        if (toolUse.name === FS_READ) {
             currentPaths = (toolUse.input as unknown as FsReadParams)?.paths
         } else {
             currentPaths.push((toolUse.input as unknown as ListDirectoryParams | FileSearchParams)?.path)
@@ -2383,9 +2407,9 @@ export class AgenticChatController implements ChatHandlers {
             title = 'Gathering context'
         } else {
             title =
-                toolUse.name === 'fsRead'
+                toolUse.name === FS_READ
                     ? `${itemCount} file${itemCount > 1 ? 's' : ''} read`
-                    : toolUse.name === 'fileSearch'
+                    : toolUse.name === FILE_SEARCH
                       ? `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} searched`
                       : `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} listed`
         }
@@ -2418,7 +2442,7 @@ export class AgenticChatController implements ChatHandlers {
         result: any,
         chatResultStream: AgenticChatResultStream
     ): ChatMessage | undefined {
-        if (toolUse.name !== 'grepSearch') {
+        if (toolUse.name !== GREP_SEARCH) {
             return undefined
         }
 
@@ -2911,7 +2935,7 @@ export class AgenticChatController implements ChatHandlers {
         const toolUseId = params.messageId
         const toolUse = toolUseId ? session.data?.toolUseLookup.get(toolUseId) : undefined
 
-        if (toolUse?.name === 'fsWrite' || toolUse?.name === 'fsReplace') {
+        if (toolUse?.name === FS_WRITE || toolUse?.name === FS_REPLACE) {
             const input = toolUse.input as unknown as FsWriteParams | FsReplaceParams
             this.#features.lsp.workspace.openFileDiff({
                 originalFileUri: input.path,
@@ -2919,7 +2943,7 @@ export class AgenticChatController implements ChatHandlers {
                 isDeleted: false,
                 fileContent: toolUse.fileChange?.after,
             })
-        } else if (toolUse?.name === 'fsRead') {
+        } else if (toolUse?.name === FS_READ) {
             await this.#features.lsp.window.showDocument({ uri: URI.file(params.filePath).toString() })
         } else {
             const absolutePath = params.fullPath ?? (await this.#resolveAbsolutePath(params.filePath))
@@ -3171,7 +3195,7 @@ export class AgenticChatController implements ChatHandlers {
 
     async #invalidateAllShellCommands(tabId: string, session: ChatSessionService) {
         for (const [toolUseId, toolUse] of session.toolUseLookup.entries()) {
-            if (toolUse.name !== 'executeBash' || this.#stoppedToolUses.has(toolUseId)) continue
+            if (toolUse.name !== EXECUTE_BASH || this.#stoppedToolUses.has(toolUseId)) continue
 
             const params = toolUse.input as unknown as ExecuteBashParams
             const command = params.command
@@ -3477,7 +3501,7 @@ export class AgenticChatController implements ChatHandlers {
         }
         const toolUses = Object.values(data.toolUses)
         for (const toolUse of toolUses) {
-            if ((toolUse.name === 'fsWrite' || toolUse.name === 'fsReplace') && typeof toolUse.input === 'string') {
+            if ((toolUse.name === FS_WRITE || toolUse.name === FS_REPLACE) && typeof toolUse.input === 'string') {
                 const filepath = extractKey(toolUse.input, 'path')
                 const msgId = progressPrefix + toolUse.toolUseId
                 // render fs write UI as soon as fs write starts
@@ -3506,7 +3530,7 @@ export class AgenticChatController implements ChatHandlers {
                 }
                 // render the tool use explanatory as soon as this is received for fsWrite/fsReplace
                 const explanation = extractKey(toolUse.input, 'explanation')
-                const messageId = progressPrefix + toolUse.toolUseId + '_explanation'
+                const messageId = progressPrefix + toolUse.toolUseId + SUFFIX_EXPLANATION
                 if (explanation && !chatResultStream.hasMessage(messageId)) {
                     await streamWriter.close()
                     await chatResultStream.writeResultBlock({

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/toolConstants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/toolConstants.ts
@@ -1,0 +1,38 @@
+/**
+ * Constants related to tools used in agenticChatController.ts
+ * This file centralizes all tool names and related constants to improve code quality and maintainability.
+ */
+
+// File system tools
+export const FS_READ = 'fsRead'
+export const FS_WRITE = 'fsWrite'
+export const FS_REPLACE = 'fsReplace'
+
+// Directory tools
+export const LIST_DIRECTORY = 'listDirectory'
+
+// Search tools
+export const GREP_SEARCH = 'grepSearch'
+export const FILE_SEARCH = 'fileSearch'
+
+// Shell tools
+export const EXECUTE_BASH = 'executeBash'
+
+// Code analysis tools
+export const Q_CODE_REVIEW = 'qCodeReview'
+
+// Tool use button IDs
+export const BUTTON_RUN_SHELL_COMMAND = 'run-shell-command'
+export const BUTTON_REJECT_SHELL_COMMAND = 'reject-shell-command'
+export const BUTTON_REJECT_MCP_TOOL = 'reject-mcp-tool'
+export const BUTTON_ALLOW_TOOLS = 'allow-tools'
+export const BUTTON_UNDO_CHANGES = 'undo-changes'
+export const BUTTON_UNDO_ALL_CHANGES = 'undo-all-changes'
+export const BUTTON_STOP_SHELL_COMMAND = 'stop-shell-command'
+export const BUTTON_PAIDTIER_UPGRADE_Q_LEARNMORE = 'paidtier-upgrade-q-learnmore'
+export const BUTTON_PAIDTIER_UPGRADE_Q = 'paidtier-upgrade-q'
+
+// Message ID suffixes
+export const SUFFIX_PERMISSION = '_permission'
+export const SUFFIX_UNDOALL = '_undoall'
+export const SUFFIX_EXPLANATION = '_explanation'


### PR DESCRIPTION
## Problem
code quality CR for moving string literals.

## Solution
Moved the string literals out.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
