### PR TITLE
feat: add basic OAuth client for remote MCP

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -1246,7 +1246,7 @@ export class McpEventHandler {
             const serverConfig = McpManager.instance.getAllServerConfigs().get(serverName)
             if (serverConfig) {
                 // Emit server initialize event after permission change
-                const transportType = serverConfig.command ? 'stdio' : 'http'
+                const transportType = serverConfig.command?.trim() ? 'stdio' : 'http'
                 this.#telemetryController?.emitMCPServerInitializeEvent({
                     source: 'updatePermission',
                     command: transportType === 'stdio' ? serverConfig.command : undefined,
@@ -1327,7 +1327,7 @@ export class McpEventHandler {
                 enabled: enabled,
                 numTools: mcpManager.getAllToolsWithPermissions(serverName).length,
                 scope: config.__configPath__ === globalAgentPath ? 'global' : 'workspace',
-                transportType: 'stdio',
+                transportType: transportType,
                 languageServerVersion: this.#features.runtime.serverInfo.version,
             })
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -331,7 +331,7 @@ export class McpManager {
                     // streamable http/SSE transport
                     const base = new URL(cfg.url!)
                     try {
-                        // Use HEAD to check if it nees OAuth
+                        // Use HEAD to check if it needs OAuth
                         let headers: Record<string, string> = { ...(cfg.headers ?? {}) }
                         let needsOAuth = false
                         try {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -37,6 +37,7 @@ import { Mutex } from 'async-mutex'
 import path = require('path')
 import { URI } from 'vscode-uri'
 import { sanitizeInput } from '../../../../shared/utils'
+import { OAuthClient } from './mcpOauthClient'
 
 export const MCP_SERVER_STATUS_CHANGED = 'mcpServerStatusChanged'
 export const AGENT_TOOLS_CHANGED = 'agentToolsChanged'
@@ -328,9 +329,27 @@ export class McpManager {
                 } else {
                     const base = new URL(cfg.url!)
                     try {
+                        // first determine if authroization is needed
+                        let headers: Record<string, string> = { ...(cfg.headers ?? {}) }
+                        const headStatus = await fetch(base, { method: 'HEAD', headers }).then(r => r.status)
+                        const needsOAuth = headStatus === 401
+
+                        if (needsOAuth) {
+                            OAuthClient.initialize(this.features.workspace, this.features.logging)
+                            const bearer = needsOAuth ? await OAuthClient.getValidAccessToken(base) : ''
+                            // add authorization header if we are able to obtain a bearer token
+                            if (bearer) {
+                                headers = {
+                                    ...headers,
+                                    Authorization: `Bearer ${bearer}`,
+                                }
+                            }
+                        }
+
                         try {
                             // try streamable http first
-                            transport = new StreamableHTTPClientTransport(base, this.buildHttpOpts(cfg.headers))
+                            transport = new StreamableHTTPClientTransport(base, this.buildHttpOpts(headers))
+
                             this.features.logging.info(`MCP: Connecting MCP server using StreamableHTTPClientTransport`)
                             await client.connect(transport)
                         } catch (err) {
@@ -338,7 +357,7 @@ export class McpManager {
                             this.features.logging.info(
                                 `MCP: streamable http connect failed for [${serverName}], fallback to SSEClientTransport: ${String(err)}`
                             )
-                            transport = new SSEClientTransport(new URL(cfg.url!), this.buildSseOpts(cfg.headers))
+                            transport = new SSEClientTransport(new URL(cfg.url!), this.buildSseOpts(headers))
                             await client.connect(transport)
                         }
                     } catch (err: any) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -279,7 +279,7 @@ export class McpManager {
             this.features.logging.debug(`MCP: initializing server [${serverName}]`)
 
             const client = new Client({
-                name: `mcp-client-${serverName}`,
+                name: `q-chat-plugin`,
                 version: '1.0.0',
             })
 
@@ -649,7 +649,7 @@ export class McpManager {
                 disabled: cfg.disabled ?? false,
             }
             // Only add timeout to agent config if it's not 0
-            if (cfg.timeout !== 0) {
+            if (cfg.timeout !== undefined) {
                 serverConfig.timeout = cfg.timeout
             }
             if (cfg.args && cfg.args.length > 0) {
@@ -1286,11 +1286,21 @@ export class McpManager {
     private handleError(server: string | undefined, err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
 
-        this.features.logging.error(`MCP ERROR${server ? ` [${server}]` : ''}: ${msg}`)
+        const isBenignSseDisconnect =
+            /SSE error:\s*TypeError:\s*terminated:\s*Body Timeout Error/i.test(msg) ||
+            /TypeError:\s*terminated:\s*Body Timeout Error/i.test(msg) ||
+            /TypeError:\s*terminated:\s*other side closed/i.test(msg) ||
+            /ECONNRESET|ENETRESET|EPIPE/i.test(msg)
 
-        if (server) {
-            this.setState(server, McpServerStatus.FAILED, 0, msg)
-            this.emitToolsChanged(server)
+        if (isBenignSseDisconnect) {
+            this.features.logging.debug(`MCP SSE idle timeout${server ? ` [${server}]` : ''}: ${msg}`)
+        } else {
+            // default path for real errors
+            this.features.logging.error(`MCP ERROR${server ? ` [${server}]` : ''}: ${msg}`)
+            if (server) {
+                this.setState(server, McpServerStatus.FAILED, 0, msg)
+                this.emitToolsChanged(server)
+            }
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -287,6 +287,7 @@ export class McpManager {
             const isStdio = !!cfg.command
             const doConnect = async () => {
                 if (isStdio) {
+                    // stdio transport
                     const mergedEnv = {
                         ...(process.env as Record<string, string>),
                         // Make sure we do not have empty key and value in mergedEnv, or adding server through UI will fail on Windows
@@ -327,22 +328,26 @@ export class McpManager {
                         )
                     }
                 } else {
+                    // streamable http/SSE transport
                     const base = new URL(cfg.url!)
                     try {
-                        // first determine if authroization is needed
+                        // Use HEAD to check if it nees OAuth
                         let headers: Record<string, string> = { ...(cfg.headers ?? {}) }
-                        const headStatus = await fetch(base, { method: 'HEAD', headers }).then(r => r.status)
-                        const needsOAuth = headStatus === 401
+                        let needsOAuth = false
+                        try {
+                            const headResp = await fetch(base, { method: 'HEAD', headers })
+                            const www = headResp.headers.get('www-authenticate') || ''
+                            needsOAuth = headResp.status === 401 || headResp.status === 403 || /bearer/i.test(www)
+                        } catch {
+                            this.features.logging.info(`MCP: HEAD not available`)
+                        }
 
                         if (needsOAuth) {
                             OAuthClient.initialize(this.features.workspace, this.features.logging)
-                            const bearer = needsOAuth ? await OAuthClient.getValidAccessToken(base) : ''
+                            const bearer = await OAuthClient.getValidAccessToken(base)
                             // add authorization header if we are able to obtain a bearer token
                             if (bearer) {
-                                headers = {
-                                    ...headers,
-                                    Authorization: `Bearer ${bearer}`,
-                                }
+                                headers = { ...headers, Authorization: `Bearer ${bearer}` }
                             }
                         }
 
@@ -362,8 +367,9 @@ export class McpManager {
                         }
                     } catch (err: any) {
                         let errorMessage = err?.message ?? String(err)
+                        const oauthHint = /oauth/i.test(errorMessage) ? ' (OAuth)' : ''
                         throw new AgenticChatError(
-                            `MCP: server '${serverName}' failed to connect: ${errorMessage}`,
+                            `MCP: server '${serverName}' failed to connect${oauthHint}: ${errorMessage}`,
                             'MCPServerConnectionFailed'
                         )
                     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpOauthClient.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpOauthClient.test.ts
@@ -1,0 +1,118 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved. SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+import * as crypto from 'crypto'
+import * as http from 'http'
+import * as path from 'path'
+import { OAuthClient } from './mcpOauthClient'
+
+const fakeLogger = {
+    log: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+}
+
+const fakeWorkspace = {
+    fs: {
+        exists: async (_path: string) => false,
+        readFile: async (_path: string) => Buffer.from('{}'),
+        writeFile: async (_path: string, _d: any) => {},
+        mkdir: async (_dir: string, _opts: any) => {},
+    },
+} as any
+
+function stubFileSystem(tokenObj?: any, regObj?: any): void {
+    const cacheDir = (OAuthClient as any).cacheDir as string
+    const tokPath = path.join(cacheDir, 'testkey.token.json')
+    const regPath = path.join(cacheDir, 'testkey.registration.json')
+
+    const existsStub = sinon.stub(fakeWorkspace.fs, 'exists')
+    existsStub.callsFake(async (p: any) => {
+        if (p === tokPath && tokenObj) return true
+        if (p === regPath && regObj) return true
+        return false
+    })
+
+    const readStub = sinon.stub(fakeWorkspace.fs, 'readFile')
+    readStub.callsFake(async (p: any) => {
+        if (p === tokPath && tokenObj) return Buffer.from(JSON.stringify(tokenObj))
+        if (p === regPath && regObj) return Buffer.from(JSON.stringify(regObj))
+        return Buffer.from('{}')
+    })
+
+    sinon.stub(fakeWorkspace.fs, 'writeFile').resolves()
+    sinon.stub(fakeWorkspace.fs, 'mkdir').resolves()
+}
+
+function stubHttpServer(): void {
+    sinon.stub(http, 'createServer').returns({
+        listen: (...args: any[]) => {
+            const cb = args.find(a => typeof a === 'function')
+            if (cb) cb()
+            return {} as any
+        },
+        close: (cb?: any) => {
+            if (cb) cb()
+            return {} as any
+        },
+        on: (..._args: any[]) => {
+            return {} as any
+        },
+        address: () => ({ address: '127.0.0.1', port: 12345, family: 'IPv4' }),
+    } as unknown as http.Server)
+}
+
+describe('OAuthClient helpers', () => {
+    it('computeKey() generates deterministic SHA-256 hex', () => {
+        const url = new URL('https://example.com/api')
+        const expected = crypto
+            .createHash('sha256')
+            .update(url.origin + url.pathname)
+            .digest('hex')
+        const actual = (OAuthClient as any).computeKey(url)
+        expect(actual).to.equal(expected)
+    })
+
+    it('b64url() strips padding and is URL-safe', () => {
+        const buf = Buffer.from('hello')
+        const actual = (OAuthClient as any).b64url(buf)
+        expect(actual).to.equal('aGVsbG8')
+    })
+})
+
+describe('OAuthClient getValidAccessToken()', () => {
+    const now = Date.now()
+
+    beforeEach(() => {
+        sinon.restore()
+        OAuthClient.initialize(fakeWorkspace, fakeLogger as any)
+        sinon.stub(OAuthClient as any, 'computeKey').returns('testkey')
+        stubHttpServer()
+    })
+
+    afterEach(() => sinon.restore())
+
+    it('returns cached token when still valid', async () => {
+        const cachedToken = {
+            access_token: 'cached_access',
+            expires_in: 3600,
+            obtained_at: now - 1_000,
+        }
+        const cachedReg = {
+            client_id: 'cid',
+            redirect_uri: 'http://localhost:12345',
+        }
+
+        stubFileSystem(cachedToken, cachedReg)
+
+        const token = await OAuthClient.getValidAccessToken(new URL('https://api.example.com/mcp'))
+        expect(token).to.equal('cached_access')
+        expect((http.createServer as any).calledOnce).to.be.true
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpOauthClient.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpOauthClient.ts
@@ -1,0 +1,370 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved. SPDX-License-Identifier: Apache-2.0
+ */
+
+import fetch, { type RequestInit } from 'node-fetch'
+import * as crypto from 'crypto'
+import * as path from 'path'
+import { spawn } from 'child_process'
+import { URL, URLSearchParams } from 'url'
+import * as http from 'http'
+import { Logger, Workspace } from '@aws/language-server-runtimes/server-interface'
+
+interface Token {
+    access_token: string
+    expires_in: number
+    refresh_token?: string
+    obtained_at: number
+}
+
+interface Meta {
+    authorization_endpoint: string
+    token_endpoint: string
+    registration_endpoint?: string
+}
+
+interface Registration {
+    client_id: string
+    client_secret?: string
+    expires_at?: number
+    redirect_uri: string
+}
+
+export class OAuthClient {
+    private static logger: Logger
+    private static workspace: Workspace
+
+    public static initialize(ws: Workspace, logger: Logger): void {
+        this.workspace = ws
+        this.logger = logger
+    }
+
+    /**
+     * Return a valid Bearer token, reusing cache or refresh-token if possible,
+     * otherwise driving one interactive PKCE flow.
+     */
+    public static async getValidAccessToken(mcpBase: URL): Promise<string> {
+        const key = this.computeKey(mcpBase)
+        const regPath = path.join(this.cacheDir, `${key}.registration.json`)
+        const tokPath = path.join(this.cacheDir, `${key}.token.json`)
+
+        // 1) Spin up (or reuse) loopback server + redirect URI
+        let server: http.Server, redirectUri: string
+        const savedReg = await this.read<Registration>(regPath)
+        if (savedReg) {
+            const port = Number(new URL(savedReg.redirect_uri).port)
+            server = http.createServer()
+            try {
+                await new Promise<void>(res => server.listen(port, '127.0.0.1', res))
+                redirectUri = savedReg.redirect_uri
+                this.logger.info(`OAuth: reusing redirect URI ${redirectUri}`)
+            } catch (e: any) {
+                if (e.code === 'EADDRINUSE') {
+                    this.logger.warn(`Port ${port} in use; falling back to new random port`)
+                    ;({ server, redirectUri } = await this.buildCallbackServer())
+                    this.logger.info(`OAuth: new redirect URI ${redirectUri}`)
+                    await this.workspace.fs.rm(regPath)
+                } else {
+                    throw e
+                }
+            }
+        } else {
+            ;({ server, redirectUri } = await this.buildCallbackServer())
+            this.logger.info(`OAuth: new redirect URI ${redirectUri}`)
+        }
+
+        try {
+            // 2) Try still-valid cached access_token
+            const cached = await this.read<Token>(tokPath)
+            if (cached) {
+                const expiry = cached.obtained_at + cached.expires_in * 1000
+                if (Date.now() < expiry) {
+                    this.logger.info(`OAuth: using still‑valid cached token`)
+                    return cached.access_token
+                }
+                this.logger.info(`OAuth: cached token expired → try refresh`)
+            }
+
+            // 3) Discover AS metadata
+            const meta = await this.discoverAS(mcpBase)
+            const scopes = ['openid']
+
+            // 4) Register (or reuse) a dynamic client
+            const reg = await this.obtainClient(meta, regPath, scopes, redirectUri)
+
+            // 5) Refresh‑token grant (one shot)
+            if (cached?.refresh_token) {
+                const refreshed = await this.refreshGrant(meta, reg, mcpBase, cached.refresh_token)
+                if (refreshed) {
+                    await this.write(tokPath, refreshed)
+                    this.logger.info(`OAuth: refresh grant succeeded`)
+                    return refreshed.access_token
+                }
+                this.logger.info(`OAuth: refresh grant failed`)
+            }
+
+            // 6) PKCE interactive flow
+            const fresh = await this.pkceGrant(meta, reg, mcpBase, scopes, redirectUri, server)
+            await this.write(tokPath, fresh)
+            return fresh.access_token
+        } finally {
+            await new Promise<void>(res => server.close(() => res()))
+        }
+    }
+
+    // Spin up a one‑time HTTP listener on localhost:randomPort */
+    private static async buildCallbackServer(): Promise<{ server: http.Server; redirectUri: string }> {
+        const server = http.createServer()
+        const port = await new Promise<number>(res =>
+            server.listen(0, '127.0.0.1', () => res((server.address() as any).port))
+        )
+        return { server, redirectUri: `http://localhost:${port}` }
+    }
+
+    /** Discover OAuth endpoints by HEAD/WWW‑Authenticate, well‑known, or fallback */
+    private static async discoverAS(rs: URL): Promise<Meta> {
+        // a) HEAD → WWW‑Authenticate → resource_metadata
+        try {
+            const h = await fetch(rs.toString(), { method: 'HEAD' })
+            const header = h.headers.get('www-authenticate') || ''
+            const m = /resource_metadata=(?:"([^"]+)"|([^,\s]+))/i.exec(header)
+            if (m) {
+                const metaUrl = new URL(m[1] || m[2], rs).toString()
+                this.logger.info(`OAuth: resource_metadata → ${metaUrl}`)
+                const raw = await this.json<any>(metaUrl)
+                return this.fetchASFromResourceMeta(raw, metaUrl)
+            }
+        } catch {
+            // ignore and fallback
+        }
+
+        // b) well‑known on resource host
+        const probes = [
+            new URL('.well-known/oauth-authorization-server', rs).toString(),
+            new URL('.well-known/openid-configuration', rs).toString(),
+            `${rs.origin}/.well-known/oauth-authorization-server`,
+            `${rs.origin}/.well-known/openid-configuration`,
+        ]
+        for (const url of probes) {
+            try {
+                this.logger.info(`OAuth: probing ${url}`)
+                return await this.json<Meta>(url)
+            } catch {
+                // next
+            }
+        }
+
+        // c) fallback to GitHub‑style
+        const base = (rs.origin + rs.pathname).replace(/\/+$/, '')
+        this.logger.warn(`OAuth: synthesising endpoints from ${base}`)
+        return {
+            authorization_endpoint: `${base}/authorize`,
+            token_endpoint: `${base}/access_token`,
+        }
+    }
+
+    /** Follow `authorization_server(s)` in resource_metadata JSON */
+    private static async fetchASFromResourceMeta(raw: any, metaUrl: string): Promise<Meta> {
+        let asBase = raw.authorization_server
+        if (!asBase && Array.isArray(raw.authorization_servers)) {
+            asBase = raw.authorization_servers[0]
+        }
+        if (!asBase) {
+            throw new Error(`resource_metadata at ${metaUrl} lacked authorization_server(s)`)
+        }
+
+        // Attempt both OAuth‑AS and OIDC well‑known
+        for (const p of ['.well-known/oauth-authorization-server', '.well-known/openid-configuration']) {
+            try {
+                return await this.json<Meta>(new URL(p, asBase).toString())
+            } catch {
+                // next
+            }
+        }
+        throw new Error(`Failed well‑known fetch from ${asBase}, the server might not support OAuth authroization`)
+    }
+
+    /** DCR: POST client metadata → client_id; cache to disk */
+    private static async obtainClient(
+        meta: Meta,
+        file: string,
+        scopes: string[],
+        redirectUri: string
+    ): Promise<Registration> {
+        const existing = await this.read<Registration>(file)
+        if (existing && (!existing.expires_at || existing.expires_at * 1000 > Date.now())) {
+            this.logger.info(`OAuth: reusing client_id ${existing.client_id}`)
+            return existing
+        }
+
+        if (!meta.registration_endpoint) {
+            throw new Error('OAuth: AS does not support dynamic registration')
+        }
+
+        const body = {
+            client_name: 'AWS MCP LSP',
+            grant_types: ['authorization_code', 'refresh_token'],
+            response_types: ['code'],
+            token_endpoint_auth_method: 'none',
+            scope: scopes.join(' '),
+            redirect_uris: [redirectUri],
+        }
+        const resp: any = await this.json(meta.registration_endpoint, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(body),
+        })
+
+        const reg: Registration = {
+            client_id: resp.client_id,
+            client_secret: resp.client_secret,
+            expires_at: resp.client_secret_expires_at,
+            redirect_uri: redirectUri,
+        }
+        await this.write(file, reg)
+        return reg
+    }
+
+    /** Try one refresh_token grant; returns new Token or `undefined` */
+    private static async refreshGrant(
+        meta: Meta,
+        reg: Registration,
+        rs: URL,
+        refresh: string
+    ): Promise<Token | undefined> {
+        const form = new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refresh,
+            client_id: reg.client_id,
+            resource: rs.toString(),
+        })
+        const res = await fetch(meta.token_endpoint, {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: form,
+        })
+        if (!res.ok) return undefined
+        const j = (await res.json()) as Record<string, unknown>
+        return { ...(j as object), obtained_at: Date.now() } as Token
+    }
+
+    /** One PKCE flow: browser + loopback → code → token */
+    private static async pkceGrant(
+        meta: Meta,
+        reg: Registration,
+        rs: URL,
+        scopes: string[],
+        redirectUri: string,
+        server: http.Server
+    ): Promise<Token> {
+        // a) generate PKCE params
+        const verifier = this.b64url(crypto.randomBytes(32))
+        const challenge = this.b64url(crypto.createHash('sha256').update(verifier).digest())
+        const state = this.b64url(crypto.randomBytes(16))
+
+        // b) build authorize URL + launch browser
+        const authz = new URL(meta.authorization_endpoint)
+        authz.search = new URLSearchParams({
+            client_id: reg.client_id,
+            response_type: 'code',
+            code_challenge: challenge,
+            code_challenge_method: 'S256',
+            resource: rs.toString(),
+            scope: scopes.join(' '),
+            redirect_uri: redirectUri,
+            state: state,
+        }).toString()
+
+        const opener =
+            process.platform === 'win32'
+                ? { cmd: 'cmd', args: ['/c', 'start', authz.toString()] }
+                : process.platform === 'darwin'
+                  ? { cmd: 'open', args: [authz.toString()] }
+                  : { cmd: 'xdg-open', args: [authz.toString()] }
+
+        void spawn(opener.cmd, opener.args, { detached: true, stdio: 'ignore' }).unref()
+
+        // c) wait for code on our loopback
+        const { code, rxState, err } = await new Promise<{ code: string; rxState: string; err?: string }>(resolve => {
+            server.on('request', (req, res) => {
+                const u = new URL(req.url || '/', redirectUri)
+                const c = u.searchParams.get('code') || ''
+                const s = u.searchParams.get('state') || ''
+                const e = u.searchParams.get('error') || undefined
+                res.writeHead(200, { 'content-type': 'text/html' }).end('<h2>You may close this tab.</h2>')
+                resolve({ code: c, rxState: s, err: e })
+            })
+        })
+        if (err) throw new Error(`Authorization error: ${err}`)
+        if (!code || rxState !== state) throw new Error('Invalid authorization response (state mismatch)')
+
+        // d) exchange code for token
+        const form2 = new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            code_verifier: verifier,
+            client_id: reg.client_id,
+            redirect_uri: redirectUri,
+            resource: rs.toString(),
+        })
+        const res2 = await fetch(meta.token_endpoint, {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: form2,
+        })
+        if (!res2.ok) throw new Error(`Token exchange failed: ${await res2.text()}`)
+
+        const tk = (await res2.json()) as Record<string, unknown>
+        return { ...(tk as object), obtained_at: Date.now() } as Token
+    }
+
+    /** Fetch + error‑check + parse JSON */
+    private static async json<T>(url: string, init?: RequestInit): Promise<T> {
+        const r = await fetch(url, init)
+        if (!r.ok) {
+            const txt = await r.text().catch(() => '')
+            throw new Error(`HTTP ${r.status}@${url} — ${txt}`)
+        }
+        return (await r.json()) as T
+    }
+
+    /** Read & parse JSON file via workspace.fs */
+    private static async read<T>(file: string): Promise<T | undefined> {
+        try {
+            if (!(await this.workspace.fs.exists(file))) return undefined
+            const buf = await this.workspace.fs.readFile(file)
+            return JSON.parse(buf.toString()) as T
+        } catch {
+            return undefined
+        }
+    }
+
+    /** Write JSON, then clamp file perms to 0600 (owner read/write) */
+    private static async write(file: string, obj: unknown): Promise<void> {
+        const dir = path.dirname(file)
+        await this.workspace.fs.mkdir(dir, { recursive: true })
+        await this.workspace.fs.writeFile(file, JSON.stringify(obj, null, 2), { mode: 0o600 })
+    }
+
+    /** SHA‑256 of resourceServer URL → hex key */
+    private static computeKey(rs: URL): string {
+        return crypto
+            .createHash('sha256')
+            .update(rs.origin + rs.pathname)
+            .digest('hex')
+    }
+
+    /** RFC‑7636 base64url without padding */
+    private static b64url(buf: Buffer): string {
+        return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+    }
+
+    /** Directory for caching registration + tokens */
+    private static readonly cacheDir = path.join(
+        process.env.HOME || process.env.USERPROFILE || '.',
+        '.aws',
+        'sso',
+        'cache'
+    )
+}

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -85,7 +85,7 @@ export class LocalProjectContextController {
         try {
             await waitUntil(async () => this.instance, {
                 interval: 1000,
-                timeout: 60_000,
+                timeout: 60,
                 truthy: true,
             })
 
@@ -359,7 +359,7 @@ export class LocalProjectContextController {
                     }
                     return false
                 },
-                { interval: 1000, timeout: 60_000, truthy: true }
+                { interval: 1000, timeout: 60, truthy: true }
             )
             return true
         } catch (error) {

--- a/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/localProjectContextController.ts
@@ -85,7 +85,7 @@ export class LocalProjectContextController {
         try {
             await waitUntil(async () => this.instance, {
                 interval: 1000,
-                timeout: 60,
+                timeout: 60_000,
                 truthy: true,
             })
 
@@ -359,7 +359,7 @@ export class LocalProjectContextController {
                     }
                     return false
                 },
-                { interval: 1000, timeout: 60, truthy: true }
+                { interval: 1000, timeout: 60_000, truthy: true }
             )
             return true
         } catch (error) {


### PR DESCRIPTION
## Problem
Currently we don't support MCP server that require OAuth with dynamic client registration.

## Solution
Add basic OAuth client to support dynamic client registration with PKCE, more details can be found, https://quip-amazon.com/DnsKAhaSjC4B/OAuth-enabled-MCP-HTTPSSE-support

## TODO:
1. Disable DCR when plugin loads
2. UX changes during browser authenticaiton
3. Some UX edge case handling. 


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
