### PR TITLE
build: add missing packagelock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27355,6 +27355,24 @@
                 "node": ">=18.0.0"
             }
         },
+        "server/aws-lsp-identity/node_modules/@aws/lsp-core": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/@aws/lsp-core/-/lsp-core-0.0.11.tgz",
+            "integrity": "sha512-8kaMbNiYwj1SlBBwy/43f1Yv09tUEInOjr26Oe4X1w4xR03vAumoPC/u5khPj7SYx2PofFl84c+8gUObBASm9g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@gerhobbelt/gitignore-parser": "^0.2.0-9",
+                "cross-spawn": "7.0.6",
+                "jose": "^5.2.4",
+                "request-light": "^0.8.0",
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3",
+                "vscode-uri": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "server/aws-lsp-identity/node_modules/@smithy/types": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
@@ -27414,6 +27432,24 @@
                 "node": ">=18.0.0"
             }
         },
+        "server/aws-lsp-notification/node_modules/@aws/lsp-core": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/@aws/lsp-core/-/lsp-core-0.0.11.tgz",
+            "integrity": "sha512-8kaMbNiYwj1SlBBwy/43f1Yv09tUEInOjr26Oe4X1w4xR03vAumoPC/u5khPj7SYx2PofFl84c+8gUObBASm9g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@gerhobbelt/gitignore-parser": "^0.2.0-9",
+                "cross-spawn": "7.0.6",
+                "jose": "^5.2.4",
+                "request-light": "^0.8.0",
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3",
+                "vscode-uri": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "server/aws-lsp-notification/node_modules/@smithy/types": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
@@ -27457,6 +27493,24 @@
                 "@aws/lsp-core": "^0.0.11",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
+            }
+        },
+        "server/aws-lsp-s3/node_modules/@aws/lsp-core": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/@aws/lsp-core/-/lsp-core-0.0.11.tgz",
+            "integrity": "sha512-8kaMbNiYwj1SlBBwy/43f1Yv09tUEInOjr26Oe4X1w4xR03vAumoPC/u5khPj7SYx2PofFl84c+8gUObBASm9g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@gerhobbelt/gitignore-parser": "^0.2.0-9",
+                "cross-spawn": "7.0.6",
+                "jose": "^5.2.4",
+                "request-light": "^0.8.0",
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3",
+                "vscode-uri": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "server/aws-lsp-yaml": {


### PR DESCRIPTION
## Problem

```
[5:30](https://amzn-aws.slack.com/archives/D03BM50BDFV/p1752791417530239)
npm error Missing: @aws/lsp-core@0.0.11 from lock file
npm error Missing: @aws/lsp-core@0.0.11 from lock file
npm error Missing: @aws/lsp-core@0.0.11 from lock file
```

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
