### PR TITLE
feat(amazonq): read tool message revamp

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -27,7 +27,7 @@
         "@aws/chat-client-ui-types": "^0.1.56",
         "@aws/language-server-runtimes": "^0.2.121",
         "@aws/language-server-runtimes-types": "^0.1.50",
-        "@aws/mynah-ui": "^4.36.2"
+        "@aws/mynah-ui": "^4.36.3"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1330,7 +1330,7 @@ export const createMynahUi = (
         isPairProgrammingMode: boolean,
         isPartialResult?: boolean
     ): Partial<ChatItem> => {
-        const contextHeader = contextListToHeader(message.contextList)
+        const contextHeader = message.type !== 'tool' ? contextListToHeader(message.contextList) : undefined
         const header = contextHeader || toMynahHeader(message.header) // Is this mutually exclusive?
         const fileList = toMynahFileList(message.fileList)
 
@@ -1353,10 +1353,15 @@ export const createMynahUi = (
                     fileTreeTitle: '',
                     hideFileCount: true,
                     details: toDetailsWithoutIcon(header.fileList.details),
+                    renderAsPills:
+                        !header.fileList.details ||
+                        (Object.values(header.fileList.details).every(detail => !detail.changes) &&
+                            (!header.buttons || !header.buttons.some(button => button.id === 'undo-changes')) &&
+                            !header.status?.icon),
                 }
             }
             if (!isPartialResult) {
-                if (processedHeader) {
+                if (processedHeader && !message.header?.status) {
                     processedHeader.status = undefined
                 }
             }
@@ -1369,7 +1374,8 @@ export const createMynahUi = (
                 processedHeader.buttons !== null &&
                 processedHeader.buttons.length > 0) ||
                 processedHeader.status !== undefined ||
-                processedHeader.icon !== undefined)
+                processedHeader.icon !== undefined ||
+                processedHeader.fileList !== undefined)
 
         const padding =
             message.type === 'tool' ? (fileList ? true : message.messageId?.endsWith('_permission')) : undefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,7 +257,7 @@
                 "@aws/chat-client-ui-types": "^0.1.56",
                 "@aws/language-server-runtimes": "^0.2.121",
                 "@aws/language-server-runtimes-types": "^0.1.50",
-                "@aws/mynah-ui": "^4.36.2"
+                "@aws/mynah-ui": "^4.36.3"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4204,9 +4204,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.36.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.36.2.tgz",
-            "integrity": "sha512-3ibfK2CTj7dlFFdgTIE1DdEyDpy+P3hdP/Fmlx76T9GGSYiGHqwunDSi59L1P61Kj46WADBrQ52mLUQ6FR8Rzg==",
+            "version": "4.36.3",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.36.3.tgz",
+            "integrity": "sha512-E8V65uPUlz2aoN1J21Tg2G3NyExL/glS6dceiTDtKh5me1uoPtxQaTecMqF5LMVfoaE9C0wzAtu/U6GkuZvlMg==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -450,7 +450,7 @@ describe('AgenticChatController', () => {
 
             assert.deepStrictEqual(chatResult, {
                 additionalMessages: [],
-                body: '\n\nHello World!',
+                body: '\nHello World!',
                 messageId: 'mock-message-id',
                 buttons: [],
                 codeReference: [],
@@ -1140,7 +1140,7 @@ describe('AgenticChatController', () => {
             sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 1) // response length + 1 loading messages
             assert.deepStrictEqual(chatResult, {
                 additionalMessages: [],
-                body: '\n\nHello World!',
+                body: '\nHello World!',
                 messageId: 'mock-message-id',
                 codeReference: [],
                 buttons: [],
@@ -1159,7 +1159,7 @@ describe('AgenticChatController', () => {
             sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 1) // response length + 1 loading message
             assert.deepStrictEqual(chatResult, {
                 additionalMessages: [],
-                body: '\n\nHello World!',
+                body: '\nHello World!',
                 messageId: 'mock-message-id',
                 buttons: [],
                 codeReference: [],

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1672,8 +1672,7 @@ export class AgenticChatController implements ChatHandlers {
                 // remove progress UI
                 await chatResultStream.removeResultBlockAndUpdateUI(progressPrefix + toolUse.toolUseId)
 
-                // fsRead and listDirectory write to an existing card and could show nothing in the current position
-                if (![FS_WRITE, FS_REPLACE, FS_READ, LIST_DIRECTORY].includes(toolUse.name)) {
+                if (![FS_WRITE, FS_REPLACE].includes(toolUse.name)) {
                     await this.#showUndoAllIfRequired(chatResultStream, session)
                 }
                 // fsWrite can take a long time, so we render fsWrite  Explanatory upon partial streaming responses.
@@ -1889,9 +1888,9 @@ export class AgenticChatController implements ChatHandlers {
                     case FS_READ:
                     case LIST_DIRECTORY:
                     case FILE_SEARCH:
-                        const initialListDirResult = this.#processReadOrListOrSearch(toolUse, chatResultStream)
-                        if (initialListDirResult) {
-                            await chatResultStream.writeResultBlock(initialListDirResult)
+                        const readToolResult = await this.#processReadTool(toolUse, chatResultStream)
+                        if (readToolResult) {
+                            await chatResultStream.writeResultBlock(readToolResult)
                         }
                         break
                     // no need to write tool result for listDir,fsRead,fileSearch into chat stream
@@ -2854,70 +2853,101 @@ export class AgenticChatController implements ChatHandlers {
         }
     }
 
-    #processReadOrListOrSearch(toolUse: ToolUse, chatResultStream: AgenticChatResultStream): ChatMessage | undefined {
-        let messageIdToUpdate = toolUse.toolUseId!
-        const currentId = chatResultStream.getMessageIdToUpdateForTool(toolUse.name!)
-
-        if (currentId) {
-            messageIdToUpdate = currentId
-        } else {
-            chatResultStream.setMessageIdToUpdateForTool(toolUse.name!, messageIdToUpdate)
-        }
-        let currentPaths = []
+    async #processReadTool(
+        toolUse: ToolUse,
+        chatResultStream: AgenticChatResultStream
+    ): Promise<ChatMessage | undefined> {
+        let currentPaths: string[] = []
         if (toolUse.name === FS_READ) {
-            currentPaths = (toolUse.input as unknown as FsReadParams)?.paths
+            currentPaths = (toolUse.input as unknown as FsReadParams)?.paths || []
+        } else if (toolUse.name === LIST_DIRECTORY) {
+            const singlePath = (toolUse.input as unknown as ListDirectoryParams)?.path
+            if (singlePath) {
+                currentPaths = [singlePath]
+            }
+        } else if (toolUse.name === FILE_SEARCH) {
+            const queryName = (toolUse.input as unknown as FileSearchParams)?.queryName
+            if (queryName) {
+                currentPaths = [queryName]
+            }
         } else {
-            currentPaths.push((toolUse.input as unknown as ListDirectoryParams | FileSearchParams)?.path)
+            return
         }
 
-        if (!currentPaths) return
+        if (currentPaths.length === 0) return
 
-        for (const currentPath of currentPaths) {
-            const existingPaths = chatResultStream.getMessageOperation(messageIdToUpdate)?.filePaths || []
-            // Check if path already exists in the list
-            const isPathAlreadyProcessed = existingPaths.some(path => path.relativeFilePath === currentPath)
-            if (!isPathAlreadyProcessed) {
-                const currentFileDetail = {
-                    relativeFilePath: currentPath,
-                    lineRanges: [{ first: -1, second: -1 }],
-                }
-                chatResultStream.addMessageOperation(messageIdToUpdate, toolUse.name!, [
-                    ...existingPaths,
-                    currentFileDetail,
-                ])
+        // Check if the last message is the same tool type
+        const lastMessage = chatResultStream.getLastMessage()
+        const isSameToolType =
+            lastMessage?.type === 'tool' && lastMessage.header?.icon === this.#toolToIcon(toolUse.name)
+
+        let allPaths = currentPaths
+
+        if (isSameToolType && lastMessage.messageId) {
+            // Combine with existing paths and overwrite the last message
+            const existingPaths = lastMessage.header?.fileList?.filePaths || []
+            allPaths = [...existingPaths, ...currentPaths]
+
+            const blockId = chatResultStream.getMessageBlockId(lastMessage.messageId)
+            if (blockId !== undefined) {
+                // Create the updated message with combined paths
+                const updatedMessage = this.#createFileListToolMessage(toolUse, allPaths, lastMessage.messageId)
+                // Overwrite the existing block
+                await chatResultStream.overwriteResultBlock(updatedMessage, blockId)
+                return undefined // Don't return a message since we already wrote it
             }
         }
+
+        // Create new message with current paths
+        return this.#createFileListToolMessage(toolUse, allPaths, toolUse.toolUseId!)
+    }
+
+    #createFileListToolMessage(toolUse: ToolUse, filePaths: string[], messageId: string): ChatMessage {
+        const itemCount = filePaths.length
         let title: string
-        const itemCount = chatResultStream.getMessageOperation(messageIdToUpdate)?.filePaths.length
-        const filePathsPushed = chatResultStream.getMessageOperation(messageIdToUpdate)?.filePaths ?? []
-        if (!itemCount) {
+        if (itemCount === 0) {
             title = 'Gathering context'
         } else {
             title =
                 toolUse.name === FS_READ
                     ? `${itemCount} file${itemCount > 1 ? 's' : ''} read`
                     : toolUse.name === FILE_SEARCH
-                      ? `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} searched`
-                      : `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} listed`
+                      ? `${itemCount} pattern${itemCount > 1 ? 's' : ''} searched`
+                      : toolUse.name === LIST_DIRECTORY
+                        ? `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} listed`
+                        : ''
         }
         const details: Record<string, FileDetails> = {}
-        for (const item of filePathsPushed) {
-            details[item.relativeFilePath] = {
-                lineRanges: item.lineRanges,
-                description: item.relativeFilePath,
+        for (const filePath of filePaths) {
+            details[filePath] = {
+                description: filePath,
+                visibleName: path.basename(filePath),
             }
-        }
-
-        const fileList: FileList = {
-            rootFolderTitle: title,
-            filePaths: filePathsPushed.map(item => item.relativeFilePath),
-            details,
         }
         return {
             type: 'tool',
-            fileList,
-            messageId: messageIdToUpdate,
-            body: '',
+            header: {
+                body: title,
+                icon: this.#toolToIcon(toolUse.name),
+                fileList: {
+                    filePaths,
+                    details,
+                },
+            },
+            messageId,
+        }
+    }
+
+    #toolToIcon(toolName: string | undefined): string | undefined {
+        switch (toolName) {
+            case FS_READ:
+                return 'eye'
+            case LIST_DIRECTORY:
+                return 'check-list'
+            case FILE_SEARCH:
+                return 'search'
+            default:
+                return undefined
         }
     }
 
@@ -2933,14 +2963,7 @@ export class AgenticChatController implements ChatHandlers {
             return undefined
         }
 
-        let messageIdToUpdate = toolUse.toolUseId!
-        const currentId = chatResultStream.getMessageIdToUpdateForTool(toolUse.name!)
-
-        if (currentId) {
-            messageIdToUpdate = currentId
-        } else {
-            chatResultStream.setMessageIdToUpdateForTool(toolUse.name!, messageIdToUpdate)
-        }
+        const messageIdToUpdate = toolUse.toolUseId!
 
         // Extract search results from the tool output
         const output = result.output.content as SanitizedRipgrepOutput

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -1,4 +1,4 @@
-import { ChatResult, FileDetails, ChatMessage } from '@aws/language-server-runtimes/protocol'
+import { ChatResult, ChatMessage } from '@aws/language-server-runtimes/protocol'
 import { randomUUID } from 'crypto'
 
 export interface ResultStreamWriter {
@@ -32,33 +32,20 @@ export interface ResultStreamWriter {
     close(): Promise<void>
 }
 
+export const progressPrefix = 'progress_'
+
 /**
  * This class wraps around lsp.sendProgress to provide a more helpful interface for streaming a ChatResult to the client.
  * ChatResults are grouped into blocks that can be written directly, or streamed in.
  * In the final message, blocks are seperated by resultDelimiter defined below.
  */
-
-interface FileDetailsWithPath extends FileDetails {
-    relativeFilePath: string
-}
-
-type OperationType = 'read' | 'write' | 'listDir'
-
-export const progressPrefix = 'progress_'
-
-interface FileOperation {
-    type: OperationType
-    filePaths: FileDetailsWithPath[]
-}
 export class AgenticChatResultStream {
-    static readonly resultDelimiter = '\n\n'
+    static readonly resultDelimiter = '\n'
     #state = {
         chatResultBlocks: [] as ChatMessage[],
         isLocked: false,
         uuid: randomUUID(),
         messageId: undefined as string | undefined,
-        messageIdToUpdateForTool: new Map<OperationType, string>(),
-        messageOperations: new Map<string, FileOperation>(),
     }
     readonly #sendProgress: (newChatResult: ChatResult | string) => Promise<void>
 
@@ -68,33 +55,6 @@ export class AgenticChatResultStream {
 
     getResult(only?: string): ChatResult {
         return this.#joinResults(this.#state.chatResultBlocks, only)
-    }
-
-    setMessageIdToUpdateForTool(toolName: string, messageId: string) {
-        this.#state.messageIdToUpdateForTool.set(toolName as OperationType, messageId)
-    }
-
-    getMessageIdToUpdateForTool(toolName: string): string | undefined {
-        return this.#state.messageIdToUpdateForTool.get(toolName as OperationType)
-    }
-
-    /**
-     * Adds a file operation for a specific message
-     * @param messageId The ID of the message
-     * @param type The type of operation ('fsRead' or 'listDirectory' or 'fsWrite')
-     * @param filePaths Array of FileDetailsWithPath involved in the operation
-     */
-    addMessageOperation(messageId: string, type: string, filePaths: FileDetailsWithPath[]) {
-        this.#state.messageOperations.set(messageId, { type: type as OperationType, filePaths })
-    }
-
-    /**
-     * Gets the file operation details for a specific message
-     * @param messageId The ID of the message
-     * @returns The file operation details or undefined if not found
-     */
-    getMessageOperation(messageId: string): FileOperation | undefined {
-        return this.#state.messageOperations.get(messageId)
     }
 
     #joinResults(chatResults: ChatMessage[], only?: string): ChatResult {
@@ -111,7 +71,7 @@ export class AgenticChatResultStream {
                     return {
                         ...acc,
                         buttons: [...(acc.buttons ?? []), ...(c.buttons ?? [])],
-                        body: acc.body + AgenticChatResultStream.resultDelimiter + c.body,
+                        body: acc.body + (c.body ? AgenticChatResultStream.resultDelimiter + c.body : ''),
                         ...(c.contextList && { contextList: c.contextList }),
                         header: Object.prototype.hasOwnProperty.call(c, 'header') ? c.header : acc.header,
                         codeReference: [...(acc.codeReference ?? []), ...(c.codeReference ?? [])],
@@ -127,7 +87,7 @@ export class AgenticChatResultStream {
                                     : am.buttons,
                             body:
                                 am.messageId === c.messageId
-                                    ? am.body + AgenticChatResultStream.resultDelimiter + c.body
+                                    ? am.body + (c.body ? AgenticChatResultStream.resultDelimiter + c.body : '')
                                     : am.body,
                             ...(am.messageId === c.messageId &&
                                 (c.contextList || acc.contextList) && {
@@ -244,6 +204,10 @@ export class AgenticChatResultStream {
             }
         }
         return undefined
+    }
+
+    getLastMessage(): ChatMessage {
+        return this.#state.chatResultBlocks[this.#state.chatResultBlocks.length - 1]
     }
 
     getResultStreamWriter(): ResultStreamWriter {


### PR DESCRIPTION
## Problem

Read/List/Search messages are combined in the same component as the conversation continues, making it easy to miss tool executions as new messages are added.

## Solution

New UI for Read/List/Search messages:
- Files are shown as pills instead of a file tree
- Updating existing message only happens if the previous message and current message are the same tool type, preventing updating messages that are earlier in the conversation.
<img width="626" height="682" alt="image" src="https://github.com/user-attachments/assets/4a0d648d-45d3-47dc-b54b-33b8156dee3a" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
