### PR TITLE
fix: Enable Test Flag For AmazonQ UI Testing

### DIFF
--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -810,6 +810,7 @@ export const createMynahUi = (
         },
         config: {
             maxTabs: 10,
+            test: true,
             dragOverlayIcon: MynahIcons.IMAGE,
             texts: {
                 ...uiComponentsTexts,


### PR DESCRIPTION
## Problem

Currently, the Mynah-UI elements do not show `data-testid` at the production level of Amazon Q. This makes UI Tests very flakey because we have to rely on CSS Selectors to grab Mynah-UI elements, and these CSS Selectors can be shared across multiple different elements.

## Solution

In `mynahUI.ts` we set `test:true` so `data-testid` will show at production level. Now instead of using CSS Selectors, test writers can grab the `data-testid`

```
const mynahUiProps: MynahUIProps = {
        ...
        config: {
            maxTabs: 10,
            test: true,
        ...
```

<img width="421" height="34" alt="Screenshot 2025-08-04 at 2 12 59 PM" src="https://github.com/user-attachments/assets/9bce3823-910a-41ae-9a8a-1473bf87d410" /> <br/>

_This is the code in Mynah-UI that turns on test-ids when test config is set to `true`_
https://github.com/aws/mynah-ui/blob/main/src/helper/dom.ts#L264


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
