### PR TITLE
feat: add IAM credentials discovery from process, metadata, and env

### DIFF
--- a/server/aws-lsp-identity/src/iam/utils.ts
+++ b/server/aws-lsp-identity/src/iam/utils.ts
@@ -13,6 +13,10 @@ import { AwsError, Observability } from '@aws/lsp-core'
 import { StsCache } from '../sts/cache/stsCache'
 import { StsAutoRefresher } from '../sts/stsAutoRefresher'
 import { ProfileStore } from '../language-server/profiles/profileService'
+import { FromProcessInit } from '@aws-sdk/credential-provider-process'
+import { AwsCredentialIdentityProvider, Provider, RuntimeConfigAwsCredentialIdentityProvider } from '@aws-sdk/types'
+import { InstanceMetadataCredentials, RemoteProviderInit } from '@smithy/credential-provider-imds'
+import { FromEnvInit } from '@aws-sdk/credential-provider-env'
 
 const defaultRegion = 'us-east-1'
 
@@ -84,6 +88,13 @@ function convertToIamArn(arn: string) {
     }
 }
 
+export type CredentialProviders = {
+    fromProcess: (init?: FromProcessInit) => RuntimeConfigAwsCredentialIdentityProvider
+    fromContainerMetadata: (init?: RemoteProviderInit) => AwsCredentialIdentityProvider
+    fromInstanceMetadata: (init?: RemoteProviderInit) => Provider<InstanceMetadataCredentials>
+    fromEnv: (init?: FromEnvInit) => AwsCredentialIdentityProvider
+}
+
 export type SendGetMfaCode = (params: GetMfaCodeParams) => Promise<GetMfaCodeResult>
 export type SendStsCredentialChanged = (params: StsCredentialChangedParams) => void
 
@@ -99,6 +110,7 @@ export type IamFlowParams = {
     stsCache: StsCache
     stsAutoRefresher: StsAutoRefresher
     handlers: IamHandlers
+    providers: CredentialProviders
     token: CancellationToken
     observability: Observability
 }

--- a/server/aws-lsp-identity/src/language-server/identityService.test.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.test.ts
@@ -34,6 +34,7 @@ let stsAutoRefresher: StubbedInstance<StsAutoRefresher>
 let iamProvider: StubbedInstance<IamProvider>
 let observability: StubbedInstance<Observability>
 let authFlowFn: SinonSpy
+let credentialProvider: SinonSpy
 let validatePermissionsStub: SinonStub<
     [credentials: IamCredentials, permissions: string[], region?: string | undefined],
     Promise<boolean>
@@ -119,6 +120,18 @@ describe('IdentityService', () => {
                 expiresAt: new Date(Date.now() + 10 * 1000).toISOString(),
             } satisfies SSOToken)
         )
+
+        credentialProvider = spy(() => {
+            return () => {
+                return {
+                    accessKeyId: 'provider-access-key',
+                    secretAccessKey: 'provider-secret-key',
+                    sessionToken: 'provider-session-token',
+                    credentialScope: 'provider-credential-scope',
+                    accountId: 'provider-account-id',
+                }
+            }
+        })
 
         observability = stubInterface<Observability>()
         observability.logging = stubInterface<Logging>()

--- a/server/aws-lsp-identity/src/language-server/identityService.ts
+++ b/server/aws-lsp-identity/src/language-server/identityService.ts
@@ -36,6 +36,9 @@ import { AwsError, Observability } from '@aws/lsp-core'
 import { __ServiceException } from '@aws-sdk/client-sso-oidc/dist-types/models/SSOOIDCServiceException'
 import { deviceCodeFlow } from '../sso/deviceCode/deviceCodeFlow'
 import { SSOToken } from '@smithy/shared-ini-file-loader'
+import { fromProcess } from '@aws-sdk/credential-provider-process'
+import { fromContainerMetadata, fromInstanceMetadata } from '@smithy/credential-provider-imds'
+import { fromEnv } from '@aws-sdk/credential-provider-env'
 import { IamProvider } from '../iam/iamProvider'
 
 type SsoTokenSource = IamIdentityCenterSsoTokenSource | AwsBuilderIdSsoTokenSource
@@ -181,6 +184,12 @@ export class IdentityService {
                 stsCache: this.stsCache,
                 stsAutoRefresher: this.stsAutoRefresher,
                 handlers: this.handlers as IamHandlers,
+                providers: {
+                    fromProcess: fromProcess,
+                    fromContainerMetadata: fromContainerMetadata,
+                    fromInstanceMetadata: fromInstanceMetadata,
+                    fromEnv: fromEnv,
+                },
                 token: token,
                 observability: this.observability,
             }


### PR DESCRIPTION
## Problem
The identity LSP can only discover IAM credentials from the shared config files, temporary credentials cache, and STS AssumeRole calls. To reach feature parity with the Toolkit extensions and for potential auth migrations in the future, the identity LSP should also discover credentials from credentials processes, EC2 metadata, ECS metadata, and environment variables.

## Solution
This is part of https://github.com/aws/language-servers/pull/1981.

- Add credentials discovery from EC2 metadata, ECS metadata, and environment variables to authenticate with STS AssumeRole
- Add credentials retrieval from credentials process

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
