### PR TITLE
fix: creating a new sesion for Edits trigger with next token

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -501,7 +501,6 @@ export const CodewhispererServerFactory =
                     partialResultToken: suggestionResponse.responseContext.nextToken,
                 }
             } else {
-                session.hasEditsPending = suggestionResponse.responseContext.nextToken ? true : false
                 return {
                     items: suggestionResponse.suggestions
                         .map(suggestion => {
@@ -690,14 +689,8 @@ export const CodewhispererServerFactory =
             if (firstCompletionDisplayLatency) emitPerceivedLatencyTelemetry(telemetry, session)
 
             // Always emit user trigger decision at session close
-            // Close session unless Edit suggestion was accepted with more pending
-            const shouldKeepSessionOpen =
-                session.suggestionType === SuggestionType.EDIT && isAccepted && session.hasEditsPending
-
-            if (!shouldKeepSessionOpen) {
-                completionSessionManager.closeSession(session)
-            }
-            const streakLength = editsEnabled ? completionSessionManager.getAndUpdateStreakLength(isAccepted) : 0
+            sessionManager.closeSession(session)
+            const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(isAccepted) : 0
             await emitUserTriggerDecisionTelemetry(
                 telemetry,
                 telemetryService,

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
@@ -80,7 +80,6 @@ export class CodeWhispererSession {
     includeImportsWithSuggestions?: boolean
     codewhispererSuggestionImportCount: number = 0
     suggestionType?: string
-    hasEditsPending?: boolean = false
     // Track the most recent itemId for paginated Edit suggestions
 
     constructor(data: SessionData) {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/telemetry.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/telemetry.ts
@@ -147,13 +147,7 @@ export const emitUserTriggerDecisionTelemetry = async (
         streakLength
     )
 
-    // Mark telemetry as complete unless Edit suggestion was accepted with more pending
-    const hasPendingEditTelemetry =
-        session.suggestionType === SuggestionType.EDIT && session.acceptedSuggestionId && session.hasEditsPending
-
-    if (!hasPendingEditTelemetry) {
-        session.reportedUserDecision = true
-    }
+    session.reportedUserDecision = true
 }
 
 export const emitAggregatedUserTriggerDecisionTelemetry = (


### PR DESCRIPTION
## Problem

Sometimes the session is closed before the UTDE telemetry is emitted

## Solution

Creating a new session for Edits trigger with next token for easier state maintenance

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
