### PR TITLE
fix: replace cancel with stop

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -179,8 +179,8 @@ export const handleChatPrompt = (
         // Add cancellation message BEFORE showing the new prompt
         mynahUi.addChatItem(tabId, {
             type: ChatItemType.DIRECTIVE,
-            messageId: 'canceled' + Date.now(),
-            body: 'You canceled your current work and asked me to work on the following task instead.',
+            messageId: 'stopped' + Date.now(),
+            body: 'You stopped your current work and asked me to work on the following task instead.',
         })
 
         // Reset loading state
@@ -704,8 +704,8 @@ export const createMynahUi = (
                 // Add cancellation message when stop button is clicked
                 mynahUi.addChatItem(tabId, {
                     type: ChatItemType.DIRECTIVE,
-                    messageId: 'canceled' + Date.now(),
-                    body: 'You canceled your current work, please provide additional examples or ask another question.',
+                    messageId: 'stopped' + Date.now(),
+                    body: 'You stopped your current work, please provide additional examples or ask another question.',
                 })
             }, 500) // 500ms delay
         },
@@ -1380,7 +1380,7 @@ export const createMynahUi = (
         // Adding this conditional check to show the stop message in the center.
         const contentHorizontalAlignment: ChatItem['contentHorizontalAlignment'] = undefined
 
-        // If message.header?.status?.text is Canceled or Rejected or Ignored or Completed etc.. card should be in disabled state.
+        // If message.header?.status?.text is Stopped or Rejected or Ignored or Completed etc.. card should be in disabled state.
         const shouldMute = message.header?.status?.text !== undefined && message.header?.status?.text !== 'Completed'
 
         return {
@@ -1725,7 +1725,7 @@ export const uiComponentsTexts = {
     save: 'Save',
     cancel: 'Cancel',
     submit: 'Submit',
-    stopGenerating: 'Cancel',
+    stopGenerating: 'Stop',
     copyToClipboard: 'Copied to clipboard',
     noMoreTabsTooltip: 'You can only open ten conversation tabs at a time.',
     codeSuggestionWithReferenceTitle: 'Some suggestions contain code with references.',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2197,7 +2197,7 @@ export class AgenticChatController implements ChatHandlers {
 
         const initialHeader: ChatMessage['header'] = {
             body: 'shell',
-            buttons: [{ id: BUTTON_STOP_SHELL_COMMAND, text: 'Cancel', icon: 'stop' }],
+            buttons: [{ id: BUTTON_STOP_SHELL_COMMAND, text: 'Stop', icon: 'stop' }],
         }
 
         const completedHeader: ChatMessage['header'] = {
@@ -2274,7 +2274,7 @@ export class AgenticChatController implements ChatHandlers {
                                   text: 'Rejected',
                               },
                           }),
-                    buttons: isAccept ? [{ id: BUTTON_STOP_SHELL_COMMAND, text: 'Cancel', icon: 'stop' }] : [],
+                    buttons: isAccept ? [{ id: BUTTON_STOP_SHELL_COMMAND, text: 'Stop', icon: 'stop' }] : [],
                 },
             }
         }
@@ -2371,7 +2371,7 @@ export class AgenticChatController implements ChatHandlers {
                             status: {
                                 status: 'error',
                                 icon: 'stop',
-                                text: 'Canceled',
+                                text: 'Stopped',
                             },
                             buttons: [],
                         },
@@ -2451,7 +2451,7 @@ export class AgenticChatController implements ChatHandlers {
         const stopKey = this.#getKeyBinding('aws.amazonq.stopCmdExecution')
         return {
             id: 'stop-shell-command',
-            text: 'Cancel',
+            text: 'Stop',
             icon: 'stop',
             ...(stopKey ? { description: `Stop:  ${stopKey}` } : {}),
         }


### PR DESCRIPTION
## Problem
- This [PR](https://github.com/aws/language-servers/pull/1922) replaced `"Stop"` with `"Cancel"`
- We would like to not use `"Cancel"` and instead go back to `"Stop"`

## Solution
- Use `"Stop"`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
