### PR TITLE
feat: adding extra context as a workspace config for inline chat

### DIFF
--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -240,6 +240,11 @@
                     "type": "string",
                     "description": "Extra context for Q Inline Suggestions"
                 },
+                "aws.q.inlineChat.extraContext": {
+                    "scope": "resource",
+                    "type": "string",
+                    "description": "Extra context for Q Inline Chat"
+                },
                 "aws.q.optOutTelemetry": {
                     "scope": "resource",
                     "type": "boolean",

--- a/server/aws-lsp-codewhisperer/README.md
+++ b/server/aws-lsp-codewhisperer/README.md
@@ -102,6 +102,8 @@ The server supports the following [workspace configurations](https://github.com/
     - This flag controls whether to opt-in or opt-out to telemetry.
 - `aws.q.inlineSuggestions.extraContext` (type: `string | undefined`, default: `undefined`)
     - The extra context to be included for suggestions, an empty string will be interpreted as undefined. See [below](#extra-context-for-q-inline-suggestions) for more context.
+- `aws.q.inlineChat.extraContext` (type: `string | undefined`, default: `undefined`)
+    - The extra context to be included for inline chat, an empty string will be interpreted as undefined. See [below](#extra-context-for-q-inline-chat) for more context.
 - `aws.codeWhisperer.includeSuggestionsWithCodeReferences`: (type: `boolean`, default: `false`)
     - This flag controls whether to include references with code suggestions.
 - `aws.codeWhisperer.shareCodeWhispererContentWithAWS`: (type: `boolean`, default: `false`)
@@ -111,3 +113,6 @@ The client can signal updates to the workspace configuration with the `DidChange
 
 #### Extra context for Q Inline Suggestions
 In cases when the client runs in a specific environment that requires customized suggestions, the server supports a `aws.q.inlineSuggestions.extraContext` workspace configuration. This extra context will be passed to the left file content of the request in the beginning of the file.
+
+#### Extra context for Q Inline Chat
+In cases when the client runs in a specific environment that requires customized inline chat responses, the server supports a `aws.q.inlineChat.extraContext` workspace configuration. This extra context will be prepended to the document text of the request, similar to how inline suggestions work.

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/inlineChatExtraContext.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/contexts/inlineChatExtraContext.test.ts
@@ -1,0 +1,197 @@
+import { TestFeatures } from '@aws/language-server-runtimes/testing'
+import { QChatTriggerContext } from './triggerContext'
+import { ChatTriggerType } from '@amzn/codewhisperer-streaming'
+import assert = require('assert')
+import sinon = require('sinon')
+
+describe('QChatTriggerContext - Inline Chat Extra Context', () => {
+    let testFeatures: TestFeatures
+    let amazonQServiceManager: any
+    let triggerContext: QChatTriggerContext
+
+    beforeEach(() => {
+        testFeatures = new TestFeatures()
+        amazonQServiceManager = {
+            getConfiguration: sinon.stub(),
+        }
+        triggerContext = new QChatTriggerContext(testFeatures.workspace, testFeatures.logging, amazonQServiceManager)
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    it('should add extra context to document text for inline chat', async () => {
+        const extraContextString = 'This is extra context for inline chat'
+        const originalDocumentText = 'const x = 1;'
+        const expectedDocumentText = extraContextString + '\n\n' + originalDocumentText
+        const mockConfig = {
+            inlineChat: {
+                extraContext: extraContextString,
+            },
+        }
+
+        amazonQServiceManager.getConfiguration.returns(mockConfig)
+
+        const mockDocumentContext = {
+            text: originalDocumentText,
+            programmingLanguage: { languageName: 'typescript' },
+            relativeFilePath: 'test.ts',
+            cursorState: { position: { line: 0, character: 0 } },
+            hasCodeSnippet: false,
+            totalEditorCharacters: originalDocumentText.length,
+        }
+
+        sinon.stub(triggerContext, 'extractDocumentContext').resolves(mockDocumentContext)
+
+        const params = {
+            prompt: {
+                prompt: 'Explain this code',
+                escapedPrompt: 'Explain this code',
+            },
+            textDocument: {
+                uri: 'file:///test.ts',
+            },
+            cursorState: [{ position: { line: 0, character: 0 } }],
+        }
+
+        const triggerContextResult = await triggerContext.getNewTriggerContext(params)
+        const chatParams = triggerContext.getChatParamsFromTrigger(
+            params,
+            triggerContextResult,
+            ChatTriggerType.INLINE_CHAT
+        )
+
+        // Verify that extra context was prepended to document text
+        const documentText =
+            chatParams.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                ?.document?.text
+        assert.strictEqual(documentText, expectedDocumentText)
+
+        // Verify that additionalContext is not used
+        const additionalContext =
+            chatParams.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.additionalContext
+        assert.strictEqual(additionalContext, undefined)
+    })
+
+    it('should not modify document text when extra context is empty', async () => {
+        const originalDocumentText = 'const x = 1;'
+        const mockConfig = {
+            inlineChat: {
+                extraContext: '',
+            },
+        }
+
+        amazonQServiceManager.getConfiguration.returns(mockConfig)
+
+        const mockDocumentContext = {
+            text: originalDocumentText,
+            programmingLanguage: { languageName: 'typescript' },
+            relativeFilePath: 'test.ts',
+            cursorState: { position: { line: 0, character: 0 } },
+            hasCodeSnippet: false,
+            totalEditorCharacters: originalDocumentText.length,
+        }
+
+        sinon.stub(triggerContext, 'extractDocumentContext').resolves(mockDocumentContext)
+
+        const params = {
+            prompt: {
+                prompt: 'Explain this code',
+                escapedPrompt: 'Explain this code',
+            },
+            textDocument: {
+                uri: 'file:///test.ts',
+            },
+            cursorState: [{ position: { line: 0, character: 0 } }],
+        }
+
+        const triggerContextResult = await triggerContext.getNewTriggerContext(params)
+        const chatParams = triggerContext.getChatParamsFromTrigger(params, triggerContextResult, ChatTriggerType.MANUAL)
+
+        const documentText =
+            chatParams.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                ?.document?.text
+        assert.strictEqual(documentText, originalDocumentText)
+    })
+
+    it('should not modify document text when amazonQServiceManager is not available', async () => {
+        const originalDocumentText = 'const x = 1;'
+        const triggerContextWithoutManager = new QChatTriggerContext(testFeatures.workspace, testFeatures.logging)
+
+        const mockDocumentContext = {
+            text: originalDocumentText,
+            programmingLanguage: { languageName: 'typescript' },
+            relativeFilePath: 'test.ts',
+            cursorState: { position: { line: 0, character: 0 } },
+            hasCodeSnippet: false,
+            totalEditorCharacters: originalDocumentText.length,
+        }
+
+        sinon.stub(triggerContextWithoutManager, 'extractDocumentContext').resolves(mockDocumentContext)
+
+        const params = {
+            prompt: {
+                prompt: 'Explain this code',
+                escapedPrompt: 'Explain this code',
+            },
+            textDocument: {
+                uri: 'file:///test.ts',
+            },
+            cursorState: [{ position: { line: 0, character: 0 } }],
+        }
+
+        const triggerContextResult = await triggerContextWithoutManager.getNewTriggerContext(params)
+        const chatParams = triggerContextWithoutManager.getChatParamsFromTrigger(
+            params,
+            triggerContextResult,
+            ChatTriggerType.MANUAL
+        )
+
+        const documentText =
+            chatParams.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                ?.document?.text
+        assert.strictEqual(documentText, originalDocumentText)
+    })
+
+    it('should handle whitespace-only extra context', async () => {
+        const originalDocumentText = 'const x = 1;'
+        const mockConfig = {
+            inlineChat: {
+                extraContext: '   \n\t  ',
+            },
+        }
+
+        amazonQServiceManager.getConfiguration.returns(mockConfig)
+
+        const mockDocumentContext = {
+            text: originalDocumentText,
+            programmingLanguage: { languageName: 'typescript' },
+            relativeFilePath: 'test.ts',
+            cursorState: { position: { line: 0, character: 0 } },
+            hasCodeSnippet: false,
+            totalEditorCharacters: originalDocumentText.length,
+        }
+
+        sinon.stub(triggerContext, 'extractDocumentContext').resolves(mockDocumentContext)
+
+        const params = {
+            prompt: {
+                prompt: 'Explain this code',
+                escapedPrompt: 'Explain this code',
+            },
+            textDocument: {
+                uri: 'file:///test.ts',
+            },
+            cursorState: [{ position: { line: 0, character: 0 } }],
+        }
+
+        const triggerContextResult = await triggerContext.getNewTriggerContext(params)
+        const chatParams = triggerContext.getChatParamsFromTrigger(params, triggerContextResult, ChatTriggerType.MANUAL)
+
+        const documentText =
+            chatParams.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext?.editorState
+                ?.document?.text
+        assert.strictEqual(documentText, originalDocumentText)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.test.ts
@@ -17,6 +17,9 @@ describe('getAmazonQRelatedWorkspaceConfigs', () => {
         inlineSuggestions: {
             extraContext: 'some-extra-context',
         },
+        inlineChat: {
+            extraContext: 'some-inline-chat-context',
+        },
         projectContext: {
             enableLocalIndexing: true,
             enableGpuAcceleration: true,
@@ -51,6 +54,7 @@ describe('getAmazonQRelatedWorkspaceConfigs', () => {
             customizationArn: MOCKED_AWS_Q_SECTION.customization,
             optOutTelemetryPreference: 'OPTOUT',
             inlineSuggestions: { extraContext: MOCKED_AWS_Q_SECTION.inlineSuggestions.extraContext },
+            inlineChat: { extraContext: MOCKED_AWS_Q_SECTION.inlineChat.extraContext },
             includeSuggestionsWithCodeReferences: MOCKED_AWS_CODEWHISPERER_SECTION.includeSuggestionsWithCodeReferences,
             includeImportsWithSuggestions: MOCKED_AWS_CODEWHISPERER_SECTION.includeImportsWithSuggestions,
             shareCodeWhispererContentWithAWS: MOCKED_AWS_CODEWHISPERER_SECTION.shareCodeWhispererContentWithAWS,
@@ -99,6 +103,9 @@ describe('AmazonQConfigurationCache', () => {
             optOutTelemetryPreference: 'OPTIN',
             inlineSuggestions: {
                 extraContext: 'some-extra-context',
+            },
+            inlineChat: {
+                extraContext: 'some-inline-chat-context',
             },
             includeSuggestionsWithCodeReferences: false,
             includeImportsWithSuggestions: false,

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/configurationUtils.ts
@@ -67,6 +67,10 @@ interface QInlineSuggestionsConfig {
     extraContext: string | undefined // aws.q.inlineSuggestions.extraContext
 }
 
+interface QInlineChatConfig {
+    extraContext: string | undefined // aws.q.inlineChat.extraContext
+}
+
 interface LocalIndexConfig {
     ignoreFilePatterns?: string[] // patterns must follow .gitignore convention
     maxFileSizeMB?: number
@@ -85,6 +89,7 @@ interface QConfigSection {
     customizationArn: string | undefined // aws.q.customization - selected customization
     optOutTelemetryPreference: 'OPTOUT' | 'OPTIN' // aws.q.optOutTelemetry - telemetry optout option
     inlineSuggestions: QInlineSuggestionsConfig
+    inlineChat: QInlineChatConfig
     projectContext: QProjectContextConfig
 }
 
@@ -129,6 +134,9 @@ export async function getAmazonQRelatedWorkspaceConfigs(
                 optOutTelemetryPreference: newQConfig['optOutTelemetry'] === true ? 'OPTOUT' : 'OPTIN',
                 inlineSuggestions: {
                     extraContext: textUtils.undefinedIfEmpty(newQConfig.inlineSuggestions?.extraContext),
+                },
+                inlineChat: {
+                    extraContext: textUtils.undefinedIfEmpty(newQConfig.inlineChat?.extraContext),
                 },
                 projectContext: {
                     enableLocalIndexing: newQConfig.projectContext?.enableLocalIndexing === true,
@@ -184,6 +192,9 @@ export const defaultAmazonQWorkspaceConfigFactory = (): AmazonQWorkspaceConfig =
         customizationArn: undefined,
         optOutTelemetryPreference: 'OPTIN',
         inlineSuggestions: {
+            extraContext: undefined,
+        },
+        inlineChat: {
             extraContext: undefined,
         },
         includeSuggestionsWithCodeReferences: false,


### PR DESCRIPTION
## Problem
We need to pass extra context for the inline chat, adding a new workspace config for the same

## Solution

- Added extra context as a new workspace config for inline chat
- This will be checked and passed in the relevant documents
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
