### PR TITLE
fix: proper path handling for additional context

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
@@ -174,6 +174,12 @@ describe('AdditionalContextProvider', () => {
                 workspaceFolder: mockWorkspaceFolder,
             }
 
+            // Mock path.join to simulate Unix behavior
+            sinon.stub(path, 'join').callsFake((...args) => {
+                // Simulate Unix path.join behavior
+                return args.join('/').replace(/\\/g, '/')
+            })
+
             const explicitContext = [
                 {
                     id: 'explicit-file',
@@ -208,6 +214,9 @@ describe('AdditionalContextProvider', () => {
             assert.strictEqual(result.length, 1)
             assert.strictEqual(result[0].name, 'Explicit File')
             assert.strictEqual(result[0].pinned, false)
+
+            // Restore original path.join
+            ;(path.join as sinon.SinonStub).restore()
         })
 
         it('should avoid duplicates between explicit and pinned context', async () => {
@@ -219,6 +228,12 @@ describe('AdditionalContextProvider', () => {
             const triggerContext: TriggerContext = {
                 workspaceFolder: mockWorkspaceFolder,
             }
+
+            // Mock path.join to simulate Unix behavior
+            sinon.stub(path, 'join').callsFake((...args) => {
+                // Simulate Unix path.join behavior
+                return args.join('/').replace(/\\/g, '/')
+            })
 
             const sharedContext = {
                 id: 'shared-file',
@@ -255,6 +270,9 @@ describe('AdditionalContextProvider', () => {
             assert.strictEqual(result.length, 1)
             assert.strictEqual(result[0].name, 'Shared File')
             assert.strictEqual(result[0].pinned, false) // Should be marked as explicit, not pinned
+
+            // Restore original path.join
+            ;(path.join as sinon.SinonStub).restore()
         })
 
         it('should handle Active File context correctly', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
@@ -406,7 +406,7 @@ export class AdditionalContextProvider {
                 const image = imageMap.get(item.description)
                 if (image) ordered.push(image)
             } else {
-                const doc = item.route ? docMap.get(item.route.join('/')) : undefined
+                const doc = item.route ? docMap.get(path.join(...item.route)) : undefined
                 if (doc) ordered.push(doc)
             }
         }


### PR DESCRIPTION
## Problem
The `@prompt` feature  was not working on Windows systems due to incorrect path separator handling, while the same functionality worked correctly on Mac

How it failed on Windows:
- Uses `Array.join('/')` which always uses forward slashes
- `['C:\\Users\\chungjac\\.aws\\amazonq\\prompts', 'hello.md'].join('/') `
- Results in: `C:\Users\chungjac\.aws\amazonq\prompts/hello.md` (mixed separators)

Why it worked on Mac:
- Unix systems use forward slashes natively
- `['/Users/chungjac/.aws/amazonq/prompts', 'hello.md'].join('/')`
- Results in: `/Users/chungjac/.aws/amazonq/prompts/hello.md` (consistent forward slashes)

## Solution
Replace `Array.join('/')` with Node.js `path.join()` for proper cross-platform path handling


## Testing
`useRelevantDocuments` is now set to `true`, as it was previously `false`
```
            "relevantDocuments": [
              {
                "text": "respond in all caps\n",
                "path": "C:\\Users\\chungjac\\.aws\\amazonq\\prompts\\prompt123.md",
                "relativeFilePath": "prompt123.md",
                "type": "PROMPT",
                "startLine": 0,
                "endLine": 0
              }
            ],
            "useRelevantDocuments": true,
```


https://github.com/user-attachments/assets/9539fba3-7153-4cd0-8192-0487d587494b






<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
