### PR TITLE
fix(amazonq): make JSTSDependencyHandler process scoped packages correctly

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/JSTSDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/JSTSDependencyHandler.ts
@@ -105,7 +105,8 @@ export class JSTSDependencyHandler extends LanguageDependencyHandler<JSTSDepende
 
         // process each dependency
         for (const [name, declaredVersion] of Object.entries(allDependencies)) {
-            const dependencyPath = path.join(nodeModulesPath, name)
+            // Handle scoped packages (@scope/package) by splitting on '/' for cross-platform compatibility
+            const dependencyPath = path.join(nodeModulesPath, ...name.split('/'))
             // Check if dependency exists in node_modules
             if (fs.existsSync(dependencyPath)) {
                 // Read the actual version from the dependency's package.json
@@ -125,6 +126,7 @@ export class JSTSDependencyHandler extends LanguageDependencyHandler<JSTSDepende
                     name,
                     version: actualVersion.toString().replace(/[\^~]/g, ''), // Remove ^ and ~ from version
                     path: dependencyPath,
+                    pathInZipOverride: name, // either package or @scope/package
                     size: this.getDirectorySize(dependencyPath),
                     zipped: false,
                 })

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/LanguageDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/LanguageDependencyHandler.ts
@@ -10,6 +10,7 @@ export interface Dependency {
     name: string
     version: string
     path: string
+    pathInZipOverride?: string
     size: number
     zipped: boolean
 }
@@ -213,7 +214,7 @@ export abstract class LanguageDependencyHandler<T extends BaseDependencyInfo> {
                         workspaceFolder,
                         dependency.path,
                         this.language,
-                        path.basename(dependency.path)
+                        dependency.pathInZipOverride || path.basename(dependency.path)
                     )
                     fileMetadataList.push(...fileMetadata)
                 }


### PR DESCRIPTION
## Problem

We observed that JavaScript/TypeScript scoped dependencies (like `@scope/package`) are either missed or put under wrong places inside the zip (for example, ``@aws/language-servers`` is put under ``language-servers`` missing the parent directory path).

## Solution

Make JSTSDependencyHandler process scoped packages correctly

## Testing

Tested the change locally and confirmed scoped packages are zipped into correct place after the fix.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
