### PR TITLE
feat(amazonq): index images from workspace

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
@@ -504,13 +504,27 @@ export class AdditionalContextProvider {
             .filter(item => item.label === 'image')
             .filter(item => !contextImages.find(ctx => ctx.description === item.description))
 
+        const buildPath = (route: string[] | undefined) => {
+            if (!route?.length) return ''
+            if (route.length === 1) return route[0]
+            if (route.length === 2) return `${route[0]}/${route[1]}`
+            return ''
+        }
+
+        const buildRelativePath = (route: string[] | undefined) => {
+            if (!route?.length) return ''
+            if (route.length === 1) return route[0]
+            if (route.length === 2) return route[1]
+            return ''
+        }
+
         const toEntry = (item: any, pinned: boolean) => ({
             name: item.command?.substring(0, additionalContentNameLimit) ?? '',
             description: item.description ?? '',
             innerContext: '',
             type: 'image',
-            path: item.route?.[0] ?? '',
-            relativePath: item.route?.[0] ?? '',
+            path: buildPath(item.route),
+            relativePath: buildRelativePath(item.route),
             startLine: -1,
             endLine: -1,
             pinned,
@@ -538,7 +552,10 @@ export class AdditionalContextProvider {
         for (const context of mergedContext) {
             if (context.label === 'image' && context.route && context.route.length > 0) {
                 try {
-                    const imagePath = context.route[0]
+                    // Route array handling:
+                    // Selected from file dialog: size 1 = full path ["/User/image.jpg"]
+                    // From workspaceL size 2 = ["/User", "image.jpg"]
+                    const imagePath = context.route.join('/')
                     let format = imagePath.split('.').pop()?.toLowerCase() || ''
                     // Both .jpg and .jpeg files use the exact same JPEG compression algorithm and file structure.
                     if (format === 'jpg') {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -197,6 +197,12 @@ export class ContextCommandsProvider implements Disposable {
                     label: 'code',
                     icon: 'code-block',
                 })
+            } else if (item.type === 'image') {
+                fileCmds.push({
+                    ...baseItem,
+                    label: 'image',
+                    icon: 'image',
+                })
             }
         }
         const userPromptsItem = await this.getUserPromptsCommand()


### PR DESCRIPTION
## Problem
When there are images from workspace, the images do not have correct icon and images can be added to context but cannot be processed correctly

<img width="526" height="504" alt="Screenshot 2025-07-30 at 4 22 36 PM" src="https://github.com/user-attachments/assets/df647d26-9bac-473e-81bb-74b02c2231b3" />

## Solution

With the change in workspace indexing logic, the image command item with label of `image` can be indexed correctly, and the route array with size 2 can be processed.

<img width="479" height="805" alt="CR-211654438" src="https://github.com/user-attachments/assets/50670d04-fc63-4aec-a24e-09c15808451e" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
