### PR TITLE
fix(amazonq): avoid workspace context server missing historical dependency events

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/JSTSDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/JSTSDependencyHandler.ts
@@ -186,10 +186,13 @@ export class JSTSDependencyHandler extends LanguageDependencyHandler<JSTSDepende
                 const callBackDependencyUpdate = async (events: string[]) => {
                     this.logging.log(`Change detected in ${packageJsonPath}`)
                     const updatedDependencyMap = this.generateDependencyMap(jstsDependencyInfo)
-                    await this.compareAndUpdateDependencyMap(
+                    const changedDependencyList = this.compareAndUpdateDependencyMap(
                         jstsDependencyInfo.workspaceFolder,
-                        updatedDependencyMap,
-                        true
+                        updatedDependencyMap
+                    )
+                    await this.zipAndUploadDependenciesByChunk(
+                        changedDependencyList,
+                        jstsDependencyInfo.workspaceFolder
                     )
                 }
                 const watcher = new DependencyWatcher(
@@ -206,7 +209,9 @@ export class JSTSDependencyHandler extends LanguageDependencyHandler<JSTSDepende
     }
 
     // JS and TS are not using LSP to sync dependencies
-    override async updateDependencyMapBasedOnLSP(paths: string[], workspaceFolder?: WorkspaceFolder): Promise<void> {}
+    override updateDependencyMapBasedOnLSP(paths: string[], workspaceFolder?: WorkspaceFolder): Dependency[] {
+        return []
+    }
     override transformPathToDependency(
         dependencyName: string,
         dependencyPath: string,

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/JavaDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/JavaDependencyHandler.ts
@@ -57,11 +57,7 @@ export class JavaDependencyHandler extends LanguageDependencyHandler<JavaDepende
             // TODO, check if try catch is necessary here
             try {
                 let generatedDependencyMap: Map<string, Dependency> = this.generateDependencyMap(javaDependencyInfo)
-                this.compareAndUpdateDependencyMap(javaDependencyInfo.workspaceFolder, generatedDependencyMap).catch(
-                    error => {
-                        this.logging.warn(`Error processing Java dependencies: ${error}`)
-                    }
-                )
+                this.compareAndUpdateDependencyMap(javaDependencyInfo.workspaceFolder, generatedDependencyMap)
                 // Log found dependencies
                 this.logging.log(
                     `Total Java dependencies found:  ${generatedDependencyMap.size} under ${javaDependencyInfo.pkgDir}`
@@ -92,10 +88,13 @@ export class JavaDependencyHandler extends LanguageDependencyHandler<JavaDepende
                 const callBackDependencyUpdate = async (events: string[]) => {
                     this.logging.log(`Change detected in ${dotClasspathPath}`)
                     const updatedDependencyMap = this.generateDependencyMap(javaDependencyInfo)
-                    await this.compareAndUpdateDependencyMap(
+                    const changedDependencyList = this.compareAndUpdateDependencyMap(
                         javaDependencyInfo.workspaceFolder,
-                        updatedDependencyMap,
-                        true
+                        updatedDependencyMap
+                    )
+                    await this.zipAndUploadDependenciesByChunk(
+                        changedDependencyList,
+                        javaDependencyInfo.workspaceFolder
                     )
                 }
                 const watcher = new DependencyWatcher(

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/PythonDependencyHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyHandler/PythonDependencyHandler.ts
@@ -78,11 +78,7 @@ export class PythonDependencyHandler extends LanguageDependencyHandler<PythonDep
             // TODO, check if the try catch is necessary here
             try {
                 let generatedDependencyMap: Map<string, Dependency> = this.generateDependencyMap(pythonDependencyInfo)
-                this.compareAndUpdateDependencyMap(pythonDependencyInfo.workspaceFolder, generatedDependencyMap).catch(
-                    error => {
-                        this.logging.warn(`Error processing Python dependencies: ${error}`)
-                    }
-                )
+                this.compareAndUpdateDependencyMap(pythonDependencyInfo.workspaceFolder, generatedDependencyMap)
                 // Log found dependencies
                 this.logging.log(
                     `Total Python dependencies found: ${generatedDependencyMap.size} under ${pythonDependencyInfo.pkgDir}`
@@ -122,10 +118,13 @@ export class PythonDependencyHandler extends LanguageDependencyHandler<PythonDep
                                 this.handlePackageChange(sitePackagesPath, fileName, updatedDependencyMap)
                             }
                         }
-                        await this.compareAndUpdateDependencyMap(
+                        const changedDependencyList = this.compareAndUpdateDependencyMap(
                             pythonDependencyInfo.workspaceFolder,
-                            updatedDependencyMap,
-                            true
+                            updatedDependencyMap
+                        )
+                        await this.zipAndUploadDependenciesByChunk(
+                            changedDependencyList,
+                            pythonDependencyInfo.workspaceFolder
                         )
                     } // end of callback function
 

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -21,7 +21,7 @@ import { makeUserContextObject } from '../../shared/telemetryUtils'
 import { safeGet } from '../../shared/utils'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 import { FileUploadJobManager, FileUploadJobType } from './fileUploadJobManager'
-import { DependencyEventBundler } from './dependency/dependencyEventBundler'
+import { DependencyEvent, DependencyEventBundler } from './dependency/dependencyEventBundler'
 import ignore = require('ignore')
 import { BUILDER_ID_START_URL, INTERNAL_USER_START_URL } from '../../shared/constants'
 
@@ -244,7 +244,7 @@ export const WorkspaceContextServer = (): Server => features => {
                 workspaceIdentifier
             )
             fileUploadJobManager = new FileUploadJobManager(logging, workspaceFolderManager)
-            dependencyEventBundler = new DependencyEventBundler(logging, dependencyDiscoverer)
+            dependencyEventBundler = new DependencyEventBundler(logging, dependencyDiscoverer, workspaceFolderManager)
             await updateConfiguration()
 
             lsp.workspace.onDidChangeWorkspaceFolders(async params => {
@@ -511,17 +511,22 @@ export const WorkspaceContextServer = (): Server => features => {
 
     lsp.extensions.onDidChangeDependencyPaths(async params => {
         try {
+            const dependencyEvent: DependencyEvent = {
+                language: params.runtimeLanguage,
+                paths: params.paths,
+                workspaceFolderUri: params.moduleName,
+            }
+            DependencyEventBundler.recordDependencyEvent(dependencyEvent)
+
             if (!isUserEligibleForWorkspaceContext()) {
                 return
             }
-            logging.log(`Received onDidChangeDependencyPaths event for ${params.moduleName}`)
 
-            const workspaceFolder = workspaceFolderManager.getWorkspaceFolder(params.moduleName)
-            dependencyEventBundler.eventQueue.push({
-                language: params.runtimeLanguage,
-                paths: params.paths,
-                workspaceFolder: workspaceFolder,
-            })
+            // Only send events separately when dependency discovery has finished ingesting previous recorded events
+            if (dependencyDiscoverer.isDependencyEventsIngested(params.moduleName)) {
+                dependencyEventBundler.sendDependencyEvent(dependencyEvent)
+                logging.log(`Processed onDidChangeDependencyPaths event for ${params.moduleName}`)
+            }
         } catch (error) {
             logging.error(`Error handling didChangeDependencyPaths event: ${error}`)
         }


### PR DESCRIPTION
## Problem

There are two issues with workspace context server receiving `didChangeDependencyPaths` events:
- **Lost initial events:** Before the workspace context server properly determines user eligibility (`isUserEligibleForWorkspaceContext()`) and completes initialization, all `didChangeDependencyPaths` events sent from the IDE extension are lost.
- **Lost historical events:** When `dependencyDiscoverer` is disposed (due to user opt-out, admin opt-out or user logout), all previously received `didChangeDependencyPaths` events are lost as dependency maps are reset. These events cannot be recovered if the workspace context server needs to run for the user again later.

## Solution

Implement an in-memory recording system for all didChangeDependencyPaths events that:
- Stores events regardless of workspace context server initialization status
- Ingests these recorded events when building initial dependency maps
- Only processes events according to the user's current qualification status

## Testing

Tested the changes locally with JetBrains Amazon Q extension and verified we are no longer missing ``didChangeDependencyPaths`` events sent at the start of IDE. Also verified the original dependency discovery and upload logic is not disturbed by this change.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
