### PR TITLE
fix: outdated history when trimming happens, add missing metric for compaction

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1021,11 +1021,8 @@ export class AgenticChatController implements ChatHandlers {
         if (currentMessage) {
             //  Get and process the messages from history DB to maintain invariants for service requests
             try {
-                const { messages: historyMessages, count: historyCharCount } = this.#chatHistoryDb.fixAndGetHistory(
-                    tabId,
-                    currentMessage,
-                    []
-                )
+                const { history: historyMessages, historyCount: historyCharCount } =
+                    this.#chatHistoryDb.fixAndGetHistory(tabId, conversationIdentifier ?? '', currentMessage, [])
                 messages = historyMessages
                 characterCount = historyCharCount
             } catch (err) {
@@ -1199,19 +1196,18 @@ export class AgenticChatController implements ChatHandlers {
             if (currentMessage) {
                 //  Get and process the messages from history DB to maintain invariants for service requests
                 try {
-                    const newUserInputCount = this.#chatHistoryDb.calculateNewMessageCharacterCount(
+                    const {
+                        history: historyMessages,
+                        historyCount: historyCharacterCount,
+                        currentCount: currentInputCount,
+                    } = this.#chatHistoryDb.fixAndGetHistory(
+                        tabId,
+                        conversationId,
                         currentMessage,
                         pinnedContextMessages
                     )
-                    const { messages: historyMessages, count: historyCharacterCount } =
-                        this.#chatHistoryDb.fixAndGetHistory(
-                            tabId,
-                            currentMessage,
-                            pinnedContextMessages,
-                            newUserInputCount
-                        )
                     messages = historyMessages
-                    currentRequestCount = newUserInputCount + historyCharacterCount
+                    currentRequestCount = currentInputCount + historyCharacterCount
                     this.#debug(`Request total character count: ${currentRequestCount}`)
                 } catch (err) {
                     if (err instanceof ToolResultValidationError) {
@@ -1437,6 +1433,10 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         if (this.#shouldCompact(currentRequestCount)) {
+            this.#telemetryController.emitCompactNudge(
+                currentRequestCount,
+                this.#features.runtime.serverInfo.version ?? ''
+            )
             const messageId = this.#getMessageIdForCompact(uuid())
             const confirmationResult = this.#processCompactConfirmation(messageId, currentRequestCount)
             const cachedButtonBlockId = await chatResultStream.writeResultBlock(confirmationResult)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
@@ -91,6 +91,30 @@ describe('ChatDatabase', () => {
         })
     })
 
+    describe('replaceHistory', () => {
+        it('should replace history with messages', async () => {
+            await chatDb.databaseInitialize(0)
+            const tabId = 'tab-1'
+            const tabType = 'cwc'
+            const conversationId = 'conv-1'
+            const messages = [
+                { body: 'Test', type: 'prompt' as any, timestamp: new Date() },
+                { body: 'Thinking...', type: 'answer', timestamp: new Date() },
+            ]
+
+            // Call the method
+            chatDb.replaceHistory(tabId, tabType, conversationId, messages)
+
+            // Verify the messages array contains the summary and a dummy response
+            const messagesFromDb = chatDb.getMessages(tabId, 250)
+            assert.strictEqual(messagesFromDb.length, 2)
+            assert.strictEqual(messagesFromDb[0].body, 'Test')
+            assert.strictEqual(messagesFromDb[0].type, 'prompt')
+            assert.strictEqual(messagesFromDb[1].body, 'Thinking...')
+            assert.strictEqual(messagesFromDb[1].type, 'answer')
+        })
+    })
+
     describe('ensureValidMessageSequence', () => {
         it('should preserve valid alternating sequence', () => {
             const messages: Message[] = [

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/util.ts
@@ -126,8 +126,9 @@ export type TabWithDbMetadata = {
 export type DbReference = { collection: Collection<Tab>; db: Loki }
 
 export type MessagesWithCharacterCount = {
-    messages: Message[]
-    count: number
+    history: Message[]
+    historyCount: number
+    currentCount: number
 }
 
 /**

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -226,6 +226,18 @@ export class ChatTelemetryController {
             data: {
                 type,
                 characters,
+                credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
+                languageServerVersion: languageServerVersion,
+            },
+        })
+    }
+
+    public emitCompactNudge(characters: number, languageServerVersion: string) {
+        this.#telemetry.emitMetric({
+            name: ChatTelemetryEventName.CompactNudge,
+            data: {
+                characters,
+                credentialStartUrl: this.#credentialsProvider.getConnectionMetadata()?.sso?.startUrl,
                 languageServerVersion: languageServerVersion,
             },
         })

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -206,6 +206,7 @@ export enum ChatTelemetryEventName {
     MCPServerInit = 'amazonq_mcpServerInit',
     LoadHistory = 'amazonq_loadHistory',
     CompactHistory = 'amazonq_compactHistory',
+    CompactNudge = 'amazonq_compactNudge',
     ChatHistoryAction = 'amazonq_performChatHistoryAction',
     ExportTab = 'amazonq_exportTab',
     UiClick = 'ui_click',
@@ -231,6 +232,7 @@ export interface ChatTelemetryEventMap {
     [ChatTelemetryEventName.MCPServerInit]: MCPServerInitializeEvent
     [ChatTelemetryEventName.LoadHistory]: LoadHistoryEvent
     [ChatTelemetryEventName.CompactHistory]: CompactHistoryEvent
+    [ChatTelemetryEventName.CompactNudge]: CompactNudgeEvent
     [ChatTelemetryEventName.ChatHistoryAction]: ChatHistoryActionEvent
     [ChatTelemetryEventName.ExportTab]: ExportTabEvent
     [ChatTelemetryEventName.UiClick]: UiClickEvent
@@ -392,6 +394,13 @@ export type LoadHistoryEvent = {
 export type CompactHistoryEvent = {
     type: CompactHistoryActionType
     characters: number
+    credentialStartUrl?: string
+    languageServerVersion?: string
+}
+
+export type CompactNudgeEvent = {
+    characters: number
+    credentialStartUrl?: string
     languageServerVersion?: string
 }
 


### PR DESCRIPTION
## Problem
- History is not updated when trimming happens, causing follow up request to throw ValidationException
- Bug in calculating context window when history trimming happened
- Missing metric for compaction 
## Solution
- Update history when trimming happens
- Fix a bug in calculating character count causing compaction nudge to show when history is trimmed
- Add missing metric for compaction


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
