### PR TITLE
feat(amazonq): use model display names

### DIFF
--- a/chat-client/src/client/texts/modelSelection.ts
+++ b/chat-client/src/client/texts/modelSelection.ts
@@ -13,8 +13,8 @@ type ModelDetails = {
 }
 
 const modelRecord: Record<BedrockModel, ModelDetails> = {
-    [BedrockModel.CLAUDE_3_7_SONNET_20250219_V1_0]: { label: 'claude-3.7-sonnet' },
-    [BedrockModel.CLAUDE_SONNET_4_20250514_V1_0]: { label: 'claude-4-sonnet' },
+    [BedrockModel.CLAUDE_3_7_SONNET_20250219_V1_0]: { label: 'Claude 3.7 Sonnet' },
+    [BedrockModel.CLAUDE_SONNET_4_20250514_V1_0]: { label: 'Claude Sonnet 4' },
 }
 
 const modelOptions = Object.entries(modelRecord).map(([value, { label }]) => ({

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -3224,9 +3224,9 @@ ${' '.repeat(8)}}
 
                 const result = await chatController.onListAvailableModels({ tabId: mockTabId })
 
-                assert.strictEqual(result.selectedModelId, 'claude-4-sonnet') // FALLBACK_MODEL_RECORD[DEFAULT_MODEL_ID].label
+                assert.strictEqual(result.selectedModelId, 'claude-sonnet-4') // FALLBACK_MODEL_RECORD[DEFAULT_MODEL_ID].label
                 // Verify session modelId is updated
-                assert.strictEqual(session.modelId, 'claude-4-sonnet')
+                assert.strictEqual(session.modelId, 'claude-sonnet-4')
             })
         })
     })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/modelSelection.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/modelSelection.test.ts
@@ -9,7 +9,7 @@ describe('modelSelection', () => {
 
             // Check that the array contains the expected models
             const modelIds = FALLBACK_MODEL_OPTIONS.map(model => model.id)
-            assert.ok(modelIds.includes('CLAUDE_SONNET_4_20250514_V1_0'), 'Should include claude-4-sonnet')
+            assert.ok(modelIds.includes('CLAUDE_SONNET_4_20250514_V1_0'), 'Should include claude-sonnet-4')
             assert.ok(modelIds.includes('CLAUDE_3_7_SONNET_20250219_V1_0'), 'Should include claude-3.7-sonnet')
 
             // Check that each model has the required properties
@@ -24,8 +24,8 @@ describe('modelSelection', () => {
             const claudeSonnet4 = FALLBACK_MODEL_OPTIONS.find(model => model.id === 'CLAUDE_SONNET_4_20250514_V1_0')
             const claudeSonnet37 = FALLBACK_MODEL_OPTIONS.find(model => model.id === 'CLAUDE_3_7_SONNET_20250219_V1_0')
 
-            assert.strictEqual(claudeSonnet4?.name, 'claude-4-sonnet', 'claude-4-sonnet should have correct name')
-            assert.strictEqual(claudeSonnet37?.name, 'claude-3.7-sonnet', 'claude-3.7-sonnet should have correct name')
+            assert.strictEqual(claudeSonnet4?.name, 'Claude Sonnet 4', 'claude-sonnet-4 should have correct name')
+            assert.strictEqual(claudeSonnet37?.name, 'Claude 3.7 Sonnet', 'claude-3.7-sonnet should have correct name')
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/modelSelection.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/modelSelection.ts
@@ -13,8 +13,13 @@ type ModelDetails = {
 }
 
 export const FALLBACK_MODEL_RECORD: Record<BedrockModel, ModelDetails> = {
-    [BedrockModel.CLAUDE_3_7_SONNET_20250219_V1_0]: { label: 'claude-3.7-sonnet' },
-    [BedrockModel.CLAUDE_SONNET_4_20250514_V1_0]: { label: 'claude-4-sonnet' },
+    [BedrockModel.CLAUDE_3_7_SONNET_20250219_V1_0]: { label: 'Claude 3.7 Sonnet' },
+    [BedrockModel.CLAUDE_SONNET_4_20250514_V1_0]: { label: 'Claude Sonnet 4' },
+}
+
+export const BEDROCK_MODEL_TO_MODEL_ID: Record<BedrockModel, string> = {
+    [BedrockModel.CLAUDE_3_7_SONNET_20250219_V1_0]: 'claude-3.7-sonnet',
+    [BedrockModel.CLAUDE_SONNET_4_20250514_V1_0]: 'claude-sonnet-4',
 }
 
 export const FALLBACK_MODEL_OPTIONS: ListAvailableModelsResult['models'] = Object.entries(FALLBACK_MODEL_RECORD).map(


### PR DESCRIPTION
## Problem

API now returns proper display names for models.

## Solution

Update the labels and update mapping logic by separating the old bedrock modelId mapping to a separate constant.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
