### PR TITLE
fix(amazonq): add fallback classpath generation

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/artifactManager.ts
@@ -694,6 +694,21 @@ export class ArtifactManager {
             additionalFiles.push(...updatedFiles)
         }
 
+        // Fallback methods to generate a .classpath at workspace folder root
+        if (projectRoots.length == 0) {
+            const javaManager = new JavaProjectAnalyzer(workspacePath)
+            const structure = await javaManager.analyze()
+            const generator = new EclipseConfigGenerator(workspaceFolder, this.logging)
+            const classpathFiles = await generator.generateDotClasspath(structure)
+            for (const classpathFile of classpathFiles) {
+                additionalFiles.push(classpathFile)
+            }
+            const projectFiles = await generator.generateDotProject(path.basename(workspacePath), structure)
+            for (const projectFile of projectFiles) {
+                additionalFiles.push(projectFile)
+            }
+        }
+
         return [...files, ...additionalFiles]
     }
 


### PR DESCRIPTION
## Problem

## Solution

Adding the original .classpath and .project file generation as a fallback from

https://github.com/aws/language-servers/pull/1955/files
## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
