### PR TITLE
fix: check available models from backend before selecting default model from fallback models

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -783,8 +783,8 @@ export class AgenticChatController implements ChatHandlers {
             if (models.some(model => model.id === modelId)) {
                 selectedModelId = modelId
             }
-            // Priority 2: Use mapped version if modelId exists in FALLBACK_MODEL_RECORD
-            else if (modelId in FALLBACK_MODEL_RECORD) {
+            // Priority 2: Use mapped version if modelId exists in FALLBACK_MODEL_RECORD and no backend models available
+            else if (models.length === 0 && modelId in FALLBACK_MODEL_RECORD) {
                 selectedModelId = getModelLabel(modelId)
             }
             // Priority 3: Fall back to default or system default


### PR DESCRIPTION
## Problem
- If user selected a default model and then switched the profile which does not have the model available from the backend. Existing plugin shows empty dropdown.
## Solution
- Check if backend models are empty before assigning the default selected hardcoded value.

### Example:
- If user is in IAD profile and selected claude-3.7-sonnet as preference and if user switched to FRA, and if FRA does not have claude-3.7-sonnet then IDE shows null right now. After this change, IDE fall back to backend default model.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
