### PR TITLE
fix: should keep reporting UTDE telemetry if there are still pending …

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -680,6 +680,7 @@ export const CodewhispererServerFactory =
                     partialResultToken: suggestionResponse.responseContext.nextToken,
                 }
             } else {
+                session.hasEditsPending = suggestionResponse.responseContext.nextToken ? true : false
                 return {
                     items: suggestionResponse.suggestions
                         .map(suggestion => {
@@ -866,7 +867,13 @@ export const CodewhispererServerFactory =
             if (firstCompletionDisplayLatency) emitPerceivedLatencyTelemetry(telemetry, session)
 
             // Always emit user trigger decision at session close
-            sessionManager.closeSession(session)
+            // Close session unless Edit suggestion was accepted with more pending
+            const shouldKeepSessionOpen =
+                session.suggestionType === SuggestionType.EDIT && isAccepted && session.hasEditsPending
+
+            if (!shouldKeepSessionOpen) {
+                sessionManager.closeSession(session)
+            }
             const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(isAccepted) : 0
             await emitUserTriggerDecisionTelemetry(
                 telemetry,

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
@@ -6,7 +6,12 @@ import {
 } from '@aws/language-server-runtimes/server-interface'
 import { v4 as uuidv4 } from 'uuid'
 import { CodewhispererAutomatedTriggerType, CodewhispererTriggerType } from '../auto-trigger/autoTrigger'
-import { GenerateSuggestionsRequest, ResponseContext, Suggestion } from '../../../shared/codeWhispererService'
+import {
+    GenerateSuggestionsRequest,
+    ResponseContext,
+    Suggestion,
+    SuggestionType,
+} from '../../../shared/codeWhispererService'
 import { CodewhispererLanguage } from '../../../shared/languageDetection'
 import { CodeWhispererSupplementalContext } from '../../../shared/models/model'
 import { Logging } from '@aws/language-server-runtimes/server-interface'
@@ -75,6 +80,9 @@ export class CodeWhispererSession {
     includeImportsWithSuggestions?: boolean
     codewhispererSuggestionImportCount: number = 0
     suggestionType?: string
+    hasEditsPending?: boolean = false
+    // Track the most recent itemId for paginated Edit suggestions
+    recentItemId?: string
 
     constructor(data: SessionData) {
         this.id = this.generateSessionId()
@@ -153,7 +161,11 @@ export class CodeWhispererSession {
         typeaheadLength?: number
     ) {
         // Skip if session results were already recorded for session of session is closed
-        if (this.state === 'CLOSED' || this.state === 'DISCARD' || this.completionSessionResult) {
+        if (
+            this.state === 'CLOSED' ||
+            this.state === 'DISCARD' ||
+            (this.completionSessionResult && this.suggestionType === SuggestionType.COMPLETION)
+        ) {
             return
         }
 
@@ -195,6 +207,8 @@ export class CodeWhispererSession {
                 // No recommendation was accepted, but user have seen this suggestion
                 this.setSuggestionState(itemId, 'Reject')
             }
+
+            this.recentItemId = itemId
         }
 
         this.firstCompletionDisplayLatency = firstCompletionDisplayLatency
@@ -239,6 +253,24 @@ export class CodeWhispererSession {
             }
         }
         return isEmpty ? 'Empty' : 'Discard'
+    }
+
+    /**
+     * Determines trigger decision based on the most recent user action.
+     * Uses the last processed itemId to determine the overall session decision.
+     */
+    getLatestUserTriggerDecision(): UserTriggerDecision | undefined {
+        // Force Discard trigger decision when session was explicitly discarded by server
+        if (this.state === 'DISCARD') {
+            return 'Discard'
+        }
+
+        if (!this.recentItemId) return
+
+        const state = this.getSuggestionState(this.recentItemId)
+        if (state === 'Accept') return 'Accept'
+        if (state === 'Reject') return 'Reject'
+        return state === 'Empty' ? 'Empty' : 'Discard'
     }
 }
 

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -117,7 +117,13 @@ export class TelemetryService {
 
     private getSuggestionState(session: CodeWhispererSession): SuggestionState {
         let suggestionState: SuggestionState
-        switch (session.getAggregatedUserTriggerDecision()) {
+        // Edits show one suggestion sequentially (with pagination), so use latest itemId state;
+        // Completions show multiple suggestions together, so aggregate all states
+        const userTriggerDecision =
+            session.suggestionType === SuggestionType.EDIT
+                ? session.getLatestUserTriggerDecision()
+                : session.getAggregatedUserTriggerDecision()
+        switch (userTriggerDecision) {
             case 'Accept':
                 suggestionState = 'ACCEPT'
                 break


### PR DESCRIPTION
…Edits suggestions

## Problem

Telemetry was not emitted for NEP pagination case.

## Solution

If an Edit suggestion was accepted with more pending, we should keep the session open and keep reporting UTDE telemetry. Edits show one suggestion sequentially (with pagination), so use latest itemId state. 


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
