### PR TITLE
fix: adjust cross file context config

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/models/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/models/constants.ts
@@ -14,10 +14,11 @@ export const supplementalContextMaxTotalLength = 20480
 
 export const supplementalContextTimeoutInMs = 100
 
+// reference: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/models/constants.ts#L827
 export const crossFileContextConfig = {
     numberOfChunkToFetch: 60,
     topK: 3,
-    numberOfLinesEachChunk: 10,
+    numberOfLinesEachChunk: 50,
     maximumTotalLength: 20480,
     maxLengthEachChunk: 10240,
     maxContextCount: 5,


### PR DESCRIPTION
## Problem

1. Config is incorrect.

2. Found another problem. The workspace.getAllTextDocuments() API only returns the open tabs that were clicked during this IDE session. If you open, close, reopen IDE, this API returns empty unless user re-click those files again.

## Solution


1. Correct the config
2. Fix the bug later.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
