### PR TITLE
fix: sometimes Enter does not auto trigger in Java when Java extension is installed

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.test.ts
@@ -119,6 +119,8 @@ describe('Auto Trigger', async () => {
             assert.strictEqual(getAutoTriggerType(createContentChange('\n')), 'Enter')
             assert.strictEqual(getAutoTriggerType(createContentChange('\r\n')), 'Enter')
             assert.strictEqual(getAutoTriggerType(createContentChange('\n    ')), 'Enter')
+            const changes = [{ text: '\n   ' }, { text: '' }]
+            assert.strictEqual(getAutoTriggerType(changes), 'Enter')
         })
 
         it('should return undefined for tab changes', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
@@ -110,9 +110,10 @@ function isTabKey(str: string): boolean {
 export const getAutoTriggerType = (
     contentChanges: TextDocumentContentChangeEvent[]
 ): CodewhispererAutomatedTriggerType | undefined => {
-    if (contentChanges.length !== 1) {
+    if (contentChanges.length < 1 || contentChanges.length > 2) {
         // Won't trigger cwspr on multi-line changes
         // event.contentChanges.length will be 2 when user press Enter key multiple times
+        // in certain cases, first contentChange item is valid, 2nd is empty string
         return undefined
     }
     const changedText = contentChanges[0].text


### PR DESCRIPTION
## Problem

In certain cases, when a user hit Enter in certain languages, the documentChangeEvent has a empty string. This is a valid auto trigger. In fact user only input Enter but the IDE decides to add some other documentChangeEvents

## Solution

Enable auto trigger for this case.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
