### PR TITLE
feat: initial subscription details handling

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -24,9 +24,9 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.1.51",
+        "@aws/chat-client-ui-types": "^0.1.52",
         "@aws/language-server-runtimes": "^0.2.109",
-        "@aws/language-server-runtimes-types": "^0.1.45",
+        "@aws/language-server-runtimes-types": "^0.1.46",
         "@aws/mynah-ui": "^4.35.9"
     },
     "devDependencies": {

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -107,6 +107,8 @@ import {
     OpenFileDialogParams,
     OPEN_FILE_DIALOG_METHOD,
     OpenFileDialogResult,
+    SUBSCRIPTION_DETAILS_NOTIFICATION_METHOD,
+    SubscriptionDetailsParams,
 } from '@aws/language-server-runtimes-types'
 import { ConfigTexts, MynahUIDataModel, MynahUITabStoreModel } from '@aws/mynah-ui'
 import { ServerMessage, TELEMETRY, TelemetryParams } from '../contracts/serverContracts'
@@ -345,6 +347,10 @@ export const createChat = (
                             : [],
                     })
                 }
+                break
+            }
+            case SUBSCRIPTION_DETAILS_NOTIFICATION_METHOD: {
+                mynahApi.showSubscriptionDetails(message.params as SubscriptionDetailsParams)
                 break
             }
             default:

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -37,6 +37,7 @@ import {
     RuleClickResult,
     SourceLinkClickParams,
     ListAvailableModelsResult,
+    SubscriptionDetailsParams,
 } from '@aws/language-server-runtimes-types'
 import {
     ChatItem,
@@ -104,6 +105,7 @@ export interface InboundChatApi {
     addSelectedFilesToContext(params: OpenFileDialogParams): void
     sendPinnedContext(params: PinnedContextParams): void
     listAvailableModels(params: ListAvailableModelsResult): void
+    showSubscriptionDetails(params: SubscriptionDetailsParams): void
 }
 
 type ContextCommandGroups = MynahUIDataModel['contextCommands']
@@ -1561,6 +1563,27 @@ ${params.message}`,
         mynahUi.addCustomContextToPrompt(params.tabId, commands, params.insertPosition)
     }
 
+    const showSubscriptionDetails = (params: SubscriptionDetailsParams) => {
+        // todo: deduplicate tabs
+
+        const tabId = createTabId()
+        if (tabId === undefined) {
+            return
+        }
+
+        const tabStore = mynahUi.getTabData(tabId).getStore()
+        if (tabStore === null) {
+            return
+        }
+
+        mynahUi.updateStore(tabId, {
+            tabTitle: 'Account Details',
+            chatItems: [
+                // todo: show account details here
+            ],
+        })
+    }
+
     const chatHistoryList = new ChatHistoryList(mynahUi, messager)
     const listConversations = (params: ListConversationsResult) => {
         chatHistoryList.show(params)
@@ -1686,6 +1709,7 @@ ${params.message}`,
         ruleClicked: ruleClicked,
         listAvailableModels: listAvailableModels,
         addSelectedFilesToContext: addSelectedFilesToContext,
+        showSubscriptionDetails: showSubscriptionDetails,
     }
 
     return [mynahUi, api]

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "integration-tests/*"
             ],
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.109",
+                "@aws/language-server-runtimes": "^0.2.110",
                 "@smithy/types": "4.2.0",
                 "clean": "^4.0.2",
                 "typescript": "^5.8.2"
@@ -252,9 +252,9 @@
             "version": "0.1.24",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.1.51",
+                "@aws/chat-client-ui-types": "^0.1.52",
                 "@aws/language-server-runtimes": "^0.2.109",
-                "@aws/language-server-runtimes-types": "^0.1.45",
+                "@aws/language-server-runtimes-types": "^0.1.46",
                 "@aws/mynah-ui": "^4.35.9"
             },
             "devDependencies": {
@@ -4016,11 +4016,12 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.51",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.51.tgz",
-            "integrity": "sha512-ILdG6VAu+Of/8Bt2pGhGHksmSC9rg24Vy1JiR2TOm0AdmsEWwYfcZUDlx+PjCYuH5rlEaNHrN31A6oAW9hQPMg==",
+            "version": "0.1.52",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.52.tgz",
+            "integrity": "sha512-+F3vhFvMMxuW5p/Xm/UzwQjGiw+EjC7EB4jl8oCEosuP0QsqkSdN2TeoOBMWaeG1Dpwf8oy1+jAU4+E6jJ0/hQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.45"
+                "@aws/language-server-runtimes-types": "^0.1.46"
             }
         },
         "node_modules/@aws/hello-world-lsp": {
@@ -4032,12 +4033,12 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.109",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.109.tgz",
-            "integrity": "sha512-SbRQ8xC17XFWBh0azzuDvr3jxvOoB1Ot+opjS5KA7SZVxQ0CDVi3qXKKq0lQxeLnnCE6GQnWUG954dfWjI52Gg==",
+            "version": "0.2.110",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.110.tgz",
+            "integrity": "sha512-Zz4eQIkbmV82VMWIW4XAJbRPZAKC675KxmiYvhDcifE4GxYl+2W7Z7bBn/5UE9xF8T+vo8OC5Jggz2Un2WidZQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.45",
+                "@aws/language-server-runtimes-types": "^0.1.46",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/api-logs": "^0.200.0",
                 "@opentelemetry/core": "^2.0.0",
@@ -4064,9 +4065,10 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.45",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.45.tgz",
-            "integrity": "sha512-QmINGPqPUYMyz4lmJVf+r+muAlVocpTvxSmK/VJytgtxVnvjIy56gL0fd8PpUOFjWUxjqFKs6DfbMqKx5hal3A==",
+            "version": "0.1.46",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.46.tgz",
+            "integrity": "sha512-MRutS0gI4VKcy9L75XrhYY8RxOAnqGcD1Q7HSWrMNjTsaOMZXQoipdUJfd+w/samhbEhE1b+eZ+PwUcOpU/9JA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "package": "npm run compile && npm run package --workspaces --if-present"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.109",
+        "@aws/language-server-runtimes": "^0.2.110",
         "@smithy/types": "4.2.0",
         "clean": "^4.0.2",
         "typescript": "^5.8.2"

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -3,7 +3,11 @@
  * Will be deleted or merged.
  */
 
-import { InitializeParams, Server } from '@aws/language-server-runtimes/server-interface'
+import {
+    InitializeParams,
+    Server,
+    SUBSCRIPTION_SHOW_COMMAND_METHOD,
+} from '@aws/language-server-runtimes/server-interface'
 import { AgenticChatController } from './agenticChatController'
 import { ChatSessionManagementService } from '../chat/chatSessionManagementService'
 import { CLEAR_QUICK_ACTION, COMPACT_QUICK_ACTION, HELP_QUICK_ACTION } from '../chat/quickActions'
@@ -18,6 +22,7 @@ import { AmazonQServiceInitializationError } from '../../shared/amazonQServiceMa
 import { isUsingIAMAuth, safeGet } from '../../shared/utils'
 import { enabledMCP } from './tools/mcp/mcpUtils'
 import { QClientCapabilities } from '../configuration/qConfigurationServer'
+import { isSubscriptionDetailsEnabled } from '../subscription/subscriptionUtils'
 
 export function enabledReroute(params: InitializeParams | undefined): boolean {
     const qCapabilities = params?.initializationOptions?.aws?.awsClientCapabilities?.q as
@@ -40,13 +45,18 @@ export const QAgenticChatServer =
 
         lsp.addInitializer((params: InitializeParams) => {
             const rerouteEnabled = enabledReroute(params)
+            
+            const subscriptionDetailsEnabled = isSubscriptionDetailsEnabled(params)
+
+            const supportedExecutionCommands: string[] = ['aws/chat/manageSubscription']
+            if (subscriptionDetailsEnabled) {
+                supportedExecutionCommands.push(SUBSCRIPTION_SHOW_COMMAND_METHOD)
+            }
 
             return {
                 capabilities: {
                     executeCommandProvider: {
-                        commands: [
-                            'aws/chat/manageSubscription',
-                        ],
+                        commands: supportedExecutionCommands,
                     }
                 },
                 awsServerCapabilities: {
@@ -63,7 +73,8 @@ export const QAgenticChatServer =
                         modelSelection: true,
                         history: true,
                         export: TabBarController.enableChatExport(params),
-                        reroute: rerouteEnabled
+                        reroute: rerouteEnabled,
+                        subscriptionDetails: subscriptionDetailsEnabled,
                     },
                 },
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -85,6 +85,8 @@ type ChatHandlers = Omit<
     | 'onPinnedContextRemove'
     | 'onOpenFileDialog'
     | 'onListAvailableModels'
+    | 'sendSubscriptionDetails'
+    | 'onSubscriptionUpgrade'
 >
 
 export class ChatController implements ChatHandlers {

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -42,6 +42,7 @@ export interface QClientCapabilities {
     modelSelection?: boolean
     reroute?: boolean
     qCodeReviewInChat?: boolean
+    subscriptionDetails?: boolean
 }
 
 type QConfigurationResponse =

--- a/server/aws-lsp-codewhisperer/src/language-server/subscription/subscriptionUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/subscription/subscriptionUtils.ts
@@ -1,0 +1,9 @@
+import { InitializeParams } from '@aws/language-server-runtimes/protocol'
+import { QClientCapabilities } from '../configuration/qConfigurationServer'
+
+export function isSubscriptionDetailsEnabled(params: InitializeParams | undefined): boolean {
+    const qCapabilities = params?.initializationOptions?.aws?.awsClientCapabilities?.q as
+        | QClientCapabilities
+        | undefined
+    return qCapabilities?.subscriptionDetails || false
+}


### PR DESCRIPTION

This change adds handlers for the recently added subscription details protocol. The changes are being worked on in a feature branch.

These changes are feature-flagged behind the capability `subscriptionDetails`. If the client sends this, the server will support the related protocols.

Some of the protocol handlers are stubbed out, this work will be performed in subsequent tasks.

Test coverage will be added for the protocol handlers in follow up changes.


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
