### PR TITLE
fix: To support backward compatibility for vs and eclipse, adding back models in chat-client

### DIFF
--- a/chat-client/src/client/texts/modelSelection.ts
+++ b/chat-client/src/client/texts/modelSelection.ts
@@ -1,10 +1,33 @@
 import { ChatItem, ChatItemFormItem, ChatItemType } from '@aws/mynah-ui'
 
+/**
+ * @deprecated use aws/chat/listAvailableModels server request instead
+ */
+export enum BedrockModel {
+    CLAUDE_SONNET_4_20250514_V1_0 = 'CLAUDE_SONNET_4_20250514_V1_0',
+    CLAUDE_3_7_SONNET_20250219_V1_0 = 'CLAUDE_3_7_SONNET_20250219_V1_0',
+}
+
+type ModelDetails = {
+    label: string
+}
+
+const modelRecord: Record<BedrockModel, ModelDetails> = {
+    [BedrockModel.CLAUDE_3_7_SONNET_20250219_V1_0]: { label: 'claude-3.7-sonnet' },
+    [BedrockModel.CLAUDE_SONNET_4_20250514_V1_0]: { label: 'claude-4-sonnet' },
+}
+
+const modelOptions = Object.entries(modelRecord).map(([value, { label }]) => ({
+    value,
+    label,
+}))
+
 export const modelSelection: ChatItemFormItem = {
     type: 'select',
     id: 'model-selection',
     mandatory: true,
     hideMandatoryIcon: true,
+    options: modelOptions,
     border: false,
     autoWidth: true,
 }


### PR DESCRIPTION
## Problem
- Older versions of VS and Eclipse will show empty value with new changes
## Solution
- Adding back hardcoded models back for backward compatibility and can be removed in future after the adaption.
- Tested with VSC changes before [this commit](https://github.com/aws/aws-toolkit-vscode/pull/7591), IDE shows hardcoded two models in the UX.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
