### PR TITLE
fix(amazonq): fix for mcp server unnecessary refresh from file watchers

### DIFF
--- a/chat-client/src/client/mcpMynahUi.ts
+++ b/chat-client/src/client/mcpMynahUi.ts
@@ -508,6 +508,7 @@ export class McpMynahUi {
                         },
                         onClose: () => {
                             this.messager.onMcpServerClick(MCP_IDS.SAVE_PERMISSION_CHANGE)
+                            this.isMcpServersListActive = false
                         },
                         onBackClick: () => {
                             this.messager.onMcpServerClick(MCP_IDS.SAVE_PERMISSION_CHANGE)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -46,6 +46,8 @@ export class McpEventHandler {
     #newlyAddedServers: Set<string> = new Set()
     #fileWatcher: ChokidarFileWatcher
     #isProgrammaticChange: boolean = false
+    #debounceTimer: NodeJS.Timeout | null = null
+    #lastProgrammaticState: boolean = false
 
     constructor(features: Features, telemetryService: TelemetryService) {
         this.#features = features
@@ -665,9 +667,8 @@ export class McpEventHandler {
                 await McpManager.instance.addServer(serverName, config, configPath, personaPath)
                 this.#newlyAddedServers.add(serverName)
             }
-        } finally {
-            // Reset flag after operations
-            this.#isProgrammaticChange = false
+        } catch (error) {
+            this.#features.logging.error(`Failed to enable MCP server: ${error}`)
         }
 
         this.#currentEditingServerName = undefined
@@ -694,6 +695,7 @@ export class McpEventHandler {
             }
 
             // Stay on add/edit page and show error to user
+            // Keep isProgrammaticChange true during error handling to prevent file watcher triggers
             if (isEditMode) {
                 params.id = 'edit-mcp'
                 params.title = sanitizedServerName
@@ -707,6 +709,8 @@ export class McpEventHandler {
             if (this.#newlyAddedServers.has(serverName)) {
                 this.#newlyAddedServers.delete(serverName)
             }
+
+            this.#isProgrammaticChange = false
 
             // Go to tools permissions page
             return this.#handleOpenMcpServer({ id: 'open-mcp-server', title: sanitizedServerName })
@@ -812,10 +816,8 @@ export class McpEventHandler {
             this.#emitMCPConfigEvent()
         } catch (error) {
             this.#features.logging.error(`Failed to enable MCP server: ${error}`)
-        } finally {
-            // Reset flag after operations
-            this.#isProgrammaticChange = false
         }
+        this.#isProgrammaticChange = false
         return { id: params.id }
     }
 
@@ -845,11 +847,9 @@ export class McpEventHandler {
             this.#emitMCPConfigEvent()
         } catch (error) {
             this.#features.logging.error(`Failed to disable MCP server: ${error}`)
-        } finally {
-            // Reset flag after operations
-            this.#isProgrammaticChange = false
         }
 
+        this.#isProgrammaticChange = false
         return { id: params.id }
     }
 
@@ -867,23 +867,25 @@ export class McpEventHandler {
 
         try {
             await McpManager.instance.removeServer(serverName)
+
+            return { id: params.id }
         } catch (error) {
             this.#features.logging.error(`Failed to delete MCP server: ${error}`)
-        } finally {
-            // Reset flag after operations
             this.#isProgrammaticChange = false
+            return { id: params.id }
         }
-
-        return { id: params.id }
     }
 
     /**
      * Handles edit MCP configuration
      */
     async #handleEditMcpServer(params: McpServerClickParams, error?: string) {
+        // Set programmatic change flag to true to prevent file watcher triggers
+        this.#isProgrammaticChange = true
         await this.#handleSavePermissionChange({ id: 'save-mcp-permission' })
         const serverName = params.title
         if (!serverName) {
+            this.#isProgrammaticChange = false
             return { id: params.id }
         }
         this.#currentEditingServerName = serverName
@@ -1101,13 +1103,12 @@ export class McpEventHandler {
             this.#pendingPermissionConfig = undefined
 
             this.#features.logging.info(`Applied permission changes for server: ${serverName}`)
+            this.#isProgrammaticChange = false
             return { id: params.id }
         } catch (error) {
             this.#features.logging.error(`Failed to save MCP permissions: ${error}`)
-            return { id: params.id }
-        } finally {
-            // Reset flag after operations
             this.#isProgrammaticChange = false
+            return { id: params.id }
         }
     }
 
@@ -1331,11 +1332,37 @@ export class McpEventHandler {
 
         const allPaths = [...configPaths, ...personaPaths]
 
-        this.#fileWatcher.watchPaths(allPaths, async () => {
-            if (this.#isProgrammaticChange) {
-                return
+        this.#fileWatcher.watchPaths(allPaths, () => {
+            // Store the current programmatic state when the event is triggered
+            this.#lastProgrammaticState = this.#isProgrammaticChange
+
+            // Log the values for debugging
+            this.#features.logging.info(
+                `File watcher triggered - isProgrammaticChange: ${this.#isProgrammaticChange}, ` +
+                    `lastProgrammaticState: ${this.#lastProgrammaticState}`
+            )
+
+            // Clear any existing timer
+            if (this.#debounceTimer) {
+                clearTimeout(this.#debounceTimer)
             }
-            await this.#handleRefreshMCPList({ id: 'refresh-mcp-list' })
+
+            // Set a new timer with 2 second debounce
+            this.#debounceTimer = setTimeout(async () => {
+                // Log the values again when the timer fires
+                this.#features.logging.debug(
+                    `Debounce timer fired - lastProgrammaticState: ${this.#lastProgrammaticState}`
+                )
+
+                // Only proceed if the stored state allows it
+                if (!this.#lastProgrammaticState) {
+                    await this.#handleRefreshMCPList({ id: 'refresh-mcp-list' })
+                } else {
+                    this.#isProgrammaticChange = false
+                    this.#features.logging.debug('Skipping refresh due to programmatic change')
+                }
+                this.#debounceTimer = null
+            }, 2000)
         })
     }
 
@@ -1343,6 +1370,10 @@ export class McpEventHandler {
      * Cleanup file watchers
      */
     dispose(): void {
+        if (this.#debounceTimer) {
+            clearTimeout(this.#debounceTimer)
+            this.#debounceTimer = null
+        }
         this.#fileWatcher.close()
     }
 }


### PR DESCRIPTION
## Problem
File Watchers are triggering mcp server refresh during permission changes and random clicks. Permission page close results into mcp list re-opening and refresh

## Solution
- Added debounce for file watchers and programmatic change tracking update to correctly track them.
- permission page close is also marked as mcp servers list page as not active.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
