### PR TITLE
feat: initial changes for account details flow

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -24,8 +24,9 @@
         "package": "webpack"
     },
     "dependencies": {
-        "@aws/chat-client-ui-types": "^0.1.51",
-        "@aws/language-server-runtimes-types": "^0.1.45",
+        "@aws/chat-client-ui-types": "^0.1.52",
+        "@aws/language-server-runtimes": "^0.2.109",
+        "@aws/language-server-runtimes-types": "^0.1.46",
         "@aws/mynah-ui": "^4.35.9"
     },
     "devDependencies": {

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -107,6 +107,8 @@ import {
     OpenFileDialogParams,
     OPEN_FILE_DIALOG_METHOD,
     OpenFileDialogResult,
+    SUBSCRIPTION_DETAILS_NOTIFICATION_METHOD,
+    SubscriptionDetailsParams,
 } from '@aws/language-server-runtimes-types'
 import { ConfigTexts, MynahUIDataModel, MynahUITabStoreModel } from '@aws/mynah-ui'
 import { ServerMessage, TELEMETRY, TelemetryParams } from '../contracts/serverContracts'
@@ -347,6 +349,10 @@ export const createChat = (
                             : [],
                     })
                 }
+                break
+            }
+            case SUBSCRIPTION_DETAILS_NOTIFICATION_METHOD: {
+                mynahApi.showSubscriptionDetails(message.params as SubscriptionDetailsParams)
                 break
             }
             default:

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -37,6 +37,7 @@ import {
     RuleClickResult,
     SourceLinkClickParams,
     ListAvailableModelsResult,
+    SubscriptionDetailsParams,
 } from '@aws/language-server-runtimes-types'
 import {
     ChatItem,
@@ -104,6 +105,7 @@ export interface InboundChatApi {
     addSelectedFilesToContext(params: OpenFileDialogParams): void
     sendPinnedContext(params: PinnedContextParams): void
     listAvailableModels(params: ListAvailableModelsResult): void
+    showSubscriptionDetails(params: SubscriptionDetailsParams): void
 }
 
 type ContextCommandGroups = MynahUIDataModel['contextCommands']
@@ -1561,6 +1563,51 @@ ${params.message}`,
         mynahUi.addCustomContextToPrompt(params.tabId, commands, params.insertPosition)
     }
 
+    const showSubscriptionDetails = (params: SubscriptionDetailsParams) => {
+        // todo: deduplicate tabs
+
+        const tabId = createTabId()
+        if (tabId === undefined) {
+            return
+        }
+
+        const tabStore = mynahUi.getTabData(tabId).getStore()
+        if (tabStore === null) {
+            return
+        }
+
+        mynahUi.updateStore(tabId, {
+            tabBackground: false,
+            compactMode: false,
+            tabTitle: 'Account Details',
+            promptInputVisible: false,
+            tabHeaderDetails: {
+                title: `Account details`,
+            },
+            chatItems: [
+                {
+                    type: ChatItemType.ANSWER,
+                    body: '### Subscription' + '\n' + 'Free Tier',
+                    buttons: [
+                        {
+                            status: 'primary',
+                            id: 'upgrade-subscription',
+                            text: `Upgrade`,
+                        },
+                    ],
+                },
+                {
+                    type: ChatItemType.ANSWER,
+                    body:
+                        '### Usage \n' +
+                        '591/1000 queries used \n' +
+                        '$0.00 incurred in overages \n' +
+                        'Limits reset on 8/1/2025 at 12:00:00 GMT \n',
+                },
+            ],
+        })
+    }
+
     const chatHistoryList = new ChatHistoryList(mynahUi, messager)
     const listConversations = (params: ListConversationsResult) => {
         chatHistoryList.show(params)
@@ -1686,6 +1733,7 @@ ${params.message}`,
         ruleClicked: ruleClicked,
         listAvailableModels: listAvailableModels,
         addSelectedFilesToContext: addSelectedFilesToContext,
+        showSubscriptionDetails: showSubscriptionDetails,
     }
 
     return [mynahUi, api]

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -85,6 +85,7 @@ import {
     freeTierLimitDirective,
 } from './texts/paidTier'
 import { isSupportedImageExtension, MAX_IMAGE_CONTEXT, verifyClientImages } from './imageVerification'
+import { upgradeToPaidTierButton } from './texts/subscription'
 
 export interface InboundChatApi {
     addChatResponse(params: ChatResult, tabId: string, isPartialResult: boolean): void
@@ -1579,40 +1580,36 @@ ${params.message}`,
         const resetString =
             params.daysRemaining === 1 ? 'Limits reset tomorrow' : `Limits reset in ${params.daysRemaining} days`
 
+        const subscriptionSection: ChatItem = {
+            type: ChatItemType.ANSWER,
+            body: '## Subscription \n' + '### ' + params.subscriptionTier + '\n', // + upgradeToPaidTierButton + '\n\n' + `## Usage\n${usageString}\n${overageString}\n${resetString}`,
+            buttons:
+                params.subscriptionTier.toLowerCase() === 'free tier'
+                    ? [upgradeToPaidTierButton]
+                    : [
+                          {
+                              status: 'primary',
+                              id: 'manage-subscription',
+                              text: 'Manage Subscription',
+                          },
+                      ],
+        }
+
+        const usageSection: ChatItem = {
+            type: ChatItemType.ANSWER,
+            body: `Usage\n${usageString}\n${overageString}\n${resetString}`,
+        }
+
         mynahUi.updateStore(tabId, {
             tabBackground: false,
             compactMode: false,
             tabTitle: 'Account Details',
             promptInputVisible: false,
             tabHeaderDetails: {
-                title: `Account details`,
+                icon: MynahIcons.Q,
+                title: 'Account Details',
             },
-            chatItems: [
-                {
-                    type: ChatItemType.ANSWER,
-                    body: '### Subscription' + '\n' + params.subscriptionTier,
-                    buttons:
-                        params.subscriptionTier.toLowerCase() === 'free tier'
-                            ? [
-                                  {
-                                      status: 'primary',
-                                      id: 'upgrade-subscription',
-                                      text: `Upgrade`,
-                                  },
-                              ]
-                            : [
-                                  {
-                                      status: 'primary',
-                                      id: 'manage-subscription',
-                                      text: `Manage Subscription`,
-                                  },
-                              ],
-                },
-                {
-                    type: ChatItemType.ANSWER,
-                    body: '### Usage \n' + `${usageString} \n` + `${overageString} \n` + `${resetString} \n` + ` \n`,
-                },
-            ],
+            chatItems: [subscriptionSection], // usageSection],
         })
     }
 

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1564,8 +1564,6 @@ ${params.message}`,
     }
 
     const showSubscriptionDetails = (params: SubscriptionDetailsParams) => {
-        // todo: deduplicate tabs
-
         const tabId = createTabId()
         if (tabId === undefined) {
             return
@@ -1575,6 +1573,11 @@ ${params.message}`,
         if (tabStore === null) {
             return
         }
+
+        const usageString = `${params.queryUsage}/${params.queryLimit} queries used`
+        const overageString = `$${params.queryOverage.toFixed(2)} incurred in overages`
+        const resetString =
+            params.daysRemaining === 1 ? 'Limits reset tomorrow' : `Limits reset in ${params.daysRemaining} days`
 
         mynahUi.updateStore(tabId, {
             tabBackground: false,
@@ -1587,22 +1590,27 @@ ${params.message}`,
             chatItems: [
                 {
                     type: ChatItemType.ANSWER,
-                    body: '### Subscription' + '\n' + 'Free Tier',
-                    buttons: [
-                        {
-                            status: 'primary',
-                            id: 'upgrade-subscription',
-                            text: `Upgrade`,
-                        },
-                    ],
+                    body: '### Subscription' + '\n' + params.subscriptionTier,
+                    buttons:
+                        params.subscriptionTier.toLowerCase() === 'free tier'
+                            ? [
+                                  {
+                                      status: 'primary',
+                                      id: 'upgrade-subscription',
+                                      text: `Upgrade`,
+                                  },
+                              ]
+                            : [
+                                  {
+                                      status: 'primary',
+                                      id: 'manage-subscription',
+                                      text: `Manage Subscription`,
+                                  },
+                              ],
                 },
                 {
                     type: ChatItemType.ANSWER,
-                    body:
-                        '### Usage \n' +
-                        '591/1000 queries used \n' +
-                        '$0.00 incurred in overages \n' +
-                        'Limits reset on 8/1/2025 at 12:00:00 GMT \n',
+                    body: '### Usage \n' + `${usageString} \n` + `${overageString} \n` + `${resetString} \n` + ` \n`,
                 },
             ],
         })

--- a/chat-client/src/client/texts/subscription.ts
+++ b/chat-client/src/client/texts/subscription.ts
@@ -1,0 +1,11 @@
+import { ChatItemButton } from '@aws/mynah-ui'
+
+export const upgradeToPaidTierButton: ChatItemButton = {
+    id: 'upgrade-to-paid-tier',
+    flash: 'once',
+    fillState: 'always',
+    position: 'inside',
+    text: `Upgrade`,
+    status: 'primary',
+    disabled: false,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "integration-tests/*"
             ],
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.108",
+                "@aws/language-server-runtimes": "^0.2.110",
                 "@smithy/types": "4.2.0",
                 "clean": "^4.0.2",
                 "typescript": "^5.8.2"
@@ -249,8 +249,9 @@
             "version": "0.1.24",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/chat-client-ui-types": "^0.1.51",
-                "@aws/language-server-runtimes-types": "^0.1.45",
+                "@aws/chat-client-ui-types": "^0.1.52",
+                "@aws/language-server-runtimes": "^0.2.109",
+                "@aws/language-server-runtimes-types": "^0.1.46",
                 "@aws/mynah-ui": "^4.35.9"
             },
             "devDependencies": {
@@ -4009,11 +4010,12 @@
             "link": true
         },
         "node_modules/@aws/chat-client-ui-types": {
-            "version": "0.1.51",
-            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.51.tgz",
-            "integrity": "sha512-ILdG6VAu+Of/8Bt2pGhGHksmSC9rg24Vy1JiR2TOm0AdmsEWwYfcZUDlx+PjCYuH5rlEaNHrN31A6oAW9hQPMg==",
+            "version": "0.1.52",
+            "resolved": "https://registry.npmjs.org/@aws/chat-client-ui-types/-/chat-client-ui-types-0.1.52.tgz",
+            "integrity": "sha512-+F3vhFvMMxuW5p/Xm/UzwQjGiw+EjC7EB4jl8oCEosuP0QsqkSdN2TeoOBMWaeG1Dpwf8oy1+jAU4+E6jJ0/hQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.45"
+                "@aws/language-server-runtimes-types": "^0.1.46"
             }
         },
         "node_modules/@aws/hello-world-lsp": {
@@ -4025,11 +4027,12 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.108",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.108.tgz",
-            "integrity": "sha512-AdvT1RMlKxaaligGavR4QzhcoVHdemia1KyMEDdBzGOoQ4sODu/HSK8VVAwp4hoGjxbOtWUsaPcDduIf00oqvg==",
+            "version": "0.2.110",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.110.tgz",
+            "integrity": "sha512-Zz4eQIkbmV82VMWIW4XAJbRPZAKC675KxmiYvhDcifE4GxYl+2W7Z7bBn/5UE9xF8T+vo8OC5Jggz2Un2WidZQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes-types": "^0.1.45",
+                "@aws/language-server-runtimes-types": "^0.1.46",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/api-logs": "^0.200.0",
                 "@opentelemetry/core": "^2.0.0",
@@ -4056,9 +4059,10 @@
             }
         },
         "node_modules/@aws/language-server-runtimes-types": {
-            "version": "0.1.45",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.45.tgz",
-            "integrity": "sha512-QmINGPqPUYMyz4lmJVf+r+muAlVocpTvxSmK/VJytgtxVnvjIy56gL0fd8PpUOFjWUxjqFKs6DfbMqKx5hal3A==",
+            "version": "0.1.46",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes-types/-/language-server-runtimes-types-0.1.46.tgz",
+            "integrity": "sha512-MRutS0gI4VKcy9L75XrhYY8RxOAnqGcD1Q7HSWrMNjTsaOMZXQoipdUJfd+w/samhbEhE1b+eZ+PwUcOpU/9JA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.12",
                 "vscode-languageserver-types": "^3.17.5"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "package": "npm run compile && npm run package --workspaces --if-present"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.108",
+        "@aws/language-server-runtimes": "^0.2.110",
         "@smithy/types": "4.2.0",
         "clean": "^4.0.2",
         "typescript": "^5.8.2"

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -428,6 +428,8 @@ export class AgenticChatController implements ChatHandlers {
             await this.onManageSubscription(params.tabId)
 
             return { success: true }
+        } else if (params.buttonId === 'upgrade-to-paid-tier') {
+            return { success: true }
         } else {
             return {
                 success: false,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -46,6 +46,7 @@ import {
     OpenFileDialogParams,
     OpenFileDialogResult,
     SUBSCRIPTION_SHOW_COMMAND_METHOD,
+    SubscriptionUpgradeParams,
 } from '@aws/language-server-runtimes/protocol'
 import {
     ApplyWorkspaceEditParams,
@@ -4115,6 +4116,12 @@ export class AgenticChatController implements ChatHandlers {
 
         this.#chatHistoryDb.setModelId(session.modelId)
         this.#chatHistoryDb.setPairProgrammingMode(session.pairProgrammingMode)
+    }
+
+    onSubscriptionUpgrade(param: SubscriptionUpgradeParams) {
+        this.#log('onSubscriptionUpgrade')
+
+        // TODO : future development here
     }
 
     updateConfiguration = (newConfig: AmazonQWorkspaceConfig) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -357,19 +357,6 @@ export class AgenticChatController implements ChatHandlers {
         }
     }
 
-    async onShowSubscription(): Promise<void> {
-        // todo: load account details
-
-        // for now, send a sample payload, so that clients under development can start seeing data
-        await this.#features.chat.sendSubscriptionDetails({
-            subscriptionTier: 'temp',
-            daysRemaining: 2,
-            queryLimit: 1000,
-            queryUsage: 457,
-            queryOverage: 0,
-        })
-    }
-
     async onButtonClick(params: ButtonClickParams): Promise<ButtonClickResult> {
         this.#log(`onButtonClick event with params: ${JSON.stringify(params)}`)
         const session = this.#chatSessionManagementService.getSession(params.tabId)
@@ -4329,5 +4316,44 @@ export class AgenticChatController implements ChatHandlers {
 
     #debug(...messages: string[]) {
         this.#features.logging.debug(messages.join(' '))
+    }
+
+    /**
+     * Handles when a user invokes "Account Details" from IDE.
+     *
+     * - Opens a new tab with "Account Details" for the user.
+     */
+    async onShowSubscription(): Promise<void> {
+        let codeWhispererServiceToken: CodeWhispererServiceToken
+        try {
+            codeWhispererServiceToken = AmazonQTokenServiceManager.getInstance().getCodewhispererService()
+        } catch (error) {
+            // getCodewhispererService only returns the cwspr client if the service manager was initialized
+            // i.e. profile was selected otherwise it throws an error
+            // we will not evaluate a/b status until profile is selected and service manager is fully initialized
+            return
+        }
+
+        const profileArn = this.#serviceManager?.getActiveProfileArn()
+
+        try {
+            const response = await codeWhispererServiceToken.getUsageLimits({
+                profileArn: profileArn,
+                // resourceType: 'CODE_GENERATION',    // todo
+                // serviceNamespace: 'codewhisperer'   // todo
+            })
+            const codeCompletionsLimit = response.limits.find(limit => limit.type === 'CODE_COMPLETIONS')
+
+            await this.#features.chat.sendSubscriptionDetails({
+                subscriptionTier: 'Free Tier', // You might need to determine this from another source
+                daysRemaining: response.daysUntilReset,
+                queryLimit: codeCompletionsLimit?.totalUsageLimit ?? 0, // response.usageBreakdown?.usageLimit ?? 0,
+                queryUsage: codeCompletionsLimit?.currentUsage ?? 0, // response.usageBreakdown?.currentUsage ?? 0,
+                queryOverage: 0, // response.usageBreakdown?.currentOverages ?? 0,
+            })
+        } catch (error) {
+            console.error('Failed to fetch usage limits:', error)
+            throw error
+        }
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -2,6 +2,7 @@
  * Copied from ../qChatServer.ts for the purpose of developing a divergent implementation.
  * Will be deleted or merged.
  */
+
 import {
     InitializeParams,
     Server,

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -85,6 +85,8 @@ type ChatHandlers = Omit<
     | 'onPinnedContextRemove'
     | 'onOpenFileDialog'
     | 'onListAvailableModels'
+    | 'sendSubscriptionDetails'
+    | 'onSubscriptionUpgrade'
 >
 
 export class ChatController implements ChatHandlers {

--- a/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/configuration/qConfigurationServer.ts
@@ -42,6 +42,7 @@ export interface QClientCapabilities {
     modelSelection?: boolean
     reroute?: boolean
     qCodeReviewInChat?: boolean
+    subscriptionDetails?: boolean
 }
 
 type QConfigurationResponse =

--- a/server/aws-lsp-codewhisperer/src/language-server/subscription/subscriptionUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/subscription/subscriptionUtils.ts
@@ -1,0 +1,9 @@
+import { InitializeParams } from '@aws/language-server-runtimes/protocol'
+import { QClientCapabilities } from '../configuration/qConfigurationServer'
+
+export function isSubscriptionDetailsEnabled(params: InitializeParams | undefined): boolean {
+    const qCapabilities = params?.initializationOptions?.aws?.awsClientCapabilities?.q as
+        | QClientCapabilities
+        | undefined
+    return qCapabilities?.subscriptionDetails || false
+}

--- a/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts
@@ -437,6 +437,15 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
     }
 
     /**
+     * @description get the usage limits
+     */
+    async getUsageLimits(
+        request: CodeWhispererTokenClient.GetUsageLimitsRequest
+    ): Promise<PromiseResult<CodeWhispererTokenClient.GetUsageLimitsResponse, AWSError>> {
+        return this.client.getUsageLimits(this.withProfileArn(request)).promise()
+    }
+
+    /**
      * (debounced by default)
      *
      * cool api you have there 🥹

--- a/server/aws-lsp-codewhisperer/src/shared/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/constants.ts
@@ -3,13 +3,14 @@ export const INVALID_TOKEN = 'The bearer token included in the request is invali
 export const GENERIC_UNAUTHORIZED_ERROR = 'User is not authorized to make this call'
 export const BUILDER_ID_START_URL = 'https://view.awsapps.com/start'
 export const INTERNAL_USER_START_URL = 'https://amzn.awsapps.com/start'
-export const DEFAULT_AWS_Q_ENDPOINT_URL = 'https://codewhisperer.us-east-1.amazonaws.com/'
-export const DEFAULT_AWS_Q_REGION = 'us-east-1'
+export const DEFAULT_AWS_Q_ENDPOINT_URL =
+    'https://rts.alpha-us-west-2.codewhisperer.ai.aws.dev/' /* 'https://codewhisperer.us-east-1.amazonaws.com/' */
+export const DEFAULT_AWS_Q_REGION = 'us-west-2'
 
 export const AWS_Q_ENDPOINTS = new Map([
     [DEFAULT_AWS_Q_REGION, DEFAULT_AWS_Q_ENDPOINT_URL],
-    ['us-east-1', 'https://codewhisperer.us-east-1.amazonaws.com/'],
-    ['eu-central-1', 'https://q.eu-central-1.amazonaws.com/'],
+    // ['us-east-1', 'https://codewhisperer.us-east-1.amazonaws.com/'],
+    // ['eu-central-1', 'https://q.eu-central-1.amazonaws.com/'],
 ])
 
 export const AWS_Q_REGION_ENV_VAR = 'AWS_Q_REGION'


### PR DESCRIPTION
## Problem

- When user clicks on Account Details button on IDE, we should fetch the `getUsageDetails` from Service and provide the details to the IDE.
- This PR address the above changes

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
