### PR TITLE
fix: cached model list should be invalidated on sign out

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -349,7 +349,7 @@ export class AgenticChatController implements ChatHandlers {
             // @ts-ignore
             this.#features.chat.chatOptionsUpdate({ region })
         })
-        this.#chatHistoryDb = new ChatDatabase(features)
+        this.#chatHistoryDb = ChatDatabase.getInstance(features)
         this.#tabBarController = new TabBarController(
             features,
             this.#chatHistoryDb,

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -33,6 +33,7 @@ import { getAmazonQRegionAndEndpoint } from './configurationUtils'
 import { getUserAgent } from '../telemetryUtils'
 import { StreamingClientServiceToken } from '../streamingClientService'
 import { parse } from '@aws-sdk/util-arn-parser'
+import { ChatDatabase } from '../../language-server/agenticChat/tools/chatDb/chatDb'
 
 /**
  * AmazonQTokenServiceManager manages state and provides centralized access to
@@ -147,6 +148,10 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
         if (type === 'iam') {
             return
         }
+
+        // Clear model cache when credentials are deleted
+        ChatDatabase.clearModelCache()
+
         this.cancelActiveProfileChangeToken()
 
         this.resetCodewhispererService()


### PR DESCRIPTION
## Problem

Cached models were getting persisted between sessions even after switching region profile.

## Solution

- Invalidate models whenever credentials are deleted
- Update singleton pattern

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
