### PR TITLE
fix: update client name to support Sagemaker AI origin for agentic chat

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
@@ -134,23 +134,33 @@ describe('getClientName', () => {
 })
 
 describe('getOriginFromClientInfo', () => {
-    it('returns MD_IDE for SMUS-IDE client name', () => {
+    it('returns MD_IDE for client names starting with SMUS-IDE prefix', () => {
         const result = getOriginFromClientInfo('AmazonQ-For-SMUS-IDE-1.0.0')
         assert.strictEqual(result, 'MD_IDE')
     })
 
-    it('returns MD_IDE for SMUS-CE client name', () => {
+    it('returns MD_IDE for client names starting with SMUS-CE prefix', () => {
         const result = getOriginFromClientInfo('AmazonQ-For-SMUS-CE-1.0.0')
         assert.strictEqual(result, 'MD_IDE')
     })
 
-    it('returns MD_IDE for client names starting with SMUS-IDE prefix', () => {
+    it('returns MD_IDE for client names starting with SMAI-CE prefix', () => {
+        const result = getOriginFromClientInfo('AmazonQ-For-SMAI-CE-1.0.0')
+        assert.strictEqual(result, 'MD_IDE')
+    })
+
+    it('returns MD_IDE for SMUS-IDE client name', () => {
         const result = getOriginFromClientInfo('AmazonQ-For-SMUS-IDE')
         assert.strictEqual(result, 'MD_IDE')
     })
 
-    it('returns MD_IDE for client names starting with SMUS-CE prefix', () => {
+    it('returns MD_IDE for SMUS-CE client name', () => {
         const result = getOriginFromClientInfo('AmazonQ-For-SMUS-CE')
+        assert.strictEqual(result, 'MD_IDE')
+    })
+
+    it('returns MD_IDE for SMAI-CE client name', () => {
+        const result = getOriginFromClientInfo('AmazonQ-For-SMAI-CE')
         assert.strictEqual(result, 'MD_IDE')
     })
 

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -381,7 +381,12 @@ export function getClientName(lspParams: InitializeParams | undefined): string |
 }
 
 export function getOriginFromClientInfo(clientName: string | undefined): Origin {
-    if (clientName?.startsWith('AmazonQ-For-SMUS-IDE') || clientName?.startsWith('AmazonQ-For-SMUS-CE')) {
+    // TODO: Update with a new origin for SMAI case, as a short-term solution Sagemaker AI CE is using same origin as that of Sagemaker Unified Studio's IDE and CE
+    if (
+        clientName?.startsWith('AmazonQ-For-SMUS-IDE') ||
+        clientName?.startsWith('AmazonQ-For-SMUS-CE') ||
+        clientName?.startsWith('AmazonQ-For-SMAI-CE')
+    ) {
         return 'MD_IDE'
     }
     return 'IDE'


### PR DESCRIPTION
## Problem
To invoke Maestro backend which is based on request origin checks, need to support client Info check from SMUS Q CodeEditor client

## Solution
- Updated origin in LSP client to support SMUS CE Q client case
- Added unit tests
- ```npm run format && npm run test``` succeeded in local
- Related [PR](https://github.com/aws/language-servers/pull/2032)
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
