### PR TITLE
fix: treat `echo`/`find`/`grep` as mutating

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
@@ -114,7 +114,7 @@ describe('ExecuteBash Tool', () => {
                 getTextDocument: async s => ({}) as TextDocument,
             },
         })
-        const result = await execBash.requiresAcceptance({ command: 'echo hello world', cwd: workspaceFolder })
+        const result = await execBash.requiresAcceptance({ command: 'ps aux', cwd: workspaceFolder })
 
         assert.equal(
             result.requiresAcceptance,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -27,12 +27,10 @@ export const commandCategories = new Map<string, CommandCategory>([
     ['cat', CommandCategory.ReadOnly],
     ['bat', CommandCategory.ReadOnly],
     ['pwd', CommandCategory.ReadOnly],
-    ['echo', CommandCategory.ReadOnly],
     ['file', CommandCategory.ReadOnly],
     ['less', CommandCategory.ReadOnly],
     ['more', CommandCategory.ReadOnly],
     ['tree', CommandCategory.ReadOnly],
-    ['find', CommandCategory.ReadOnly],
     ['top', CommandCategory.ReadOnly],
     ['htop', CommandCategory.ReadOnly],
     ['ps', CommandCategory.ReadOnly],
@@ -54,7 +52,6 @@ export const commandCategories = new Map<string, CommandCategory>([
     ['diff', CommandCategory.ReadOnly],
     ['head', CommandCategory.ReadOnly],
     ['tail', CommandCategory.ReadOnly],
-    ['grep', CommandCategory.ReadOnly],
 
     // Mutable commands
     ['chmod', CommandCategory.Mutate],
@@ -81,6 +78,9 @@ export const commandCategories = new Map<string, CommandCategory>([
     ['exec', CommandCategory.Mutate],
     ['eval', CommandCategory.Mutate],
     ['xargs', CommandCategory.Mutate],
+    ['echo', CommandCategory.Mutate],
+    ['grep', CommandCategory.Mutate],
+    ['find', CommandCategory.Mutate],
 
     // Destructive commands
     ['rm', CommandCategory.Destructive],


### PR DESCRIPTION
as discussed in internal channels

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
