### PR TITLE
fix: emit metric for tool error

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1986,7 +1986,8 @@ export class AgenticChatController implements ChatHandlers {
                         latency,
                         session.pairProgrammingMode,
                         this.#abTestingAllocation?.experimentName,
-                        this.#abTestingAllocation?.userVariation
+                        this.#abTestingAllocation?.userVariation,
+                        'Succeeded'
                     )
                 }
             } catch (err) {
@@ -2023,6 +2024,18 @@ export class AgenticChatController implements ChatHandlers {
                     if (toolUse.name === EXECUTE_BASH || toolUse.name) {
                         throw err
                     }
+                } else {
+                    // only emit if this is an actual tool error (not a user rejecting/canceling tool)
+                    this.#telemetryController.emitToolUseSuggested(
+                        toolUse,
+                        session.conversationId ?? '',
+                        this.#features.runtime.serverInfo.version ?? '',
+                        undefined,
+                        session.pairProgrammingMode,
+                        this.#abTestingAllocation?.experimentName,
+                        this.#abTestingAllocation?.userVariation,
+                        'Failed'
+                    )
                 }
 
                 // display fs write failure status in the UX of that file card

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -226,7 +226,8 @@ export class ChatTelemetryController {
         latency?: number,
         agenticCodingMode?: boolean,
         experimentName?: string,
-        userVariation?: string
+        userVariation?: string,
+        result?: string
     ) {
         this.#telemetry.emitMetric({
             name: ChatTelemetryEventName.ToolUseSuggested,
@@ -237,7 +238,7 @@ export class ChatTelemetryController {
                 cwsprToolName: toolUse.name ?? '',
                 cwsprToolUseId: toolUse.toolUseId ?? '',
                 perfE2ELatency: latency,
-                result: 'Succeeded',
+                result: result,
                 languageServerVersion: languageServerVersion,
                 enabled: agenticCodingMode,
                 experimentName: experimentName,


### PR DESCRIPTION
## Problem
- missing metric for tool error

## Solution
- emit metric when there is a tool error
    - exclude tool errors relating to user rejecting/canceling the shell command, as this is intended by the user

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
