### PR TITLE
feat: enable webforms to blazor transformation via validation bypass

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { StartTransformRequest, TransformProjectMetadata } from '../models'
-import { isProject, isSolution, validateProject } from '../validation'
+import { isProject, isSolution, validateProject, validateSolution } from '../validation'
 import { supportedProjects, unsupportedViewComponents } from '../resources/SupportedProjects'
 import mock = require('mock-fs')
 import { Logging } from '@aws/language-server-runtimes/server-interface'
@@ -95,5 +95,73 @@ describe('Test validation functionality', () => {
         mockStartTransformationRequest.ProjectMetadata.push(mockProjectMeta)
 
         expect(validateProject(mockStartTransformationRequest, mockedLogging)).to.equal(false)
+    })
+
+    // New tests for AspNetWebForms validation
+    it('should return true when project is AspNetWebForms type', () => {
+        let mockStartTransformationRequest: StartTransformRequest = sampleStartTransformRequest
+        const mockProjectMeta = {
+            Name: '',
+            ProjectTargetFramework: '',
+            ProjectPath: 'test.csproj',
+            SourceCodeFilePaths: [],
+            ProjectLanguage: '',
+            ProjectType: 'AspNetWebForms',
+            ExternalReferences: [],
+        }
+        mockStartTransformationRequest.ProjectMetadata = []
+        mockStartTransformationRequest.ProjectMetadata.push(mockProjectMeta)
+
+        expect(validateProject(mockStartTransformationRequest, mockedLogging)).to.equal(true)
+    })
+
+    it('should not include AspNetWebForms in unsupported projects list', () => {
+        let mockStartTransformationRequest: StartTransformRequest = sampleStartTransformRequest
+
+        // Add a supported project
+        const supportedProjectMeta = {
+            Name: 'Supported',
+            ProjectTargetFramework: '',
+            ProjectPath: 'supported.csproj',
+            SourceCodeFilePaths: [],
+            ProjectLanguage: '',
+            ProjectType: 'AspNetCoreMvc',
+            ExternalReferences: [],
+        }
+
+        // Add an unsupported project
+        const unsupportedProjectMeta = {
+            Name: 'Unsupported',
+            ProjectTargetFramework: '',
+            ProjectPath: 'unsupported.csproj',
+            SourceCodeFilePaths: [],
+            ProjectLanguage: '',
+            ProjectType: 'UnsupportedType',
+            ExternalReferences: [],
+        }
+
+        // Add an AspNetWebForms project
+        const webFormsProjectMeta = {
+            Name: 'WebForms',
+            ProjectTargetFramework: '',
+            ProjectPath: 'webforms.csproj',
+            SourceCodeFilePaths: [],
+            ProjectLanguage: '',
+            ProjectType: 'AspNetWebForms',
+            ExternalReferences: [],
+        }
+
+        mockStartTransformationRequest.ProjectMetadata = [
+            supportedProjectMeta,
+            unsupportedProjectMeta,
+            webFormsProjectMeta,
+        ]
+
+        const unsupportedProjects = validateSolution(mockStartTransformationRequest)
+
+        // Should only contain the unsupported project, not the AspNetWebForms project
+        expect(unsupportedProjects).to.have.lengthOf(1)
+        expect(unsupportedProjects[0]).to.equal('unsupported.csproj')
+        expect(unsupportedProjects).to.not.include('webforms.csproj')
     })
 })


### PR DESCRIPTION
This PR enables WebForms to Blazor transformation without officially adding 'AspNetWebForms' to the supportedProjects array. It implements a temporary solution by modifying the validation logic to specifically allow AspNetWebForms projects while maintaining backward compatibility with existing project types.

Changes:
- Modified validateProject function to accept AspNetWebForms projects
- Updated validateSolution function to exclude AspNetWebForms from unsupported projects list
- Added documentation explaining the temporary nature of this approach

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
