### PR TITLE
fix(amazonq): fix for mcp server permissions

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -1174,11 +1174,6 @@ export class McpEventHandler {
      * Applies the stored permission changes
      */
     async #handleSavePermissionChange(params: McpServerClickParams) {
-        if (!params.optionsValues) {
-            return this.#getDefaultMcpResponse(params.id)
-        }
-        const selectedTransport = params.optionsValues.transport
-
         if (!this.#pendingPermissionConfig) {
             this.#features.logging.warn('No pending permission changes to save')
             return { id: params.id }
@@ -1198,10 +1193,11 @@ export class McpEventHandler {
             const serverConfig = McpManager.instance.getAllServerConfigs().get(serverName)
             if (serverConfig) {
                 // Emit server initialize event after permission change
+                const transportType = serverConfig.command ? 'stdio' : 'http'
                 this.#telemetryController?.emitMCPServerInitializeEvent({
                     source: 'updatePermission',
-                    command: selectedTransport === 'stdio' ? params.optionsValues.command : undefined,
-                    url: selectedTransport === 'http' ? params.optionsValues.url : undefined,
+                    command: transportType === 'stdio' ? serverConfig.command : undefined,
+                    url: transportType === 'http' ? serverConfig.url : undefined,
                     enabled: true,
                     numTools: McpManager.instance.getAllToolsWithPermissions(serverName).length,
                     scope:
@@ -1209,7 +1205,7 @@ export class McpEventHandler {
                         getGlobalAgentConfigPath(this.#features.workspace.fs.getUserHomeDir())
                             ? 'global'
                             : 'workspace',
-                    transportType: selectedTransport,
+                    transportType: transportType,
                     languageServerVersion: this.#features.runtime.serverInfo.version,
                 })
             }


### PR DESCRIPTION
## Problem
MCP server permissions save has seen regression due to recent changes.

## Solution
fixed the permission save for mcp server tools and its telemetry

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
