### PR TITLE
fix(amazonq): fix the issue that invalid image notification always show

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -776,20 +776,22 @@ export const createMynahUi = (
                 mynahUi.addCustomContextToPrompt(tabId, commands, insertPosition)
             }
 
-            const imageVerificationBanner: Partial<ChatItem> = {
-                messageId: 'image-verification-banner',
-                header: {
-                    icon: 'warning',
-                    iconStatus: 'warning',
-                    body: '### Invalid Image',
-                },
-                body: `${errors.join('\n')}`,
-                canBeDismissed: true,
-            }
+            if (errors.length > 0) {
+                const imageVerificationBanner: Partial<ChatItem> = {
+                    messageId: 'image-verification-banner',
+                    header: {
+                        icon: 'warning',
+                        iconStatus: 'warning',
+                        body: '### Invalid Image',
+                    },
+                    body: `${errors.join('\n')}`,
+                    canBeDismissed: true,
+                }
 
-            mynahUi.updateStore(tabId, {
-                promptInputStickyCard: imageVerificationBanner,
-            })
+                mynahUi.updateStore(tabId, {
+                    promptInputStickyCard: imageVerificationBanner,
+                })
+            }
         },
     }
 


### PR DESCRIPTION
## Problem

Invalid Image notification shown even all dropped images are valid.

<img width="572" height="768" alt="Screenshot 2025-07-29 at 3 56 37 PM" src="https://github.com/user-attachments/assets/9b42b33c-5afb-40ff-9389-f95c443a63f9" />


## Solution
Add conditional check to only show the notification when there are more than one errors

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
