### PR TITLE
fix: bug for credential refresh in StreamingClientServiceIAM

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQIAMServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQIAMServiceManager.test.ts
@@ -42,8 +42,9 @@ describe('AmazonQIAMServiceManager', () => {
         })
 
         it('should initialize the streaming client only once', () => {
-            // Mock getIAMCredentialsFromProvider to return dummy credentials
-            const getIAMCredentialsStub = sinon.stub(utils, 'getIAMCredentialsFromProvider').returns({
+            // Mock the credentials provider to return credentials when requested
+            features.credentialsProvider.hasCredentials.withArgs('iam').returns(true)
+            features.credentialsProvider.getCredentials.withArgs('iam').returns({
                 accessKeyId: 'dummy-access-key',
                 secretAccessKey: 'dummy-secret-key',
                 sessionToken: 'dummy-session-token',
@@ -51,9 +52,8 @@ describe('AmazonQIAMServiceManager', () => {
 
             const streamingClient = serviceManager.getStreamingClient()
 
+            // Verify that getting the client again returns the same instance
             deepStrictEqual(serviceManager.getStreamingClient(), streamingClient)
-
-            getIAMCredentialsStub.restore()
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.test.ts
@@ -271,4 +271,56 @@ describe('StreamingClientServiceIAM', () => {
         sinon.assert.calledTwice(abortStub)
         expect(streamingClientServiceIAM['inflightRequests'].size).to.eq(0)
     })
+
+    it('uses expireTime from credentials when available', async () => {
+        // Get the credential provider function from the client config
+        const credentialProvider = streamingClientServiceIAM.client.config.credentials
+        expect(credentialProvider).to.not.be.undefined
+
+        // Reset call count on the stub
+        features.credentialsProvider.getCredentials.resetHistory()
+
+        // Set up credentials with expireTime
+        const futureDate = new Date(Date.now() + 3600000) // 1 hour in the future
+        const CREDENTIALS_WITH_EXPIRY = {
+            ...MOCKED_IAM_CREDENTIALS,
+            expireTime: futureDate.toISOString(),
+        }
+        features.credentialsProvider.getCredentials.withArgs('iam').returns(CREDENTIALS_WITH_EXPIRY)
+
+        // Call the credential provider
+        const credentialsPromise = (credentialProvider as any)()
+        await clock.tickAsync(TIME_TO_ADVANCE_MS)
+        const credentials = await credentialsPromise
+
+        // Verify expiration is set to the expireTime from credentials
+        expect(credentials.expiration).to.be.instanceOf(Date)
+        expect(credentials.expiration.getTime()).to.equal(futureDate.getTime())
+    })
+
+    it('falls back to current date when expireTime is not available', async () => {
+        // Get the credential provider function from the client config
+        const credentialProvider = streamingClientServiceIAM.client.config.credentials
+        expect(credentialProvider).to.not.be.undefined
+
+        // Reset call count on the stub
+        features.credentialsProvider.getCredentials.resetHistory()
+
+        // Set up credentials without expireTime
+        features.credentialsProvider.getCredentials.withArgs('iam').returns(MOCKED_IAM_CREDENTIALS)
+
+        // Set a fixed time for testing
+        const fixedNow = new Date()
+        clock.tick(0) // Ensure clock is at the fixed time
+
+        // Call the credential provider
+        const credentialsPromise = (credentialProvider as any)()
+        await clock.tickAsync(TIME_TO_ADVANCE_MS)
+        const credentials = await credentialsPromise
+
+        // Verify expiration is set to current date when expireTime is missing
+        expect(credentials.expiration).to.be.instanceOf(Date)
+        // The expiration should be very close to the current time
+        expect(credentials.expiration.getTime()).to.be.closeTo(fixedNow.getTime(), 100)
+    })
 })

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -13,12 +13,13 @@ import {
     SendMessageCommandOutput as SendMessageCommandOutputQDeveloperStreaming,
 } from '@amzn/amazon-q-developer-streaming-client'
 import { CredentialsProvider, SDKInitializator, Logging } from '@aws/language-server-runtimes/server-interface'
-import { getBearerTokenFromProvider, getIAMCredentialsFromProvider, isUsageLimitError } from './utils'
+import { getBearerTokenFromProvider, isUsageLimitError } from './utils'
 import { ConfiguredRetryStrategy } from '@aws-sdk/util-retry'
 import { CredentialProviderChain, Credentials } from 'aws-sdk'
 import { CLIENT_TIMEOUT_MS } from '../language-server/agenticChat/constants/constants'
 import { AmazonQUsageLimitError } from './amazonQServiceManager/errors'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
+import { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@aws-sdk/types'
 
 export type SendMessageCommandInput =
     | SendMessageCommandInputCodeWhispererStreaming
@@ -171,10 +172,23 @@ export class StreamingClientServiceIAM extends StreamingClientServiceBase {
         logging.log(
             `Passing client for class QDeveloperStreaming to sdkInitializator (v3) for additional setup (e.g. proxy)`
         )
+
+        // Create a credential provider that fetches fresh credentials on each request
+        const iamCredentialProvider: AwsCredentialIdentityProvider = async (): Promise<AwsCredentialIdentity> => {
+            const creds = (await credentialsProvider.getCredentials('iam')) as Credentials
+            logging.log(`Fetching new IAM credentials`)
+            return {
+                accessKeyId: creds.accessKeyId,
+                secretAccessKey: creds.secretAccessKey,
+                sessionToken: creds.sessionToken,
+                expiration: creds.expireTime ? new Date(creds.expireTime) : new Date(), // Force refresh on each request if creds do not have expiration time
+            }
+        }
+
         this.client = sdkInitializator(QDeveloperStreaming, {
             region: region,
             endpoint: endpoint,
-            credentials: getIAMCredentialsFromProvider(credentialsProvider),
+            credentials: iamCredentialProvider,
             retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
         })
     }

--- a/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
@@ -14,7 +14,6 @@ import { BUILDER_ID_START_URL } from './constants'
 import {
     getBearerTokenFromProvider,
     getEndPositionForAcceptedSuggestion,
-    getIAMCredentialsFromProvider,
     getSsoConnectionType,
     getUnmodifiedAcceptedTokens,
     isAwsThrottlingError,
@@ -91,44 +90,6 @@ describe('getOriginFromClientInfo', () => {
     it('returns IDE for empty string client name', () => {
         const result = getOriginFromClientInfo('')
         assert.strictEqual(result, 'IDE')
-    })
-})
-
-describe('getIAMCredentialsFromProvider', () => {
-    const mockIAMCredentials = {
-        accessKeyId: 'mock-access-key',
-        secretAccessKey: 'mock-secret-key',
-        sessionToken: 'mock-session-token',
-    }
-
-    it('returns the IAM credentials from the provider', () => {
-        const mockCredentialsProvider: CredentialsProvider = {
-            hasCredentials: sinon.stub().returns(true),
-            getCredentials: sinon.stub().returns(mockIAMCredentials),
-            getConnectionMetadata: sinon.stub(),
-            getConnectionType: sinon.stub(),
-            onCredentialsDeleted: sinon.stub(),
-        }
-
-        const result = getIAMCredentialsFromProvider(mockCredentialsProvider)
-
-        assert.deepStrictEqual(result, {
-            accessKeyId: 'mock-access-key',
-            secretAccessKey: 'mock-secret-key',
-            sessionToken: 'mock-session-token',
-        })
-    })
-
-    it('throws an error if the credentials provider does not have IAM credentials', () => {
-        const mockCredentialsProvider: CredentialsProvider = {
-            hasCredentials: sinon.stub().returns(false),
-            getCredentials: sinon.stub().returns(mockIAMCredentials),
-            getConnectionMetadata: sinon.stub(),
-            getConnectionType: sinon.stub(),
-            onCredentialsDeleted: sinon.stub(),
-        }
-
-        assert.throws(() => getIAMCredentialsFromProvider(mockCredentialsProvider), Error, 'Missing IAM creds')
     })
 })
 

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -372,19 +372,6 @@ export function getBearerTokenFromProvider(credentialsProvider: CredentialsProvi
     return credentials.token
 }
 
-export function getIAMCredentialsFromProvider(credentialsProvider: CredentialsProvider) {
-    if (!credentialsProvider.hasCredentials('iam')) {
-        throw new Error('Missing IAM creds')
-    }
-
-    const credentials = credentialsProvider.getCredentials('iam') as Credentials
-    return {
-        accessKeyId: credentials.accessKeyId,
-        secretAccessKey: credentials.secretAccessKey,
-        sessionToken: credentials.sessionToken,
-    }
-}
-
 export function getOriginFromClientInfo(clientName: string | undefined): Origin {
     if (clientName?.startsWith('AmazonQ-For-SMUS-IDE')) {
         return 'MD_IDE'


### PR DESCRIPTION
Added expiration time to credential provider so SDK will refresh creds automatically.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
