### PR TITLE
fix: Make the classifier of auto trigger output the same score as the IDE auto trigger classifier

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
@@ -1,3 +1,4 @@
+import * as os from 'os'
 import { Logging } from '@aws/language-server-runtimes/server-interface'
 import { FileContext } from '../../../shared/codeWhispererService'
 import typedCoefficients = require('./coefficients.json')
@@ -133,6 +134,35 @@ export const getAutoTriggerType = (
     }
     return undefined
 }
+// reference: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/classifierTrigger.ts#L579
+export function getNormalizeOsName(): string {
+    const name = os.platform()
+    const version = os.version()
+    const lowercaseName = name.toLowerCase()
+    if (lowercaseName.includes('windows')) {
+        if (!version) {
+            return 'Windows'
+        } else if (version.includes('Windows NT 10') || version.startsWith('10')) {
+            return 'Windows 10'
+        } else if (version.includes('6.1')) {
+            return 'Windows 7'
+        } else if (version.includes('6.3')) {
+            return 'Windows 8.1'
+        } else {
+            return 'Windows'
+        }
+    } else if (
+        lowercaseName.includes('macos') ||
+        lowercaseName.includes('mac os') ||
+        lowercaseName.includes('darwin')
+    ) {
+        return 'Mac OS X'
+    } else if (lowercaseName.includes('linux')) {
+        return 'Linux'
+    } else {
+        return name
+    }
+}
 
 // Normalize values based on minn and maxx values in the coefficients.
 const normalize = (val: number, field: keyof typeof typedCoefficients.minn & keyof typeof typedCoefficients.maxx) =>
@@ -243,37 +273,6 @@ export const autoTrigger = (
         previousDecisionCoefficient +
         languageCoefficient +
         leftContextLengthCoefficient
-    console.log(
-        'Classifier Debug:',
-        JSON.stringify(
-            {
-                lengthOfRight: lengthOfRight,
-                lengthOfLeftCurrent: lengthOfLeftCurrent,
-                lengthOfLeftPrev: lengthOfLeftPrev,
-                rightLengthComponent: coefficients.lengthOfRightCoefficient * normalize(lengthOfRight, 'lenRight'),
-                leftCurrentLengthComponent:
-                    coefficients.lengthOfLeftCurrentCoefficient * normalize(lengthOfLeftCurrent, 'lenLeftCur'),
-                leftPreviousLengthComponent:
-                    coefficients.lengthOfLeftPrevCoefficient * normalize(lengthOfLeftPrev, 'lenLeftPrev'),
-                lineNumberComponent: coefficients.lineNumCoefficient * normalize(lineNum, 'lineNum'),
-                osCoefficient,
-                triggerTypeCoefficient,
-                charCoefficient,
-                keyWordCoefficient,
-                ideCoefficient,
-                intercept: coefficients.intercept,
-                previousDecisionCoefficient,
-                languageCoefficient,
-                leftContextLengthCoefficient,
-                finalClassifierResult: classifierResult,
-                sigmoidResult: sigmoid(classifierResult),
-                threshold: TRIGGER_THRESHOLD,
-                shouldTrigger: sigmoid(classifierResult) > TRIGGER_THRESHOLD,
-            },
-            null,
-            2
-        )
-    )
     const shouldTrigger = sigmoid(classifierResult) > TRIGGER_THRESHOLD
 
     return {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
@@ -243,7 +243,37 @@ export const autoTrigger = (
         previousDecisionCoefficient +
         languageCoefficient +
         leftContextLengthCoefficient
-
+    console.log(
+        'Classifier Debug:',
+        JSON.stringify(
+            {
+                lengthOfRight: lengthOfRight,
+                lengthOfLeftCurrent: lengthOfLeftCurrent,
+                lengthOfLeftPrev: lengthOfLeftPrev,
+                rightLengthComponent: coefficients.lengthOfRightCoefficient * normalize(lengthOfRight, 'lenRight'),
+                leftCurrentLengthComponent:
+                    coefficients.lengthOfLeftCurrentCoefficient * normalize(lengthOfLeftCurrent, 'lenLeftCur'),
+                leftPreviousLengthComponent:
+                    coefficients.lengthOfLeftPrevCoefficient * normalize(lengthOfLeftPrev, 'lenLeftPrev'),
+                lineNumberComponent: coefficients.lineNumCoefficient * normalize(lineNum, 'lineNum'),
+                osCoefficient,
+                triggerTypeCoefficient,
+                charCoefficient,
+                keyWordCoefficient,
+                ideCoefficient,
+                intercept: coefficients.intercept,
+                previousDecisionCoefficient,
+                languageCoefficient,
+                leftContextLengthCoefficient,
+                finalClassifierResult: classifierResult,
+                sigmoidResult: sigmoid(classifierResult),
+                threshold: TRIGGER_THRESHOLD,
+                shouldTrigger: sigmoid(classifierResult) > TRIGGER_THRESHOLD,
+            },
+            null,
+            2
+        )
+    )
     const shouldTrigger = sigmoid(classifierResult) > TRIGGER_THRESHOLD
 
     return {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -17,7 +17,7 @@ import {
     IdeDiagnostic,
 } from '@aws/language-server-runtimes/server-interface'
 import { AWSError } from 'aws-sdk'
-import { autoTrigger, getAutoTriggerType, triggerType } from './auto-trigger/autoTrigger'
+import { autoTrigger, getAutoTriggerType, getNormalizeOsName, triggerType } from './auto-trigger/autoTrigger'
 import {
     CodeWhispererServiceToken,
     GenerateSuggestionsRequest,
@@ -460,7 +460,7 @@ export const CodewhispererServerFactory =
                             lineNum: params.position.line, // the line number of the invocation, this is the line of the cursor
                             char: triggerCharacters, // Add the character just inserted, if any, before the invication position
                             ide: ideCategory ?? '',
-                            os: '', // TODO: We should get this in a platform-agnostic way (i.e., compatible with the browser)
+                            os: getNormalizeOsName(),
                             previousDecision, // The last decision by the user on the previous invocation
                             triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
                         },

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
@@ -139,7 +139,7 @@ describe('Telemetry', () => {
             },
         }
         const EMPTY_RESULT = { items: [], sessionId: '' }
-        const classifierResult = getNormalizeOsName() === 'Windows' ? 0.4114381148145918 : 0.46733811481459187
+        const classifierResult = getNormalizeOsName() !== 'Linux' ? 0.4114381148145918 : 0.46733811481459187
 
         let features: TestFeatures
         let server: Server

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
@@ -19,6 +19,7 @@ import {
 import { CodeWhispererSession, SessionManager } from './session/sessionManager'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { initBaseTestServiceManager, TestAmazonQServiceManager } from '../../shared/amazonQServiceManager/testUtils'
+import { getNormalizeOsName } from './auto-trigger/autoTrigger'
 
 describe('Telemetry', () => {
     const sandbox = sinon.createSandbox()
@@ -138,6 +139,7 @@ describe('Telemetry', () => {
             },
         }
         const EMPTY_RESULT = { items: [], sessionId: '' }
+        const classifierResult = getNormalizeOsName() === 'Windows' ? 0.4114381148145918 : 0.46733811481459187
 
         let features: TestFeatures
         let server: Server
@@ -253,7 +255,7 @@ describe('Telemetry', () => {
                 triggerType: 'AutoTrigger',
                 autoTriggerType: 'SpecialCharacters',
                 triggerCharacter: '(',
-                classifierResult: 0.46733811481459187,
+                classifierResult: classifierResult,
                 classifierThreshold: 0.43,
                 language: 'csharp',
                 requestContext: {
@@ -1045,7 +1047,7 @@ describe('Telemetry', () => {
                     triggerType: 'AutoTrigger',
                     autoTriggerType: 'SpecialCharacters',
                     triggerCharacter: '(',
-                    classifierResult: 0.46733811481459187,
+                    classifierResult: classifierResult,
                     classifierThreshold: 0.43,
                     language: 'csharp',
                     requestContext: {
@@ -1359,7 +1361,7 @@ describe('Telemetry', () => {
                     triggerType: 'AutoTrigger',
                     autoTriggerType: 'SpecialCharacters',
                     triggerCharacter: '(',
-                    classifierResult: 0.46733811481459187,
+                    classifierResult: classifierResult,
                     classifierThreshold: 0.43,
                     language: 'csharp',
                     requestContext: {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
@@ -58,6 +58,12 @@ describe('Telemetry', () => {
         telemetryServiceSpy.restore()
     })
 
+    // Add a hook that runs after all tests in this describe block
+    after(() => {
+        // Force process to exit after tests complete to prevent hanging
+        setTimeout(() => process.exit(0), 1000)
+    })
+
     describe('User Trigger Decision telemetry', () => {
         const HELLO_WORLD_IN_CSHARP = `class HelloWorld
 {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
@@ -400,6 +400,7 @@ describe('Telemetry', () => {
                 assert(currentSession)
                 assert.equal(currentSession?.state, 'CLOSED')
                 sinon.assert.calledOnceWithExactly(sessionManagerSpy.closeSession, currentSession)
+                const classifierResult = getNormalizeOsName() !== 'Linux' ? -0.9083073111924993 : -0.8524073111924992
 
                 const expectedUserTriggerDecisionMetric = aUserTriggerDecision({
                     startPosition: { line: 0, character: 0 },
@@ -446,7 +447,7 @@ describe('Telemetry', () => {
                     triggerType: 'OnDemand',
                     autoTriggerType: undefined,
                     triggerCharacter: '',
-                    classifierResult: -0.8524073111924992,
+                    classifierResult: classifierResult,
                     requestContext: {
                         fileContext: {
                             filename: 'test.cs',

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
@@ -1251,7 +1251,7 @@ describe('Telemetry', () => {
                     triggerType: 'AutoTrigger',
                     autoTriggerType: 'SpecialCharacters',
                     triggerCharacter: '(',
-                    classifierResult: 0.30173811481459184,
+                    classifierResult: getNormalizeOsName() === 'Linux' ? 0.30173811481459184 : 0.2458381148145919,
                     classifierThreshold: 0.43,
                     language: 'csharp',
                     requestContext: {


### PR DESCRIPTION
## Problem

When a keystroke is input, the classifier of Flare will output a different score, which result in different behavior in auto trigger.

## Solution

By comparing the classifier score given the example same input, AFTER the fix of document event based trigger, we find that the only difference between the IDE auto trigger and Flare is the OS. 

The Flare auto trigger has a OS field that is not implemented correctly, it is marked as TODO. 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
