### PR TITLE
fix: enable repomap as inline completion supplemental context for all users

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -272,10 +272,7 @@ export class LocalProjectContextController {
     public async queryInlineProjectContext(
         request: QueryInlineProjectContextRequestV2
     ): Promise<InlineProjectContext[]> {
-        if (!this.isIndexingEnabled()) {
-            return []
-        }
-
+        // inline project context is available for all users regardless of local indexing enabled or disabled
         try {
             const resp = await this._vecLib?.queryInlineProjectContext(request.query, request.filePath, request.target)
             return resp ?? []

--- a/server/aws-lsp-codewhisperer/src/shared/supplementalContextUtil/crossFileContextUtil.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/supplementalContextUtil/crossFileContextUtil.ts
@@ -148,18 +148,6 @@ export async function fetchProjectContext(
         filePath: fsPath,
         target,
     }
-    let enableWorkspaceContext = true
-
-    if (amazonQServiceManager) {
-        const config = amazonQServiceManager.getConfiguration()
-        if (config.projectContext?.enableLocalIndexing === false) {
-            enableWorkspaceContext = false
-        }
-    }
-    if (!enableWorkspaceContext) {
-        return []
-    }
-
     try {
         controller = await LocalProjectContextController.getInstance()
     } catch (e) {


### PR DESCRIPTION
## Problem

The repomap index, aka the inline completion index should be enabled for all users and it should be used in supplemental context. But it was turned off for users who do not have workspace index enabled. The workspace index enable flag is only meant for vector index. 


## Solution

<img width="995" height="374" alt="Screenshot 2025-07-23 at 2 08 37 PM" src="https://github.com/user-attachments/assets/36635066-3b54-4160-86c4-315d3d7f7a07" />

Enable repomap as inline completion supplemental context for all users

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
