### PR TITLE
fix: remove malicious characters from MCP tool description

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -18,7 +18,14 @@ import {
     MCPServerPermission,
     AgentConfig,
 } from './mcpTypes'
-import { isEmptyEnv, loadAgentConfig, saveAgentConfig, sanitizeName, getGlobalAgentConfigPath } from './mcpUtils'
+import {
+    isEmptyEnv,
+    loadAgentConfig,
+    saveAgentConfig,
+    sanitizeName,
+    getGlobalAgentConfigPath,
+    sanitizeContent,
+} from './mcpUtils'
 import { AgenticChatError } from '../../errors'
 import { EventEmitter } from 'events'
 import { Mutex } from 'async-mutex'
@@ -340,7 +347,7 @@ export class McpManager {
                 this.mcpTools.push({
                     serverName,
                     toolName: t.name,
-                    description: t.description ?? '',
+                    description: sanitizeContent(t.description ?? ''),
                     inputSchema: t.inputSchema ?? {},
                 })
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.test.ts
@@ -20,6 +20,7 @@ import {
     enabledMCP,
     normalizePathFromUri,
     saveAgentConfig,
+    sanitizeContent,
 } from './mcpUtils'
 import type { MCPServerConfig } from './mcpTypes'
 import { pathToFileURL } from 'url'
@@ -582,5 +583,13 @@ describe('normalizePathFromUri', () => {
         URI.parse = originalParse
 
         expect(result).to.equal(invalidUri)
+    })
+})
+
+describe('sanitizeContent', () => {
+    it('removes Unicode Tag characters (U+E0000–U+E007F)', () => {
+        const input = 'foo\u{E0001}bar\u{E0060}baz'
+        const expected = 'foobarbaz'
+        expect(sanitizeContent(input)).to.equal(expected)
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -1009,3 +1009,8 @@ export function createNamespacedToolName(
         duplicateNum++
     }
 }
+
+export function sanitizeContent(input: string): string {
+    // Remove any Unicode Tag characters (U+E0000–U+E007F)
+    return input.replace(/[\u{E0000}-\u{E007F}]/gu, '')
+}


### PR DESCRIPTION
## Problem
Fix issues from security ticket
## Solution
Malicious characters should be removed from command description

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
