### PR TITLE
chore(amazonq): revert for emergency reverts for auto-approve feature

### DIFF
--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -187,7 +187,7 @@ export class TabFactory {
             tabBarButtons.push({
                 id: McpServerTabButtonId,
                 icon: MynahIcons.TOOLS,
-                description: 'Configure MCP servers',
+                description: 'Configure MCP servers and Built-in tools',
             })
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -185,6 +185,9 @@ import {
     DEFAULT_WINDOW_REJECT_SHORTCUT,
     DEFAULT_MACOS_STOP_SHORTCUT,
     DEFAULT_WINDOW_STOP_SHORTCUT,
+    OUT_OF_WORKSPACE_WARNING_MSG,
+    CREDENTIAL_FILE_WARNING_MSG,
+    BINARY_FILE_WARNING_MSG,
 } from './constants/constants'
 import {
     AgenticChatError,
@@ -1692,9 +1695,9 @@ export class AgenticChatController implements ChatHandlers {
                         const tool = new Tool(this.#features)
 
                         // For MCP tools, get the permission from McpManager
-                        // const permission = McpManager.instance.getToolPerm('Built-in', toolUse.name)
+                        const permission = McpManager.instance.getToolPerm('Built-in', toolUse.name)
                         // If permission is 'alwaysAllow', we don't need to ask for acceptance
-                        // const builtInPermission = permission !== 'alwaysAllow'
+                        const builtInPermission = permission !== 'alwaysAllow'
 
                         // Get the approved paths from the session
                         const approvedPaths = session.approvedPaths
@@ -1705,19 +1708,40 @@ export class AgenticChatController implements ChatHandlers {
                             approvedPaths
                         )
 
-                        // Honor built-in permission if available, otherwise use tool's requiresAcceptance
-                        // const requiresAcceptance = builtInPermission || toolRequiresAcceptance
+                        const isExecuteBash = toolUse.name === EXECUTE_BASH
 
-                        if (requiresAcceptance || toolUse.name === EXECUTE_BASH) {
+                        // check if tool execution's path is out of workspace
+                        const isOutOfWorkSpace = warning === OUT_OF_WORKSPACE_WARNING_MSG
+                        // check if tool involved secured files
+                        const isSecuredFilesInvoled =
+                            warning === BINARY_FILE_WARNING_MSG || warning === CREDENTIAL_FILE_WARNING_MSG
+
+                        // Honor built-in permission if available, otherwise use tool's requiresAcceptance
+                        let toolRequiresAcceptance =
+                            (builtInPermission || isOutOfWorkSpace || isSecuredFilesInvoled) ?? requiresAcceptance
+
+                        // if the command is read-only and in-workspace --> flip back to no approval needed
+                        if (
+                            isExecuteBash &&
+                            commandCategory === CommandCategory.ReadOnly &&
+                            !isOutOfWorkSpace &&
+                            !requiresAcceptance
+                        ) {
+                            toolRequiresAcceptance = false
+                        }
+
+                        if (toolRequiresAcceptance || isExecuteBash) {
                             // for executeBash, we till send the confirmation message without action buttons
                             const confirmationResult = this.#processToolConfirmation(
                                 toolUse,
-                                requiresAcceptance,
+                                toolRequiresAcceptance,
                                 warning,
-                                commandCategory
+                                commandCategory,
+                                toolUse.name,
+                                builtInPermission
                             )
                             cachedButtonBlockId = await chatResultStream.writeResultBlock(confirmationResult)
-                            const isExecuteBash = toolUse.name === EXECUTE_BASH
+
                             if (isExecuteBash) {
                                 this.#telemetryController.emitInteractWithAgenticChat(
                                     'GeneratedCommand',
@@ -1728,7 +1752,7 @@ export class AgenticChatController implements ChatHandlers {
                                     this.#abTestingAllocation?.userVariation
                                 )
                             }
-                            if (requiresAcceptance) {
+                            if (toolRequiresAcceptance) {
                                 await this.waitForToolApproval(
                                     toolUse,
                                     chatResultStream,
@@ -2699,7 +2723,7 @@ export class AgenticChatController implements ChatHandlers {
                     body = builtInPermission
                         ? `I need permission to read files.\n${formattedPaths.join('\n')}`
                         : `I need permission to read files outside the workspace.\n${formattedPaths.join('\n')}`
-                } else {
+                } else if (toolName === 'listDirectory') {
                     const readFilePath = (toolUse.input as unknown as ListDirectoryParams).path
 
                     // Validate the path using our synchronous utility
@@ -2709,6 +2733,11 @@ export class AgenticChatController implements ChatHandlers {
                     body = builtInPermission
                         ? `I need permission to list directories.\n\`${readFilePath}\``
                         : `I need permission to list directories outside the workspace.\n\`${readFilePath}\``
+                } else {
+                    const readFilePath = (toolUse.input as unknown as ListDirectoryParams).path
+                    body = builtInPermission
+                        ? `I need permission to search files.\n\`${readFilePath}\``
+                        : `I need permission to search files outside the workspace.\n\`${readFilePath}\``
                 }
                 break
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
@@ -88,3 +88,11 @@ export const DEFAULT_LINUX_STOP_SHORTCUT = 'Meta + &#8679; + &#9003;'
 export const DEFAULT_MACOS_REJECT_SHORTCUT = '&#8679; &#8984; R'
 export const DEFAULT_WINDOW_REJECT_SHORTCUT = 'Ctrl + &#8679; + R'
 export const DEFAULT_LINUX_REJECT_SHORTCUT = 'Meta + &#8679; + R'
+
+// Warning Message Constants
+export const DESTRUCTIVE_COMMAND_WARNING_MSG = 'WARNING: Potentially destructive command detected:\n\n'
+export const MUTATE_COMMAND_WARNING_MSG = 'Mutation command:\n\n'
+export const OUT_OF_WORKSPACE_WARNING_MSG = 'Execution out of workspace scope:\n\n'
+export const CREDENTIAL_FILE_WARNING_MSG =
+    'WARNING: Command involves credential files that require secure permissions:\n\n'
+export const BINARY_FILE_WARNING_MSG = 'WARNING: Command involves binary files that require secure permissions:\n\n'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -13,6 +13,15 @@ import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
 // eslint-disable-next-line import/no-nodejs-modules
 import { existsSync, statSync } from 'fs'
 
+// Warning message
+import {
+    BINARY_FILE_WARNING_MSG,
+    CREDENTIAL_FILE_WARNING_MSG,
+    DESTRUCTIVE_COMMAND_WARNING_MSG,
+    MUTATE_COMMAND_WARNING_MSG,
+    OUT_OF_WORKSPACE_WARNING_MSG,
+} from '../constants/constants'
+
 export enum CommandCategory {
     ReadOnly,
     Mutate,
@@ -108,12 +117,6 @@ export const commandCategories = new Map<string, CommandCategory>([
 ])
 export const maxToolResponseSize: number = 1024 * 1024 // 1MB
 export const lineCount: number = 1024
-export const destructiveCommandWarningMessage = 'WARNING: Potentially destructive command detected:\n\n'
-export const mutateCommandWarningMessage = 'Mutation command:\n\n'
-export const outOfWorkspaceWarningmessage = 'Execution out of workspace scope:\n\n'
-export const credentialFileWarningMessage =
-    'WARNING: Command involves credential files that require secure permissions:\n\n'
-export const binaryFileWarningMessage = 'WARNING: Command involves binary files that require secure permissions:\n\n'
 
 /**
  * Parameters for executing a command on the system shell.
@@ -232,7 +235,7 @@ export class ExecuteBash {
                             // Treat tilde paths as absolute paths (they will be expanded by the shell)
                             return {
                                 requiresAcceptance: true,
-                                warning: destructiveCommandWarningMessage,
+                                warning: DESTRUCTIVE_COMMAND_WARNING_MSG,
                                 commandCategory: CommandCategory.Destructive,
                             }
                         } else if (!isAbsolute(arg) && params.cwd) {
@@ -255,7 +258,7 @@ export class ExecuteBash {
                                     this.logging.info(`Detected credential file in command: ${fullPath}`)
                                     return {
                                         requiresAcceptance: true,
-                                        warning: credentialFileWarningMessage,
+                                        warning: CREDENTIAL_FILE_WARNING_MSG,
                                         commandCategory: CommandCategory.Mutate,
                                     }
                                 }
@@ -265,7 +268,7 @@ export class ExecuteBash {
                                     this.logging.info(`Detected binary file in command: ${fullPath}`)
                                     return {
                                         requiresAcceptance: true,
-                                        warning: binaryFileWarningMessage,
+                                        warning: BINARY_FILE_WARNING_MSG,
                                         commandCategory: CommandCategory.Mutate,
                                     }
                                 }
@@ -282,7 +285,7 @@ export class ExecuteBash {
                         if (!isInWorkspace) {
                             return {
                                 requiresAcceptance: true,
-                                warning: outOfWorkspaceWarningmessage,
+                                warning: OUT_OF_WORKSPACE_WARNING_MSG,
                                 commandCategory: highestCommandCategory,
                             }
                         }
@@ -306,13 +309,13 @@ export class ExecuteBash {
                     case CommandCategory.Destructive:
                         return {
                             requiresAcceptance: true,
-                            warning: destructiveCommandWarningMessage,
+                            warning: DESTRUCTIVE_COMMAND_WARNING_MSG,
                             commandCategory: CommandCategory.Destructive,
                         }
                     case CommandCategory.Mutate:
                         return {
                             requiresAcceptance: true,
-                            warning: mutateCommandWarningMessage,
+                            warning: MUTATE_COMMAND_WARNING_MSG,
                             commandCategory: CommandCategory.Mutate,
                         }
                     case CommandCategory.ReadOnly:
@@ -334,7 +337,7 @@ export class ExecuteBash {
                     if (!workspaceFolders || workspaceFolders.length === 0) {
                         return {
                             requiresAcceptance: true,
-                            warning: outOfWorkspaceWarningmessage,
+                            warning: OUT_OF_WORKSPACE_WARNING_MSG,
                             commandCategory: highestCommandCategory,
                         }
                     }
@@ -351,7 +354,7 @@ export class ExecuteBash {
                     if (!isInWorkspace) {
                         return {
                             requiresAcceptance: true,
-                            warning: outOfWorkspaceWarningmessage,
+                            warning: OUT_OF_WORKSPACE_WARNING_MSG,
                             commandCategory: highestCommandCategory,
                         }
                     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/grepSearch.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/grepSearch.ts
@@ -7,6 +7,7 @@ import { ChildProcess, ChildProcessOptions } from '@aws/lsp-core/out/util/proces
 import path = require('path')
 import { dirname } from 'path'
 import { pathToFileURL } from 'url'
+import { OUT_OF_WORKSPACE_WARNING_MSG } from '../constants/constants'
 
 export interface GrepSearchParams {
     path?: string
@@ -81,7 +82,8 @@ export class GrepSearch {
 
     public async requiresAcceptance(params: GrepSearchParams): Promise<CommandValidation> {
         const path = this.getSearchDirectory(params.path)
-        return { requiresAcceptance: !workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.workspace), path) }
+        const isInWorkspace = workspaceUtils.isInWorkspace(getWorkspaceFolderPaths(this.workspace), path)
+        return { requiresAcceptance: !isInWorkspace, warning: !isInWorkspace ? OUT_OF_WORKSPACE_WARNING_MSG : '' }
     }
 
     public async invoke(params: GrepSearchParams, token?: CancellationToken): Promise<InvokeOutput> {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.test.ts
@@ -49,6 +49,7 @@ describe('McpEventHandler error handling', () => {
             },
             agent: {
                 getTools: sinon.stub().returns([]),
+                getBuiltInToolNames: sinon.stub().returns([]),
             },
             lsp: {},
             telemetry: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -34,6 +34,7 @@ import { URI } from 'vscode-uri'
 interface PermissionOption {
     label: string
     value: string
+    description?: string
 }
 
 export class McpEventHandler {
@@ -127,38 +128,42 @@ export class McpEventHandler {
         // Transform server configs into DetailedListItem objects
         const activeItems: DetailedListItem[] = []
         const disabledItems: DetailedListItem[] = []
-        const builtInItems: DetailedListItem[] = []
 
         // Get built-in tools programmatically
         const allTools = this.#features.agent.getTools({ format: 'bedrock' })
-        const mcpToolNames = new Set(mcpManager.getAllTools().map(tool => tool.toolName))
+        const builtInToolNames = new Set(this.#features.agent.getBuiltInToolNames())
         const builtInTools = allTools
-            .filter(tool => !mcpToolNames.has(tool.toolSpecification.name))
+            .filter(tool => {
+                return builtInToolNames.has(tool.toolSpecification.name) && tool.toolSpecification.name !== 'fsReplace'
+            })
             .map(tool => ({
                 name: tool.toolSpecification.name,
-                description: tool.toolSpecification.description || `${tool.toolSpecification.name} tool`,
+                description:
+                    this.#getBuiltInToolDescription(tool.toolSpecification.name) ||
+                    tool.toolSpecification.description ||
+                    `${tool.toolSpecification.name} tool`,
             }))
 
         // Add built-in tools as a server in the active items
-        // activeItems.push({
-        //     title: 'Built-in',
-        //     description: `${builtInTools.length} tools`,
-        //     children: [
-        //         {
-        //             groupName: 'serverInformation',
-        //             children: [
-        //                 {
-        //                     title: 'status',
-        //                     description: 'ENABLED',
-        //                 },
-        //                 {
-        //                     title: 'toolcount',
-        //                     description: `${builtInTools.length}`,
-        //                 },
-        //             ],
-        //         },
-        //     ],
-        // })
+        activeItems.push({
+            title: 'Built-in',
+            description: `${builtInTools.length} tools`,
+            children: [
+                {
+                    groupName: 'serverInformation',
+                    children: [
+                        {
+                            title: 'status',
+                            description: 'ENABLED',
+                        },
+                        {
+                            title: 'toolcount',
+                            description: `${builtInTools.length}`,
+                        },
+                    ],
+                },
+            ],
+        })
 
         Array.from(mcpManagerServerConfigs.entries()).forEach(([serverName, config]) => {
             const toolsWithPermissions = mcpManager.getAllToolsWithPermissions(serverName)
@@ -221,7 +226,7 @@ export class McpEventHandler {
 
         // Return the result in the expected format
         const header = {
-            title: 'MCP Servers',
+            title: 'MCP Servers and Built-in Tools',
             description: "Add MCP servers to extend Q's capabilities.",
             // only  show error on list mcp server page if unable to read mcp.json file
             status: configLoadErrors
@@ -270,7 +275,7 @@ export class McpEventHandler {
         return {
             id,
             header: {
-                title: 'MCP Servers',
+                title: 'MCP Servers and Built-in Tools',
                 status: {},
                 description: `Add MCP servers to extend Q's capabilities.`,
                 actions: [],
@@ -727,17 +732,23 @@ export class McpEventHandler {
         if (serverName === 'Built-in') {
             // Handle Built-in server specially
             const allTools = this.#features.agent.getTools({ format: 'bedrock' })
-            const mcpToolNames = new Set(McpManager.instance.getAllTools().map(tool => tool.toolName))
+            const builtInToolNames = new Set(this.#features.agent.getBuiltInToolNames())
+            // combine fsWrite and fsReplace into fsWrite
             const builtInTools = allTools
-                .filter(tool => !mcpToolNames.has(tool.toolSpecification.name))
+                .filter(tool => {
+                    return (
+                        builtInToolNames.has(tool.toolSpecification.name) && tool.toolSpecification.name !== 'fsReplace'
+                    )
+                })
                 .map(tool => {
-                    // Set default permission based on tool name
-                    const permission = 'alwaysAllow'
-
+                    const permission = McpManager.instance.getToolPerm(serverName, tool.toolSpecification.name)
                     return {
                         tool: {
                             toolName: tool.toolSpecification.name,
-                            description: tool.toolSpecification.description || `${tool.toolSpecification.name} tool`,
+                            description:
+                                this.#getBuiltInToolDescription(tool.toolSpecification.name) ||
+                                tool.toolSpecification.description ||
+                                `${tool.toolSpecification.name} tool`,
                         },
                         permission,
                     }
@@ -750,6 +761,7 @@ export class McpEventHandler {
                 header: {
                     title: serverName,
                     status: serverStatusError || {},
+                    description: 'TOOLS',
                     actions: [],
                 },
                 list: [],
@@ -945,17 +957,23 @@ export class McpEventHandler {
         // Add tool select options
         toolsWithPermissions.forEach(item => {
             const toolName = item.tool.toolName
-            const currentPermission = this.#getCurrentPermission(item.permission)
             // For Built-in server, use a special function that doesn't include the 'Deny' option
-            const permissionOptions = this.#buildPermissionOptions(item.permission)
+            let permissionOptions = this.#buildPermissionOptions(item.permission)
+
+            if (serverName === 'Built-in') {
+                permissionOptions = this.#buildBuiltInPermissionOptions(item.permission)
+            }
 
             filterOptions.push({
                 type: 'select',
                 id: `${toolName}`,
                 title: toolName,
                 description: item.tool.description,
-                placeholder: currentPermission,
                 options: permissionOptions,
+                ...(toolName === 'fsWrite'
+                    ? { disabled: true, selectTooltip: 'Permission for this tool is not configurable yet' }
+                    : {}),
+                ...{ value: item.permission, boldTitle: true, mandatory: true, hideMandatoryIcon: true },
             })
         })
 
@@ -981,17 +999,19 @@ export class McpEventHandler {
     #buildPermissionOptions(currentPermission: string) {
         const permissionOptions: PermissionOption[] = []
 
-        if (currentPermission !== McpPermissionType.alwaysAllow) {
-            permissionOptions.push({ label: 'Always allow', value: McpPermissionType.alwaysAllow })
-        }
+        permissionOptions.push({
+            label: 'Ask',
+            value: McpPermissionType.ask,
+            description: 'Ask for your approval each time this tool is run',
+        })
 
-        if (currentPermission !== McpPermissionType.ask) {
-            permissionOptions.push({ label: 'Ask', value: McpPermissionType.ask })
-        }
+        permissionOptions.push({
+            label: 'Always allow',
+            value: McpPermissionType.alwaysAllow,
+            description: 'Always allow this tool to run without asking for approval',
+        })
 
-        if (currentPermission !== McpPermissionType.deny) {
-            permissionOptions.push({ label: 'Deny', value: McpPermissionType.deny })
-        }
+        permissionOptions.push({ label: 'Deny', value: McpPermissionType.deny, description: 'Never run this tool' })
 
         return permissionOptions
     }
@@ -999,33 +1019,57 @@ export class McpEventHandler {
     /**
      * Builds permission options for Built-in tools (no 'Disable' option)
      */
-    // #buildBuiltInPermissionOptions(currentPermission: string) {
-    //     const permissionOptions: PermissionOption[] = []
+    #buildBuiltInPermissionOptions(currentPermission: string) {
+        const permissionOptions: PermissionOption[] = []
 
-    //     if (currentPermission !== 'alwaysAllow') {
-    //         permissionOptions.push({
-    //             label: 'Always run',
-    //             value: 'alwaysAllow',
-    //         })
-    //     }
+        permissionOptions.push({
+            label: 'Ask',
+            value: 'ask',
+            description: 'Ask for your approval each time this tool is run',
+        })
 
-    //     if (currentPermission !== 'ask') {
-    //         permissionOptions.push({
-    //             label: 'Ask to run',
-    //             value: 'ask',
-    //         })
-    //     }
+        permissionOptions.push({
+            label: 'Always Allow',
+            value: 'alwaysAllow',
+            description: 'Always allow this tool to run without asking for approval',
+        })
 
-    //     return permissionOptions
-    // }
+        return permissionOptions
+    }
+
+    #getBuiltInToolDescription(toolName: string) {
+        switch (toolName) {
+            case 'fsRead':
+                return 'Read the content of files.'
+            case 'listDirectory':
+                return 'List the structure of a directory and its subdirectories.'
+            case 'fileSearch':
+                return 'Search for files and directories using fuzzy name matching.'
+            case 'executeBash':
+                return 'Run shell or powershell commands.\n\nNote: read-only commands are auto-run'
+            case 'fsWrite':
+            case 'fsReplace':
+                return 'Create or edit files.'
+            case 'qCodeReview':
+                return 'Review tool analyzes code for security vulnerabilities, quality issues, and best practices across multiple programming languages.'
+            default:
+                return ''
+        }
+    }
 
     /**
      * Handles MCP permission change events to update the pending permission config without applying changes
      */
     async #handleMcpPermissionChange(params: McpServerClickParams) {
         const serverName = params.title
-        const updatedPermissionConfig = params.optionsValues
 
+        // combine fsWrite and fsReplace into fsWrite
+        if (serverName === 'Built-in' && params.optionsValues?.fsWrite) {
+            // add fsReplace along
+            params.optionsValues.fsReplace = params.optionsValues.fsWrite
+        }
+
+        const updatedPermissionConfig = params.optionsValues
         if (!serverName || !updatedPermissionConfig) {
             return { id: params.id }
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -237,7 +237,7 @@ export class McpEventHandler {
      */
 
     async onMcpServerClick(params: McpServerClickParams) {
-        this.#features.logging.log(`[VSCode Server] onMcpServerClick event with params: ${JSON.stringify(params)}`)
+        this.#features.logging.log(`onMcpServerClick event with params: ${JSON.stringify(params)}`)
 
         // Use a map of handlers for different action types
         const handlers: Record<string, () => Promise<any>> = {
@@ -1099,7 +1099,6 @@ export class McpEventHandler {
             this.#pendingPermissionConfig = undefined
 
             this.#features.logging.info(`Applied permission changes for server: ${serverName}`)
-            this.#isProgrammaticChange = false
             return { id: params.id }
         } catch (error) {
             this.#features.logging.error(`Failed to save MCP permissions: ${error}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -26,6 +26,7 @@ const fakeWorkspace = {
         mkdir: (_: string, __: any) => Promise.resolve(),
     },
     getUserHomeDir: () => '',
+    getAllWorkspaceFolders: () => [{ uri: '/fake/workspace' }],
 }
 const features = { logging: fakeLogging, workspace: fakeWorkspace, lsp: {} } as any
 
@@ -234,10 +235,26 @@ describe('addServer()', () => {
 describe('removeServer()', () => {
     let loadStub: sinon.SinonStub
     let saveAgentConfigStub: sinon.SinonStub
+    let existsStub: sinon.SinonStub
+    let readFileStub: sinon.SinonStub
+    let writeFileStub: sinon.SinonStub
+    let mkdirStub: sinon.SinonStub
+    let getWorkspaceMcpConfigPathsStub: sinon.SinonStub
+    let getGlobalMcpConfigPathStub: sinon.SinonStub
 
     beforeEach(() => {
         loadStub = stubAgentConfig()
         saveAgentConfigStub = sinon.stub(mcpUtils, 'saveAgentConfig').resolves()
+        existsStub = sinon.stub(fakeWorkspace.fs, 'exists').resolves(true)
+        readFileStub = sinon
+            .stub(fakeWorkspace.fs, 'readFile')
+            .resolves(Buffer.from(JSON.stringify({ mcpServers: { x: {} } })))
+        writeFileStub = sinon.stub(fakeWorkspace.fs, 'writeFile').resolves()
+        mkdirStub = sinon.stub(fakeWorkspace.fs, 'mkdir').resolves()
+        getWorkspaceMcpConfigPathsStub = sinon
+            .stub(mcpUtils, 'getWorkspaceMcpConfigPaths')
+            .returns(['ws1/config.json', 'ws2/config.json'])
+        getGlobalMcpConfigPathStub = sinon.stub(mcpUtils, 'getGlobalMcpConfigPath').returns('global/config.json')
     })
 
     afterEach(async () => {
@@ -274,6 +291,106 @@ describe('removeServer()', () => {
         await mgr.removeServer('x')
         expect(saveAgentConfigStub.calledOnce).to.be.true
         expect((mgr as any).clients.has('x')).to.be.false
+    })
+
+    it('removes server from all config files', async () => {
+        const mgr = await McpManager.init([], features)
+        const dummy = new Client({ name: 'c', version: 'v' })
+        ;(mgr as any).clients.set('x', dummy)
+        ;(mgr as any).mcpServers.set('x', {
+            command: '',
+            args: [],
+            env: {},
+            timeout: 0,
+            __configPath__: 'c.json',
+        } as MCPServerConfig)
+        ;(mgr as any).serverNameMapping.set('x', 'x')
+        ;(mgr as any).agentConfig = {
+            name: 'test-agent',
+            version: '1.0.0',
+            description: 'Test agent',
+            mcpServers: { x: {} },
+            tools: ['@x'],
+            allowedTools: [],
+            toolsSettings: {},
+            includedFiles: [],
+            resources: [],
+        }
+
+        await mgr.removeServer('x')
+
+        // Verify that writeFile was called for each config path (2 workspace + 1 global)
+        expect(writeFileStub.callCount).to.equal(3)
+
+        // Verify the content of the writes (should have removed the server)
+        writeFileStub.getCalls().forEach(call => {
+            const content = JSON.parse(call.args[1])
+            expect(content.mcpServers).to.not.have.property('x')
+        })
+    })
+})
+
+describe('mutateConfigFile()', () => {
+    let existsStub: sinon.SinonStub
+    let readFileStub: sinon.SinonStub
+    let writeFileStub: sinon.SinonStub
+    let mkdirStub: sinon.SinonStub
+    let mgr: McpManager
+
+    beforeEach(async () => {
+        sinon.restore()
+        stubAgentConfig()
+        existsStub = sinon.stub(fakeWorkspace.fs, 'exists').resolves(true)
+        readFileStub = sinon
+            .stub(fakeWorkspace.fs, 'readFile')
+            .resolves(Buffer.from(JSON.stringify({ mcpServers: { test: {} } })))
+        writeFileStub = sinon.stub(fakeWorkspace.fs, 'writeFile').resolves()
+        mkdirStub = sinon.stub(fakeWorkspace.fs, 'mkdir').resolves()
+        mgr = await McpManager.init([], features)
+    })
+
+    afterEach(async () => {
+        sinon.restore()
+        try {
+            await McpManager.instance.close()
+        } catch {}
+    })
+
+    it('reads, mutates, and writes config file', async () => {
+        // Access the private method using type assertion
+        const mutateConfigFile = (mgr as any).mutateConfigFile.bind(mgr)
+
+        await mutateConfigFile('test/path.json', (json: any) => {
+            json.mcpServers.newServer = { command: 'test' }
+            delete json.mcpServers.test
+        })
+
+        expect(readFileStub.calledOnce).to.be.true
+        expect(writeFileStub.calledOnce).to.be.true
+
+        // Verify the content was modified correctly
+        const writtenContent = JSON.parse(writeFileStub.firstCall.args[1])
+        expect(writtenContent.mcpServers).to.have.property('newServer')
+        expect(writtenContent.mcpServers).to.not.have.property('test')
+    })
+
+    it('creates new config file if it does not exist', async () => {
+        existsStub.resolves(false)
+        readFileStub.rejects({ code: 'ENOENT' })
+
+        // Access the private method using type assertion
+        const mutateConfigFile = (mgr as any).mutateConfigFile.bind(mgr)
+
+        await mutateConfigFile('test/path.json', (json: any) => {
+            json.mcpServers.newServer = { command: 'test' }
+        })
+
+        expect(mkdirStub.calledOnce).to.be.true
+        expect(writeFileStub.calledOnce).to.be.true
+
+        // Verify the content was created correctly
+        const writtenContent = JSON.parse(writeFileStub.firstCall.args[1])
+        expect(writtenContent.mcpServers).to.have.property('newServer')
     })
 })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -25,7 +25,7 @@ import {
     getGlobalAgentConfigPath,
     getWorkspaceMcpConfigPaths,
     getGlobalMcpConfigPath,
-    sanitizeContent
+    sanitizeContent,
 } from './mcpUtils'
 import { AgenticChatError } from '../../errors'
 import { EventEmitter } from 'events'

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -442,7 +442,7 @@ export class McpManager {
      */
     public getToolPerm(server: string, tool: string): McpPermissionType {
         // For built-in tools, check directly without prefix
-        if (server === 'builtIn') {
+        if (server === 'Built-in') {
             return this.agentConfig.allowedTools.includes(tool) ? McpPermissionType.alwaysAllow : McpPermissionType.ask
         }
 
@@ -852,7 +852,7 @@ export class McpManager {
 
             // Process each tool permission
             for (const [toolName, permission] of Object.entries(perm.toolPerms || {})) {
-                const toolId = `${serverPrefix}/${toolName}`
+                const toolId = (unsanitizedServerName !== 'Built-in' ? `${serverPrefix}/` : '') + `${toolName}`
 
                 if (permission === McpPermissionType.deny) {
                     // For deny: if server is enabled as a whole, we need to switch to individual tools
@@ -962,7 +962,7 @@ export class McpManager {
      */
     public requiresApproval(server: string, tool: string): boolean {
         // For built-in tools, check directly without prefix
-        const toolId = server === 'builtIn' ? tool : `@${server}/${tool}`
+        const toolId = server === 'Built-in' ? tool : `@${server}/${tool}`
         return !this.agentConfig.allowedTools.includes(toolId)
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -14,11 +14,18 @@ import {
     McpServerRuntimeState,
     McpServerStatus,
     McpPermissionType,
-    PersonaModel,
     MCPServerPermission,
     AgentConfig,
 } from './mcpTypes'
-import { isEmptyEnv, loadAgentConfig, saveAgentConfig, sanitizeName, getGlobalAgentConfigPath } from './mcpUtils'
+import {
+    isEmptyEnv,
+    loadAgentConfig,
+    saveAgentConfig,
+    sanitizeName,
+    getGlobalAgentConfigPath,
+    getWorkspaceMcpConfigPaths,
+    getGlobalMcpConfigPath,
+} from './mcpUtils'
 import { AgenticChatError } from '../../errors'
 import { EventEmitter } from 'events'
 import { Mutex } from 'async-mutex'
@@ -658,6 +665,30 @@ export class McpManager {
 
             // Save agent config
             await saveAgentConfig(this.features.workspace, this.features.logging, this.agentConfig, cfg.__configPath__)
+
+            // Get all config paths and delete the server from each one
+            const wsUris = this.features.workspace.getAllWorkspaceFolders()?.map(f => f.uri) ?? []
+            const wsConfigPaths = getWorkspaceMcpConfigPaths(wsUris)
+            const globalConfigPath = getGlobalMcpConfigPath(this.features.workspace.fs.getUserHomeDir())
+            const allConfigPaths = [...wsConfigPaths, globalConfigPath]
+
+            // Delete the server from all config files
+            for (const configPath of allConfigPaths) {
+                try {
+                    await this.mutateConfigFile(configPath, json => {
+                        if (json.mcpServers && json.mcpServers[unsanitizedName]) {
+                            delete json.mcpServers[unsanitizedName]
+                            this.features.logging.info(
+                                `Deleted server '${unsanitizedName}' from config file: ${configPath}`
+                            )
+                        }
+                    })
+                } catch (err) {
+                    this.features.logging.warn(
+                        `Failed to delete server '${unsanitizedName}' from config file ${configPath}: ${err}`
+                    )
+                }
+            }
         }
 
         this.mcpServers.delete(serverName)
@@ -1045,6 +1076,46 @@ export class McpManager {
         } catch (err) {
             this.features.logging.error(`Error removing server '${serverName}' from agent config file: ${err}`)
         }
+    }
+
+    /**
+     * Read, mutate, and write the MCP JSON config at the given path.
+     * @private
+     */
+    private async mutateConfigFile(configPath: string, mutator: (json: any) => void): Promise<void> {
+        return McpManager.configMutex
+            .runExclusive(async () => {
+                let json: any = { mcpServers: {} }
+                try {
+                    const raw = await this.features.workspace.fs.readFile(configPath)
+                    this.features.logging.info(`Updating MCP config file: ${configPath}`)
+                    const existing = JSON.parse(raw.toString())
+                    json = { mcpServers: {}, ...existing }
+                } catch (err: any) {
+                    // ignore fire not exist error
+                    if (err?.code !== 'ENOENT') throw err
+                }
+                mutator(json)
+
+                let fsPath: string
+                try {
+                    const uri = URI.parse(configPath)
+                    fsPath = uri.scheme === 'file' ? uri.fsPath : configPath
+                } catch {
+                    fsPath = configPath
+                }
+                fsPath = path.normalize(fsPath)
+
+                const dir = path.dirname(fsPath)
+                await this.features.workspace.fs.mkdir(dir, { recursive: true })
+
+                await this.features.workspace.fs.writeFile(fsPath, JSON.stringify(json, null, 2))
+                this.features.logging.debug(`MCP config file write complete: ${configPath}`)
+            })
+            .catch((e: any) => {
+                this.features.logging.error(`MCP: failed to update config at ${configPath}: ${e.message}`)
+                throw e
+            })
     }
 
     public getOriginalToolNames(namespacedName: string): { serverName: string; toolName: string } | undefined {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -10,6 +10,7 @@ import path = require('path')
 import { QClientCapabilities } from '../../../configuration/qConfigurationServer'
 import crypto = require('crypto')
 import { Features } from '@aws/language-server-runtimes/server-interface/server'
+import { EXECUTE_BASH } from '../../constants/toolConstants'
 
 /**
  * Load, validate, and parse MCP server configurations from JSON files.
@@ -644,7 +645,7 @@ export function convertPersonaToAgent(
 
     // Add default allowed tools
     const writeToolNames = new Set(featureAgent.getBuiltInWriteToolNames())
-    const defaultAllowedTools = featureAgent.getBuiltInToolNames().filter(toolName => !writeToolNames.has(toolName))
+    const defaultAllowedTools = featureAgent.getBuiltInToolNames().filter(toolName => toolName !== EXECUTE_BASH)
     for (const toolName of defaultAllowedTools) {
         if (!agent.allowedTools.includes(toolName)) {
             agent.allowedTools.push(toolName)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolShared.ts
@@ -3,6 +3,7 @@ import { workspaceUtils } from '@aws/lsp-core'
 import { getWorkspaceFolderPaths } from '@aws/lsp-core/out/util/workspaceUtils'
 import * as path from 'path'
 import { CommandCategory } from './executeBash'
+import { OUT_OF_WORKSPACE_WARNING_MSG } from '../constants/constants'
 
 interface Output<Kind, Content> {
     kind: Kind
@@ -127,10 +128,13 @@ export async function requiresPathAcceptance(
             if (logging) {
                 logging.debug('No workspace folders found when checking file acceptance')
             }
-            return { requiresAcceptance: true }
+            return { requiresAcceptance: true, warning: OUT_OF_WORKSPACE_WARNING_MSG }
         }
         const isInWorkspace = workspaceUtils.isInWorkspace(workspaceFolders, path)
-        return { requiresAcceptance: !isInWorkspace }
+        return {
+            requiresAcceptance: !isInWorkspace,
+            warning: !isInWorkspace ? OUT_OF_WORKSPACE_WARNING_MSG : undefined,
+        }
     } catch (error) {
         if (logging) {
             logging.error(`Error checking file acceptance: ${error}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/validation.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { StartTransformRequest, TransformProjectMetadata } from '../models'
-import { isProject, isSolution, validateProject } from '../validation'
+import { isProject, isSolution, validateProject, validateSolution } from '../validation'
 import { supportedProjects, unsupportedViewComponents } from '../resources/SupportedProjects'
 import mock = require('mock-fs')
 import { Logging } from '@aws/language-server-runtimes/server-interface'
@@ -95,5 +95,73 @@ describe('Test validation functionality', () => {
         mockStartTransformationRequest.ProjectMetadata.push(mockProjectMeta)
 
         expect(validateProject(mockStartTransformationRequest, mockedLogging)).to.equal(false)
+    })
+
+    // New tests for AspNetWebForms validation
+    it('should return true when project is AspNetWebForms type', () => {
+        let mockStartTransformationRequest: StartTransformRequest = sampleStartTransformRequest
+        const mockProjectMeta = {
+            Name: '',
+            ProjectTargetFramework: '',
+            ProjectPath: 'test.csproj',
+            SourceCodeFilePaths: [],
+            ProjectLanguage: '',
+            ProjectType: 'AspNetWebForms',
+            ExternalReferences: [],
+        }
+        mockStartTransformationRequest.ProjectMetadata = []
+        mockStartTransformationRequest.ProjectMetadata.push(mockProjectMeta)
+
+        expect(validateProject(mockStartTransformationRequest, mockedLogging)).to.equal(true)
+    })
+
+    it('should not include AspNetWebForms in unsupported projects list', () => {
+        let mockStartTransformationRequest: StartTransformRequest = sampleStartTransformRequest
+
+        // Add a supported project
+        const supportedProjectMeta = {
+            Name: 'Supported',
+            ProjectTargetFramework: '',
+            ProjectPath: 'supported.csproj',
+            SourceCodeFilePaths: [],
+            ProjectLanguage: '',
+            ProjectType: 'AspNetCoreMvc',
+            ExternalReferences: [],
+        }
+
+        // Add an unsupported project
+        const unsupportedProjectMeta = {
+            Name: 'Unsupported',
+            ProjectTargetFramework: '',
+            ProjectPath: 'unsupported.csproj',
+            SourceCodeFilePaths: [],
+            ProjectLanguage: '',
+            ProjectType: 'UnsupportedType',
+            ExternalReferences: [],
+        }
+
+        // Add an AspNetWebForms project
+        const webFormsProjectMeta = {
+            Name: 'WebForms',
+            ProjectTargetFramework: '',
+            ProjectPath: 'webforms.csproj',
+            SourceCodeFilePaths: [],
+            ProjectLanguage: '',
+            ProjectType: 'AspNetWebForms',
+            ExternalReferences: [],
+        }
+
+        mockStartTransformationRequest.ProjectMetadata = [
+            supportedProjectMeta,
+            unsupportedProjectMeta,
+            webFormsProjectMeta,
+        ]
+
+        const unsupportedProjects = validateSolution(mockStartTransformationRequest)
+
+        // Should only contain the unsupported project, not the AspNetWebForms project
+        expect(unsupportedProjects).to.have.lengthOf(1)
+        expect(unsupportedProjects[0]).to.equal('unsupported.csproj')
+        expect(unsupportedProjects).to.not.include('webforms.csproj')
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -221,6 +221,7 @@ export const WorkspaceContextServer = (): Server => features => {
             isLoggedInUsingBearerToken(credentialsProvider) &&
             abTestingEnabled &&
             !workspaceFolderManager.getOptOutStatus() &&
+            !workspaceFolderManager.getServiceQuotaExceededStatus() &&
             workspaceIdentifier
         )
     }
@@ -302,6 +303,7 @@ export const WorkspaceContextServer = (): Server => features => {
                     await evaluateABTesting()
                     isWorkflowInitialized = true
 
+                    workspaceFolderManager.resetAdminOptOutAndServiceQuotaStatus()
                     if (!isUserEligibleForWorkspaceContext()) {
                         return
                     }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.test.ts
@@ -1,0 +1,131 @@
+import { WorkspaceFolderManager } from './workspaceFolderManager'
+import sinon, { stubInterface, StubbedInstance } from 'ts-sinon'
+import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
+import { CredentialsProvider, Logging } from '@aws/language-server-runtimes/server-interface'
+import { DependencyDiscoverer } from './dependency/dependencyDiscoverer'
+import { WorkspaceFolder } from 'vscode-languageserver-protocol'
+import { ArtifactManager } from './artifactManager'
+import { CodeWhispererServiceToken } from '../../shared/codeWhispererService'
+import { CreateWorkspaceResponse } from '../../client/token/codewhispererbearertokenclient'
+import { AWSError } from 'aws-sdk'
+
+describe('WorkspaceFolderManager', () => {
+    let mockServiceManager: StubbedInstance<AmazonQTokenServiceManager>
+    let mockLogging: StubbedInstance<Logging>
+    let mockCredentialsProvider: StubbedInstance<CredentialsProvider>
+    let mockDependencyDiscoverer: StubbedInstance<DependencyDiscoverer>
+    let mockArtifactManager: StubbedInstance<ArtifactManager>
+    let mockCodeWhispererService: StubbedInstance<CodeWhispererServiceToken>
+    let workspaceFolderManager: WorkspaceFolderManager
+
+    beforeEach(() => {
+        mockServiceManager = stubInterface<AmazonQTokenServiceManager>()
+        mockLogging = stubInterface<Logging>()
+        mockCredentialsProvider = stubInterface<CredentialsProvider>()
+        mockDependencyDiscoverer = stubInterface<DependencyDiscoverer>()
+        mockArtifactManager = stubInterface<ArtifactManager>()
+        mockCodeWhispererService = stubInterface<CodeWhispererServiceToken>()
+
+        mockServiceManager.getCodewhispererService.returns(mockCodeWhispererService)
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('getServiceQuotaExceededStatus', () => {
+        it('should return true when service quota is exceeded', async () => {
+            // Setup
+            const workspaceFolders: WorkspaceFolder[] = [
+                {
+                    uri: 'file:///test/workspace',
+                    name: 'test-workspace',
+                },
+            ]
+
+            // Mock the createWorkspace method to throw a ServiceQuotaExceededException
+            const mockError: AWSError = {
+                name: 'ServiceQuotaExceededException',
+                message: 'You have too many active running workspaces.',
+                code: 'ServiceQuotaExceededException',
+                time: new Date(),
+                retryable: false,
+                statusCode: 400,
+            }
+
+            mockCodeWhispererService.createWorkspace.rejects(mockError)
+
+            // Create the WorkspaceFolderManager instance using the static createInstance method
+            workspaceFolderManager = WorkspaceFolderManager.createInstance(
+                mockServiceManager,
+                mockLogging,
+                mockArtifactManager,
+                mockDependencyDiscoverer,
+                workspaceFolders,
+                mockCredentialsProvider,
+                'test-workspace-identifier'
+            )
+
+            // Spy on clearAllWorkspaceResources and related methods
+            const clearAllWorkspaceResourcesSpy = sinon.stub(
+                workspaceFolderManager as any,
+                'clearAllWorkspaceResources'
+            )
+
+            // Act - trigger the createNewWorkspace method which sets isServiceQuotaExceeded
+            await (workspaceFolderManager as any).createNewWorkspace()
+
+            // Assert
+            expect(workspaceFolderManager.getServiceQuotaExceededStatus()).toBe(true)
+
+            // Verify that clearAllWorkspaceResources was called
+            sinon.assert.calledOnce(clearAllWorkspaceResourcesSpy)
+        })
+
+        it('should return false when service quota is not exceeded', async () => {
+            // Setup
+            const workspaceFolders: WorkspaceFolder[] = [
+                {
+                    uri: 'file:///test/workspace',
+                    name: 'test-workspace',
+                },
+            ]
+
+            // Mock successful response
+            const mockResponse: CreateWorkspaceResponse = {
+                workspace: {
+                    workspaceId: 'test-workspace-id',
+                    workspaceStatus: 'RUNNING',
+                },
+            }
+
+            mockCodeWhispererService.createWorkspace.resolves(mockResponse as any)
+
+            // Create the WorkspaceFolderManager instance using the static createInstance method
+            workspaceFolderManager = WorkspaceFolderManager.createInstance(
+                mockServiceManager,
+                mockLogging,
+                mockArtifactManager,
+                mockDependencyDiscoverer,
+                workspaceFolders,
+                mockCredentialsProvider,
+                'test-workspace-identifier'
+            )
+
+            // Spy on clearAllWorkspaceResources
+            const clearAllWorkspaceResourcesSpy = sinon.stub(
+                workspaceFolderManager as any,
+                'clearAllWorkspaceResources'
+            )
+
+            // Act - trigger the createNewWorkspace method
+            await (workspaceFolderManager as any).createNewWorkspace()
+
+            // Assert
+            expect(workspaceFolderManager.getServiceQuotaExceededStatus()).toBe(false)
+
+            // Verify that clearAllWorkspaceResources was not called
+            sinon.assert.notCalled(clearAllWorkspaceResourcesSpy)
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
@@ -19,6 +19,7 @@ import { DependencyDiscoverer } from './dependency/dependencyDiscoverer'
 import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
 import { URI } from 'vscode-uri'
 import path = require('path')
+import { isAwsError } from '../../shared/utils'
 
 interface WorkspaceState {
     remoteWorkspaceState: WorkspaceStatus
@@ -47,12 +48,14 @@ export class WorkspaceFolderManager {
     private credentialsProvider: CredentialsProvider
     private readonly INITIAL_CHECK_INTERVAL = 40 * 1000 // 40 seconds
     private readonly INITIAL_CONNECTION_TIMEOUT = 2 * 60 * 1000 // 2 minutes
-    private readonly CONTINUOUS_MONITOR_INTERVAL = 5 * 60 * 1000 // 30 minutes
+    private readonly CONTINUOUS_MONITOR_INTERVAL = 30 * 60 * 1000 // 30 minutes
     private readonly MESSAGE_PUBLISH_INTERVAL: number = 100 // 100 milliseconds
     private continuousMonitorInterval: NodeJS.Timeout | undefined
     private optOutMonitorInterval: NodeJS.Timeout | undefined
     private messageQueueConsumerInterval: NodeJS.Timeout | undefined
     private isOptedOut: boolean = false
+    // Tracks if the user has reached their maximum allowed remote workspaces quota
+    private isServiceQuotaExceeded: boolean = false
 
     static createInstance(
         serviceManager: AmazonQTokenServiceManager,
@@ -133,6 +136,15 @@ export class WorkspaceFolderManager {
 
     getOptOutStatus(): boolean {
         return this.isOptedOut
+    }
+
+    getServiceQuotaExceededStatus(): boolean {
+        return this.isServiceQuotaExceeded
+    }
+
+    resetAdminOptOutAndServiceQuotaStatus(): void {
+        this.isOptedOut = false
+        this.isServiceQuotaExceeded = false
     }
 
     getWorkspaceState(): WorkspaceState {
@@ -343,7 +355,7 @@ export class WorkspaceFolderManager {
         await this.checkRemoteWorkspaceStatusAndReact(true)
 
         // Set up continuous monitoring which periodically invokes checkRemoteWorkspaceStatusAndReact
-        if (!this.isOptedOut && this.continuousMonitorInterval === undefined) {
+        if (!this.isOptedOut && !this.isServiceQuotaExceeded && this.continuousMonitorInterval === undefined) {
             this.logging.log(`Starting continuous monitor for workspace [${this.workspaceIdentifier}]`)
             this.continuousMonitorInterval = setInterval(async () => {
                 try {
@@ -592,6 +604,13 @@ export class WorkspaceFolderManager {
 
     private async createNewWorkspace() {
         const createWorkspaceResult = await this.createWorkspace(this.workspaceIdentifier)
+
+        this.isServiceQuotaExceeded = createWorkspaceResult.isServiceQuotaExceeded
+        if (this.isServiceQuotaExceeded) {
+            // Stop continuous monitor and all actions
+            this.clearAllWorkspaceResources()
+        }
+
         const workspaceDetails = createWorkspaceResult.response
         if (!workspaceDetails) {
             this.logging.warn(`Failed to create remote workspace for [${this.workspaceIdentifier}]`)
@@ -712,23 +731,31 @@ export class WorkspaceFolderManager {
         return { metadata, optOut, error }
     }
 
-    private async createWorkspace(workspaceRoot: WorkspaceRoot) {
+    private async createWorkspace(workspaceRoot: WorkspaceRoot): Promise<{
+        response: CreateWorkspaceResponse | undefined | null
+        isServiceQuotaExceeded: boolean
+        error: any
+    }> {
         let response: CreateWorkspaceResponse | undefined | null
+        let isServiceQuotaExceeded = false
+        let error: any
         try {
             response = await this.serviceManager.getCodewhispererService().createWorkspace({
                 workspaceRoot: workspaceRoot,
             })
-            return { response, error: null }
         } catch (e: any) {
             this.logging.warn(
                 `Error while creating workspace (${workspaceRoot}): ${e.message}. Error is ${e.retryable ? '' : 'not'} retryable}`
             )
-            const error = {
+            if (isAwsError(e) && e.code === 'ServiceQuotaExceededException') {
+                isServiceQuotaExceeded = true
+            }
+            error = {
                 message: e.message,
                 retryable: e.retryable ?? false,
                 originalError: e,
             }
-            return { response: null, error }
         }
+        return { response, isServiceQuotaExceeded, error }
     }
 }


### PR DESCRIPTION
## Problem
- Reverted commits for auto-approve feature emergency deployment revert.

## Solution
- reapplying the commits that are reverted
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
