### PR TITLE
fix(amazonq): Emitting Telemetry Metrics for QCodeReview Tool

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/qCodeReviewConstants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/qCodeReviewConstants.ts
@@ -202,3 +202,5 @@ export const SKIP_DIRECTORIES = [
 ]
 
 export const FINDINGS_MESSAGE_SUFFIX = '_qCodeReviewFindings'
+
+export const Q_CODE_REVIEW_METRICS_PARENT_NAME = 'amazonq_qCodeReviewTool'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/qCodeReviewTypes.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/qCodeReviewTypes.ts
@@ -2,14 +2,15 @@ export type FileArtifacts = Array<{ path: string }>
 export type FolderArtifacts = Array<{ path: string }>
 export type RuleArtifacts = Array<{ path: string }>
 export type ArtifactType = 'FILE' | 'FOLDER'
-type metricType =
-    | 'MissingFileOrFolder'
-    | 'CreateUploadUrlFailed'
-    | 'CodeScanTimeout'
-    | 'CodeScanSuccess'
-    | 'CodeScanFailed'
-    | 'CreateUploadUrlSucceded'
-type metricResult = 'Succeeded' | 'Failed'
+export enum FailedMetricName {
+    MissingFileOrFolder = 'missingFileOrFolder',
+    CreateUploadUrlFailed = 'createUploadUrlFailed',
+    CodeScanTimeout = 'codeScanTimeout',
+    CodeScanFailed = 'codeScanFailed',
+}
+export enum SuccessMetricName {
+    CodeScanSuccess = 'codeScanSuccess',
+}
 
 export type ValidateInputAndSetupResult = {
     fileArtifacts: FileArtifacts
@@ -24,6 +25,7 @@ export type ValidateInputAndSetupResult = {
 export type PrepareAndUploadArtifactsResult = {
     uploadId: string
     isCodeDiffPresent: boolean
+    artifactSize: number
 }
 
 export type StartCodeAnalysisResult = {
@@ -60,11 +62,13 @@ export type QCodeReviewFinding = {
 
 export type QCodeReviewMetric =
     | {
-          type: metricType
+          name: SuccessMetricName
           result: 'Succeeded'
+          metadata?: object
       }
     | {
-          type: metricType
+          name: FailedMetricName
           result: 'Failed'
           reason: string
+          metadata?: object
       }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/qCodeReviewUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/qCodeReviewUtils.ts
@@ -6,7 +6,7 @@
 /* eslint-disable import/no-nodejs-modules */
 
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
-import { SKIP_DIRECTORIES, EXTENSION_TO_LANGUAGE } from './qCodeReviewConstants'
+import { SKIP_DIRECTORIES, EXTENSION_TO_LANGUAGE, Q_CODE_REVIEW_METRICS_PARENT_NAME } from './qCodeReviewConstants'
 import JSZip = require('jszip')
 import { exec } from 'child_process'
 import * as path from 'path'
@@ -361,21 +361,19 @@ export class QCodeReviewUtils {
      */
     public static emitMetric(
         metric: QCodeReviewMetric,
-        metricData: object,
         logging: Features['logging'],
-        telemetry: Features['telemetry'],
-        credentialStartUrl?: string
+        telemetry: Features['telemetry']
     ): void {
-        const metricName = `amazonq_qCodeReviewTool`
+        const { name, metadata, ...metricStatus } = metric
         const metricPayload = {
-            name: metricName,
+            name: `${Q_CODE_REVIEW_METRICS_PARENT_NAME}_${name}`,
             data: {
-                ...(credentialStartUrl ? { credentialStartUrl } : {}),
-                ...metricData,
-                ...metric,
+                // metadata is optional attribute
+                ...(metadata || {}),
+                ...metricStatus,
             },
         }
-        logging.info(`Emitting telemetry metric: ${metricName} with data: ${JSON.stringify(metricPayload.data)}`)
+        logging.info(`Emitting telemetry metric: ${metric.name} with data: ${JSON.stringify(metricPayload.data)}`)
         telemetry.emitMetric(metricPayload)
     }
 


### PR DESCRIPTION
## Problem
Metrics are not emitted for QCodeReview Tool

## Solution
Created metric definitions for QCodeReview Tool and emitting metrics along with metadata

## Testing
tested in sandbox environment

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
