### PR TITLE
fix(amazonq): wrong path in the logs for the function

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -342,7 +342,7 @@ export class AgenticChatTriggerContext {
             const content = await this.#workspace.fs.readFile(URI.parse(uri).fsPath)
             return TextDocument.create(uri, '', 0, content)
         } catch (err) {
-            this.#logging.error(`Unable to load from ${path}: ${err}`)
+            this.#logging.error(`Unable to load from ${uri}: ${err}`)
             return
         }
     }


### PR DESCRIPTION
## Problem
The logs are printing the wrong path for the function.

## Solution
Fixed the logs.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
