### PR TITLE
feat(amazonq): enhance workspaceContext classpath generation

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
@@ -6,7 +6,11 @@ import JSZip = require('jszip')
 import { EclipseConfigGenerator, JavaProjectAnalyzer } from './javaManager'
 import { resolveSymlink, isDirectory, isEmptyDirectory } from './util'
 import glob = require('fast-glob')
-import { CodewhispererLanguage, getCodeWhispererLanguageIdFromPath } from '../../shared/languageDetection'
+import {
+    CodewhispererLanguage,
+    getCodeWhispererLanguageIdFromPath,
+    isJavaProjectFileFromPath,
+} from '../../shared/languageDetection'
 
 export interface FileMetadata {
     filePath: string
@@ -633,25 +637,49 @@ export class ArtifactManager {
             return files
         }
 
+        // Extract project roots from file paths for scenarios that workspace were not opened up from project roots
+        const projectRoots = this.extractJavaProjectRoots(files)
         const additionalFiles: FileMetadata[] = []
 
-        // Generate Eclipse configuration files
-        const javaManager = new JavaProjectAnalyzer(workspacePath)
-        const structure = await javaManager.analyze()
-        const generator = new EclipseConfigGenerator(workspaceFolder, this.logging)
+        // Process each project root separately
+        for (const projectRoot of projectRoots) {
+            const isRootProject = projectRoot === '.'
+            const projectPath = path.join(workspacePath, projectRoot)
 
-        // Generate and add .classpath file
-        const classpathFiles = await generator.generateDotClasspath(structure)
-        for (const classpathFile of classpathFiles) {
-            additionalFiles.push(classpathFile)
-        }
+            // Create project-specific "workspace folder" for analyzing
+            const projectWorkspaceFolder: WorkspaceFolder = {
+                ...workspaceFolder,
+                uri: URI.file(projectPath).toString(),
+            }
 
-        // Generate and add .project file
-        const projectFiles = await generator.generateDotProject(path.basename(workspacePath), structure)
-        for (const projectFile of projectFiles) {
-            additionalFiles.push(projectFile)
+            const javaManager = new JavaProjectAnalyzer(projectPath)
+            const structure = await javaManager.analyze()
+            const generator = new EclipseConfigGenerator(projectWorkspaceFolder, this.logging)
+
+            const classpathFiles = await generator.generateDotClasspath(structure)
+            const projectConfigFiles = await generator.generateDotProject(
+                isRootProject ? workspaceFolder.name : projectRoot,
+                structure
+            )
+
+            // Update relativePath to include project directory for zip upload
+            const updatedFiles = [...classpathFiles, ...projectConfigFiles].map(file => ({
+                ...file,
+                relativePath: isRootProject ? file.relativePath : path.join(projectRoot, file.relativePath),
+            }))
+
+            additionalFiles.push(...updatedFiles)
         }
 
         return [...files, ...additionalFiles]
+    }
+
+    private extractJavaProjectRoots(files: FileMetadata[]): string[] {
+        const projectRoots = new Set<string>()
+        files
+            .filter(file => isJavaProjectFileFromPath(file.relativePath))
+            .map(file => path.dirname(file.relativePath))
+            .forEach(projectRoot => projectRoots.add(projectRoot))
+        return Array.from(projectRoots)
     }
 }

--- a/server/aws-lsp-codewhisperer/src/shared/languageDetection.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/languageDetection.ts
@@ -294,6 +294,8 @@ export function getCodeWhispererLanguageIdFromPath(filePath: string): Codewhispe
         return 'javascript'
     }
 
+    if (isJavaProjectFileFromPath(filePath)) return 'java'
+
     for (const [extension, languageId] of Object.entries(languageByExtension)) {
         if (filePath.endsWith(extension)) {
             return getRuntimeLanguage(languageId)
@@ -301,4 +303,13 @@ export function getCodeWhispererLanguageIdFromPath(filePath: string): Codewhispe
     }
 
     return undefined
+}
+
+export function isJavaProjectFileFromPath(filePath: string): boolean {
+    return (
+        filePath.endsWith(`build.gradle`) ||
+        filePath.endsWith(`build.gradle.kts`) ||
+        filePath.endsWith(`pom.xml`) ||
+        filePath.endsWith(`build.xml`)
+    )
 }


### PR DESCRIPTION
## Problem

- In previous setup, when user open up workspace that's not at java root folder, we won't able to generating `.classpath` and `.project` correctly because there's no /src /tst folder available. For exmaple if I have `workspace/src/package1` and `workspace/src/package2`. When user open the folder at `workspace/src` flare will generating `.classpath` and `.project` under `src` with no source folder

-  Introducing this change to identify the actual project root folder by looking at project files like `build.xml, gradle.build, build.gradle.kts, pom.xml`  Loop through those directory to generate `.classpath` and `.project` for each folder.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
