### PR TITLE
feat: enhance profile fetching logs to diagnose developerProfiles errors

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.test.ts
@@ -134,23 +134,6 @@ describe('ListAllAvailableProfiles Handler', () => {
                 assert.ok(hasCompleteErrorLogging, 'Should log complete error object in debug logs')
             }
         })
-
-        it('should log endpoint information during profile fetching', async () => {
-            await handler({
-                connectionType: 'identityCenter',
-                logging,
-                endpoints: SOME_AWS_Q_ENDPOINT,
-                token: tokenSource.token,
-            })
-
-            // Verify that endpoint information is logged
-            sinon.assert.called(logging.debug)
-            const debugCalls = logging.debug.getCalls()
-            const hasEndpointLogging = debugCalls.some(
-                call => call.args[0].includes('endpoint') && call.args[0].includes(DEFAULT_AWS_Q_ENDPOINT_URL)
-            )
-            assert.ok(hasEndpointLogging, 'Should log endpoint information')
-        })
     })
 
     describe('Pagination', () => {

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
@@ -45,9 +45,9 @@ export const getListAllAvailableProfilesHandler =
         let allProfiles: AmazonQDeveloperProfile[] = []
         const qEndpoints = endpoints ?? AWS_Q_ENDPOINTS
 
-        // Log all endpoints we're going to try
+        // Log all regions we're going to try
         logging.log(
-            `Attempting to fetch profiles from ${qEndpoints.size} endpoints: ${JSON.stringify(Array.from(qEndpoints.entries()))}`
+            `Attempting to fetch profiles from ${qEndpoints.size} regions: ${Array.from(qEndpoints.keys()).join(', ')}`
         )
 
         if (token.isCancellationRequested) {
@@ -56,7 +56,7 @@ export const getListAllAvailableProfilesHandler =
 
         const result = await Promise.allSettled(
             Array.from(qEndpoints.entries(), ([region, endpoint]) => {
-                logging.log(`Creating service client for region: ${region}, endpoint: ${endpoint}`)
+                logging.log(`Creating service client for region: ${region}`)
                 const codeWhispererService = service(region, endpoint)
                 return fetchProfilesFromRegion(codeWhispererService, region, endpoint, logging, token)
             })
@@ -72,12 +72,10 @@ export const getListAllAvailableProfilesHandler =
                 const [region, endpoint] = Array.from(qEndpoints.entries())[index]
                 if (settledResult.status === 'fulfilled') {
                     const profiles = settledResult.value
-                    logging.log(
-                        `Successfully fetched ${profiles.length} profiles from region: ${region}, endpoint: ${endpoint}`
-                    )
+                    logging.log(`Successfully fetched ${profiles.length} profiles from region: ${region}`)
                 } else {
                     logging.error(
-                        `Failed to fetch profiles from region: ${region}, endpoint: ${endpoint}, error: ${settledResult.reason?.name || 'unknown'}, message: ${settledResult.reason?.message || 'No message'}`
+                        `Failed to fetch profiles from region: ${region}, error: ${settledResult.reason?.name || 'unknown'}, message: ${settledResult.reason?.message || 'No message'}`
                     )
                 }
             })
@@ -130,12 +128,10 @@ async function fetchProfilesFromRegion(
     let numberOfPages = 0
 
     try {
-        logging.log(`Starting profile fetch from region: ${region}, endpoint: ${endpoint}`)
+        logging.log(`Starting profile fetch from region: ${region}`)
 
         do {
-            logging.debug(
-                `Fetching profiles from region: ${region}, endpoint: ${endpoint} (page: ${numberOfPages + 1})`
-            )
+            logging.debug(`Fetching profiles from region: ${region} (page: ${numberOfPages + 1})`)
 
             if (token.isCancellationRequested) {
                 logging.debug(`Cancellation requested during profile fetch from region: ${region}`)
@@ -181,7 +177,7 @@ async function fetchProfilesFromRegion(
         return allRegionalProfiles
     } catch (error) {
         // Enhanced error logging with complete error object
-        logging.error(`Error fetching profiles from region: ${region}, endpoint: ${endpoint}`)
+        logging.error(`Error fetching profiles from region: ${region}`)
         logging.log(`Complete error object: ${JSON.stringify(error, Object.getOwnPropertyNames(error), 2)}`)
 
         throw error

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
@@ -45,20 +45,41 @@ export const getListAllAvailableProfilesHandler =
         let allProfiles: AmazonQDeveloperProfile[] = []
         const qEndpoints = endpoints ?? AWS_Q_ENDPOINTS
 
+        // Log all endpoints we're going to try
+        logging.debug(
+            `Attempting to fetch profiles from ${qEndpoints.size} endpoints: ${JSON.stringify(Array.from(qEndpoints.entries()))}`
+        )
+
         if (token.isCancellationRequested) {
             return []
         }
 
         const result = await Promise.allSettled(
             Array.from(qEndpoints.entries(), ([region, endpoint]) => {
+                logging.debug(`Creating service client for region: ${region}, endpoint: ${endpoint}`)
                 const codeWhispererService = service(region, endpoint)
-                return fetchProfilesFromRegion(codeWhispererService, region, logging, token)
+                return fetchProfilesFromRegion(codeWhispererService, region, endpoint, logging, token)
             })
         )
 
         if (token.isCancellationRequested) {
             return []
         }
+
+        // Log detailed results from each region
+        result.forEach((settledResult, index) => {
+            const [region, endpoint] = Array.from(qEndpoints.entries())[index]
+            if (settledResult.status === 'fulfilled') {
+                const profiles = settledResult.value
+                logging.debug(
+                    `Successfully fetched ${profiles.length} profiles from region: ${region}, endpoint: ${endpoint}`
+                )
+            } else {
+                logging.error(
+                    `Failed to fetch profiles from region: ${region}, endpoint: ${endpoint}, error: ${settledResult.reason?.name || 'unknown'}, message: ${settledResult.reason?.message || 'No message'}`
+                )
+            }
+        })
 
         const fulfilledResults = result.filter(settledResult => settledResult.status === 'fulfilled')
         const hasThrottlingError = result.some(
@@ -77,6 +98,13 @@ export const getListAllAvailableProfilesHandler =
 
         fulfilledResults.forEach(fulfilledResult => allProfiles.push(...fulfilledResult.value))
 
+        // Log summary of all profiles fetched
+        logging.debug(`Total profiles fetched: ${allProfiles.length}`)
+        if (allProfiles.length > 0) {
+            logging.debug(`Profile names: ${allProfiles.map(p => p.name).join(', ')}`)
+            logging.debug(`Profile regions: ${allProfiles.map(p => p.identityDetails?.region).join(', ')}`)
+        }
+
         // Check for partial throttling
         if (hasThrottlingError && allProfiles.length == 0) {
             logging.error(throttlingErrorMessage)
@@ -89,6 +117,7 @@ export const getListAllAvailableProfilesHandler =
 async function fetchProfilesFromRegion(
     service: CodeWhispererServiceToken,
     region: string,
+    endpoint: string,
     logging: Logging,
     token: CancellationToken
 ): Promise<AmazonQDeveloperProfile[]> {
@@ -97,17 +126,27 @@ async function fetchProfilesFromRegion(
     let numberOfPages = 0
 
     try {
+        logging.debug(`Starting profile fetch from region: ${region}, endpoint: ${endpoint}`)
+
         do {
-            logging.debug(`Fetching profiles from region: ${region} (iteration: ${numberOfPages})`)
+            logging.debug(
+                `Fetching profiles from region: ${region}, endpoint: ${endpoint} (page: ${numberOfPages + 1})`
+            )
 
             if (token.isCancellationRequested) {
+                logging.debug(`Cancellation requested during profile fetch from region: ${region}`)
                 return allRegionalProfiles
             }
 
-            const response = await service.listAvailableProfiles({
+            const requestParams = {
                 maxResults: MAX_Q_DEVELOPER_PROFILES_PER_PAGE,
                 nextToken: nextToken,
-            })
+            }
+            logging.debug(`Request params for region ${region}: ${JSON.stringify(requestParams)}`)
+
+            const response = await service.listAvailableProfiles(requestParams)
+
+            logging.debug(`Raw response from ${region}: ${JSON.stringify(response)}`)
 
             const profiles = response.profiles.map(profile => ({
                 arn: profile.arn,
@@ -117,16 +156,40 @@ async function fetchProfilesFromRegion(
                 },
             }))
 
+            logging.debug(`Fetched ${profiles.length} profiles from ${region} (page: ${numberOfPages + 1})`)
+            if (profiles.length > 0) {
+                logging.debug(`Profile names from ${region}: ${profiles.map(p => p.name).join(', ')}`)
+            }
+
             allRegionalProfiles.push(...profiles)
 
-            logging.debug(`Fetched profiles from ${region}: ${JSON.stringify(response)} (iteration: ${numberOfPages})`)
             nextToken = response.nextToken
+            if (nextToken) {
+                logging.debug(`Next token received from ${region}: ${nextToken.substring(0, 10)}...`)
+            } else {
+                logging.debug(`No next token received from ${region}, pagination complete`)
+            }
+
             numberOfPages++
         } while (nextToken !== undefined && numberOfPages < MAX_Q_DEVELOPER_PROFILE_PAGES)
 
+        logging.debug(`Completed fetching profiles from ${region}, total profiles: ${allRegionalProfiles.length}`)
         return allRegionalProfiles
     } catch (error) {
-        logging.error(`Error fetching profiles from ${region}: ${error}`)
+        // Enhanced error logging with more details
+        logging.error(`Error fetching profiles from region: ${region}, endpoint: ${endpoint}`)
+        logging.error(`Error type: ${error?.constructor?.name || 'Unknown'}`)
+        logging.error(`Error name: ${(error as any)?.name || 'Unknown'}`)
+        logging.error(`Error message: ${(error as Error)?.message || 'No message'}`)
+        logging.error(`Error code: ${(error as any)?.code || 'No code'}`)
+
+        if ((error as any)?.statusCode) {
+            logging.error(`HTTP status code: ${(error as any).statusCode}`)
+        }
+
+        if ((error as any)?.$metadata) {
+            logging.error(`Request metadata: ${JSON.stringify((error as any).$metadata)}`)
+        }
 
         throw error
     }

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/qDeveloperProfiles.ts
@@ -58,7 +58,7 @@ export const getListAllAvailableProfilesHandler =
             Array.from(qEndpoints.entries(), ([region, endpoint]) => {
                 logging.log(`Creating service client for region: ${region}`)
                 const codeWhispererService = service(region, endpoint)
-                return fetchProfilesFromRegion(codeWhispererService, region, endpoint, logging, token)
+                return fetchProfilesFromRegion(codeWhispererService, region, logging, token)
             })
         )
 
@@ -119,7 +119,6 @@ export const getListAllAvailableProfilesHandler =
 async function fetchProfilesFromRegion(
     service: CodeWhispererServiceToken,
     region: string,
-    endpoint: string,
     logging: Logging,
     token: CancellationToken
 ): Promise<AmazonQDeveloperProfile[]> {


### PR DESCRIPTION
This PR adds comprehensive logging to the Amazon Q Developer Profiles fetching process to help diagnose the "failed to fetch: developerProfiles" error that customers are experiencing with ATX transformation. The enhanced logging captures detailed information about endpoints accessed, regions queried, profiles returned, and provides structured error details without modifying any existing functionality.

Key improvements:
- Log all endpoints and regions being queried
- Capture raw API responses and request parameters
- Track profile retrieval success/failure by region
- Provide detailed error information including HTTP status codes and AWS metadata
- Summarize total profiles fetched across all regions

These changes will help identify the root cause of login issues by providing visibility into the profile fetching process.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
