### PR TITLE
feat: add shared config file watcher

### DIFF
--- a/server/aws-lsp-identity/src/iam/utils.ts
+++ b/server/aws-lsp-identity/src/iam/utils.ts
@@ -7,6 +7,7 @@ import {
     GetMfaCodeResult,
     IamCredentials,
     Profile,
+    ProfileChangedParams,
     StsCredentialChangedParams,
 } from '@aws/language-server-runtimes/server-interface'
 import { AwsError, Observability } from '@aws/lsp-core'
@@ -97,6 +98,7 @@ export type CredentialProviders = {
 
 export type SendGetMfaCode = (params: GetMfaCodeParams) => Promise<GetMfaCodeResult>
 export type SendStsCredentialChanged = (params: StsCredentialChangedParams) => void
+export type SendProfileChanged = (params: ProfileChangedParams) => void
 
 export type IamHandlers = {
     sendGetMfaCode: SendGetMfaCode

--- a/server/aws-lsp-identity/src/language-server/profiles/profileWatcher.test.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/profileWatcher.test.ts
@@ -1,0 +1,54 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import mock = require('mock-fs')
+import { ProfileData, ProfileStore } from './profileService'
+import { Logging, Telemetry } from '@aws/language-server-runtimes/server-interface'
+import { SinonSpy, spy } from 'sinon'
+import { StubbedInstance, stubInterface } from 'ts-sinon'
+import { use } from 'chai'
+import { Observability } from '@aws/lsp-core'
+import { ProfileWatcher } from './profileWatcher'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+use(require('chai-as-promised'))
+
+let sut: ProfileWatcher
+
+let store: StubbedInstance<ProfileStore>
+let sendProfileChangedSpy: SinonSpy
+let observability: StubbedInstance<Observability>
+
+describe('ProfileWatcher', async () => {
+    beforeEach(() => {
+        store = stubInterface<ProfileStore>({
+            load: Promise.resolve({
+                profiles: [],
+                ssoSessions: [],
+            } satisfies ProfileData),
+            save: Promise.resolve(),
+        })
+
+        sendProfileChangedSpy = spy()
+
+        observability = stubInterface<Observability>()
+        observability.logging = stubInterface<Logging>()
+        observability.telemetry = stubInterface<Telemetry>()
+
+        sut = new ProfileWatcher(store, sendProfileChangedSpy, observability)
+    })
+
+    afterEach(() => {
+        mock.restore()
+    })
+
+    it('should watch without errors when called multiple times', () => {
+        sut.watch()
+        sut.watch()
+    })
+
+    it('should unwatch without errors when called multiple times', () => {
+        sut.watch()
+        sut.watch()
+    })
+
+    // TODO: figure out how to mock fs.watch and setTimeout for notification calls
+})

--- a/server/aws-lsp-identity/src/language-server/profiles/profileWatcher.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/profileWatcher.ts
@@ -38,7 +38,7 @@ export class ProfileWatcher implements Disposable {
         this.fileWatchers = []
     }
 
-    private onFileChange() {
+    onFileChange() {
         // Reset the debounce time if this change occurred shortly after previous change
         if (this.debounceTimeout) {
             clearTimeout(this.debounceTimeout)

--- a/server/aws-lsp-identity/src/language-server/profiles/profileWatcher.ts
+++ b/server/aws-lsp-identity/src/language-server/profiles/profileWatcher.ts
@@ -1,0 +1,72 @@
+import { FSWatcher, watch } from 'fs'
+import { SendProfileChanged } from '../../iam/utils'
+import { ProfileStore } from './profileService'
+import { Observability } from '@aws/lsp-core'
+import { getHomeDir } from '@smithy/shared-ini-file-loader'
+import { join } from 'path'
+
+// Minimum period between file changes to send updated profile notifications
+export const fileDebounceMillis = 500
+
+export class ProfileWatcher implements Disposable {
+    private fileWatchers: FSWatcher[] = []
+    private debounceTimeout?: NodeJS.Timeout
+
+    constructor(
+        private profileStore: ProfileStore,
+        private readonly raiseProfileChanged: SendProfileChanged,
+        private readonly observability: Observability
+    ) {}
+
+    [Symbol.dispose](): void {
+        this.unwatch()
+    }
+
+    watch(): void {
+        if (this.fileWatchers.length > 0) {
+            return
+        }
+
+        const filepaths = [this.getConfigFilepath(), this.getCredentialsFilepath()]
+        for (const filepath of filepaths) {
+            this.fileWatchers.push(watch(filepath, { persistent: false }, this.onFileChange.bind(this)))
+        }
+    }
+
+    unwatch(): void {
+        this.fileWatchers.forEach(watcher => watcher.close())
+        this.fileWatchers = []
+    }
+
+    private onFileChange() {
+        // Reset the debounce time if this change occurred shortly after previous change
+        if (this.debounceTimeout) {
+            clearTimeout(this.debounceTimeout)
+        }
+        // Send profile change notification after debounce time elapses
+        this.debounceTimeout = setTimeout(async () => {
+            try {
+                const response = await this.profileStore.load()
+                this.raiseProfileChanged(response)
+            } catch (error) {
+                this.observability.logging.log(`Error reloading profiles: ${error}`)
+            }
+        }, fileDebounceMillis)
+    }
+
+    private getConfigFilepath(): string {
+        const envVar = process.env['AWS_CONFIG_FILE']
+        if (envVar) {
+            return envVar.startsWith('~/') ? join(getHomeDir(), envVar.substring(2)) : envVar
+        }
+        return join(getHomeDir(), '.aws', 'config')
+    }
+
+    private getCredentialsFilepath(): string {
+        const envVar = process.env['AWS_SHARED_CREDENTIALS_FILE']
+        if (envVar) {
+            return envVar.startsWith('~/') ? join(getHomeDir(), envVar.substring(2)) : envVar
+        }
+        return join(getHomeDir(), '.aws', 'credentials')
+    }
+}


### PR DESCRIPTION
## Problem
To reach feature parity with the Toolkits and allow them to automatically refresh their profile UI, Flare should send notifications to the language client when the shared config files change.

## Solution
This is part of https://github.com/aws/language-servers/pull/1981.

This PR allows the identity LSP to send notifications containing profile data whenever the shared config files change.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
