### PR TITLE
fix(amazonq): persist mcp configs in agent json on start-up

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -920,8 +920,8 @@ async function migrateConfigToAgent(
             ...existingAgentConfig,
             // Merge MCP servers, keeping existing ones if they exist
             mcpServers: {
-                ...existingAgentConfig.mcpServers,
                 ...newAgentConfig.mcpServers,
+                ...existingAgentConfig.mcpServers,
             },
             // Merge tools lists without duplicates
             tools: [...new Set([...existingAgentConfig.tools, ...newAgentConfig.tools])],


### PR DESCRIPTION
## Problem

MCP server config in agent config (default.json) get overwritten by the mcp.json config

## Solution

Change the order of spread operator so that mcp.json will not overwrite default.json

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
