### PR TITLE
fix: fix to remove config from agent file for failed initialization

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -754,8 +754,9 @@ export async function migrateToAgentConfig(workspace: Workspace, logging: Logger
     // Migrate workspace configs
     for (let i = 0; i < wsUris.length; i++) {
         if (wsConfigPaths[i] && wsPersonaPaths[i] && wsAgentPaths[i]) {
-            // Check if the workspace config path exists before migrating
-            const wsConfigExists = await workspace.fs.exists(wsConfigPaths[i]).catch(() => false)
+            // Normalize and check if the workspace config path exists before migrating
+            const normalizedWsConfigPath = normalizePathFromUri(wsConfigPaths[i], logging)
+            const wsConfigExists = await workspace.fs.exists(normalizedWsConfigPath).catch(() => false)
             if (wsConfigExists) {
                 await migrateConfigToAgent(
                     workspace,


### PR DESCRIPTION
## Problem
- Failed MCP config should not be saved in agent config file and should be stored in memory. 
- If timeout is zero it should not be added to timeout in config which would fail initialization in Q CLI
- Error validation for multiple failed servers.

## Solution
- MCP config removed from config in case of failure to initialize
- Timeout is not added to config incase it is zero and is considered undefined in case of no timeout

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
