### PR TITLE
refactor: separate auto trigger and manual trigger code path

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -269,22 +269,6 @@ export const CodewhispererServerFactory =
                         ? workspaceState.workspaceId
                         : undefined
 
-                    let triggerCharacters = ''
-                    let codewhispererAutoTriggerType = undefined
-                    // Reference: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/classifierTrigger.ts#L477
-                    if (
-                        params.documentChangeParams?.contentChanges &&
-                        params.documentChangeParams.contentChanges.length > 0 &&
-                        params.documentChangeParams.contentChanges[0].text !== undefined
-                    ) {
-                        triggerCharacters = params.documentChangeParams.contentChanges[0].text
-                        codewhispererAutoTriggerType = getAutoTriggerType(params.documentChangeParams.contentChanges)
-                    } else {
-                        // if the client does not emit document change for the trigger, use left most character.
-                        triggerCharacters = fileContext.leftFileContent.trim().at(-1) ?? ''
-                        codewhispererAutoTriggerType = triggerType(fileContext)
-                    }
-
                     const previousSession = sessionManager.getPreviousSession()
                     const previousDecision = previousSession?.getAggregatedUserTriggerDecision() ?? ''
                     let ideCategory: string | undefined = ''
@@ -293,32 +277,53 @@ export const CodewhispererServerFactory =
                         ideCategory = getIdeCategory(initializeParams)
                     }
 
-                    // See: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/keyStrokeHandler.ts#L132
-                    // In such cases, do not auto trigger.
-                    if (codewhispererAutoTriggerType === undefined) {
-                        return EMPTY_RESULT
-                    }
+                    // auto trigger code path
+                    let codewhispererAutoTriggerType = undefined
+                    let triggerCharacters = ''
+                    let autoTriggerResult = undefined
 
-                    const autoTriggerResult = autoTrigger(
-                        {
-                            fileContext, // The left/right file context and programming language
-                            lineNum: params.position.line, // the line number of the invocation, this is the line of the cursor
-                            char: triggerCharacters, // Add the character just inserted, if any, before the invication position
-                            ide: ideCategory ?? '',
-                            os: getNormalizeOsName(),
-                            previousDecision, // The last decision by the user on the previous invocation
-                            triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
-                        },
-                        logging
-                    )
+                    if (isAutomaticLspTriggerKind) {
+                        // Reference: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/classifierTrigger.ts#L477
+                        if (
+                            params.documentChangeParams?.contentChanges &&
+                            params.documentChangeParams.contentChanges.length > 0 &&
+                            params.documentChangeParams.contentChanges[0].text !== undefined
+                        ) {
+                            triggerCharacters = params.documentChangeParams.contentChanges[0].text
+                            codewhispererAutoTriggerType = getAutoTriggerType(
+                                params.documentChangeParams.contentChanges
+                            )
+                        } else {
+                            // if the client does not emit document change for the trigger, use left most character.
+                            triggerCharacters = fileContext.leftFileContent.trim().at(-1) ?? ''
+                            codewhispererAutoTriggerType = triggerType(fileContext)
+                        }
+                        // See: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/keyStrokeHandler.ts#L132
+                        // In such cases, do not auto trigger.
+                        if (codewhispererAutoTriggerType === undefined) {
+                            return EMPTY_RESULT
+                        }
 
-                    if (
-                        isAutomaticLspTriggerKind &&
-                        codewhispererAutoTriggerType === 'Classifier' &&
-                        !autoTriggerResult.shouldTrigger &&
-                        !(editsEnabled && codeWhispererService instanceof CodeWhispererServiceToken) // There is still potentially a Edit trigger without Completion if NEP is enabled (current only BearerTokenClient)
-                    ) {
-                        return EMPTY_RESULT
+                        autoTriggerResult = autoTrigger(
+                            {
+                                fileContext, // The left/right file context and programming language
+                                lineNum: params.position.line, // the line number of the invocation, this is the line of the cursor
+                                char: triggerCharacters, // Add the character just inserted, if any, before the invication position
+                                ide: ideCategory ?? '',
+                                os: getNormalizeOsName(),
+                                previousDecision, // The last decision by the user on the previous invocation
+                                triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
+                            },
+                            logging
+                        )
+
+                        if (
+                            codewhispererAutoTriggerType === 'Classifier' &&
+                            !autoTriggerResult.shouldTrigger &&
+                            !(editsEnabled && codeWhispererService instanceof CodeWhispererServiceToken) // There is still potentially a Edit trigger without Completion if NEP is enabled (current only BearerTokenClient)
+                        ) {
+                            return EMPTY_RESULT
+                        }
                     }
 
                     // Get supplemental context from recent edits if available.
@@ -367,7 +372,7 @@ export const CodewhispererServerFactory =
                                 (isAutomaticLspTriggerKind && codewhispererAutoTriggerType !== 'Classifier') ||
                                 (isAutomaticLspTriggerKind &&
                                     codewhispererAutoTriggerType === 'Classifier' &&
-                                    autoTriggerResult.shouldTrigger)
+                                    autoTriggerResult?.shouldTrigger)
                             ) {
                                 predictionTypes.push(['COMPLETIONS'])
                             }

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
@@ -400,7 +400,6 @@ describe('Telemetry', () => {
                 assert(currentSession)
                 assert.equal(currentSession?.state, 'CLOSED')
                 sinon.assert.calledOnceWithExactly(sessionManagerSpy.closeSession, currentSession)
-                const classifierResult = getNormalizeOsName() !== 'Linux' ? -0.9083073111924993 : -0.8524073111924992
 
                 const expectedUserTriggerDecisionMetric = aUserTriggerDecision({
                     startPosition: { line: 0, character: 0 },
@@ -448,6 +447,7 @@ describe('Telemetry', () => {
                     autoTriggerType: undefined,
                     triggerCharacter: '',
                     classifierResult: undefined,
+                    classifierThreshold: undefined,
                     requestContext: {
                         fileContext: {
                             filename: 'test.cs',

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
@@ -447,7 +447,7 @@ describe('Telemetry', () => {
                     triggerType: 'OnDemand',
                     autoTriggerType: undefined,
                     triggerCharacter: '',
-                    classifierResult: classifierResult,
+                    classifierResult: undefined,
                     requestContext: {
                         fileContext: {
                             filename: 'test.cs',


### PR DESCRIPTION
## Problem

Previously auto trigger and manual trigger are not separated in if-else branches. They are entangled.

## Solution

Perform auto trigger logic under the `if (isAutomaticLspTriggerKind) {` branch

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
