### PR TITLE
fix: update ChatHandlers before adding new types dependency

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -238,6 +238,8 @@ type ChatHandlers = Omit<
     | 'onPinnedContextRemove'
     | 'onOpenFileDialog'
     | 'onListAvailableModels'
+    | 'sendSubscriptionDetails'
+    | 'onSubscriptionUpgrade'
 >
 
 export class AgenticChatController implements ChatHandlers {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -85,6 +85,8 @@ type ChatHandlers = Omit<
     | 'onPinnedContextRemove'
     | 'onOpenFileDialog'
     | 'onListAvailableModels'
+    | 'sendSubscriptionDetails'
+    | 'onSubscriptionUpgrade'
 >
 
 export class ChatController implements ChatHandlers {


### PR DESCRIPTION

This change adds type omissions to ChatHandlers, so that a future runtimes dependency update (https://github.com/aws/language-server-runtimes/pull/620) will not cause this codebase to fail.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
