### PR TITLE
fix:  Improve model selection fallback logic when user's preferred model is unavailable

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -3224,7 +3224,7 @@ ${' '.repeat(8)}}
 
                 const result = await chatController.onListAvailableModels({ tabId: mockTabId })
 
-                assert.strictEqual(result.selectedModelId, 'claude-4-sonnet') // MODEL_RECORD[DEFAULT_MODEL_ID].label
+                assert.strictEqual(result.selectedModelId, 'claude-4-sonnet') // FALLBACK_MODEL_RECORD[DEFAULT_MODEL_ID].label
                 // Verify session modelId is updated
                 assert.strictEqual(session.modelId, 'claude-4-sonnet')
             })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -220,7 +220,7 @@ import {
     Message as DbMessage,
     messageToStreamingMessage,
 } from './tools/chatDb/util'
-import { FALLBACK_MODEL_OPTIONS, MODEL_RECORD } from './constants/modelSelection'
+import { FALLBACK_MODEL_OPTIONS, FALLBACK_MODEL_RECORD } from './constants/modelSelection'
 import { DEFAULT_IMAGE_VERIFICATION_OPTIONS, verifyServerImage } from '../../shared/imageVerification'
 import { sanitize } from '@aws/lsp-core/out/util/path'
 import { ActiveUserTracker } from '../../shared/activeUserTracker'
@@ -755,7 +755,7 @@ export class AgenticChatController implements ChatHandlers {
 
         // Get the first fallback model option as default
         const defaultModelOption = FALLBACK_MODEL_OPTIONS[1]
-        const DEFAULT_MODEL_ID = defaultModelOption?.id || Object.keys(MODEL_RECORD)[1]
+        const DEFAULT_MODEL_ID = defaultModelOption?.id || Object.keys(FALLBACK_MODEL_RECORD)[1]
 
         const sessionResult = this.#chatSessionManagementService.getSession(params.tabId)
         const { data: session, success } = sessionResult
@@ -773,22 +773,27 @@ export class AgenticChatController implements ChatHandlers {
         let selectedModelId: string
         let modelId = this.#chatHistoryDb.getModelId()
 
+        // Helper function to get model label from FALLBACK_MODEL_RECORD
+        const getModelLabel = (modelKey: string) =>
+            FALLBACK_MODEL_RECORD[modelKey as keyof typeof FALLBACK_MODEL_RECORD]?.label || modelKey
+
+        // Determine selected model ID based on priority
         if (modelId) {
-            // Case 1: User has previously selected a model - use that model or its mapped version
-            // Check if modelId is a key in MODEL_RECORD
-            if (modelId in MODEL_RECORD) {
-                // If it's a valid model key, use its mapped label
-                selectedModelId = MODEL_RECORD[modelId as keyof typeof MODEL_RECORD]?.label || modelId
-            } else {
-                // Otherwise use as is (might be a direct model ID from the API)
+            // Priority 1: Use modelId if it exists in available models
+            if (models.some(model => model.id === modelId)) {
                 selectedModelId = modelId
             }
-        } else if (defaultModelId) {
-            // Case 2: No user selection, but API provided a default model - use server recommendation
-            selectedModelId = defaultModelId
+            // Priority 2: Use mapped version if modelId exists in FALLBACK_MODEL_RECORD
+            else if (modelId in FALLBACK_MODEL_RECORD) {
+                selectedModelId = getModelLabel(modelId)
+            }
+            // Priority 3: Fall back to default or system default
+            else {
+                selectedModelId = defaultModelId || getModelLabel(DEFAULT_MODEL_ID)
+            }
         } else {
-            // Case 3: Last resort - use default model's label
-            selectedModelId = MODEL_RECORD[DEFAULT_MODEL_ID as keyof typeof MODEL_RECORD]?.label || DEFAULT_MODEL_ID
+            // No user-selected model - use API default or system default
+            selectedModelId = defaultModelId || getModelLabel(DEFAULT_MODEL_ID)
         }
 
         // Store the selected model in the session

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -779,7 +779,7 @@ export class AgenticChatController implements ChatHandlers {
 
         // Determine selected model ID based on priority
         if (modelId) {
-            // Priority 1: Use modelId if it exists in available models
+            // Priority 1: Use modelId if it exists in available models from backend
             if (models.some(model => model.id === modelId)) {
                 selectedModelId = modelId
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/modelSelection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/modelSelection.ts
@@ -12,12 +12,12 @@ type ModelDetails = {
     label: string
 }
 
-export const MODEL_RECORD: Record<BedrockModel, ModelDetails> = {
+export const FALLBACK_MODEL_RECORD: Record<BedrockModel, ModelDetails> = {
     [BedrockModel.CLAUDE_3_7_SONNET_20250219_V1_0]: { label: 'claude-3.7-sonnet' },
     [BedrockModel.CLAUDE_SONNET_4_20250514_V1_0]: { label: 'claude-4-sonnet' },
 }
 
-export const FALLBACK_MODEL_OPTIONS: ListAvailableModelsResult['models'] = Object.entries(MODEL_RECORD).map(
+export const FALLBACK_MODEL_OPTIONS: ListAvailableModelsResult['models'] = Object.entries(FALLBACK_MODEL_RECORD).map(
     ([value, { label }]) => ({
         id: value,
         name: label,


### PR DESCRIPTION
## Problem: 
The model selection logic had inconsistent fallback behavior when a user's previously selected model was no longer available from the API.

## Solution: 
Enhanced the model selection priority system with proper fallback handling:

### 1. Renamed constants for clarity: 
- MODEL_RECORD → FALLBACK_MODEL_RECORD to better reflect its purpose as fallback options

### 2. Improved model selection logic with clear priority order:

- Priority 1: Use user's saved model if it exists in available models from backend
- Priority 2: Use mapped fallback version if the saved model exists in FALLBACK_MODEL_RECORD
- Priority 3: Fall back to API default model or system default
- Default case: Use API default or system default when no user preference exists

### 3.Added helper function 
- getModelLabel() to consistently retrieve model labels from the fallback record


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
