### PR TITLE
fix(amazonq): fix flickering issue for model selection dropdown and agenticCoding toggle

### DIFF
--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -260,7 +260,8 @@ describe('MynahUI', () => {
             sinon.assert.calledThrice(updateStoreSpy)
         })
 
-        it('should create a new tab if current tab is loading', () => {
+        it('should create a new tab if current tab is loading', function (done) {
+            this.timeout(8000)
             // clear create tab stub since set up process calls it twice
             createTabStub.resetHistory()
             getAllTabsStub.returns({ 'tab-1': { store: { loadingChat: true } } })
@@ -274,6 +275,7 @@ describe('MynahUI', () => {
 
             sinon.assert.calledOnceWithExactly(createTabStub, false)
             sinon.assert.calledThrice(updateStoreSpy)
+            done()
         })
 
         it('should not create a new tab if one exists already', () => {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -151,11 +151,20 @@ export const handlePromptInputChange = (mynahUi: MynahUI, tabId: string, options
         }
     }
 
+    const updatedPromptInputOptions = promptInputOptions?.map(option => {
+        option.value = optionsValues[option.id]
+        return option
+    })
+
     mynahUi.updateStore(tabId, {
-        promptInputOptions: promptInputOptions?.map(option => {
-            option.value = optionsValues[option.id]
-            return option
-        }),
+        promptInputOptions: updatedPromptInputOptions,
+    })
+
+    // Store the updated values in tab defaults for new tabs
+    mynahUi.updateTabDefaults({
+        store: {
+            promptInputOptions: updatedPromptInputOptions,
+        },
     })
 }
 
@@ -414,6 +423,12 @@ export const createMynahUi = (
             }
 
             const tabStore = mynahUi.getTabData(tabId).getStore()
+            const storedPromptInputOptions = mynahUi.getTabDefaults().store?.promptInputOptions
+
+            // Retrieve stored model selection and pair programming mode from defaults
+            if (storedPromptInputOptions) {
+                defaultTabConfig.promptInputOptions = storedPromptInputOptions
+            }
 
             // Tabs can be opened through different methods, including server-initiated 'openTab' requests.
             // The 'openTab' request is specifically used for loading historical chat sessions with pre-existing messages.


### PR DESCRIPTION
## Problem
- If user opens a new tab, both agentic coding toggle and model selection drop down flickers.

https://github.com/user-attachments/assets/5ca2f0ca-eba7-4fcb-aa06-dd6496b7f855


## Solution
- Fixed above issue.
- This issue will be completely fixed once user changes any `promptInputOptions`

https://github.com/user-attachments/assets/94337177-5c58-4331-b95f-b52b14b6b64f



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
