### PR TITLE
feat(amazonq): enable sonnet 4 for fra region

### DIFF
--- a/chat-client/src/client/texts/modelSelection.test.ts
+++ b/chat-client/src/client/texts/modelSelection.test.ts
@@ -39,18 +39,15 @@ describe('modelSelection', () => {
             )
         })
 
-        it('should provide limited models for eu-central-1 region', () => {
+        it('should provide all models for eu-central-1 region', () => {
             const euCentral1ModelSelection = modelSelectionForRegion['eu-central-1']
             assert.ok(euCentral1ModelSelection, 'euCentral1ModelSelection should exist')
             assert.ok(euCentral1ModelSelection.type === 'select', 'euCentral1ModelSelection should be type select')
             assert.ok(Array.isArray(euCentral1ModelSelection.options), 'options should be an array')
-            assert.strictEqual(euCentral1ModelSelection.options.length, 1, 'should have 1 option')
+            assert.strictEqual(euCentral1ModelSelection.options.length, 2, 'should have 2 option')
 
             const modelIds = euCentral1ModelSelection.options.map(option => option.value)
-            assert.ok(
-                !modelIds.includes(BedrockModel.CLAUDE_SONNET_4_20250514_V1_0),
-                'should not include Claude Sonnet 4'
-            )
+            assert.ok(modelIds.includes(BedrockModel.CLAUDE_SONNET_4_20250514_V1_0), 'should include Claude Sonnet 4')
             assert.ok(
                 modelIds.includes(BedrockModel.CLAUDE_3_7_SONNET_20250219_V1_0),
                 'should include Claude Sonnet 3.7'

--- a/chat-client/src/client/texts/modelSelection.ts
+++ b/chat-client/src/client/texts/modelSelection.ts
@@ -37,10 +37,7 @@ const modelSelection: ChatItemFormItem = {
  */
 export const modelSelectionForRegion: Record<string, ChatItemFormItem> = {
     'us-east-1': modelSelection,
-    'eu-central-1': {
-        ...modelSelection,
-        options: modelOptions.filter(option => option.value !== BedrockModel.CLAUDE_SONNET_4_20250514_V1_0),
-    },
+    'eu-central-1': modelSelection,
 }
 
 export const getModelSelectionChatItem = (modelName: string): ChatItem => ({

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -3028,7 +3028,7 @@ ${' '.repeat(8)}}
             assert.ok(modelIds.includes('CLAUDE_3_7_SONNET_20250219_V1_0'))
         })
 
-        it('should return limited models for eu-central-1 region', async () => {
+        it('should return all available models for eu-central-1 region', async () => {
             // Set up the region to be eu-central-1
             tokenServiceManagerStub.returns('eu-central-1')
 
@@ -3038,12 +3038,12 @@ ${' '.repeat(8)}}
 
             // Verify the result
             assert.strictEqual(result.tabId, mockTabId)
-            assert.strictEqual(result.models.length, 1)
-            assert.strictEqual(result.selectedModelId, 'CLAUDE_3_7_SONNET_20250219_V1_0')
+            assert.strictEqual(result.models.length, 2)
+            assert.strictEqual(result.selectedModelId, 'CLAUDE_SONNET_4_20250514_V1_0')
 
-            // Check that the models only include Claude 3.7
+            // Check that the models include both Claude versions
             const modelIds = result.models.map(model => model.id)
-            assert.ok(!modelIds.includes('CLAUDE_SONNET_4_20250514_V1_0'))
+            assert.ok(modelIds.includes('CLAUDE_SONNET_4_20250514_V1_0'))
             assert.ok(modelIds.includes('CLAUDE_3_7_SONNET_20250219_V1_0'))
         })
 
@@ -3058,7 +3058,7 @@ ${' '.repeat(8)}}
             // Verify the result
             assert.strictEqual(result.tabId, mockTabId)
             assert.strictEqual(result.models.length, 2)
-            assert.strictEqual(result.selectedModelId, 'CLAUDE_3_7_SONNET_20250219_V1_0')
+            assert.strictEqual(result.selectedModelId, 'CLAUDE_SONNET_4_20250514_V1_0')
         })
 
         it('should return undefined for selectedModelId when no session data exists', async () => {
@@ -3083,10 +3083,29 @@ ${' '.repeat(8)}}
         })
 
         it('should fallback to latest available model when saved model is not available in current region', async () => {
-            // Set up the region to be eu-central-1 (which only has Claude 3.7)
-            tokenServiceManagerStub.returns('eu-central-1')
+            // Import the module to stub
+            const modelSelection = await import('./constants/modelSelection')
 
-            // Mock database to return Claude Sonnet 4 (not available in eu-central-1)
+            // Create a mock region with only Claude 3.7
+            const mockModelOptionsForRegion = {
+                ...modelSelection.MODEL_OPTIONS_FOR_REGION,
+                'test-region-limited': [
+                    {
+                        id: 'CLAUDE_3_7_SONNET_20250219_V1_0',
+                        name: 'Claude Sonnet 3.7',
+                    },
+                ],
+            }
+
+            // Stub the MODEL_OPTIONS_FOR_REGION
+            const modelOptionsStub = sinon
+                .stub(modelSelection, 'MODEL_OPTIONS_FOR_REGION')
+                .value(mockModelOptionsForRegion)
+
+            // Set up the region to be the test region (which only has Claude 3.7)
+            tokenServiceManagerStub.returns('test-region-limited')
+
+            // Mock database to return Claude Sonnet 4 (not available in test-region-limited)
             const getModelIdStub = sinon.stub(ChatDatabase.prototype, 'getModelId')
             getModelIdStub.returns('CLAUDE_SONNET_4_20250514_V1_0')
 
@@ -3100,6 +3119,7 @@ ${' '.repeat(8)}}
             assert.strictEqual(result.selectedModelId, 'CLAUDE_3_7_SONNET_20250219_V1_0')
 
             getModelIdStub.restore()
+            modelOptionsStub.restore()
         })
 
         it('should use saved model when it is available in current region', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/modelSelection.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/modelSelection.test.ts
@@ -43,26 +43,17 @@ describe('modelSelection', () => {
             )
         })
 
-        it('should provide limited models for eu-central-1 region', () => {
+        it('should provide all models for eu-central-1 region', () => {
             const euCentral1Models = MODEL_OPTIONS_FOR_REGION['eu-central-1']
-            assert.ok(Array.isArray(euCentral1Models), 'eu-central-1 models should be an array')
-            assert.strictEqual(euCentral1Models.length, 1, 'eu-central-1 should have 1 model')
+            assert.deepStrictEqual(euCentral1Models, MODEL_OPTIONS, 'us-east-1 should have all models')
+            assert.strictEqual(euCentral1Models.length, 2, 'us-east-1 should have 2 models')
 
             const modelIds = euCentral1Models.map(model => model.id)
-            assert.ok(
-                !modelIds.includes('CLAUDE_SONNET_4_20250514_V1_0'),
-                'eu-central-1 should not include Claude Sonnet 4'
-            )
+            assert.ok(modelIds.includes('CLAUDE_SONNET_4_20250514_V1_0'), 'eu-central-1 should include Claude Sonnet 4')
             assert.ok(
                 modelIds.includes('CLAUDE_3_7_SONNET_20250219_V1_0'),
                 'eu-central-1 should include Claude Sonnet 3.7'
             )
-        })
-
-        it('should filter out Claude Sonnet 4 for eu-central-1 region', () => {
-            const euCentral1Models = MODEL_OPTIONS_FOR_REGION['eu-central-1']
-            const claudeSonnet4 = euCentral1Models.find(model => model.id === 'CLAUDE_SONNET_4_20250514_V1_0')
-            assert.strictEqual(claudeSonnet4, undefined, 'Claude Sonnet 4 should be filtered out for eu-central-1')
         })
 
         it('should fall back to all models for unknown regions', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/modelSelection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/modelSelection.ts
@@ -23,5 +23,5 @@ export const MODEL_OPTIONS: ListAvailableModelsResult['models'] = Object.entries
 
 export const MODEL_OPTIONS_FOR_REGION: Record<string, ListAvailableModelsResult['models']> = {
     'us-east-1': MODEL_OPTIONS,
-    'eu-central-1': MODEL_OPTIONS.filter(option => option.id !== BedrockModel.CLAUDE_SONNET_4_20250514_V1_0),
+    'eu-central-1': MODEL_OPTIONS,
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/utils/agenticChatControllerHelper.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/utils/agenticChatControllerHelper.ts
@@ -12,5 +12,5 @@ export function getLatestAvailableModel(
     exclude?: string
 ): ListAvailableModelsResult['models'][0] {
     const models = region && MODEL_OPTIONS_FOR_REGION[region] ? MODEL_OPTIONS_FOR_REGION[region] : MODEL_OPTIONS
-    return models.reverse().find(model => model.id !== exclude) ?? models[models.length - 1]
+    return [...models].reverse().find(model => model.id !== exclude) ?? models[models.length - 1]
 }


### PR DESCRIPTION
## Problem

Sonnet 4 is available for eu-central-1

## Solution

Enable Sonnet 4 for eu-central-1 region profile

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
