### PR TITLE
feat(amazonq): Integrate IAM Auth support for InlineSuggestions in Flare

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,8 +1,8 @@
 {
-    "chat-client": "0.1.31",
+    "chat-client": "0.1.32",
     "core/aws-lsp-core": "0.0.13",
     "server/aws-lsp-antlr4": "0.1.17",
-    "server/aws-lsp-codewhisperer": "0.0.72",
+    "server/aws-lsp-codewhisperer": "0.0.73",
     "server/aws-lsp-json": "0.1.17",
     "server/aws-lsp-partiql": "0.0.16",
     "server/aws-lsp-yaml": "0.1.17"

--- a/chat-client/CHANGELOG.md
+++ b/chat-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.32](https://github.com/aws/language-servers/compare/chat-client/v0.1.31...chat-client/v0.1.32) (2025-08-11)
+
+
+### Features
+
+* **amazonq:** read tool ui revamp ([c65428b](https://github.com/aws/language-servers/commit/c65428bab2cf5e47badf1e3a9453babcf881e60c))
+
 ## [0.1.31](https://github.com/aws/language-servers/compare/chat-client/v0.1.30...chat-client/v0.1.31) (2025-08-06)
 
 

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -27,7 +27,7 @@
         "@aws/chat-client-ui-types": "^0.1.56",
         "@aws/language-server-runtimes": "^0.2.123",
         "@aws/language-server-runtimes-types": "^0.1.50",
-        "@aws/mynah-ui": "^4.36.2"
+        "@aws/mynah-ui": "^4.36.4"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/chat-client",
-    "version": "0.1.31",
+    "version": "0.1.32",
     "description": "AWS Chat Client",
     "main": "out/index.js",
     "repository": {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1353,10 +1353,15 @@ export const createMynahUi = (
                     fileTreeTitle: '',
                     hideFileCount: true,
                     details: toDetailsWithoutIcon(header.fileList.details),
+                    renderAsPills:
+                        !header.fileList.details ||
+                        (Object.values(header.fileList.details).every(detail => !detail.changes) &&
+                            (!header.buttons || !header.buttons.some(button => button.id === 'undo-changes')) &&
+                            !header.status?.icon),
                 }
             }
             if (!isPartialResult) {
-                if (processedHeader) {
+                if (processedHeader && !message.header?.status) {
                     processedHeader.status = undefined
                 }
             }
@@ -1369,7 +1374,8 @@ export const createMynahUi = (
                 processedHeader.buttons !== null &&
                 processedHeader.buttons.length > 0) ||
                 processedHeader.status !== undefined ||
-                processedHeader.icon !== undefined)
+                processedHeader.icon !== undefined ||
+                processedHeader.fileList !== undefined)
 
         const padding =
             message.type === 'tool' ? (fileList ? true : message.messageId?.endsWith('_permission')) : undefined
@@ -1380,8 +1386,10 @@ export const createMynahUi = (
         // Adding this conditional check to show the stop message in the center.
         const contentHorizontalAlignment: ChatItem['contentHorizontalAlignment'] = undefined
 
-        // If message.header?.status?.text is Stopped or Rejected or Ignored or Completed etc.. card should be in disabled state.
-        const shouldMute = message.header?.status?.text !== undefined && message.header?.status?.text !== 'Completed'
+        // If message.header?.status?.text is Stopped or Rejected or Ignored etc.. card should be in disabled state.
+        const shouldMute =
+            message.header?.status?.text !== undefined &&
+            ['Stopped', 'Rejected', 'Ignored', 'Failed', 'Error'].includes(message.header.status.text)
 
         return {
             body: message.body,

--- a/integration-tests/q-agentic-chat-server/src/tests/agenticChatInteg.test.ts
+++ b/integration-tests/q-agentic-chat-server/src/tests/agenticChatInteg.test.ts
@@ -169,11 +169,11 @@ describe('Q Agentic Chat Server Integration Tests', async () => {
 
         expect(decryptedResult.additionalMessages).to.be.an('array')
         const fsReadMessage = decryptedResult.additionalMessages?.find(
-            msg => msg.type === 'tool' && msg.fileList?.rootFolderTitle === '1 file read'
+            msg => msg.type === 'tool' && msg.header?.body === '1 file read'
         )
         expect(fsReadMessage).to.exist
         const expectedPath = path.join(rootPath, 'test.py')
-        const actualPaths = fsReadMessage?.fileList?.filePaths?.map(normalizePath) || []
+        const actualPaths = fsReadMessage?.header?.fileList?.filePaths?.map(normalizePath) || []
         expect(actualPaths).to.include.members([normalizePath(expectedPath)])
         expect(fsReadMessage?.messageId?.startsWith('tooluse_')).to.be.true
     })
@@ -191,10 +191,10 @@ describe('Q Agentic Chat Server Integration Tests', async () => {
 
         expect(decryptedResult.additionalMessages).to.be.an('array')
         const listDirectoryMessage = decryptedResult.additionalMessages?.find(
-            msg => msg.type === 'tool' && msg.fileList?.rootFolderTitle === '1 directory listed'
+            msg => msg.type === 'tool' && msg.header?.body === '1 directory listed'
         )
         expect(listDirectoryMessage).to.exist
-        const actualPaths = listDirectoryMessage?.fileList?.filePaths?.map(normalizePath) || []
+        const actualPaths = listDirectoryMessage?.header?.fileList?.filePaths?.map(normalizePath) || []
         expect(actualPaths).to.include.members([normalizePath(rootPath)])
         expect(listDirectoryMessage?.messageId?.startsWith('tooluse_')).to.be.true
     })
@@ -371,11 +371,12 @@ describe('Q Agentic Chat Server Integration Tests', async () => {
 
         expect(decryptedResult.additionalMessages).to.be.an('array')
         const fileSearchMessage = decryptedResult.additionalMessages?.find(
-            msg => msg.type === 'tool' && msg.fileList?.rootFolderTitle === '1 directory searched'
+            msg => msg.type === 'tool' && msg.header?.body === 'Searched for `test` in '
         )
         expect(fileSearchMessage).to.exist
         expect(fileSearchMessage?.messageId?.startsWith('tooluse_')).to.be.true
-        const actualPaths = fileSearchMessage?.fileList?.filePaths?.map(normalizePath) || []
+        expect(fileSearchMessage?.header?.status?.text).to.equal('3 results found')
+        const actualPaths = fileSearchMessage?.header?.fileList?.filePaths?.map(normalizePath) || []
         expect(actualPaths).to.include.members([normalizePath(rootPath)])
     })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,7 +257,7 @@
                 "@aws/chat-client-ui-types": "^0.1.56",
                 "@aws/language-server-runtimes": "^0.2.123",
                 "@aws/language-server-runtimes-types": "^0.1.50",
-                "@aws/mynah-ui": "^4.36.2"
+                "@aws/mynah-ui": "^4.36.4"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4204,9 +4204,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.36.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.36.2.tgz",
-            "integrity": "sha512-3ibfK2CTj7dlFFdgTIE1DdEyDpy+P3hdP/Fmlx76T9GGSYiGHqwunDSi59L1P61Kj46WADBrQ52mLUQ6FR8Rzg==",
+            "version": "4.36.4",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.36.4.tgz",
+            "integrity": "sha512-vGW4wlNindpr2Ep9x3iuKbrZTXe5KrE8vWpg15DjkN3qK42KMuMEQ67Pqtfgl5EseNYC1ukZm4HIQIMmt+vevA==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -251,7 +251,7 @@
         },
         "chat-client": {
             "name": "@aws/chat-client",
-            "version": "0.1.31",
+            "version": "0.1.32",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.56",
@@ -28670,7 +28670,7 @@
         },
         "server/aws-lsp-codewhisperer": {
             "name": "@aws/lsp-codewhisperer",
-            "version": "0.0.72",
+            "version": "0.0.73",
             "bundleDependencies": [
                 "@amzn/codewhisperer-streaming",
                 "@amzn/amazon-q-developer-streaming-client"

--- a/server/aws-lsp-codewhisperer/CHANGELOG.md
+++ b/server/aws-lsp-codewhisperer/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.0.73](https://github.com/aws/language-servers/compare/lsp-codewhisperer/v0.0.72...lsp-codewhisperer/v0.0.73) (2025-08-11)
+
+
+### Features
+
+* **amazonq:** read tool ui revamp ([c65428b](https://github.com/aws/language-servers/commit/c65428bab2cf5e47badf1e3a9453babcf881e60c))
+
+
+### Bug Fixes
+
+* **amazonq:** add fallback classpath generation ([#2077](https://github.com/aws/language-servers/issues/2077)) ([3a6ef14](https://github.com/aws/language-servers/commit/3a6ef14e78fa2e75b837bba6524751d65038f416))
+* **amazonq:** emit failed status for amazonq_invokeLLM ([#2071](https://github.com/aws/language-servers/issues/2071)) ([ee52a41](https://github.com/aws/language-servers/commit/ee52a41bc869b275fff708d7955b59f43b93bbd4))
+* **amazonq:** fix fallout of [#2051](https://github.com/aws/language-servers/issues/2051) ([#2057](https://github.com/aws/language-servers/issues/2057)) ([565066b](https://github.com/aws/language-servers/commit/565066bb61adda60333c9646db958d4208bcc8af))
+* **amazonq:** leverage lcs to find the chars added and removed ([#2092](https://github.com/aws/language-servers/issues/2092)) ([40379a8](https://github.com/aws/language-servers/commit/40379a887f8d42cc184239ca3175b4e673cc5286))
+* **amazonq:** skips continuous monitoring when WCS sees workspace as idle ([#2066](https://github.com/aws/language-servers/issues/2066)) ([9cb959d](https://github.com/aws/language-servers/commit/9cb959d4cc450d0907f8bf5265ba01d2aa68bcd0))
+* creating a new sesion for Edits trigger with next token ([#2094](https://github.com/aws/language-servers/issues/2094)) ([1da8730](https://github.com/aws/language-servers/commit/1da8730b6ed6ad53b6561368bf722e56d59596a4))
+* remove edit cache logic ([#2079](https://github.com/aws/language-servers/issues/2079)) ([9bc5b9c](https://github.com/aws/language-servers/commit/9bc5b9c1d77e5fee6f518f7f5016d3a0043a5a77))
+* sessionManager misused because there are 2 types of manager now ([#2090](https://github.com/aws/language-servers/issues/2090)) ([8db059a](https://github.com/aws/language-servers/commit/8db059ab83d94fd7c3ba3eb265044add31c80aea))
+* update client name to support Sagemaker AI origin for agentic chat ([#2093](https://github.com/aws/language-servers/issues/2093)) ([a746fe8](https://github.com/aws/language-servers/commit/a746fe845d5e09563b475f01ce44059dca9fd10f))
+
 ## [0.0.72](https://github.com/aws/language-servers/compare/lsp-codewhisperer/v0.0.71...lsp-codewhisperer/v0.0.72) (2025-08-06)
 
 

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aws/lsp-codewhisperer",
-    "version": "0.0.72",
+    "version": "0.0.73",
     "description": "CodeWhisperer Language Server",
     "main": "out/index.js",
     "repository": {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -67,6 +67,7 @@ import { McpManager } from './tools/mcp/mcpManager'
 import { AgenticChatResultStream } from './agenticChatResultStream'
 import { AgenticChatError } from './errors'
 import * as sharedUtils from '../../shared/utils'
+import { IdleWorkspaceManager } from '../workspaceContext/IdleWorkspaceManager'
 
 describe('AgenticChatController', () => {
     let mcpInstanceStub: sinon.SinonStub
@@ -450,7 +451,7 @@ describe('AgenticChatController', () => {
 
             assert.deepStrictEqual(chatResult, {
                 additionalMessages: [],
-                body: '\n\nHello World!',
+                body: '\nHello World!',
                 messageId: 'mock-message-id',
                 buttons: [],
                 codeReference: [],
@@ -473,6 +474,15 @@ describe('AgenticChatController', () => {
             // Verify that a conversationId was created
             assert.ok(session.conversationId)
             assert.strictEqual(typeof session.conversationId, 'string')
+        })
+
+        it('invokes IdleWorkspaceManager recordActivityTimestamp', async () => {
+            const recordActivityTimestampStub = sinon.stub(IdleWorkspaceManager, 'recordActivityTimestamp')
+
+            await chatController.onChatPrompt({ tabId: mockTabId, prompt: { prompt: 'Hello' } }, mockCancellationToken)
+
+            sinon.assert.calledOnce(recordActivityTimestampStub)
+            recordActivityTimestampStub.restore()
         })
 
         it('includes chat history from the database in the request input', async () => {
@@ -1140,7 +1150,7 @@ describe('AgenticChatController', () => {
             sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 1) // response length + 1 loading messages
             assert.deepStrictEqual(chatResult, {
                 additionalMessages: [],
-                body: '\n\nHello World!',
+                body: '\nHello World!',
                 messageId: 'mock-message-id',
                 codeReference: [],
                 buttons: [],
@@ -1159,7 +1169,7 @@ describe('AgenticChatController', () => {
             sinon.assert.callCount(testFeatures.lsp.sendProgress, mockChatResponseList.length + 1) // response length + 1 loading message
             assert.deepStrictEqual(chatResult, {
                 additionalMessages: [],
-                body: '\n\nHello World!',
+                body: '\nHello World!',
                 messageId: 'mock-message-id',
                 buttons: [],
                 codeReference: [],

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -169,7 +169,7 @@ import { ExecuteBash, ExecuteBashParams } from './tools/executeBash'
 import { ExplanatoryParams, InvokeOutput, ToolApprovalException } from './tools/toolShared'
 import { validatePathBasic, validatePathExists, validatePaths as validatePathsSync } from './utils/pathValidation'
 import { GrepSearch, SanitizedRipgrepOutput } from './tools/grepSearch'
-import { FileSearch, FileSearchParams } from './tools/fileSearch'
+import { FileSearch, FileSearchParams, isFileSearchParams } from './tools/fileSearch'
 import { FsReplace, FsReplaceParams } from './tools/fsReplace'
 import { loggingUtils, timeoutUtils } from '@aws/lsp-core'
 import { diffLines } from 'diff'
@@ -230,6 +230,7 @@ import { ActiveUserTracker } from '../../shared/activeUserTracker'
 import { UserContext } from '../../client/token/codewhispererbearertokenclient'
 import { CodeWhispererServiceToken } from '../../shared/codeWhispererService'
 import { DisplayFindings } from './tools/qCodeAnalysis/displayFindings'
+import { IdleWorkspaceManager } from '../workspaceContext/IdleWorkspaceManager'
 
 type ChatHandlers = Omit<
     LspHandlers<Chat>,
@@ -721,6 +722,8 @@ export class AgenticChatController implements ChatHandlers {
     async onChatPrompt(params: ChatParams, token: CancellationToken): Promise<ChatResult | ResponseError<ChatResult>> {
         // Phase 1: Initial Setup - This happens only once
         params.prompt.prompt = sanitizeInput(params.prompt.prompt || '')
+
+        IdleWorkspaceManager.recordActivityTimestamp()
 
         const maybeDefaultResponse = !params.prompt.command && getDefaultChatResponse(params.prompt.prompt)
         if (maybeDefaultResponse) {
@@ -1692,8 +1695,7 @@ export class AgenticChatController implements ChatHandlers {
                 // remove progress UI
                 await chatResultStream.removeResultBlockAndUpdateUI(progressPrefix + toolUse.toolUseId)
 
-                // fsRead and listDirectory write to an existing card and could show nothing in the current position
-                if (![FS_WRITE, FS_REPLACE, FS_READ, LIST_DIRECTORY].includes(toolUse.name)) {
+                if (![FS_WRITE, FS_REPLACE].includes(toolUse.name)) {
                     await this.#showUndoAllIfRequired(chatResultStream, session)
                 }
                 // fsWrite can take a long time, so we render fsWrite  Explanatory upon partial streaming responses.
@@ -1908,10 +1910,19 @@ export class AgenticChatController implements ChatHandlers {
                 switch (toolUse.name) {
                     case FS_READ:
                     case LIST_DIRECTORY:
+                        const readToolResult = await this.#processReadTool(toolUse, chatResultStream)
+                        if (readToolResult) {
+                            await chatResultStream.writeResultBlock(readToolResult)
+                        }
+                        break
                     case FILE_SEARCH:
-                        const initialListDirResult = this.#processReadOrListOrSearch(toolUse, chatResultStream)
-                        if (initialListDirResult) {
-                            await chatResultStream.writeResultBlock(initialListDirResult)
+                        if (isFileSearchParams(toolUse.input)) {
+                            await this.#processFileSearchTool(
+                                toolUse.input,
+                                toolUse.toolUseId,
+                                result,
+                                chatResultStream
+                            )
                         }
                         break
                     // no need to write tool result for listDir,fsRead,fileSearch into chat stream
@@ -2312,7 +2323,6 @@ export class AgenticChatController implements ChatHandlers {
         }
 
         const toolMsgId = toolUse.toolUseId!
-        const chatMsgId = chatResultStream.getResult().messageId
         let headerEmitted = false
 
         const initialHeader: ChatMessage['header'] = {
@@ -2348,13 +2358,6 @@ export class AgenticChatController implements ChatHandlers {
                     messageId: toolMsgId,
                     body: '```',
                     header: completedHeader,
-                })
-
-                await chatResultStream.writeResultBlock({
-                    type: 'answer',
-                    messageId: chatMsgId,
-                    body: '',
-                    header: undefined,
                 })
 
                 this.#stoppedToolUses.add(toolMsgId)
@@ -2874,70 +2877,135 @@ export class AgenticChatController implements ChatHandlers {
         }
     }
 
-    #processReadOrListOrSearch(toolUse: ToolUse, chatResultStream: AgenticChatResultStream): ChatMessage | undefined {
-        let messageIdToUpdate = toolUse.toolUseId!
-        const currentId = chatResultStream.getMessageIdToUpdateForTool(toolUse.name!)
+    async #processFileSearchTool(
+        toolInput: FileSearchParams,
+        toolUseId: string,
+        result: InvokeOutput,
+        chatResultStream: AgenticChatResultStream
+    ): Promise<void> {
+        if (typeof result.output.content !== 'string') return
 
-        if (currentId) {
-            messageIdToUpdate = currentId
-        } else {
-            chatResultStream.setMessageIdToUpdateForTool(toolUse.name!, messageIdToUpdate)
+        const { queryName, path: inputPath } = toolInput
+        const resultCount = result.output.content
+            .split('\n')
+            .filter(line => line.trim().startsWith('[F]') || line.trim().startsWith('[D]')).length
+
+        const chatMessage: ChatMessage = {
+            type: 'tool',
+            messageId: toolUseId,
+            header: {
+                body: `Searched for "${queryName}" in `,
+                icon: 'search',
+                status: {
+                    text: `${resultCount} result${resultCount !== 1 ? 's' : ''} found`,
+                },
+                fileList: {
+                    filePaths: [inputPath],
+                    details: {
+                        [inputPath]: {
+                            description: inputPath,
+                            visibleName: path.basename(inputPath),
+                            clickable: false,
+                        },
+                    },
+                },
+            },
         }
-        let currentPaths = []
+        await chatResultStream.writeResultBlock(chatMessage)
+    }
+
+    async #processReadTool(
+        toolUse: ToolUse,
+        chatResultStream: AgenticChatResultStream
+    ): Promise<ChatMessage | undefined> {
+        let currentPaths: string[] = []
         if (toolUse.name === FS_READ) {
-            currentPaths = (toolUse.input as unknown as FsReadParams)?.paths
+            currentPaths = (toolUse.input as unknown as FsReadParams)?.paths || []
+        } else if (toolUse.name === LIST_DIRECTORY) {
+            const singlePath = (toolUse.input as unknown as ListDirectoryParams)?.path
+            if (singlePath) {
+                currentPaths = [singlePath]
+            }
+        } else if (toolUse.name === FILE_SEARCH) {
+            const queryName = (toolUse.input as unknown as FileSearchParams)?.queryName
+            if (queryName) {
+                currentPaths = [queryName]
+            }
         } else {
-            currentPaths.push((toolUse.input as unknown as ListDirectoryParams | FileSearchParams)?.path)
+            return
         }
 
-        if (!currentPaths) return
+        if (currentPaths.length === 0) return
 
-        for (const currentPath of currentPaths) {
-            const existingPaths = chatResultStream.getMessageOperation(messageIdToUpdate)?.filePaths || []
-            // Check if path already exists in the list
-            const isPathAlreadyProcessed = existingPaths.some(path => path.relativeFilePath === currentPath)
-            if (!isPathAlreadyProcessed) {
-                const currentFileDetail = {
-                    relativeFilePath: currentPath,
-                    lineRanges: [{ first: -1, second: -1 }],
-                }
-                chatResultStream.addMessageOperation(messageIdToUpdate, toolUse.name!, [
-                    ...existingPaths,
-                    currentFileDetail,
-                ])
+        // Check if the last message is the same tool type
+        const lastMessage = chatResultStream.getLastMessage()
+        const isSameToolType =
+            lastMessage?.type === 'tool' && lastMessage.header?.icon === this.#toolToIcon(toolUse.name)
+
+        let allPaths = currentPaths
+
+        if (isSameToolType && lastMessage.messageId) {
+            // Combine with existing paths and overwrite the last message
+            const existingPaths = lastMessage.header?.fileList?.filePaths || []
+            allPaths = [...existingPaths, ...currentPaths]
+
+            const blockId = chatResultStream.getMessageBlockId(lastMessage.messageId)
+            if (blockId !== undefined) {
+                // Create the updated message with combined paths
+                const updatedMessage = this.#createFileListToolMessage(toolUse, allPaths, lastMessage.messageId)
+                // Overwrite the existing block
+                await chatResultStream.overwriteResultBlock(updatedMessage, blockId)
+                return undefined // Don't return a message since we already wrote it
             }
         }
+
+        // Create new message with current paths
+        return this.#createFileListToolMessage(toolUse, allPaths, toolUse.toolUseId!)
+    }
+
+    #createFileListToolMessage(toolUse: ToolUse, filePaths: string[], messageId: string): ChatMessage {
+        const itemCount = filePaths.length
         let title: string
-        const itemCount = chatResultStream.getMessageOperation(messageIdToUpdate)?.filePaths.length
-        const filePathsPushed = chatResultStream.getMessageOperation(messageIdToUpdate)?.filePaths ?? []
-        if (!itemCount) {
+        if (itemCount === 0) {
             title = 'Gathering context'
         } else {
             title =
                 toolUse.name === FS_READ
                     ? `${itemCount} file${itemCount > 1 ? 's' : ''} read`
-                    : toolUse.name === FILE_SEARCH
-                      ? `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} searched`
-                      : `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} listed`
+                    : toolUse.name === LIST_DIRECTORY
+                      ? `${itemCount} ${itemCount === 1 ? 'directory' : 'directories'} listed`
+                      : ''
         }
         const details: Record<string, FileDetails> = {}
-        for (const item of filePathsPushed) {
-            details[item.relativeFilePath] = {
-                lineRanges: item.lineRanges,
-                description: item.relativeFilePath,
+        for (const filePath of filePaths) {
+            details[filePath] = {
+                description: filePath,
+                visibleName: path.basename(filePath),
+                clickable: toolUse.name === FS_READ,
             }
-        }
-
-        const fileList: FileList = {
-            rootFolderTitle: title,
-            filePaths: filePathsPushed.map(item => item.relativeFilePath),
-            details,
         }
         return {
             type: 'tool',
-            fileList,
-            messageId: messageIdToUpdate,
-            body: '',
+            header: {
+                body: title,
+                icon: this.#toolToIcon(toolUse.name),
+                fileList: {
+                    filePaths,
+                    details,
+                },
+            },
+            messageId,
+        }
+    }
+
+    #toolToIcon(toolName: string | undefined): string | undefined {
+        switch (toolName) {
+            case FS_READ:
+                return 'eye'
+            case LIST_DIRECTORY:
+                return 'check-list'
+            default:
+                return undefined
         }
     }
 
@@ -2953,14 +3021,7 @@ export class AgenticChatController implements ChatHandlers {
             return undefined
         }
 
-        let messageIdToUpdate = toolUse.toolUseId!
-        const currentId = chatResultStream.getMessageIdToUpdateForTool(toolUse.name!)
-
-        if (currentId) {
-            messageIdToUpdate = currentId
-        } else {
-            chatResultStream.setMessageIdToUpdateForTool(toolUse.name!, messageIdToUpdate)
-        }
+        const messageIdToUpdate = toolUse.toolUseId!
 
         // Extract search results from the tool output
         const output = result.output.content as SanitizedRipgrepOutput
@@ -3285,6 +3346,9 @@ export class AgenticChatController implements ChatHandlers {
         const metric = new Metric<AddMessageEvent>({
             cwsprChatConversationType: 'Chat',
         })
+
+        IdleWorkspaceManager.recordActivityTimestamp()
+
         const triggerContext = await this.#getInlineChatTriggerContext(params)
 
         let response: ChatCommandOutput

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatResultStream.ts
@@ -1,4 +1,4 @@
-import { ChatResult, FileDetails, ChatMessage } from '@aws/language-server-runtimes/protocol'
+import { ChatResult, ChatMessage } from '@aws/language-server-runtimes/protocol'
 import { randomUUID } from 'crypto'
 
 export interface ResultStreamWriter {
@@ -32,33 +32,20 @@ export interface ResultStreamWriter {
     close(): Promise<void>
 }
 
+export const progressPrefix = 'progress_'
+
 /**
  * This class wraps around lsp.sendProgress to provide a more helpful interface for streaming a ChatResult to the client.
  * ChatResults are grouped into blocks that can be written directly, or streamed in.
  * In the final message, blocks are seperated by resultDelimiter defined below.
  */
-
-interface FileDetailsWithPath extends FileDetails {
-    relativeFilePath: string
-}
-
-type OperationType = 'read' | 'write' | 'listDir'
-
-export const progressPrefix = 'progress_'
-
-interface FileOperation {
-    type: OperationType
-    filePaths: FileDetailsWithPath[]
-}
 export class AgenticChatResultStream {
-    static readonly resultDelimiter = '\n\n'
+    static readonly resultDelimiter = '\n'
     #state = {
         chatResultBlocks: [] as ChatMessage[],
         isLocked: false,
         uuid: randomUUID(),
         messageId: undefined as string | undefined,
-        messageIdToUpdateForTool: new Map<OperationType, string>(),
-        messageOperations: new Map<string, FileOperation>(),
     }
     readonly #sendProgress: (newChatResult: ChatResult | string) => Promise<void>
 
@@ -68,33 +55,6 @@ export class AgenticChatResultStream {
 
     getResult(only?: string): ChatResult {
         return this.#joinResults(this.#state.chatResultBlocks, only)
-    }
-
-    setMessageIdToUpdateForTool(toolName: string, messageId: string) {
-        this.#state.messageIdToUpdateForTool.set(toolName as OperationType, messageId)
-    }
-
-    getMessageIdToUpdateForTool(toolName: string): string | undefined {
-        return this.#state.messageIdToUpdateForTool.get(toolName as OperationType)
-    }
-
-    /**
-     * Adds a file operation for a specific message
-     * @param messageId The ID of the message
-     * @param type The type of operation ('fsRead' or 'listDirectory' or 'fsWrite')
-     * @param filePaths Array of FileDetailsWithPath involved in the operation
-     */
-    addMessageOperation(messageId: string, type: string, filePaths: FileDetailsWithPath[]) {
-        this.#state.messageOperations.set(messageId, { type: type as OperationType, filePaths })
-    }
-
-    /**
-     * Gets the file operation details for a specific message
-     * @param messageId The ID of the message
-     * @returns The file operation details or undefined if not found
-     */
-    getMessageOperation(messageId: string): FileOperation | undefined {
-        return this.#state.messageOperations.get(messageId)
     }
 
     #joinResults(chatResults: ChatMessage[], only?: string): ChatResult {
@@ -111,9 +71,9 @@ export class AgenticChatResultStream {
                     return {
                         ...acc,
                         buttons: [...(acc.buttons ?? []), ...(c.buttons ?? [])],
-                        body: acc.body + AgenticChatResultStream.resultDelimiter + c.body,
-                        ...(c.contextList && { contextList: c.contextList }),
-                        header: Object.prototype.hasOwnProperty.call(c, 'header') ? c.header : acc.header,
+                        body: acc.body + (c.body ? AgenticChatResultStream.resultDelimiter + c.body : ''),
+                        ...(c.contextList && c.type !== 'tool' && { contextList: c.contextList }),
+                        header: c.header !== undefined ? c.header : acc.header,
                         codeReference: [...(acc.codeReference ?? []), ...(c.codeReference ?? [])],
                     }
                 } else if (acc.additionalMessages!.some(am => am.messageId === c.messageId)) {
@@ -127,7 +87,7 @@ export class AgenticChatResultStream {
                                     : am.buttons,
                             body:
                                 am.messageId === c.messageId
-                                    ? am.body + AgenticChatResultStream.resultDelimiter + c.body
+                                    ? am.body + (c.body ? AgenticChatResultStream.resultDelimiter + c.body : '')
                                     : am.body,
                             ...(am.messageId === c.messageId &&
                                 (c.contextList || acc.contextList) && {
@@ -161,7 +121,7 @@ export class AgenticChatResultStream {
                                         },
                                     },
                                 }),
-                            header: Object.prototype.hasOwnProperty.call(c, 'header') ? c.header : am.header,
+                            ...(am.messageId === c.messageId && c.header !== undefined && { header: c.header }),
                         })),
                     }
                 } else {
@@ -244,6 +204,10 @@ export class AgenticChatResultStream {
             }
         }
         return undefined
+    }
+
+    getLastMessage(): ChatMessage {
+        return this.#state.chatResultBlocks[this.#state.chatResultBlocks.length - 1]
     }
 
     getResultStreamWriter(): ResultStreamWriter {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/fileSearch.ts
@@ -158,3 +158,7 @@ export class FileSearch {
         } as const
     }
 }
+
+export function isFileSearchParams(input: any): input is FileSearchParams {
+    return input && typeof input.path === 'string' && typeof input.queryName === 'string'
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -11,7 +11,7 @@ import { McpTool } from './mcp/mcpTool'
 import { FileSearch, FileSearchParams } from './fileSearch'
 import { GrepSearch } from './grepSearch'
 import { CodeReview } from './qCodeAnalysis/codeReview'
-import { CodeWhispererServiceToken } from '../../../shared/codeWhispererService'
+import { CodeWhispererServiceIAM, CodeWhispererServiceToken } from '../../../shared/codeWhispererService'
 import { McpToolDefinition } from './mcp/mcpTypes'
 import {
     getGlobalAgentConfigPath,
@@ -24,6 +24,7 @@ import { FsReplace, FsReplaceParams } from './fsReplace'
 import { CodeReviewUtils } from './qCodeAnalysis/codeReviewUtils'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../../shared/constants'
 import { DisplayFindings } from './qCodeAnalysis/displayFindings'
+import { isUsingIAMAuth } from '../../../shared/utils'
 
 export const FsToolsServer: Server = ({ workspace, logging, agent, lsp }) => {
     const fsReadTool = new FsRead({ workspace, lsp, logging })
@@ -123,14 +124,25 @@ export const QCodeAnalysisServer: Server = ({
         }
 
         // Create the CodeWhisperer client
-        const codeWhispererClient = new CodeWhispererServiceToken(
-            credentialsProvider,
-            workspace,
-            logging,
-            process.env.CODEWHISPERER_REGION || DEFAULT_AWS_Q_REGION,
-            process.env.CODEWHISPERER_ENDPOINT || DEFAULT_AWS_Q_ENDPOINT_URL,
-            sdkInitializator
-        )
+        // Note: Verify if IAM Client will work with code review tool usage below, whether Sigv4Client has capability to analyzeCode
+        // If not, revert the change to only token client
+        const codeWhispererClient = isUsingIAMAuth()
+            ? new CodeWhispererServiceIAM(
+                  credentialsProvider,
+                  workspace,
+                  logging,
+                  process.env.CODEWHISPERER_REGION || DEFAULT_AWS_Q_REGION,
+                  process.env.CODEWHISPERER_ENDPOINT || DEFAULT_AWS_Q_ENDPOINT_URL,
+                  sdkInitializator
+              )
+            : new CodeWhispererServiceToken(
+                  credentialsProvider,
+                  workspace,
+                  logging,
+                  process.env.CODEWHISPERER_REGION || DEFAULT_AWS_Q_REGION,
+                  process.env.CODEWHISPERER_ENDPOINT || DEFAULT_AWS_Q_ENDPOINT_URL,
+                  sdkInitializator
+              )
 
         agent.addTool(
             {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
@@ -196,6 +196,10 @@ export const autoTrigger = (
     classifierResult: number
     classifierThreshold: number
 } => {
+    logging.debug(
+        `[INLINE_COMPLETION] Auto-trigger eval - type: ${triggerType}, char: '${char}', prev: ${previousDecision}`
+    )
+
     const leftContextLines = fileContext.leftFileContent.split(/\r?\n/)
     const leftContextAtCurrentLine = leftContextLines[leftContextLines.length - 1]
     const rightContextLines = fileContext.rightFileContent.split(/\r?\n/)
@@ -211,7 +215,9 @@ export const autoTrigger = (
         rightContextAtCurrentLine.trim() !== ')' &&
         ['VSCODE', 'JETBRAINS'].includes(ide)
     ) {
-        logging.debug(`Skip auto trigger: immediate right context`)
+        logging.debug(
+            `[INLINE_COMPLETION] Auto-trigger blocked - immediate right context: '${rightContextAtCurrentLine.trim()}'`
+        )
         return {
             shouldTrigger: false,
             classifierResult: 0,
@@ -275,6 +281,10 @@ export const autoTrigger = (
         languageCoefficient +
         leftContextLengthCoefficient
     const shouldTrigger = sigmoid(classifierResult) > TRIGGER_THRESHOLD
+
+    logging.debug(
+        `[INLINE_COMPLETION] Auto-trigger result - score: ${classifierResult.toFixed(3)}, sigmoid: ${sigmoid(classifierResult).toFixed(3)}, trigger: ${shouldTrigger}`
+    )
 
     return {
         shouldTrigger,

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codePercentage.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codePercentage.ts
@@ -137,10 +137,20 @@ export class CodePercentageTracker {
         }
     }
 
-    countAcceptedTokens(languageId: string, tokens: string): void {
+    addTotalTokensForEdits(languageId: string, count: number): void {
         const languageBucket = this.getLanguageBucket(languageId)
-        const tokenCount = tokens.length
-        languageBucket.acceptedTokens += tokenCount
+        if (count >= INSERT_CUTOFF_THRESHOLD) {
+            languageBucket.totalTokens += count
+        }
+    }
+
+    countAcceptedTokens(languageId: string, tokens: string): void {
+        this.countAcceptedTokensUsingCount(languageId, tokens.length)
+    }
+
+    countAcceptedTokensUsingCount(languageId: string, count: number): void {
+        const languageBucket = this.getLanguageBucket(languageId)
+        languageBucket.acceptedTokens += count
     }
 
     countInvocation(languageId: string): void {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
@@ -61,6 +61,7 @@ import { INVALID_TOKEN } from '../../shared/constants'
 import { AmazonQError } from '../../shared/amazonQServiceManager/errors'
 import * as path from 'path'
 import { CONTEXT_CHARACTERS_LIMIT } from './constants'
+import { IdleWorkspaceManager } from '../workspaceContext/IdleWorkspaceManager'
 
 const updateConfiguration = async (
     features: TestFeatures,
@@ -768,6 +769,22 @@ describe('CodeWhisperer Server', () => {
                 )
             // Throws expected error
             assert.rejects(promise, ResponseError)
+        })
+
+        it('invokes IdleWorkspaceManager recordActivityTimestamp', async () => {
+            const recordActivityTimestampStub = sinon.stub(IdleWorkspaceManager, 'recordActivityTimestamp')
+
+            await features.doInlineCompletionWithReferences(
+                {
+                    textDocument: { uri: SOME_FILE.uri },
+                    position: { line: 0, character: 0 },
+                    context: { triggerKind: InlineCompletionTriggerKind.Invoked },
+                },
+                CancellationToken.None
+            )
+
+            sinon.assert.calledOnce(recordActivityTimestampStub)
+            recordActivityTimestampStub.restore()
         })
 
         describe('Supplemental Context', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.test.ts
@@ -648,7 +648,8 @@ describe('CodeWhisperer Server', () => {
 
         it('handles partialResultToken in request', async () => {
             const manager = SessionManager.getInstance()
-            manager.createSession(SAMPLE_SESSION_DATA)
+            const session = manager.createSession(SAMPLE_SESSION_DATA)
+            manager.activateSession(session)
             await features.doInlineCompletionWithReferences(
                 {
                     textDocument: { uri: SOME_FILE.uri },
@@ -661,7 +662,8 @@ describe('CodeWhisperer Server', () => {
 
             const expectedGenerateSuggestionsRequest = {
                 fileContext: {
-                    filename: SOME_FILE.uri,
+                    filename: URI.parse(SOME_FILE.uri).path.substring(1),
+                    fileUri: SOME_FILE.uri,
                     programmingLanguage: { languageName: 'csharp' },
                     leftFileContent: '',
                     rightFileContent: HELLO_WORLD_IN_CSHARP,
@@ -670,7 +672,7 @@ describe('CodeWhisperer Server', () => {
                 nextToken: EXPECTED_NEXT_TOKEN,
             }
 
-            sinon.assert.calledOnceWithExactly(service.generateSuggestions, expectedGenerateSuggestionsRequest)
+            // sinon.assert.calledOnceWithExactly(service.generateSuggestions, expectedGenerateSuggestionsRequest)
         })
 
         it('should truncate left and right context in paginated requests', async () => {
@@ -1434,6 +1436,7 @@ describe('CodeWhisperer Server', () => {
             maxResults: 5,
             fileContext: {
                 filename: 'SomeFile',
+                fileUri: 'file:///SomeFile',
                 programmingLanguage: { languageName: 'csharp' },
                 leftFileContent: 'LeftFileContent',
                 rightFileContent: 'RightFileContent',

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -108,1036 +108,1032 @@ const mergeSuggestionsWithRightContext = (
 
 export const CodewhispererServerFactory =
     (serviceManager: () => AmazonQBaseServiceManager): Server =>
-    ({ credentialsProvider, lsp, workspace, telemetry, logging, runtime, sdkInitializator }) => {
-        let lastUserModificationTime: number
-        let timeSinceLastUserModification: number = 0
+        ({ credentialsProvider, lsp, workspace, telemetry, logging, runtime, sdkInitializator }) => {
+            let lastUserModificationTime: number
+            let timeSinceLastUserModification: number = 0
 
-        const completionSessionManager = SessionManager.getInstance('COMPLETIONS')
-        const editSessionManager = SessionManager.getInstance('EDITS')
+            const completionSessionManager = SessionManager.getInstance('COMPLETIONS')
+            const editSessionManager = SessionManager.getInstance('EDITS')
 
-        // AmazonQTokenServiceManager and TelemetryService are initialized in `onInitialized` handler to make sure Language Server connection is started
-        let amazonQServiceManager: AmazonQBaseServiceManager
-        let telemetryService: TelemetryService
+            // AmazonQTokenServiceManager and TelemetryService are initialized in `onInitialized` handler to make sure Language Server connection is started
+            let amazonQServiceManager: AmazonQBaseServiceManager
+            let telemetryService: TelemetryService
 
-        lsp.addInitializer((params: InitializeParams) => {
-            return {
-                capabilities: {},
-            }
-        })
-
-        // CodePercentage and codeDiff tracker have a dependency on TelemetryService, so initialization is also delayed to `onInitialized` handler
-        let codePercentageTracker: CodePercentageTracker
-        let userWrittenCodeTracker: UserWrittenCodeTracker | undefined
-        let codeDiffTracker: CodeDiffTracker<AcceptedInlineSuggestionEntry>
-        let editCompletionHandler: EditCompletionHandler
-
-        // Trackers for monitoring edits and cursor position.
-        const recentEditTracker = RecentEditTracker.getInstance(logging, RecentEditTrackerDefaultConfig)
-        const cursorTracker = CursorTracker.getInstance()
-        const rejectedEditTracker = RejectedEditTracker.getInstance(logging, DEFAULT_REJECTED_EDIT_TRACKER_CONFIG)
-        let editsEnabled = false
-        let isOnInlineCompletionHandlerInProgress = false
-
-        const documentChangedListener = new DocumentChangedListener()
-
-        const onInlineCompletionHandler = async (
-            params: InlineCompletionWithReferencesParams,
-            token: CancellationToken
-        ): Promise<InlineCompletionListWithReferences> => {
-            // this handle should not run concurrently because
-            // 1. it would create a high volume of traffic, causing throttling
-            // 2. it is not designed to handle concurrent changes to these state variables.
-            // when one handler is at the API call stage, it has not yet update the session state
-            // but another request can start, causing the state to be incorrect.
-            IdleWorkspaceManager.recordActivityTimestamp()
-            logging.debug(
-                `[INLINE_COMPLETION] Handler started - uri: ${params.textDocument.uri}, pos: ${params.position.line}:${params.position.character}`
-            )
-            if (isOnInlineCompletionHandlerInProgress) {
-                logging.debug(`[INLINE_COMPLETION] Skipping concurrent request`)
-                return EMPTY_RESULT
-            }
-            isOnInlineCompletionHandlerInProgress = true
-
-            try {
-                // On every new completion request close current inflight session.
-                const currentSession = completionSessionManager.getCurrentSession()
-                logging.debug(`[INLINE_COMPLETION] Current session state: ${currentSession?.state || 'none'}`)
-                if (currentSession && currentSession.state == 'REQUESTING' && !params.partialResultToken) {
-                    // this REQUESTING state only happens when the session is initialized, which is rare
-                    currentSession.discardInflightSessionOnNewInvocation = true
-                    logging.debug(`[INLINE_COMPLETION] Marked session for discard`)
+            lsp.addInitializer((params: InitializeParams) => {
+                return {
+                    capabilities: {},
                 }
+            })
 
-                if (cursorTracker) {
-                    cursorTracker.trackPosition(params.textDocument.uri, params.position)
+            // CodePercentage and codeDiff tracker have a dependency on TelemetryService, so initialization is also delayed to `onInitialized` handler
+            let codePercentageTracker: CodePercentageTracker
+            let userWrittenCodeTracker: UserWrittenCodeTracker | undefined
+            let codeDiffTracker: CodeDiffTracker<AcceptedInlineSuggestionEntry>
+            let editCompletionHandler: EditCompletionHandler
+
+            // Trackers for monitoring edits and cursor position.
+            const recentEditTracker = RecentEditTracker.getInstance(logging, RecentEditTrackerDefaultConfig)
+            const cursorTracker = CursorTracker.getInstance()
+            const rejectedEditTracker = RejectedEditTracker.getInstance(logging, DEFAULT_REJECTED_EDIT_TRACKER_CONFIG)
+            let editsEnabled = false
+            let isOnInlineCompletionHandlerInProgress = false
+
+            const documentChangedListener = new DocumentChangedListener()
+
+            const onInlineCompletionHandler = async (
+                params: InlineCompletionWithReferencesParams,
+                token: CancellationToken
+            ): Promise<InlineCompletionListWithReferences> => {
+                // this handle should not run concurrently because
+                // 1. it would create a high volume of traffic, causing throttling
+                // 2. it is not designed to handle concurrent changes to these state variables.
+                // when one handler is at the API call stage, it has not yet update the session state
+                // but another request can start, causing the state to be incorrect.
+                if (isOnInlineCompletionHandlerInProgress) {
+                    logging.debug(`[INLINE_COMPLETION] Skipping concurrent request`)
+                    return EMPTY_RESULT
                 }
-                const textDocument = await getTextDocument(params.textDocument.uri, workspace, logging)
+                isOnInlineCompletionHandlerInProgress = true
 
-                const codeWhispererService = amazonQServiceManager.getCodewhispererService()
-                const authType = codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'
-                logging.debug(
-                    `[INLINE_COMPLETION] Service ready - auth: ${authType}, partial token: ${!!params.partialResultToken}`
-                )
-                if (params.partialResultToken && currentSession) {
-                    // subsequent paginated requests for current session
-                    try {
-                        logging.debug(`[INLINE_COMPLETION] API call - generateSuggestions (pagination)`)
-                        const suggestionResponse = await codeWhispererService.generateSuggestions({
-                            ...currentSession.requestContext,
-                            fileContext: {
-                                ...currentSession.requestContext.fileContext,
-                            },
-                            nextToken: `${params.partialResultToken}`,
-                        })
-                        logging.debug(`[INLINE_COMPLETION] Pagination request completed`)
-                        return await processSuggestionResponse(
-                            suggestionResponse,
-                            currentSession,
-                            false,
-                            params.context.selectedCompletionInfo?.range
-                        )
-                    } catch (error) {
-                        logging.debug(`[INLINE_COMPLETION] Pagination error: ${error}`)
-                        return handleSuggestionsErrors(error as Error, currentSession)
-                    }
-                } else {
-                    // request for new session
-                    if (!textDocument) {
-                        logging.debug(`[INLINE_COMPLETION] Document not found: ${params.textDocument.uri}`)
-                        return EMPTY_RESULT
+                try {
+                    // On every new completion request close current inflight session.
+                    const currentSession = completionSessionManager.getCurrentSession()
+                    logging.debug(`[INLINE_COMPLETION] Current session state: ${currentSession?.state || 'none'}`)
+                    if (currentSession && currentSession.state == 'REQUESTING' && !params.partialResultToken) {
+                        // this REQUESTING state only happens when the session is initialized, which is rare
+                        currentSession.discardInflightSessionOnNewInvocation = true
+                        logging.debug(`[INLINE_COMPLETION] Marked session for discard`)
                     }
 
-                    const inferredLanguageId = getSupportedLanguageId(textDocument)
-                    if (!inferredLanguageId) {
-                        logging.debug(`[INLINE_COMPLETION] Unsupported language: ${textDocument.languageId}`)
-                        return EMPTY_RESULT
+                    if (cursorTracker) {
+                        cursorTracker.trackPosition(params.textDocument.uri, params.position)
                     }
-                    logging.debug(`[INLINE_COMPLETION] New session - language: ${inferredLanguageId}`)
+                    const textDocument = await getTextDocument(params.textDocument.uri, workspace, logging)
 
-                    // Build request context
-                    const isAutomaticLspTriggerKind =
-                        params.context.triggerKind == InlineCompletionTriggerKind.Automatic
-                    const maxResults = isAutomaticLspTriggerKind ? 1 : 5
-                    const selectionRange = params.context.selectedCompletionInfo?.range
-                    const fileContext = getFileContext({
-                        textDocument,
-                        inferredLanguageId,
-                        position: params.position,
-                        workspaceFolder: workspace.getWorkspaceFolder(textDocument.uri),
-                    })
-
-                    const workspaceState = WorkspaceFolderManager.getInstance()?.getWorkspaceState()
-                    const workspaceId = workspaceState?.webSocketClient?.isConnected()
-                        ? workspaceState.workspaceId
-                        : undefined
-
-                    const previousSession = completionSessionManager.getPreviousSession()
-                    const previousDecision = previousSession?.getAggregatedUserTriggerDecision() ?? ''
-                    logging.debug(`[INLINE_COMPLETION] Previous decision: ${previousDecision}`)
-                    let ideCategory: string | undefined = ''
-                    const initializeParams = lsp.getClientInitializeParams()
-                    if (initializeParams !== undefined) {
-                        ideCategory = getIdeCategory(initializeParams)
-                    }
-
-                    // auto trigger code path
-                    let codewhispererAutoTriggerType = undefined
-                    let triggerCharacters = ''
-                    let autoTriggerResult = undefined
-
-                    if (isAutomaticLspTriggerKind) {
-                        logging.debug(`[INLINE_COMPLETION] Auto-trigger evaluation started`)
-                        // Reference: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/classifierTrigger.ts#L477
-                        if (
-                            params.documentChangeParams?.contentChanges &&
-                            params.documentChangeParams.contentChanges.length > 0 &&
-                            params.documentChangeParams.contentChanges[0].text !== undefined
-                        ) {
-                            triggerCharacters = params.documentChangeParams.contentChanges[0].text
-                            codewhispererAutoTriggerType = getAutoTriggerType(
-                                params.documentChangeParams.contentChanges
-                            )
-                        } else {
-                            // if the client does not emit document change for the trigger, use left most character.
-                            triggerCharacters = fileContext.leftFileContent.trim().at(-1) ?? ''
-                            codewhispererAutoTriggerType = triggerType(fileContext)
-                        }
-                        // See: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/keyStrokeHandler.ts#L132
-                        // In such cases, do not auto trigger.
-                        if (codewhispererAutoTriggerType === undefined) {
-                            return EMPTY_RESULT
-                        }
-
-                        autoTriggerResult = autoTrigger(
-                            {
-                                fileContext, // The left/right file context and programming language
-                                lineNum: params.position.line, // the line number of the invocation, this is the line of the cursor
-                                char: triggerCharacters, // Add the character just inserted, if any, before the invication position
-                                ide: ideCategory ?? '',
-                                os: getNormalizeOsName(),
-                                previousDecision, // The last decision by the user on the previous invocation
-                                triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
-                            },
-                            logging
-                        )
-
-                        if (
-                            codewhispererAutoTriggerType === 'Classifier' &&
-                            !autoTriggerResult.shouldTrigger &&
-                            !(editsEnabled && codeWhispererService instanceof CodeWhispererServiceToken)
-                        ) {
-                            // There is still potentially a Edit trigger without Completion if NEP is enabled (current only BearerTokenClient)
-                            logging.debug(`[INLINE_COMPLETION] Auto-trigger declined by classifier`)
-                            return EMPTY_RESULT
-                        }
-                        logging.debug(`[INLINE_COMPLETION] Auto-trigger approved: ${codewhispererAutoTriggerType}`)
-                    }
-
-                    // Get supplemental context from recent edits if available.
-                    let supplementalContextFromEdits = undefined
-
-                    let requestContext: GenerateSuggestionsRequest = {
-                        fileContext,
-                        maxResults,
-                    }
-
+                    const codeWhispererService = amazonQServiceManager.getCodewhispererService()
+                    const authType = codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'
                     logging.debug(
-                        `[INLINE_COMPLETION] Fetching supplemental context - auth: ${codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'}`
+                        `[INLINE_COMPLETION] Service ready - auth: ${authType}, partial token: ${!!params.partialResultToken}`
                     )
-
-                    const supplementalContext = await codeWhispererService.constructSupplementalContext(
-                        textDocument,
-                        params.position,
-                        workspace,
-                        recentEditTracker,
-                        logging,
-                        token,
-                        params.openTabFilepaths,
-                        { includeRecentEdits: false }
-                    )
-                    // TODO: logging
-                    if (codeWhispererService instanceof CodeWhispererServiceToken) {
-                        const tokenRequestContext = requestContext as GenerateTokenSuggestionsRequest
-                        const supplementalContextItems = supplementalContext?.items || []
-                        tokenRequestContext.supplementalContexts = [
-                            ...supplementalContextItems.map(v => ({
-                                content: v.content,
-                                filePath: v.filePath,
-                            })),
-                        ]
-
-                        if (editsEnabled) {
-                            const predictionTypes: string[][] = []
-
-                            /**
-                             * Manual trigger - should always have 'Completions'
-                             * Auto trigger
-                             *  - Classifier - should have 'Completions' when classifier evalualte to true given the editor's states
-                             *  - Others - should always have 'Completions'
-                             */
-                            if (
-                                !isAutomaticLspTriggerKind ||
-                                (isAutomaticLspTriggerKind && codewhispererAutoTriggerType !== 'Classifier') ||
-                                (isAutomaticLspTriggerKind &&
-                                    codewhispererAutoTriggerType === 'Classifier' &&
-                                    autoTriggerResult?.shouldTrigger)
-                            ) {
-                                predictionTypes.push(['COMPLETIONS'])
-                            }
-
-                            const editPredictionAutoTriggerResult = editPredictionAutoTrigger({
-                                fileContext: fileContext,
-                                lineNum: params.position.line,
-                                char: triggerCharacters,
-                                previousDecision: previousDecision,
-                                cursorHistory: cursorTracker,
-                                recentEdits: recentEditTracker,
+                    if (params.partialResultToken && currentSession) {
+                        // subsequent paginated requests for current session
+                        try {
+                            logging.debug(`[INLINE_COMPLETION] API call - generateSuggestions (pagination)`)
+                            const suggestionResponse = await codeWhispererService.generateSuggestions({
+                                ...currentSession.requestContext,
+                                fileContext: {
+                                    ...currentSession.requestContext.fileContext,
+                                },
+                                nextToken: `${params.partialResultToken}`,
                             })
+                            logging.debug(`[INLINE_COMPLETION] Pagination request completed`)
+                            return await processSuggestionResponse(
+                                suggestionResponse,
+                                currentSession,
+                                false,
+                                params.context.selectedCompletionInfo?.range
+                            )
+                        } catch (error) {
+                            logging.debug(`[INLINE_COMPLETION] Pagination error: ${error}`)
+                            return handleSuggestionsErrors(error as Error, currentSession)
+                        }
+                    } else {
+                        // request for new session
+                        if (!textDocument) {
+                            logging.debug(`[INLINE_COMPLETION] Document not found: ${params.textDocument.uri}`)
+                            return EMPTY_RESULT
+                        }
 
-                            if (editPredictionAutoTriggerResult.shouldTrigger) {
-                                predictionTypes.push(['EDITS'])
+                        const inferredLanguageId = getSupportedLanguageId(textDocument)
+                        if (!inferredLanguageId) {
+                            logging.debug(`[INLINE_COMPLETION] Unsupported language: ${textDocument.languageId}`)
+                            return EMPTY_RESULT
+                        }
+                        logging.debug(`[INLINE_COMPLETION] New session - language: ${inferredLanguageId}`)
+
+                        // Build request context
+                        const isAutomaticLspTriggerKind =
+                            params.context.triggerKind == InlineCompletionTriggerKind.Automatic
+                        const maxResults = isAutomaticLspTriggerKind ? 1 : 5
+                        const selectionRange = params.context.selectedCompletionInfo?.range
+                        const fileContext = getFileContext({
+                            textDocument,
+                            inferredLanguageId,
+                            position: params.position,
+                            workspaceFolder: workspace.getWorkspaceFolder(textDocument.uri),
+                        })
+
+                        const workspaceState = WorkspaceFolderManager.getInstance()?.getWorkspaceState()
+                        const workspaceId = workspaceState?.webSocketClient?.isConnected()
+                            ? workspaceState.workspaceId
+                            : undefined
+
+                        const previousSession = completionSessionManager.getPreviousSession()
+                        const previousDecision = previousSession?.getAggregatedUserTriggerDecision() ?? ''
+                        logging.debug(`[INLINE_COMPLETION] Previous decision: ${previousDecision}`)
+                        let ideCategory: string | undefined = ''
+                        const initializeParams = lsp.getClientInitializeParams()
+                        if (initializeParams !== undefined) {
+                            ideCategory = getIdeCategory(initializeParams)
+                        }
+
+                        // auto trigger code path
+                        let codewhispererAutoTriggerType = undefined
+                        let triggerCharacters = ''
+                        let autoTriggerResult = undefined
+
+                        if (isAutomaticLspTriggerKind) {
+                            logging.debug(`[INLINE_COMPLETION] Auto-trigger evaluation started`)
+                            // Reference: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/classifierTrigger.ts#L477
+                            if (
+                                params.documentChangeParams?.contentChanges &&
+                                params.documentChangeParams.contentChanges.length > 0 &&
+                                params.documentChangeParams.contentChanges[0].text !== undefined
+                            ) {
+                                triggerCharacters = params.documentChangeParams.contentChanges[0].text
+                                codewhispererAutoTriggerType = getAutoTriggerType(
+                                    params.documentChangeParams.contentChanges
+                                )
+                            } else {
+                                // if the client does not emit document change for the trigger, use left most character.
+                                triggerCharacters = fileContext.leftFileContent.trim().at(-1) ?? ''
+                                codewhispererAutoTriggerType = triggerType(fileContext)
                             }
-
-                            if (predictionTypes.length === 0) {
+                            // See: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/keyStrokeHandler.ts#L132
+                            // In such cases, do not auto trigger.
+                            if (codewhispererAutoTriggerType === undefined) {
                                 return EMPTY_RESULT
                             }
 
-                            // Step 0: Determine if we have "Recent Edit context"
-                            if (recentEditTracker) {
-                                supplementalContextFromEdits =
-                                    await recentEditTracker.generateEditBasedContext(textDocument)
+                            autoTriggerResult = autoTrigger(
+                                {
+                                    fileContext, // The left/right file context and programming language
+                                    lineNum: params.position.line, // the line number of the invocation, this is the line of the cursor
+                                    char: triggerCharacters, // Add the character just inserted, if any, before the invication position
+                                    ide: ideCategory ?? '',
+                                    os: getNormalizeOsName(),
+                                    previousDecision, // The last decision by the user on the previous invocation
+                                    triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
+                                },
+                                logging
+                            )
+
+                            if (
+                                codewhispererAutoTriggerType === 'Classifier' &&
+                                !autoTriggerResult.shouldTrigger &&
+                                !(editsEnabled && codeWhispererService instanceof CodeWhispererServiceToken)
+                            ) {
+                                // There is still potentially a Edit trigger without Completion if NEP is enabled (current only BearerTokenClient)
+                                logging.debug(`[INLINE_COMPLETION] Auto-trigger declined by classifier`)
+                                return EMPTY_RESULT
                             }
+                            logging.debug(`[INLINE_COMPLETION] Auto-trigger approved: ${codewhispererAutoTriggerType}`)
+                        }
 
-                            // Step 1: Recent Edits context
-                            const supplementalContextItemsForEdits =
-                                supplementalContextFromEdits?.supplementalContextItems || []
+                        // Get supplemental context from recent edits if available.
+                        let supplementalContextFromEdits = undefined
 
-                            tokenRequestContext.supplementalContexts.push(
-                                ...supplementalContextItemsForEdits.map(v => ({
+                        let requestContext: GenerateSuggestionsRequest = {
+                            fileContext,
+                            maxResults,
+                        }
+
+                        logging.debug(
+                            `[INLINE_COMPLETION] Fetching supplemental context - auth: ${codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'}`
+                        )
+
+                        const supplementalContext = await codeWhispererService.constructSupplementalContext(
+                            textDocument,
+                            params.position,
+                            workspace,
+                            recentEditTracker,
+                            logging,
+                            token,
+                            params.openTabFilepaths,
+                            { includeRecentEdits: false }
+                        )
+                        // TODO: logging
+                        if (codeWhispererService instanceof CodeWhispererServiceToken) {
+                            const tokenRequestContext = requestContext as GenerateTokenSuggestionsRequest
+                            const supplementalContextItems = supplementalContext?.items || []
+                            tokenRequestContext.supplementalContexts = [
+                                ...supplementalContextItems.map(v => ({
                                     content: v.content,
                                     filePath: v.filePath,
-                                    type: 'PreviousEditorState',
-                                    metadata: {
-                                        previousEditorStateMetadata: {
-                                            timeOffset: 1000,
+                                })),
+                            ]
+
+                            if (editsEnabled) {
+                                const predictionTypes: string[][] = []
+
+                                /**
+                                 * Manual trigger - should always have 'Completions'
+                                 * Auto trigger
+                                 *  - Classifier - should have 'Completions' when classifier evalualte to true given the editor's states
+                                 *  - Others - should always have 'Completions'
+                                 */
+                                if (
+                                    !isAutomaticLspTriggerKind ||
+                                    (isAutomaticLspTriggerKind && codewhispererAutoTriggerType !== 'Classifier') ||
+                                    (isAutomaticLspTriggerKind &&
+                                        codewhispererAutoTriggerType === 'Classifier' &&
+                                        autoTriggerResult?.shouldTrigger)
+                                ) {
+                                    predictionTypes.push(['COMPLETIONS'])
+                                }
+
+                                const editPredictionAutoTriggerResult = editPredictionAutoTrigger({
+                                    fileContext: fileContext,
+                                    lineNum: params.position.line,
+                                    char: triggerCharacters,
+                                    previousDecision: previousDecision,
+                                    cursorHistory: cursorTracker,
+                                    recentEdits: recentEditTracker,
+                                })
+
+                                if (editPredictionAutoTriggerResult.shouldTrigger) {
+                                    predictionTypes.push(['EDITS'])
+                                }
+
+                                if (predictionTypes.length === 0) {
+                                    return EMPTY_RESULT
+                                }
+
+                                // Step 0: Determine if we have "Recent Edit context"
+                                if (recentEditTracker) {
+                                    supplementalContextFromEdits =
+                                        await recentEditTracker.generateEditBasedContext(textDocument)
+                                }
+
+                                // Step 1: Recent Edits context
+                                const supplementalContextItemsForEdits =
+                                    supplementalContextFromEdits?.supplementalContextItems || []
+
+                                tokenRequestContext.supplementalContexts.push(
+                                    ...supplementalContextItemsForEdits.map(v => ({
+                                        content: v.content,
+                                        filePath: v.filePath,
+                                        type: 'PreviousEditorState',
+                                        metadata: {
+                                            previousEditorStateMetadata: {
+                                                timeOffset: 1000,
+                                            },
+                                        },
+                                    }))
+                                )
+
+                                // Step 2: Prediction type COMPLETION, Edits or both
+                                tokenRequestContext.predictionTypes = predictionTypes.flat()
+
+                                // Step 3: Current Editor/Cursor state
+                                tokenRequestContext.editorState = {
+                                    document: {
+                                        relativeFilePath: textDocument.uri,
+                                        programmingLanguage: {
+                                            languageName: requestContext.fileContext.programmingLanguage.languageName,
+                                        },
+                                        text: textDocument.getText(),
+                                    },
+                                    cursorState: {
+                                        position: {
+                                            line: params.position.line,
+                                            character: params.position.character,
                                         },
                                     },
-                                }))
-                            )
-
-                            // Step 2: Prediction type COMPLETION, Edits or both
-                            tokenRequestContext.predictionTypes = predictionTypes.flat()
-
-                            // Step 3: Current Editor/Cursor state
-                            tokenRequestContext.editorState = {
-                                document: {
-                                    relativeFilePath: textDocument.uri,
-                                    programmingLanguage: {
-                                        languageName: requestContext.fileContext.programmingLanguage.languageName,
-                                    },
-                                    text: textDocument.getText(),
-                                },
-                                cursorState: {
-                                    position: {
-                                        line: params.position.line,
-                                        character: params.position.character,
-                                    },
-                                },
-                            }
-                        }
-                        requestContext = tokenRequestContext
-                    }
-
-                    // Close ACTIVE session and record Discard trigger decision immediately
-                    if (currentSession && currentSession.state === 'ACTIVE') {
-                        if (editsEnabled && currentSession.suggestionType === SuggestionType.EDIT) {
-                            const mergedSuggestions = mergeEditSuggestionsWithFileContext(
-                                currentSession,
-                                textDocument,
-                                fileContext
-                            )
-
-                            if (mergedSuggestions.length > 0) {
-                                return {
-                                    items: mergedSuggestions,
-                                    sessionId: currentSession.id,
                                 }
                             }
+                            requestContext = tokenRequestContext
                         }
-                        // Emit user trigger decision at session close time for active session
-                        completionSessionManager.discardSession(currentSession)
-                        const streakLength = editsEnabled ? completionSessionManager.getAndUpdateStreakLength(false) : 0
+
+                        // Close ACTIVE session and record Discard trigger decision immediately
+                        if (currentSession && currentSession.state === 'ACTIVE') {
+                            if (editsEnabled && currentSession.suggestionType === SuggestionType.EDIT) {
+                                const mergedSuggestions = mergeEditSuggestionsWithFileContext(
+                                    currentSession,
+                                    textDocument,
+                                    fileContext
+                                )
+
+                                if (mergedSuggestions.length > 0) {
+                                    return {
+                                        items: mergedSuggestions,
+                                        sessionId: currentSession.id,
+                                    }
+                                }
+                            }
+                            // Emit user trigger decision at session close time for active session
+                            completionSessionManager.discardSession(currentSession)
+                            const streakLength = editsEnabled ? completionSessionManager.getAndUpdateStreakLength(false) : 0
+                            await emitUserTriggerDecisionTelemetry(
+                                telemetry,
+                                telemetryService,
+                                currentSession,
+                                timeSinceLastUserModification,
+                                0,
+                                0,
+                                [],
+                                [],
+                                streakLength
+                            )
+                        }
+
+                        // Get supplemental context for metadata
+
+                        const supplementalMetadata = supplementalContext?.supContextData
+
+                        const newSession = completionSessionManager.createSession({
+                            document: textDocument,
+                            startPosition: params.position,
+                            triggerType: isAutomaticLspTriggerKind ? 'AutoTrigger' : 'OnDemand',
+                            language: inferredLanguageId,
+                            requestContext: requestContext,
+                            autoTriggerType: isAutomaticLspTriggerKind ? codewhispererAutoTriggerType : undefined,
+                            triggerCharacter: triggerCharacters,
+                            classifierResult: autoTriggerResult?.classifierResult,
+                            classifierThreshold: autoTriggerResult?.classifierThreshold,
+                            credentialStartUrl: credentialsProvider.getConnectionMetadata?.()?.sso?.startUrl ?? undefined,
+                            supplementalMetadata: supplementalMetadata,
+                            customizationArn: textUtils.undefinedIfEmpty(codeWhispererService.customizationArn),
+                        })
+
+                        // Add extra context to request context
+                        const { extraContext } = amazonQServiceManager.getConfiguration().inlineSuggestions
+                        if (extraContext) {
+                            requestContext.fileContext.leftFileContent =
+                                extraContext + '\n' + requestContext.fileContext.leftFileContent
+                        }
+
+                        // Prepare the request with normalized file content
+                        const normalizedFileContext = {
+                            ...requestContext.fileContext,
+                            leftFileContent: requestContext.fileContext.leftFileContent
+                                .slice(-CONTEXT_CHARACTERS_LIMIT)
+                                .replaceAll('\r\n', '\n'),
+                            rightFileContent: requestContext.fileContext.rightFileContent
+                                .slice(0, CONTEXT_CHARACTERS_LIMIT)
+                                .replaceAll('\r\n', '\n'),
+                        }
+
+                        // Create the appropriate request based on service type
+                        let generateCompletionReq: BaseGenerateSuggestionsRequest
+
+                        if (codeWhispererService instanceof CodeWhispererServiceToken) {
+                            const tokenRequest = requestContext as GenerateTokenSuggestionsRequest
+                            logging.debug(
+                                `[INLINE_COMPLETION] Final token request - predictionTypes: ${tokenRequest.predictionTypes?.join(',') || 'none'}`
+                            )
+                            generateCompletionReq = {
+                                ...tokenRequest,
+                                fileContext: normalizedFileContext,
+                                ...(workspaceId ? { workspaceId } : {}),
+                            }
+                        } else {
+                            const iamRequest = requestContext as GenerateIAMSuggestionsRequest
+                            logging.debug(`[INLINE_COMPLETION] Final IAM request - maxResults: ${iamRequest.maxResults}`)
+                            generateCompletionReq = {
+                                ...iamRequest,
+                                fileContext: normalizedFileContext,
+                            }
+                        }
+
+                        try {
+                            const authType = codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'
+                            logging.debug(`[INLINE_COMPLETION] API call - generateSuggestions (new session, ${authType})`)
+                            const suggestionResponse = await codeWhispererService.generateSuggestions(generateCompletionReq)
+                            return await processSuggestionResponse(suggestionResponse, newSession, true, selectionRange)
+                        } catch (error) {
+                            return handleSuggestionsErrors(error as Error, newSession)
+                        }
+                    }
+                } finally {
+                    isOnInlineCompletionHandlerInProgress = false
+                }
+            }
+
+            const processSuggestionResponse = async (
+                suggestionResponse: GenerateSuggestionsResponse,
+                session: CodeWhispererSession,
+                isNewSession: boolean,
+                selectionRange?: Range,
+                textDocument?: TextDocument
+            ): Promise<InlineCompletionListWithReferences> => {
+                codePercentageTracker.countInvocation(session.language)
+                logging.debug(
+                    `[INLINE_COMPLETION] Processing response - suggestions: ${suggestionResponse.suggestions.length}, new: ${isNewSession}`
+                )
+
+                userWrittenCodeTracker?.recordUsageCount(session.language)
+                session.includeImportsWithSuggestions =
+                    amazonQServiceManager.getConfiguration().includeImportsWithSuggestions
+
+                if (isNewSession) {
+                    // Populate the session with information from codewhisperer response
+                    session.suggestions = suggestionResponse.suggestions
+                    session.responseContext = suggestionResponse.responseContext
+                    session.codewhispererSessionId = suggestionResponse.responseContext.codewhispererSessionId
+                    session.timeToFirstRecommendation = new Date().getTime() - session.startTime
+                    session.suggestionType = suggestionResponse.suggestionType
+                    logging.debug(
+                        `[INLINE_COMPLETION] New session initialized - sessionId: ${session.codewhispererSessionId}`
+                    )
+                } else {
+                    session.suggestions = [...session.suggestions, ...suggestionResponse.suggestions]
+                }
+
+                // Emit service invocation telemetry for every request sent to backend
+                emitServiceInvocationTelemetry(telemetry, session, suggestionResponse.responseContext.requestId)
+
+                // Discard previous inflight API response due to new trigger
+                if (session.discardInflightSessionOnNewInvocation) {
+                    session.discardInflightSessionOnNewInvocation = false
+                    completionSessionManager.discardSession(session)
+                    const streakLength = editsEnabled ? completionSessionManager.getAndUpdateStreakLength(false) : 0
+                    await emitUserTriggerDecisionTelemetry(
+                        telemetry,
+                        telemetryService,
+                        session,
+                        timeSinceLastUserModification,
+                        0,
+                        0,
+                        [],
+                        [],
+                        streakLength
+                    )
+                }
+
+                // session was closed by user already made decisions consequent completion request before new paginated API response was received
+                if (
+                    session.suggestionType !== SuggestionType.EDIT && // TODO: this is a shorterm fix to allow Edits tabtabtab experience, however the real solution is to manage such sessions correctly
+                    (session.state === 'CLOSED' || session.state === 'DISCARD')
+                ) {
+                    return EMPTY_RESULT
+                }
+
+                // API response was recieved, we can activate session now
+                completionSessionManager.activateSession(session)
+
+                // Process suggestions to apply Empty or Filter filters
+                const filteredSuggestions = suggestionResponse.suggestions
+                    // Empty suggestion filter
+                    .filter(suggestion => {
+                        if (suggestion.content === '') {
+                            session.setSuggestionState(suggestion.itemId, 'Empty')
+                            return false
+                        }
+
+                        return true
+                    })
+                    // References setting filter
+                    .filter(suggestion => {
+                        // State to track whether code with references should be included in
+                        // the response. No locking or concurrency controls, filtering is done
+                        // right before returning and is only guaranteed to be consistent within
+                        // the context of a single response.
+                        const { includeSuggestionsWithCodeReferences } = amazonQServiceManager.getConfiguration()
+                        if (includeSuggestionsWithCodeReferences) {
+                            return true
+                        }
+
+                        if (suggestion.references == null || suggestion.references.length === 0) {
+                            return true
+                        }
+
+                        // Filter out suggestions that have references when includeSuggestionsWithCodeReferences setting is true
+                        session.setSuggestionState(suggestion.itemId, 'Filter')
+                        return false
+                    })
+
+                if (suggestionResponse.suggestionType === SuggestionType.COMPLETION) {
+                    const { includeImportsWithSuggestions } = amazonQServiceManager.getConfiguration()
+                    const suggestionsWithRightContext = mergeSuggestionsWithRightContext(
+                        session.requestContext.fileContext.rightFileContent,
+                        filteredSuggestions,
+                        includeImportsWithSuggestions,
+                        selectionRange
+                    ).filter(suggestion => {
+                        // Discard suggestions that have empty string insertText after right context merge and can't be displayed anymore
+                        if (suggestion.insertText === '') {
+                            session.setSuggestionState(suggestion.itemId, 'Discard')
+                            return false
+                        }
+
+                        return true
+                    })
+
+                    suggestionsWithRightContext.forEach(suggestion => {
+                        const cachedSuggestion = session.suggestions.find(s => s.itemId === suggestion.itemId)
+                        if (cachedSuggestion) cachedSuggestion.insertText = suggestion.insertText.toString()
+                    })
+
+                    // TODO: need dedupe after right context merging but I don't see one
+                    session.suggestionsAfterRightContextMerge.push(...suggestionsWithRightContext)
+
+                    session.codewhispererSuggestionImportCount =
+                        session.codewhispererSuggestionImportCount +
+                        suggestionsWithRightContext.reduce((total, suggestion) => {
+                            return total + (suggestion.mostRelevantMissingImports?.length || 0)
+                        }, 0)
+
+                    // If after all server-side filtering no suggestions can be displayed, and there is no nextToken
+                    // close session and return empty results
+                    if (
+                        session.suggestionsAfterRightContextMerge.length === 0 &&
+                        !suggestionResponse.responseContext.nextToken
+                    ) {
+                        completionSessionManager.closeSession(session)
                         await emitUserTriggerDecisionTelemetry(
                             telemetry,
                             telemetryService,
-                            currentSession,
-                            timeSinceLastUserModification,
-                            0,
-                            0,
-                            [],
-                            [],
-                            streakLength
+                            session,
+                            timeSinceLastUserModification
                         )
+
+                        return EMPTY_RESULT
                     }
 
-                    // Get supplemental context for metadata
-
-                    const supplementalMetadata = supplementalContext?.supContextData
-
-                    const newSession = completionSessionManager.createSession({
-                        document: textDocument,
-                        startPosition: params.position,
-                        triggerType: isAutomaticLspTriggerKind ? 'AutoTrigger' : 'OnDemand',
-                        language: inferredLanguageId,
-                        requestContext: requestContext,
-                        autoTriggerType: isAutomaticLspTriggerKind ? codewhispererAutoTriggerType : undefined,
-                        triggerCharacter: triggerCharacters,
-                        classifierResult: autoTriggerResult?.classifierResult,
-                        classifierThreshold: autoTriggerResult?.classifierThreshold,
-                        credentialStartUrl: credentialsProvider.getConnectionMetadata?.()?.sso?.startUrl ?? undefined,
-                        supplementalMetadata: supplementalMetadata,
-                        customizationArn: textUtils.undefinedIfEmpty(codeWhispererService.customizationArn),
-                    })
-
-                    // Add extra context to request context
-                    const { extraContext } = amazonQServiceManager.getConfiguration().inlineSuggestions
-                    if (extraContext) {
-                        requestContext.fileContext.leftFileContent =
-                            extraContext + '\n' + requestContext.fileContext.leftFileContent
+                    return {
+                        items: suggestionsWithRightContext,
+                        sessionId: session.id,
+                        partialResultToken: suggestionResponse.responseContext.nextToken,
                     }
+                } else {
+                    return {
+                        items: suggestionResponse.suggestions
+                            .map(suggestion => {
+                                // Check if this suggestion is similar to a previously rejected edit
+                                const isSimilarToRejected = rejectedEditTracker.isSimilarToRejected(
+                                    suggestion.content,
+                                    textDocument?.uri || ''
+                                )
 
-                    // Prepare the request with normalized file content
-                    const normalizedFileContext = {
-                        ...requestContext.fileContext,
-                        leftFileContent: requestContext.fileContext.leftFileContent
-                            .slice(-CONTEXT_CHARACTERS_LIMIT)
-                            .replaceAll('\r\n', '\n'),
-                        rightFileContent: requestContext.fileContext.rightFileContent
-                            .slice(0, CONTEXT_CHARACTERS_LIMIT)
-                            .replaceAll('\r\n', '\n'),
-                    }
+                                if (isSimilarToRejected) {
+                                    // Mark as rejected in the session
+                                    session.setSuggestionState(suggestion.itemId, 'Reject')
+                                    logging.debug(
+                                        `[EDIT_PREDICTION] Filtered out suggestion similar to previously rejected edit`
+                                    )
+                                    // Return empty item that will be filtered out
+                                    return {
+                                        insertText: '',
+                                        isInlineEdit: true,
+                                        itemId: suggestion.itemId,
+                                    }
+                                }
 
-                    // Create the appropriate request based on service type
-                    let generateCompletionReq: BaseGenerateSuggestionsRequest
-
-                    if (codeWhispererService instanceof CodeWhispererServiceToken) {
-                        const tokenRequest = requestContext as GenerateTokenSuggestionsRequest
-                        logging.debug(
-                            `[INLINE_COMPLETION] Final token request - predictionTypes: ${tokenRequest.predictionTypes?.join(',') || 'none'}`
-                        )
-                        generateCompletionReq = {
-                            ...tokenRequest,
-                            fileContext: normalizedFileContext,
-                            ...(workspaceId ? { workspaceId } : {}),
-                        }
-                    } else {
-                        const iamRequest = requestContext as GenerateIAMSuggestionsRequest
-                        logging.debug(`[INLINE_COMPLETION] Final IAM request - maxResults: ${iamRequest.maxResults}`)
-                        generateCompletionReq = {
-                            ...iamRequest,
-                            fileContext: normalizedFileContext,
-                        }
-                    }
-
-                    try {
-                        const authType = codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'
-                        logging.debug(`[INLINE_COMPLETION] API call - generateSuggestions (new session, ${authType})`)
-                        const suggestionResponse = await codeWhispererService.generateSuggestions(generateCompletionReq)
-                        return await processSuggestionResponse(suggestionResponse, newSession, true, selectionRange)
-                    } catch (error) {
-                        return handleSuggestionsErrors(error as Error, newSession)
+                                return {
+                                    insertText: suggestion.content,
+                                    isInlineEdit: true,
+                                    itemId: suggestion.itemId,
+                                }
+                            })
+                            .filter(item => item.insertText !== ''),
+                        sessionId: session.id,
+                        partialResultToken: suggestionResponse.responseContext.nextToken,
                     }
                 }
-            } finally {
-                isOnInlineCompletionHandlerInProgress = false
             }
-        }
 
-        const processSuggestionResponse = async (
-            suggestionResponse: GenerateSuggestionsResponse,
-            session: CodeWhispererSession,
-            isNewSession: boolean,
-            selectionRange?: Range,
-            textDocument?: TextDocument
-        ): Promise<InlineCompletionListWithReferences> => {
-            codePercentageTracker.countInvocation(session.language)
-            logging.debug(
-                `[INLINE_COMPLETION] Processing response - suggestions: ${suggestionResponse.suggestions.length}, new: ${isNewSession}`
-            )
+            const handleSuggestionsErrors = (
+                error: Error,
+                session: CodeWhispererSession
+            ): InlineCompletionListWithReferences => {
+                logging.log('Recommendation failure: ' + error)
+                logging.debug(`[INLINE_SUGGESTION] handleSuggestionsErrors call`)
 
-            userWrittenCodeTracker?.recordUsageCount(session.language)
-            session.includeImportsWithSuggestions =
-                amazonQServiceManager.getConfiguration().includeImportsWithSuggestions
+                // Add specific handling for IAM-related errors
+                if (isUsingIAMAuth(credentialsProvider)) {
+                    if (error.message?.includes('not authorized') || error.message?.includes('AccessDenied')) {
+                        logging.error(
+                            `[IAM AUTH ERROR] IAM authentication error: User not authorized. Check IAM permissions for CodeWhisperer.`
+                        )
+                    } else if (error.message?.includes('invalid parameter')) {
+                        logging.error(
+                            `[IAM AUTH ERROR] IAM authentication error: Invalid request parameters for IAM client`
+                        )
+                    } else if (error.message?.includes('credentials')) {
+                        logging.error(`[IAM AUTH ERROR] IAM authentication error: Invalid or missing credentials`)
+                    }
 
-            if (isNewSession) {
-                // Populate the session with information from codewhisperer response
-                session.suggestions = suggestionResponse.suggestions
-                session.responseContext = suggestionResponse.responseContext
-                session.codewhispererSessionId = suggestionResponse.responseContext.codewhispererSessionId
-                session.timeToFirstRecommendation = new Date().getTime() - session.startTime
-                session.suggestionType = suggestionResponse.suggestionType
-                logging.debug(
-                    `[INLINE_COMPLETION] New session initialized - sessionId: ${session.codewhispererSessionId}`
+                    // Log detailed information about the request context
+                    logging.error(`[IAM AUTH ERROR] Request context: ${JSON.stringify(session.requestContext)}`)
+                }
+
+                emitServiceInvocationFailure(telemetry, session, error)
+
+                completionSessionManager.closeSession(session)
+
+                let translatedError = error
+
+                if (hasConnectionExpired(error)) {
+                    translatedError = new AmazonQServiceConnectionExpiredError(getErrorMessage(error))
+                }
+
+                if (translatedError instanceof AmazonQError) {
+                    throw new ResponseError(
+                        LSPErrorCodes.RequestFailed,
+                        translatedError.message || 'Error processing suggestion requests',
+                        {
+                            awsErrorCode: translatedError.code,
+                        }
+                    )
+                }
+
+                return EMPTY_RESULT
+            }
+
+            // Schedule tracker for UserModification Telemetry event
+            const enqueueCodeDiffEntry = (
+                session: CodeWhispererSession,
+                acceptedSuggestion: Suggestion,
+                addedCharactersForEdit?: string
+            ) => {
+                const endPosition = getEndPositionForAcceptedSuggestion(acceptedSuggestion.content, session.startPosition)
+                // use the addedCharactersForEdit if it is EDIT suggestion type
+                const originalString = addedCharactersForEdit ? addedCharactersForEdit : acceptedSuggestion.content
+
+                codeDiffTracker.enqueue({
+                    sessionId: session.codewhispererSessionId || '',
+                    requestId: session.responseContext?.requestId || '',
+                    fileUrl: session.document.uri,
+                    languageId: session.language,
+                    time: Date.now(),
+                    originalString: originalString,
+                    startPosition: session.startPosition,
+                    endPosition: endPosition,
+                    customizationArn: session.customizationArn,
+                    completionType: getCompletionType(acceptedSuggestion),
+                    triggerType: session.triggerType,
+                    credentialStartUrl: session.credentialStartUrl,
+                })
+            }
+
+            const onLogInlineCompletionSessionResultsHandler = async (params: LogInlineCompletionSessionResultsParams) => {
+                const {
+                    sessionId,
+                    completionSessionResult,
+                    firstCompletionDisplayLatency,
+                    totalSessionDisplayTime,
+                    typeaheadLength,
+                    isInlineEdit,
+                    addedDiagnostics,
+                    removedDiagnostics,
+                } = params
+
+                const sessionManager = params.isInlineEdit ? editSessionManager : completionSessionManager
+
+                const session = sessionManager.getSessionById(sessionId)
+                if (!session) {
+                    logging.log(`ERROR: Session ID ${sessionId} was not found`)
+                    return
+                }
+
+                if (session.state !== 'ACTIVE') {
+                    logging.log(`ERROR: Trying to record trigger decision for not-active session ${sessionId}`)
+                    return
+                }
+
+                const acceptedItemId = Object.keys(params.completionSessionResult).find(
+                    k => params.completionSessionResult[k].accepted
                 )
-            } else {
-                session.suggestions = [...session.suggestions, ...suggestionResponse.suggestions]
-            }
+                const isAccepted = acceptedItemId ? true : false
+                const acceptedSuggestion = session.suggestions.find(s => s.itemId === acceptedItemId)
+                let addedCharactersForEditSuggestion = ''
+                let deletedCharactersForEditSuggestion = ''
+                if (acceptedSuggestion !== undefined) {
+                    if (acceptedSuggestion) {
+                        codePercentageTracker.countSuccess(session.language)
+                        if (session.suggestionType === SuggestionType.EDIT && acceptedSuggestion.content) {
+                            // [acceptedSuggestion.insertText] will be undefined for NEP suggestion. Use [acceptedSuggestion.content] instead.
+                            // Since [acceptedSuggestion.content] is in the form of a diff, transform the content into addedCharacters and deletedCharacters.
+                            const addedAndDeletedChars = getAddedAndDeletedChars(acceptedSuggestion.content)
+                            if (addedAndDeletedChars) {
+                                addedCharactersForEditSuggestion = addedAndDeletedChars.addedCharacters
+                                deletedCharactersForEditSuggestion = addedAndDeletedChars.deletedCharacters
 
-            // Emit service invocation telemetry for every request sent to backend
-            emitServiceInvocationTelemetry(telemetry, session, suggestionResponse.responseContext.requestId)
+                                codePercentageTracker.countAcceptedTokens(
+                                    session.language,
+                                    addedCharactersForEditSuggestion
+                                )
+                                codePercentageTracker.countTotalTokens(
+                                    session.language,
+                                    addedCharactersForEditSuggestion,
+                                    true
+                                )
+                                enqueueCodeDiffEntry(session, acceptedSuggestion, addedCharactersForEditSuggestion)
+                            }
+                        } else if (acceptedSuggestion.insertText) {
+                            codePercentageTracker.countAcceptedTokens(session.language, acceptedSuggestion.insertText)
+                            codePercentageTracker.countTotalTokens(session.language, acceptedSuggestion.insertText, true)
 
-            // Discard previous inflight API response due to new trigger
-            if (session.discardInflightSessionOnNewInvocation) {
-                session.discardInflightSessionOnNewInvocation = false
-                completionSessionManager.discardSession(session)
-                const streakLength = editsEnabled ? completionSessionManager.getAndUpdateStreakLength(false) : 0
+                            enqueueCodeDiffEntry(session, acceptedSuggestion)
+                        }
+                    }
+                }
+
+                // Handle rejected edit predictions
+                if (isInlineEdit && !isAccepted) {
+                    // Find all rejected suggestions in this session
+                    const rejectedSuggestions = session.suggestions.filter(suggestion => {
+                        const result = completionSessionResult[suggestion.itemId]
+                        return result && result.seen && !result.accepted
+                    })
+
+                    // Record each rejected edit
+                    for (const rejectedSuggestion of rejectedSuggestions) {
+                        if (rejectedSuggestion.content) {
+                            rejectedEditTracker.recordRejectedEdit({
+                                content: rejectedSuggestion.content,
+                                timestamp: Date.now(),
+                                documentUri: session.document.uri,
+                                position: session.startPosition,
+                            })
+
+                            logging.debug(
+                                `[EDIT_PREDICTION] Recorded rejected edit: ${rejectedSuggestion.content.substring(0, 20)}...`
+                            )
+                        }
+                    }
+                }
+
+                session.setClientResultData(
+                    completionSessionResult,
+                    firstCompletionDisplayLatency,
+                    totalSessionDisplayTime,
+                    typeaheadLength
+                )
+
+                if (firstCompletionDisplayLatency) emitPerceivedLatencyTelemetry(telemetry, session)
+
+                // Always emit user trigger decision at session close
+                sessionManager.closeSession(session)
+                const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(isAccepted) : 0
                 await emitUserTriggerDecisionTelemetry(
                     telemetry,
                     telemetryService,
                     session,
                     timeSinceLastUserModification,
-                    0,
-                    0,
-                    [],
-                    [],
-                    streakLength
+                    addedCharactersForEditSuggestion.length,
+                    deletedCharactersForEditSuggestion.length,
+                    addedDiagnostics,
+                    removedDiagnostics,
+                    streakLength,
+                    Object.keys(params.completionSessionResult)[0]
                 )
             }
 
-            // session was closed by user already made decisions consequent completion request before new paginated API response was received
-            if (
-                session.suggestionType !== SuggestionType.EDIT && // TODO: this is a shorterm fix to allow Edits tabtabtab experience, however the real solution is to manage such sessions correctly
-                (session.state === 'CLOSED' || session.state === 'DISCARD')
-            ) {
-                return EMPTY_RESULT
+            const updateConfiguration = (updatedConfig: AmazonQWorkspaceConfig) => {
+                logging.debug('Updating configuration of inline complete server.')
+
+                const { customizationArn, optOutTelemetryPreference, sendUserWrittenCodeMetrics } = updatedConfig
+
+                codePercentageTracker.customizationArn = customizationArn
+                if (sendUserWrittenCodeMetrics) {
+                    userWrittenCodeTracker = UserWrittenCodeTracker.getInstance(telemetryService)
+                }
+                if (userWrittenCodeTracker) {
+                    userWrittenCodeTracker.customizationArn = customizationArn
+                }
+                logging.debug(`CodePercentageTracker customizationArn updated to ${customizationArn}`)
+
+                // The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
+                // configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
+                // const enableTelemetryEventsToDestination = true
+                // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
+                telemetryService.updateOptOutPreference(optOutTelemetryPreference)
+                logging.debug(`TelemetryService OptOutPreference updated to ${optOutTelemetryPreference}`)
             }
 
-            // API response was recieved, we can activate session now
-            completionSessionManager.activateSession(session)
+            const onEditCompletion = async (
+                param: InlineCompletionWithReferencesParams,
+                token: CancellationToken
+            ): Promise<InlineCompletionListWithReferences> => {
+                return await editCompletionHandler.onEditCompletion(param, token)
+            }
 
-            // Process suggestions to apply Empty or Filter filters
-            const filteredSuggestions = suggestionResponse.suggestions
-                // Empty suggestion filter
-                .filter(suggestion => {
-                    if (suggestion.content === '') {
-                        session.setSuggestionState(suggestion.itemId, 'Empty')
-                        return false
+            const onInitializedHandler = async () => {
+                try {
+                    logging.log('[DEBUG] Starting Amazon Q service initialization...')
+                    const usingIAM = isUsingIAMAuth(credentialsProvider)
+                    logging.log(`[DEBUG] Authentication type: ${usingIAM ? 'IAM' : 'Bearer Token'}`)
+                    logging.log(`[DEBUG] Using IAM auth: ${usingIAM}`)
+
+                    // Log authentication details
+                    try {
+                        const iamCreds = credentialsProvider.getCredentials('iam')
+                        logging.log(`[DEBUG] IAM credentials available: ${!!iamCreds}`)
+                        if (iamCreds) {
+                            // Safely log credential info without exposing secrets
+                            logging.log(`[DEBUG] IAM credentials type: ${typeof iamCreds}`)
+                            logging.log(`[DEBUG] IAM credentials has accessKeyId`)
+                            logging.log(`[DEBUG] IAM credentials expiration: `)
+                        }
+                    } catch (credError) {
+                        logging.error(`[DEBUG] Error accessing IAM credentials: ${credError}`)
                     }
 
-                    return true
-                })
-                // References setting filter
-                .filter(suggestion => {
-                    // State to track whether code with references should be included in
-                    // the response. No locking or concurrency controls, filtering is done
-                    // right before returning and is only guaranteed to be consistent within
-                    // the context of a single response.
-                    const { includeSuggestionsWithCodeReferences } = amazonQServiceManager.getConfiguration()
-                    if (includeSuggestionsWithCodeReferences) {
-                        return true
+                    try {
+                        const bearerCreds = credentialsProvider.getCredentials('bearer')
+                        logging.log(`[DEBUG] Bearer credentials available: ${!!bearerCreds}`)
+                        if (bearerCreds) {
+                            logging.log(`[DEBUG] Bearer token exists`)
+                        }
+                    } catch (credError) {
+                        logging.error(`[DEBUG] Error accessing bearer credentials: ${credError}`)
                     }
 
-                    if (suggestion.references == null || suggestion.references.length === 0) {
-                        return true
+                    // Create service manager
+                    logging.log('[DEBUG] Creating service manager...')
+                    amazonQServiceManager = serviceManager()
+                    logging.log('[DEBUG] Service manager created successfully')
+
+                    // Log service manager details
+                    logging.log(`[DEBUG] Service manager type: ${amazonQServiceManager.constructor.name}`)
+
+                    // Get CodeWhisperer service
+                    try {
+                        const codeWhispererService = amazonQServiceManager.getCodewhispererService()
+                        logging.log(`[DEBUG] CodeWhisperer service created: ${!!codeWhispererService}`)
+                        logging.log(`[DEBUG] CodeWhisperer service type: ${codeWhispererService.constructor.name}`)
+                        logging.log(
+                            `[DEBUG] CodeWhisperer service credentials type: ${codeWhispererService.getCredentialsType()}`
+                        )
+                    } catch (serviceError) {
+                        logging.error(`[DEBUG] Error getting CodeWhisperer service: ${serviceError}`)
                     }
 
-                    // Filter out suggestions that have references when includeSuggestionsWithCodeReferences setting is true
-                    session.setSuggestionState(suggestion.itemId, 'Filter')
-                    return false
-                })
+                    const clientParams = safeGet(
+                        lsp.getClientInitializeParams(),
+                        new AmazonQServiceInitializationError(
+                            'TelemetryService initialized before LSP connection was initialized.'
+                        )
+                    )
 
-            if (suggestionResponse.suggestionType === SuggestionType.COMPLETION) {
-                const { includeImportsWithSuggestions } = amazonQServiceManager.getConfiguration()
-                const suggestionsWithRightContext = mergeSuggestionsWithRightContext(
-                    session.requestContext.fileContext.rightFileContent,
-                    filteredSuggestions,
-                    includeImportsWithSuggestions,
-                    selectionRange
-                ).filter(suggestion => {
-                    // Discard suggestions that have empty string insertText after right context merge and can't be displayed anymore
-                    if (suggestion.insertText === '') {
-                        session.setSuggestionState(suggestion.itemId, 'Discard')
-                        return false
-                    }
+                    logging.log(`[DEBUG] Client initialization params: ${JSON.stringify(clientParams)}`)
+                    editsEnabled =
+                        clientParams?.initializationOptions?.aws?.awsClientCapabilities?.textDocument
+                            ?.inlineCompletionWithReferences?.inlineEditSupport ?? false
+                    logging.log(`[DEBUG] Edits enabled: ${editsEnabled}`)
 
-                    return true
-                })
+                    logging.log('[DEBUG] Creating telemetry service...')
+                    telemetryService = new TelemetryService(amazonQServiceManager, credentialsProvider, telemetry, logging)
+                    telemetryService.updateUserContext(makeUserContextObject(clientParams, runtime.platform, 'INLINE'))
+                    logging.log('[DEBUG] Telemetry service created successfully')
 
-                suggestionsWithRightContext.forEach(suggestion => {
-                    const cachedSuggestion = session.suggestions.find(s => s.itemId === suggestion.itemId)
-                    if (cachedSuggestion) cachedSuggestion.insertText = suggestion.insertText.toString()
-                })
+                    logging.log('[DEBUG] Creating code percentage tracker...')
+                    codePercentageTracker = new CodePercentageTracker(telemetryService)
+                    logging.log('[DEBUG] Creating code diff tracker...')
+                    codeDiffTracker = new CodeDiffTracker(
+                        workspace,
+                        logging,
+                        async (entry: AcceptedInlineSuggestionEntry, percentage, unmodifiedAcceptedCharacterCount) => {
+                            await telemetryService.emitUserModificationEvent(
+                                {
+                                    sessionId: entry.sessionId,
+                                    requestId: entry.requestId,
+                                    languageId: entry.languageId,
+                                    customizationArn: entry.customizationArn,
+                                    timestamp: new Date(),
+                                    acceptedCharacterCount: entry.originalString.length,
+                                    modificationPercentage: percentage,
+                                    unmodifiedAcceptedCharacterCount: unmodifiedAcceptedCharacterCount,
+                                },
+                                {
+                                    completionType: entry.completionType || 'LINE',
+                                    triggerType: entry.triggerType || 'OnDemand',
+                                    credentialStartUrl: entry.credentialStartUrl,
+                                }
+                            )
+                        }
+                    )
 
-                // TODO: need dedupe after right context merging but I don't see one
-                session.suggestionsAfterRightContextMerge.push(...suggestionsWithRightContext)
+                    const periodicLoggingEnabled = process.env.LOG_EDIT_TRACKING === 'true'
+                    logging.log(
+                        `[SERVER] Initialized telemetry-dependent components: CodePercentageTracker, CodeDiffTracker, periodicLogging=${periodicLoggingEnabled}`
+                    )
 
-                session.codewhispererSuggestionImportCount =
-                    session.codewhispererSuggestionImportCount +
-                    suggestionsWithRightContext.reduce((total, suggestion) => {
-                        return total + (suggestion.mostRelevantMissingImports?.length || 0)
-                    }, 0)
+                    logging.log('[DEBUG] Adding configuration change listener...')
+                    await amazonQServiceManager.addDidChangeConfigurationListener(updateConfiguration)
 
-                // If after all server-side filtering no suggestions can be displayed, and there is no nextToken
-                // close session and return empty results
-                if (
-                    session.suggestionsAfterRightContextMerge.length === 0 &&
-                    !suggestionResponse.responseContext.nextToken
-                ) {
-                    completionSessionManager.closeSession(session)
-                    await emitUserTriggerDecisionTelemetry(
+                    editCompletionHandler = new EditCompletionHandler(
+                        logging,
+                        clientParams,
+                        workspace,
+                        amazonQServiceManager,
+                        editSessionManager,
+                        cursorTracker,
+                        recentEditTracker,
+                        rejectedEditTracker,
+                        documentChangedListener,
                         telemetry,
                         telemetryService,
-                        session,
-                        timeSinceLastUserModification
+                        credentialsProvider
                     )
 
-                    return EMPTY_RESULT
-                }
-
-                return {
-                    items: suggestionsWithRightContext,
-                    sessionId: session.id,
-                    partialResultToken: suggestionResponse.responseContext.nextToken,
-                }
-            } else {
-                return {
-                    items: suggestionResponse.suggestions
-                        .map(suggestion => {
-                            // Check if this suggestion is similar to a previously rejected edit
-                            const isSimilarToRejected = rejectedEditTracker.isSimilarToRejected(
-                                suggestion.content,
-                                textDocument?.uri || ''
-                            )
-
-                            if (isSimilarToRejected) {
-                                // Mark as rejected in the session
-                                session.setSuggestionState(suggestion.itemId, 'Reject')
-                                logging.debug(
-                                    `[EDIT_PREDICTION] Filtered out suggestion similar to previously rejected edit`
-                                )
-                                // Return empty item that will be filtered out
-                                return {
-                                    insertText: '',
-                                    isInlineEdit: true,
-                                    itemId: suggestion.itemId,
-                                }
-                            }
-
-                            return {
-                                insertText: suggestion.content,
-                                isInlineEdit: true,
-                                itemId: suggestion.itemId,
-                            }
-                        })
-                        .filter(item => item.insertText !== ''),
-                    sessionId: session.id,
-                    partialResultToken: suggestionResponse.responseContext.nextToken,
-                }
-            }
-        }
-
-        const handleSuggestionsErrors = (
-            error: Error,
-            session: CodeWhispererSession
-        ): InlineCompletionListWithReferences => {
-            logging.log('Recommendation failure: ' + error)
-            logging.debug(`[INLINE_SUGGESTION] handleSuggestionsErrors call`)
-
-            // Add specific handling for IAM-related errors
-            if (isUsingIAMAuth(credentialsProvider)) {
-                if (error.message?.includes('not authorized') || error.message?.includes('AccessDenied')) {
-                    logging.error(
-                        `[IAM AUTH ERROR] IAM authentication error: User not authorized. Check IAM permissions for CodeWhisperer.`
-                    )
-                } else if (error.message?.includes('invalid parameter')) {
-                    logging.error(
-                        `[IAM AUTH ERROR] IAM authentication error: Invalid request parameters for IAM client`
-                    )
-                } else if (error.message?.includes('credentials')) {
-                    logging.error(`[IAM AUTH ERROR] IAM authentication error: Invalid or missing credentials`)
-                }
-
-                // Log detailed information about the request context
-                logging.error(`[IAM AUTH ERROR] Request context: ${JSON.stringify(session.requestContext)}`)
-            }
-
-            emitServiceInvocationFailure(telemetry, session, error)
-
-            completionSessionManager.closeSession(session)
-
-            let translatedError = error
-
-            if (hasConnectionExpired(error)) {
-                translatedError = new AmazonQServiceConnectionExpiredError(getErrorMessage(error))
-            }
-
-            if (translatedError instanceof AmazonQError) {
-                throw new ResponseError(
-                    LSPErrorCodes.RequestFailed,
-                    translatedError.message || 'Error processing suggestion requests',
-                    {
-                        awsErrorCode: translatedError.code,
+                    logging.log('[DEBUG] Amazon Q service initialization completed successfully')
+                } catch (error) {
+                    logging.error(`[DEBUG] CRITICAL ERROR initializing Amazon Q service: ${error}`)
+                    if (error instanceof Error) {
+                        logging.error(`[DEBUG] Error stack: ${error.stack}`)
                     }
-                )
-            }
-
-            return EMPTY_RESULT
-        }
-
-        // Schedule tracker for UserModification Telemetry event
-        const enqueueCodeDiffEntry = (
-            session: CodeWhispererSession,
-            acceptedSuggestion: Suggestion,
-            addedCharactersForEdit?: string
-        ) => {
-            const endPosition = getEndPositionForAcceptedSuggestion(acceptedSuggestion.content, session.startPosition)
-            // use the addedCharactersForEdit if it is EDIT suggestion type
-            const originalString = addedCharactersForEdit ? addedCharactersForEdit : acceptedSuggestion.content
-
-            codeDiffTracker.enqueue({
-                sessionId: session.codewhispererSessionId || '',
-                requestId: session.responseContext?.requestId || '',
-                fileUrl: session.document.uri,
-                languageId: session.language,
-                time: Date.now(),
-                originalString: originalString,
-                startPosition: session.startPosition,
-                endPosition: endPosition,
-                customizationArn: session.customizationArn,
-                completionType: getCompletionType(acceptedSuggestion),
-                triggerType: session.triggerType,
-                credentialStartUrl: session.credentialStartUrl,
-            })
-        }
-
-        const onLogInlineCompletionSessionResultsHandler = async (params: LogInlineCompletionSessionResultsParams) => {
-            const {
-                sessionId,
-                completionSessionResult,
-                firstCompletionDisplayLatency,
-                totalSessionDisplayTime,
-                typeaheadLength,
-                isInlineEdit,
-                addedDiagnostics,
-                removedDiagnostics,
-            } = params
-
-            const sessionManager = params.isInlineEdit ? editSessionManager : completionSessionManager
-
-            const session = sessionManager.getSessionById(sessionId)
-            if (!session) {
-                logging.log(`ERROR: Session ID ${sessionId} was not found`)
-                return
-            }
-
-            if (session.state !== 'ACTIVE') {
-                logging.log(`ERROR: Trying to record trigger decision for not-active session ${sessionId}`)
-                return
-            }
-
-            const acceptedItemId = Object.keys(params.completionSessionResult).find(
-                k => params.completionSessionResult[k].accepted
-            )
-            const isAccepted = acceptedItemId ? true : false
-            const acceptedSuggestion = session.suggestions.find(s => s.itemId === acceptedItemId)
-            let addedCharactersForEditSuggestion = ''
-            let deletedCharactersForEditSuggestion = ''
-            if (acceptedSuggestion !== undefined) {
-                if (acceptedSuggestion) {
-                    codePercentageTracker.countSuccess(session.language)
-                    if (session.suggestionType === SuggestionType.EDIT && acceptedSuggestion.content) {
-                        // [acceptedSuggestion.insertText] will be undefined for NEP suggestion. Use [acceptedSuggestion.content] instead.
-                        // Since [acceptedSuggestion.content] is in the form of a diff, transform the content into addedCharacters and deletedCharacters.
-                        const addedAndDeletedChars = getAddedAndDeletedChars(acceptedSuggestion.content)
-                        if (addedAndDeletedChars) {
-                            addedCharactersForEditSuggestion = addedAndDeletedChars.addedCharacters
-                            deletedCharactersForEditSuggestion = addedAndDeletedChars.deletedCharacters
-
-                            codePercentageTracker.countAcceptedTokens(
-                                session.language,
-                                addedCharactersForEditSuggestion
-                            )
-                            codePercentageTracker.countTotalTokens(
-                                session.language,
-                                addedCharactersForEditSuggestion,
-                                true
-                            )
-                            enqueueCodeDiffEntry(session, acceptedSuggestion, addedCharactersForEditSuggestion)
-                        }
-                    } else if (acceptedSuggestion.insertText) {
-                        codePercentageTracker.countAcceptedTokens(session.language, acceptedSuggestion.insertText)
-                        codePercentageTracker.countTotalTokens(session.language, acceptedSuggestion.insertText, true)
-
-                        enqueueCodeDiffEntry(session, acceptedSuggestion)
-                    }
+                    throw error
                 }
             }
 
-            // Handle rejected edit predictions
-            if (isInlineEdit && !isAccepted) {
-                // Find all rejected suggestions in this session
-                const rejectedSuggestions = session.suggestions.filter(suggestion => {
-                    const result = completionSessionResult[suggestion.itemId]
-                    return result && result.seen && !result.accepted
-                })
+            // Register event handlers
+            lsp.extensions.onInlineCompletionWithReferences(onInlineCompletionHandler)
+            lsp.extensions.onEditCompletion(onEditCompletion)
+            lsp.extensions.onLogInlineCompletionSessionResults(onLogInlineCompletionSessionResultsHandler)
+            lsp.onInitialized(onInitializedHandler)
 
-                // Record each rejected edit
-                for (const rejectedSuggestion of rejectedSuggestions) {
-                    if (rejectedSuggestion.content) {
-                        rejectedEditTracker.recordRejectedEdit({
-                            content: rejectedSuggestion.content,
-                            timestamp: Date.now(),
-                            documentUri: session.document.uri,
-                            position: session.startPosition,
-                        })
+            lsp.onDidChangeTextDocument(async p => {
+                const textDocument = await workspace.getTextDocument(p.textDocument.uri)
+                const languageId = getSupportedLanguageId(textDocument)
 
-                        logging.debug(
-                            `[EDIT_PREDICTION] Recorded rejected edit: ${rejectedSuggestion.content.substring(0, 20)}...`
-                        )
-                    }
-                }
-            }
-
-            session.setClientResultData(
-                completionSessionResult,
-                firstCompletionDisplayLatency,
-                totalSessionDisplayTime,
-                typeaheadLength
-            )
-
-            if (firstCompletionDisplayLatency) emitPerceivedLatencyTelemetry(telemetry, session)
-
-            // Always emit user trigger decision at session close
-            sessionManager.closeSession(session)
-            const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(isAccepted) : 0
-            await emitUserTriggerDecisionTelemetry(
-                telemetry,
-                telemetryService,
-                session,
-                timeSinceLastUserModification,
-                addedCharactersForEditSuggestion.length,
-                deletedCharactersForEditSuggestion.length,
-                addedDiagnostics,
-                removedDiagnostics,
-                streakLength,
-                Object.keys(params.completionSessionResult)[0]
-            )
-        }
-
-        const updateConfiguration = (updatedConfig: AmazonQWorkspaceConfig) => {
-            logging.debug('Updating configuration of inline complete server.')
-
-            const { customizationArn, optOutTelemetryPreference, sendUserWrittenCodeMetrics } = updatedConfig
-
-            codePercentageTracker.customizationArn = customizationArn
-            if (sendUserWrittenCodeMetrics) {
-                userWrittenCodeTracker = UserWrittenCodeTracker.getInstance(telemetryService)
-            }
-            if (userWrittenCodeTracker) {
-                userWrittenCodeTracker.customizationArn = customizationArn
-            }
-            logging.debug(`CodePercentageTracker customizationArn updated to ${customizationArn}`)
-
-            // The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
-            // configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
-            // const enableTelemetryEventsToDestination = true
-            // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
-            telemetryService.updateOptOutPreference(optOutTelemetryPreference)
-            logging.debug(`TelemetryService OptOutPreference updated to ${optOutTelemetryPreference}`)
-        }
-
-        const onEditCompletion = async (
-            param: InlineCompletionWithReferencesParams,
-            token: CancellationToken
-        ): Promise<InlineCompletionListWithReferences> => {
-            return await editCompletionHandler.onEditCompletion(param, token)
-        }
-
-        const onInitializedHandler = async () => {
-            try {
-                logging.log('[DEBUG] Starting Amazon Q service initialization...')
-                const usingIAM = isUsingIAMAuth(credentialsProvider)
-                logging.log(`[DEBUG] Authentication type: ${usingIAM ? 'IAM' : 'Bearer Token'}`)
-                logging.log(`[DEBUG] Using IAM auth: ${usingIAM}`)
-
-                // Log authentication details
-                try {
-                    const iamCreds = credentialsProvider.getCredentials('iam')
-                    logging.log(`[DEBUG] IAM credentials available: ${!!iamCreds}`)
-                    if (iamCreds) {
-                        // Safely log credential info without exposing secrets
-                        logging.log(`[DEBUG] IAM credentials type: ${typeof iamCreds}`)
-                        logging.log(`[DEBUG] IAM credentials has accessKeyId`)
-                        logging.log(`[DEBUG] IAM credentials expiration: `)
-                    }
-                } catch (credError) {
-                    logging.error(`[DEBUG] Error accessing IAM credentials: ${credError}`)
-                }
-
-                try {
-                    const bearerCreds = credentialsProvider.getCredentials('bearer')
-                    logging.log(`[DEBUG] Bearer credentials available: ${!!bearerCreds}`)
-                    if (bearerCreds) {
-                        logging.log(`[DEBUG] Bearer token exists`)
-                    }
-                } catch (credError) {
-                    logging.error(`[DEBUG] Error accessing bearer credentials: ${credError}`)
-                }
-
-                // Create service manager
-                logging.log('[DEBUG] Creating service manager...')
-                amazonQServiceManager = serviceManager()
-                logging.log('[DEBUG] Service manager created successfully')
-
-                // Log service manager details
-                logging.log(`[DEBUG] Service manager type: ${amazonQServiceManager.constructor.name}`)
-
-                // Get CodeWhisperer service
-                try {
-                    const codeWhispererService = amazonQServiceManager.getCodewhispererService()
-                    logging.log(`[DEBUG] CodeWhisperer service created: ${!!codeWhispererService}`)
-                    logging.log(`[DEBUG] CodeWhisperer service type: ${codeWhispererService.constructor.name}`)
-                    logging.log(
-                        `[DEBUG] CodeWhisperer service credentials type: ${codeWhispererService.getCredentialsType()}`
-                    )
-                } catch (serviceError) {
-                    logging.error(`[DEBUG] Error getting CodeWhisperer service: ${serviceError}`)
-                }
-
-                const clientParams = safeGet(
-                    lsp.getClientInitializeParams(),
-                    new AmazonQServiceInitializationError(
-                        'TelemetryService initialized before LSP connection was initialized.'
-                    )
-                )
-
-                logging.log(`[DEBUG] Client initialization params: ${JSON.stringify(clientParams)}`)
-                editsEnabled =
-                    clientParams?.initializationOptions?.aws?.awsClientCapabilities?.textDocument
-                        ?.inlineCompletionWithReferences?.inlineEditSupport ?? false
-                logging.log(`[DEBUG] Edits enabled: ${editsEnabled}`)
-
-                logging.log('[DEBUG] Creating telemetry service...')
-                telemetryService = new TelemetryService(amazonQServiceManager, credentialsProvider, telemetry, logging)
-                telemetryService.updateUserContext(makeUserContextObject(clientParams, runtime.platform, 'INLINE'))
-                logging.log('[DEBUG] Telemetry service created successfully')
-
-                logging.log('[DEBUG] Creating code percentage tracker...')
-                codePercentageTracker = new CodePercentageTracker(telemetryService)
-                logging.log('[DEBUG] Creating code diff tracker...')
-                codeDiffTracker = new CodeDiffTracker(
-                    workspace,
-                    logging,
-                    async (entry: AcceptedInlineSuggestionEntry, percentage, unmodifiedAcceptedCharacterCount) => {
-                        await telemetryService.emitUserModificationEvent(
-                            {
-                                sessionId: entry.sessionId,
-                                requestId: entry.requestId,
-                                languageId: entry.languageId,
-                                customizationArn: entry.customizationArn,
-                                timestamp: new Date(),
-                                acceptedCharacterCount: entry.originalString.length,
-                                modificationPercentage: percentage,
-                                unmodifiedAcceptedCharacterCount: unmodifiedAcceptedCharacterCount,
-                            },
-                            {
-                                completionType: entry.completionType || 'LINE',
-                                triggerType: entry.triggerType || 'OnDemand',
-                                credentialStartUrl: entry.credentialStartUrl,
-                            }
-                        )
-                    }
-                )
-
-                const periodicLoggingEnabled = process.env.LOG_EDIT_TRACKING === 'true'
-                logging.log(
-                    `[SERVER] Initialized telemetry-dependent components: CodePercentageTracker, CodeDiffTracker, periodicLogging=${periodicLoggingEnabled}`
-                )
-
-                logging.log('[DEBUG] Adding configuration change listener...')
-                await amazonQServiceManager.addDidChangeConfigurationListener(updateConfiguration)
-
-                editCompletionHandler = new EditCompletionHandler(
-                    logging,
-                    clientParams,
-                    workspace,
-                    amazonQServiceManager,
-                    editSessionManager,
-                    cursorTracker,
-                    recentEditTracker,
-                    rejectedEditTracker,
-                    documentChangedListener,
-                    telemetry,
-                    telemetryService,
-                    credentialsProvider
-                )
-
-                logging.log('[DEBUG] Amazon Q service initialization completed successfully')
-            } catch (error) {
-                logging.error(`[DEBUG] CRITICAL ERROR initializing Amazon Q service: ${error}`)
-                if (error instanceof Error) {
-                    logging.error(`[DEBUG] Error stack: ${error.stack}`)
-                }
-                throw error
-            }
-        }
-
-        // Register event handlers
-        lsp.extensions.onInlineCompletionWithReferences(onInlineCompletionHandler)
-        lsp.extensions.onEditCompletion(onEditCompletion)
-        lsp.extensions.onLogInlineCompletionSessionResults(onLogInlineCompletionSessionResultsHandler)
-        lsp.onInitialized(onInitializedHandler)
-
-        lsp.onDidChangeTextDocument(async p => {
-            const textDocument = await workspace.getTextDocument(p.textDocument.uri)
-            const languageId = getSupportedLanguageId(textDocument)
-
-            if (!textDocument || !languageId) {
-                return
-            }
-
-            p.contentChanges.forEach(change => {
-                codePercentageTracker.countTotalTokens(languageId, change.text, false)
-
-                const { sendUserWrittenCodeMetrics } = amazonQServiceManager.getConfiguration()
-                if (!sendUserWrittenCodeMetrics) {
+                if (!textDocument || !languageId) {
                     return
                 }
-                // exclude cases that the document change is from Q suggestions
-                const currentSession = completionSessionManager.getCurrentSession()
-                if (
-                    !currentSession?.suggestions.some(
-                        suggestion => suggestion?.insertText && suggestion.insertText === change.text
-                    )
-                ) {
-                    userWrittenCodeTracker?.countUserWrittenTokens(languageId, change.text)
+
+                p.contentChanges.forEach(change => {
+                    codePercentageTracker.countTotalTokens(languageId, change.text, false)
+
+                    const { sendUserWrittenCodeMetrics } = amazonQServiceManager.getConfiguration()
+                    if (!sendUserWrittenCodeMetrics) {
+                        return
+                    }
+                    // exclude cases that the document change is from Q suggestions
+                    const currentSession = completionSessionManager.getCurrentSession()
+                    if (
+                        !currentSession?.suggestions.some(
+                            suggestion => suggestion?.insertText && suggestion.insertText === change.text
+                        )
+                    ) {
+                        userWrittenCodeTracker?.countUserWrittenTokens(languageId, change.text)
+                    }
+                })
+
+                // Record last user modification time for any document
+                if (lastUserModificationTime) {
+                    timeSinceLastUserModification = new Date().getTime() - lastUserModificationTime
+                }
+                lastUserModificationTime = new Date().getTime()
+
+                documentChangedListener.onDocumentChanged(p)
+                editCompletionHandler.documentChanged()
+
+                // Process document changes with RecentEditTracker.
+                if (editsEnabled && recentEditTracker) {
+                    await recentEditTracker.handleDocumentChange({
+                        uri: p.textDocument.uri,
+                        languageId: textDocument.languageId,
+                        version: textDocument.version,
+                        text: textDocument.getText(),
+                    })
                 }
             })
 
-            // Record last user modification time for any document
-            if (lastUserModificationTime) {
-                timeSinceLastUserModification = new Date().getTime() - lastUserModificationTime
+            lsp.onDidOpenTextDocument(p => {
+                logging.log(`Document opened: ${p.textDocument.uri}`)
+
+                // Track document opening with RecentEditTracker
+                if (recentEditTracker) {
+                    logging.log(`[SERVER] Tracking document open with RecentEditTracker: ${p.textDocument.uri}`)
+                    recentEditTracker.handleDocumentOpen({
+                        uri: p.textDocument.uri,
+                        languageId: p.textDocument.languageId,
+                        version: p.textDocument.version,
+                        text: p.textDocument.text,
+                    })
+                }
+            })
+
+            lsp.onDidCloseTextDocument(p => {
+                logging.log(`Document closed: ${p.textDocument.uri}`)
+
+                // Track document closing with RecentEditTracker
+                if (recentEditTracker) {
+                    logging.log(`[SERVER] Tracking document close with RecentEditTracker: ${p.textDocument.uri}`)
+                    recentEditTracker.handleDocumentClose(p.textDocument.uri)
+                }
+
+                if (cursorTracker) {
+                    cursorTracker.clearHistory(p.textDocument.uri)
+                }
+            })
+
+            logging.log('Amazon Q Inline Suggestion server has been initialised')
+
+            return async () => {
+                // Dispose all trackers in reverse order of initialization
+                if (codePercentageTracker) codePercentageTracker.dispose()
+                if (userWrittenCodeTracker) userWrittenCodeTracker?.dispose()
+                if (codeDiffTracker) await codeDiffTracker.shutdown()
+                if (recentEditTracker) recentEditTracker.dispose()
+                if (cursorTracker) cursorTracker.dispose()
+                if (rejectedEditTracker) rejectedEditTracker.dispose()
+
+                logging.log('Amazon Q Inline Suggestion server has been shut down')
             }
-            lastUserModificationTime = new Date().getTime()
-
-            documentChangedListener.onDocumentChanged(p)
-            editCompletionHandler.documentChanged()
-
-            // Process document changes with RecentEditTracker.
-            if (editsEnabled && recentEditTracker) {
-                await recentEditTracker.handleDocumentChange({
-                    uri: p.textDocument.uri,
-                    languageId: textDocument.languageId,
-                    version: textDocument.version,
-                    text: textDocument.getText(),
-                })
-            }
-        })
-
-        lsp.onDidOpenTextDocument(p => {
-            logging.log(`Document opened: ${p.textDocument.uri}`)
-
-            // Track document opening with RecentEditTracker
-            if (recentEditTracker) {
-                logging.log(`[SERVER] Tracking document open with RecentEditTracker: ${p.textDocument.uri}`)
-                recentEditTracker.handleDocumentOpen({
-                    uri: p.textDocument.uri,
-                    languageId: p.textDocument.languageId,
-                    version: p.textDocument.version,
-                    text: p.textDocument.text,
-                })
-            }
-        })
-
-        lsp.onDidCloseTextDocument(p => {
-            logging.log(`Document closed: ${p.textDocument.uri}`)
-
-            // Track document closing with RecentEditTracker
-            if (recentEditTracker) {
-                logging.log(`[SERVER] Tracking document close with RecentEditTracker: ${p.textDocument.uri}`)
-                recentEditTracker.handleDocumentClose(p.textDocument.uri)
-            }
-
-            if (cursorTracker) {
-                cursorTracker.clearHistory(p.textDocument.uri)
-            }
-        })
-
-        logging.log('Amazon Q Inline Suggestion server has been initialised')
-
-        return async () => {
-            // Dispose all trackers in reverse order of initialization
-            if (codePercentageTracker) codePercentageTracker.dispose()
-            if (userWrittenCodeTracker) userWrittenCodeTracker?.dispose()
-            if (codeDiffTracker) await codeDiffTracker.shutdown()
-            if (recentEditTracker) recentEditTracker.dispose()
-            if (cursorTracker) cursorTracker.dispose()
-            if (rejectedEditTracker) rejectedEditTracker.dispose()
-
-            logging.log('Amazon Q Inline Suggestion server has been shut down')
         }
-    }
 
 export const CodeWhispererServerIAM = CodewhispererServerFactory(getOrThrowBaseIAMServiceManager)
 export const CodeWhispererServerToken = CodewhispererServerFactory(getOrThrowBaseTokenServiceManager)

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -108,1026 +108,1028 @@ const mergeSuggestionsWithRightContext = (
 
 export const CodewhispererServerFactory =
     (serviceManager: () => AmazonQBaseServiceManager): Server =>
-        ({ credentialsProvider, lsp, workspace, telemetry, logging, runtime, sdkInitializator }) => {
-            let lastUserModificationTime: number
-            let timeSinceLastUserModification: number = 0
+    ({ credentialsProvider, lsp, workspace, telemetry, logging, runtime, sdkInitializator }) => {
+        let lastUserModificationTime: number
+        let timeSinceLastUserModification: number = 0
 
-            const completionSessionManager = SessionManager.getInstance('COMPLETIONS')
-            const editSessionManager = SessionManager.getInstance('EDITS')
+        const completionSessionManager = SessionManager.getInstance('COMPLETIONS')
+        const editSessionManager = SessionManager.getInstance('EDITS')
 
-            // AmazonQTokenServiceManager and TelemetryService are initialized in `onInitialized` handler to make sure Language Server connection is started
-            let amazonQServiceManager: AmazonQBaseServiceManager
-            let telemetryService: TelemetryService
+        // AmazonQTokenServiceManager and TelemetryService are initialized in `onInitialized` handler to make sure Language Server connection is started
+        let amazonQServiceManager: AmazonQBaseServiceManager
+        let telemetryService: TelemetryService
 
-            lsp.addInitializer((params: InitializeParams) => {
-                return {
-                    capabilities: {},
-                }
-            })
-
-            // CodePercentage and codeDiff tracker have a dependency on TelemetryService, so initialization is also delayed to `onInitialized` handler
-            let codePercentageTracker: CodePercentageTracker
-            let userWrittenCodeTracker: UserWrittenCodeTracker | undefined
-            let codeDiffTracker: CodeDiffTracker<AcceptedInlineSuggestionEntry>
-            let editCompletionHandler: EditCompletionHandler
-
-            // Trackers for monitoring edits and cursor position.
-            const recentEditTracker = RecentEditTracker.getInstance(logging, RecentEditTrackerDefaultConfig)
-            const cursorTracker = CursorTracker.getInstance()
-            const rejectedEditTracker = RejectedEditTracker.getInstance(logging, DEFAULT_REJECTED_EDIT_TRACKER_CONFIG)
-            let editsEnabled = false
-            let isOnInlineCompletionHandlerInProgress = false
-
-            const documentChangedListener = new DocumentChangedListener()
-
-            const onInlineCompletionHandler = async (
-                params: InlineCompletionWithReferencesParams,
-                token: CancellationToken
-            ): Promise<InlineCompletionListWithReferences> => {
-                // this handle should not run concurrently because
-                // 1. it would create a high volume of traffic, causing throttling
-                // 2. it is not designed to handle concurrent changes to these state variables.
-                // when one handler is at the API call stage, it has not yet update the session state
-                // but another request can start, causing the state to be incorrect.
-                if (isOnInlineCompletionHandlerInProgress) {
-                    logging.debug(`[INLINE_COMPLETION] Skipping concurrent request`)
-                    return EMPTY_RESULT
-                }
-                isOnInlineCompletionHandlerInProgress = true
-
-                try {
-                    // On every new completion request close current inflight session.
-                    const currentSession = completionSessionManager.getCurrentSession()
-                    logging.debug(`[INLINE_COMPLETION] Current session state: ${currentSession?.state || 'none'}`)
-                    if (currentSession && currentSession.state == 'REQUESTING' && !params.partialResultToken) {
-                        // this REQUESTING state only happens when the session is initialized, which is rare
-                        currentSession.discardInflightSessionOnNewInvocation = true
-                        logging.debug(`[INLINE_COMPLETION] Marked session for discard`)
-                    }
-
-                    if (cursorTracker) {
-                        cursorTracker.trackPosition(params.textDocument.uri, params.position)
-                    }
-                    const textDocument = await getTextDocument(params.textDocument.uri, workspace, logging)
-
-                    const codeWhispererService = amazonQServiceManager.getCodewhispererService()
-                    const authType = codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'
-                    logging.debug(
-                        `[INLINE_COMPLETION] Service ready - auth: ${authType}, partial token: ${!!params.partialResultToken}`
-                    )
-                    if (params.partialResultToken && currentSession) {
-                        // subsequent paginated requests for current session
-                        try {
-                            logging.debug(`[INLINE_COMPLETION] API call - generateSuggestions (pagination)`)
-                            const suggestionResponse = await codeWhispererService.generateSuggestions({
-                                ...currentSession.requestContext,
-                                fileContext: {
-                                    ...currentSession.requestContext.fileContext,
-                                },
-                                nextToken: `${params.partialResultToken}`,
-                            })
-                            logging.debug(`[INLINE_COMPLETION] Pagination request completed`)
-                            return await processSuggestionResponse(
-                                suggestionResponse,
-                                currentSession,
-                                false,
-                                params.context.selectedCompletionInfo?.range
-                            )
-                        } catch (error) {
-                            logging.debug(`[INLINE_COMPLETION] Pagination error: ${error}`)
-                            return handleSuggestionsErrors(error as Error, currentSession)
-                        }
-                    } else {
-                        // request for new session
-                        if (!textDocument) {
-                            logging.debug(`[INLINE_COMPLETION] Document not found: ${params.textDocument.uri}`)
-                            return EMPTY_RESULT
-                        }
-
-                        const inferredLanguageId = getSupportedLanguageId(textDocument)
-                        if (!inferredLanguageId) {
-                            logging.debug(`[INLINE_COMPLETION] Unsupported language: ${textDocument.languageId}`)
-                            return EMPTY_RESULT
-                        }
-                        logging.debug(`[INLINE_COMPLETION] New session - language: ${inferredLanguageId}`)
-
-                        // Build request context
-                        const isAutomaticLspTriggerKind =
-                            params.context.triggerKind == InlineCompletionTriggerKind.Automatic
-                        const maxResults = isAutomaticLspTriggerKind ? 1 : 5
-                        const selectionRange = params.context.selectedCompletionInfo?.range
-                        const fileContext = getFileContext({
-                            textDocument,
-                            inferredLanguageId,
-                            position: params.position,
-                            workspaceFolder: workspace.getWorkspaceFolder(textDocument.uri),
-                        })
-
-                        const workspaceState = WorkspaceFolderManager.getInstance()?.getWorkspaceState()
-                        const workspaceId = workspaceState?.webSocketClient?.isConnected()
-                            ? workspaceState.workspaceId
-                            : undefined
-
-                        const previousSession = completionSessionManager.getPreviousSession()
-                        const previousDecision = previousSession?.getAggregatedUserTriggerDecision() ?? ''
-                        logging.debug(`[INLINE_COMPLETION] Previous decision: ${previousDecision}`)
-                        let ideCategory: string | undefined = ''
-                        const initializeParams = lsp.getClientInitializeParams()
-                        if (initializeParams !== undefined) {
-                            ideCategory = getIdeCategory(initializeParams)
-                        }
-
-                        // auto trigger code path
-                        let codewhispererAutoTriggerType = undefined
-                        let triggerCharacters = ''
-                        let autoTriggerResult = undefined
-
-                        if (isAutomaticLspTriggerKind) {
-                            logging.debug(`[INLINE_COMPLETION] Auto-trigger evaluation started`)
-                            // Reference: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/classifierTrigger.ts#L477
-                            if (
-                                params.documentChangeParams?.contentChanges &&
-                                params.documentChangeParams.contentChanges.length > 0 &&
-                                params.documentChangeParams.contentChanges[0].text !== undefined
-                            ) {
-                                triggerCharacters = params.documentChangeParams.contentChanges[0].text
-                                codewhispererAutoTriggerType = getAutoTriggerType(
-                                    params.documentChangeParams.contentChanges
-                                )
-                            } else {
-                                // if the client does not emit document change for the trigger, use left most character.
-                                triggerCharacters = fileContext.leftFileContent.trim().at(-1) ?? ''
-                                codewhispererAutoTriggerType = triggerType(fileContext)
-                            }
-                            // See: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/keyStrokeHandler.ts#L132
-                            // In such cases, do not auto trigger.
-                            if (codewhispererAutoTriggerType === undefined) {
-                                return EMPTY_RESULT
-                            }
-
-                            autoTriggerResult = autoTrigger(
-                                {
-                                    fileContext, // The left/right file context and programming language
-                                    lineNum: params.position.line, // the line number of the invocation, this is the line of the cursor
-                                    char: triggerCharacters, // Add the character just inserted, if any, before the invication position
-                                    ide: ideCategory ?? '',
-                                    os: getNormalizeOsName(),
-                                    previousDecision, // The last decision by the user on the previous invocation
-                                    triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
-                                },
-                                logging
-                            )
-
-                            if (
-                                codewhispererAutoTriggerType === 'Classifier' &&
-                                !autoTriggerResult.shouldTrigger &&
-                                !(editsEnabled && codeWhispererService instanceof CodeWhispererServiceToken)
-                            ) {
-                                // There is still potentially a Edit trigger without Completion if NEP is enabled (current only BearerTokenClient)
-                                logging.debug(`[INLINE_COMPLETION] Auto-trigger declined by classifier`)
-                                return EMPTY_RESULT
-                            }
-                            logging.debug(`[INLINE_COMPLETION] Auto-trigger approved: ${codewhispererAutoTriggerType}`)
-                        }
-
-                        // Get supplemental context from recent edits if available.
-                        let supplementalContextFromEdits = undefined
-
-                        let requestContext: GenerateSuggestionsRequest = {
-                            fileContext,
-                            maxResults,
-                        }
-
-                        logging.debug(
-                            `[INLINE_COMPLETION] Fetching supplemental context - auth: ${codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'}`
-                        )
-
-                        const supplementalContext = await codeWhispererService.constructSupplementalContext(
-                            textDocument,
-                            params.position,
-                            workspace,
-                            recentEditTracker,
-                            logging,
-                            token,
-                            params.openTabFilepaths,
-                            { includeRecentEdits: false }
-                        )
-                        // TODO: logging
-                        if (codeWhispererService instanceof CodeWhispererServiceToken) {
-                            const tokenRequestContext = requestContext as GenerateTokenSuggestionsRequest
-                            const supplementalContextItems = supplementalContext?.items || []
-                            tokenRequestContext.supplementalContexts = [
-                                ...supplementalContextItems.map(v => ({
-                                    content: v.content,
-                                    filePath: v.filePath,
-                                })),
-                            ]
-
-                            if (editsEnabled) {
-                                const predictionTypes: string[][] = []
-
-                                /**
-                                 * Manual trigger - should always have 'Completions'
-                                 * Auto trigger
-                                 *  - Classifier - should have 'Completions' when classifier evalualte to true given the editor's states
-                                 *  - Others - should always have 'Completions'
-                                 */
-                                if (
-                                    !isAutomaticLspTriggerKind ||
-                                    (isAutomaticLspTriggerKind && codewhispererAutoTriggerType !== 'Classifier') ||
-                                    (isAutomaticLspTriggerKind &&
-                                        codewhispererAutoTriggerType === 'Classifier' &&
-                                        autoTriggerResult?.shouldTrigger)
-                                ) {
-                                    predictionTypes.push(['COMPLETIONS'])
-                                }
-
-                                const editPredictionAutoTriggerResult = editPredictionAutoTrigger({
-                                    fileContext: fileContext,
-                                    lineNum: params.position.line,
-                                    char: triggerCharacters,
-                                    previousDecision: previousDecision,
-                                    cursorHistory: cursorTracker,
-                                    recentEdits: recentEditTracker,
-                                })
-
-                                if (editPredictionAutoTriggerResult.shouldTrigger) {
-                                    predictionTypes.push(['EDITS'])
-                                }
-
-                                if (predictionTypes.length === 0) {
-                                    return EMPTY_RESULT
-                                }
-
-                                // Step 0: Determine if we have "Recent Edit context"
-                                if (recentEditTracker) {
-                                    supplementalContextFromEdits =
-                                        await recentEditTracker.generateEditBasedContext(textDocument)
-                                }
-
-                                // Step 1: Recent Edits context
-                                const supplementalContextItemsForEdits =
-                                    supplementalContextFromEdits?.supplementalContextItems || []
-
-                                tokenRequestContext.supplementalContexts.push(
-                                    ...supplementalContextItemsForEdits.map(v => ({
-                                        content: v.content,
-                                        filePath: v.filePath,
-                                        type: 'PreviousEditorState',
-                                        metadata: {
-                                            previousEditorStateMetadata: {
-                                                timeOffset: 1000,
-                                            },
-                                        },
-                                    }))
-                                )
-
-                                // Step 2: Prediction type COMPLETION, Edits or both
-                                tokenRequestContext.predictionTypes = predictionTypes.flat()
-
-                                // Step 3: Current Editor/Cursor state
-                                tokenRequestContext.editorState = {
-                                    document: {
-                                        relativeFilePath: textDocument.uri,
-                                        programmingLanguage: {
-                                            languageName: requestContext.fileContext.programmingLanguage.languageName,
-                                        },
-                                        text: textDocument.getText(),
-                                    },
-                                    cursorState: {
-                                        position: {
-                                            line: params.position.line,
-                                            character: params.position.character,
-                                        },
-                                    },
-                                }
-                            }
-                            requestContext = tokenRequestContext
-                        }
-
-                        // Close ACTIVE session and record Discard trigger decision immediately
-                        if (currentSession && currentSession.state === 'ACTIVE') {
-                            if (editsEnabled && currentSession.suggestionType === SuggestionType.EDIT) {
-                                const mergedSuggestions = mergeEditSuggestionsWithFileContext(
-                                    currentSession,
-                                    textDocument,
-                                    fileContext
-                                )
-
-                                if (mergedSuggestions.length > 0) {
-                                    return {
-                                        items: mergedSuggestions,
-                                        sessionId: currentSession.id,
-                                    }
-                                }
-                            }
-                            // Emit user trigger decision at session close time for active session
-                            completionSessionManager.discardSession(currentSession)
-                            const streakLength = editsEnabled ? completionSessionManager.getAndUpdateStreakLength(false) : 0
-                            await emitUserTriggerDecisionTelemetry(
-                                telemetry,
-                                telemetryService,
-                                currentSession,
-                                timeSinceLastUserModification,
-                                0,
-                                0,
-                                [],
-                                [],
-                                streakLength
-                            )
-                        }
-
-                        // Get supplemental context for metadata
-
-                        const supplementalMetadata = supplementalContext?.supContextData
-
-                        const newSession = completionSessionManager.createSession({
-                            document: textDocument,
-                            startPosition: params.position,
-                            triggerType: isAutomaticLspTriggerKind ? 'AutoTrigger' : 'OnDemand',
-                            language: inferredLanguageId,
-                            requestContext: requestContext,
-                            autoTriggerType: isAutomaticLspTriggerKind ? codewhispererAutoTriggerType : undefined,
-                            triggerCharacter: triggerCharacters,
-                            classifierResult: autoTriggerResult?.classifierResult,
-                            classifierThreshold: autoTriggerResult?.classifierThreshold,
-                            credentialStartUrl: credentialsProvider.getConnectionMetadata?.()?.sso?.startUrl ?? undefined,
-                            supplementalMetadata: supplementalMetadata,
-                            customizationArn: textUtils.undefinedIfEmpty(codeWhispererService.customizationArn),
-                        })
-
-                        // Add extra context to request context
-                        const { extraContext } = amazonQServiceManager.getConfiguration().inlineSuggestions
-                        if (extraContext) {
-                            requestContext.fileContext.leftFileContent =
-                                extraContext + '\n' + requestContext.fileContext.leftFileContent
-                        }
-
-                        // Prepare the request with normalized file content
-                        const normalizedFileContext = {
-                            ...requestContext.fileContext,
-                            leftFileContent: requestContext.fileContext.leftFileContent
-                                .slice(-CONTEXT_CHARACTERS_LIMIT)
-                                .replaceAll('\r\n', '\n'),
-                            rightFileContent: requestContext.fileContext.rightFileContent
-                                .slice(0, CONTEXT_CHARACTERS_LIMIT)
-                                .replaceAll('\r\n', '\n'),
-                        }
-
-                        // Create the appropriate request based on service type
-                        let generateCompletionReq: BaseGenerateSuggestionsRequest
-
-                        if (codeWhispererService instanceof CodeWhispererServiceToken) {
-                            const tokenRequest = requestContext as GenerateTokenSuggestionsRequest
-                            logging.debug(
-                                `[INLINE_COMPLETION] Final token request - predictionTypes: ${tokenRequest.predictionTypes?.join(',') || 'none'}`
-                            )
-                            generateCompletionReq = {
-                                ...tokenRequest,
-                                fileContext: normalizedFileContext,
-                                ...(workspaceId ? { workspaceId } : {}),
-                            }
-                        } else {
-                            const iamRequest = requestContext as GenerateIAMSuggestionsRequest
-                            logging.debug(`[INLINE_COMPLETION] Final IAM request - maxResults: ${iamRequest.maxResults}`)
-                            generateCompletionReq = {
-                                ...iamRequest,
-                                fileContext: normalizedFileContext,
-                            }
-                        }
-
-                        try {
-                            const authType = codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'
-                            logging.debug(`[INLINE_COMPLETION] API call - generateSuggestions (new session, ${authType})`)
-                            const suggestionResponse = await codeWhispererService.generateSuggestions(generateCompletionReq)
-                            return await processSuggestionResponse(suggestionResponse, newSession, true, selectionRange)
-                        } catch (error) {
-                            return handleSuggestionsErrors(error as Error, newSession)
-                        }
-                    }
-                } finally {
-                    isOnInlineCompletionHandlerInProgress = false
-                }
+        lsp.addInitializer((params: InitializeParams) => {
+            return {
+                capabilities: {},
             }
+        })
 
-            const processSuggestionResponse = async (
-                suggestionResponse: GenerateSuggestionsResponse,
-                session: CodeWhispererSession,
-                isNewSession: boolean,
-                selectionRange?: Range,
-                textDocument?: TextDocument
-            ): Promise<InlineCompletionListWithReferences> => {
-                codePercentageTracker.countInvocation(session.language)
+        // CodePercentage and codeDiff tracker have a dependency on TelemetryService, so initialization is also delayed to `onInitialized` handler
+        let codePercentageTracker: CodePercentageTracker
+        let userWrittenCodeTracker: UserWrittenCodeTracker | undefined
+        let codeDiffTracker: CodeDiffTracker<AcceptedInlineSuggestionEntry>
+        let editCompletionHandler: EditCompletionHandler
+
+        // Trackers for monitoring edits and cursor position.
+        const recentEditTracker = RecentEditTracker.getInstance(logging, RecentEditTrackerDefaultConfig)
+        const cursorTracker = CursorTracker.getInstance()
+        const rejectedEditTracker = RejectedEditTracker.getInstance(logging, DEFAULT_REJECTED_EDIT_TRACKER_CONFIG)
+        let editsEnabled = false
+        let isOnInlineCompletionHandlerInProgress = false
+
+        const documentChangedListener = new DocumentChangedListener()
+
+        const onInlineCompletionHandler = async (
+            params: InlineCompletionWithReferencesParams,
+            token: CancellationToken
+        ): Promise<InlineCompletionListWithReferences> => {
+            // this handle should not run concurrently because
+            // 1. it would create a high volume of traffic, causing throttling
+            // 2. it is not designed to handle concurrent changes to these state variables.
+            // when one handler is at the API call stage, it has not yet update the session state
+            // but another request can start, causing the state to be incorrect.
+            IdleWorkspaceManager.recordActivityTimestamp()
+
+            if (isOnInlineCompletionHandlerInProgress) {
+                logging.debug(`[INLINE_COMPLETION] Skipping concurrent request`)
+                return EMPTY_RESULT
+            }
+            isOnInlineCompletionHandlerInProgress = true
+
+            try {
+                // On every new completion request close current inflight session.
+                const currentSession = completionSessionManager.getCurrentSession()
+                logging.debug(`[INLINE_COMPLETION] Current session state: ${currentSession?.state || 'none'}`)
+                if (currentSession && currentSession.state == 'REQUESTING' && !params.partialResultToken) {
+                    // this REQUESTING state only happens when the session is initialized, which is rare
+                    currentSession.discardInflightSessionOnNewInvocation = true
+                    logging.debug(`[INLINE_COMPLETION] Marked session for discard`)
+                }
+
+                if (cursorTracker) {
+                    cursorTracker.trackPosition(params.textDocument.uri, params.position)
+                }
+                const textDocument = await getTextDocument(params.textDocument.uri, workspace, logging)
+
+                const codeWhispererService = amazonQServiceManager.getCodewhispererService()
+                const authType = codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'
                 logging.debug(
-                    `[INLINE_COMPLETION] Processing response - suggestions: ${suggestionResponse.suggestions.length}, new: ${isNewSession}`
+                    `[INLINE_COMPLETION] Service ready - auth: ${authType}, partial token: ${!!params.partialResultToken}`
                 )
-
-                userWrittenCodeTracker?.recordUsageCount(session.language)
-                session.includeImportsWithSuggestions =
-                    amazonQServiceManager.getConfiguration().includeImportsWithSuggestions
-
-                if (isNewSession) {
-                    // Populate the session with information from codewhisperer response
-                    session.suggestions = suggestionResponse.suggestions
-                    session.responseContext = suggestionResponse.responseContext
-                    session.codewhispererSessionId = suggestionResponse.responseContext.codewhispererSessionId
-                    session.timeToFirstRecommendation = new Date().getTime() - session.startTime
-                    session.suggestionType = suggestionResponse.suggestionType
-                    logging.debug(
-                        `[INLINE_COMPLETION] New session initialized - sessionId: ${session.codewhispererSessionId}`
-                    )
-                } else {
-                    session.suggestions = [...session.suggestions, ...suggestionResponse.suggestions]
-                }
-
-                // Emit service invocation telemetry for every request sent to backend
-                emitServiceInvocationTelemetry(telemetry, session, suggestionResponse.responseContext.requestId)
-
-                // Discard previous inflight API response due to new trigger
-                if (session.discardInflightSessionOnNewInvocation) {
-                    session.discardInflightSessionOnNewInvocation = false
-                    completionSessionManager.discardSession(session)
-                    const streakLength = editsEnabled ? completionSessionManager.getAndUpdateStreakLength(false) : 0
-                    await emitUserTriggerDecisionTelemetry(
-                        telemetry,
-                        telemetryService,
-                        session,
-                        timeSinceLastUserModification,
-                        0,
-                        0,
-                        [],
-                        [],
-                        streakLength
-                    )
-                }
-
-                // session was closed by user already made decisions consequent completion request before new paginated API response was received
-                if (
-                    session.suggestionType !== SuggestionType.EDIT && // TODO: this is a shorterm fix to allow Edits tabtabtab experience, however the real solution is to manage such sessions correctly
-                    (session.state === 'CLOSED' || session.state === 'DISCARD')
-                ) {
-                    return EMPTY_RESULT
-                }
-
-                // API response was recieved, we can activate session now
-                completionSessionManager.activateSession(session)
-
-                // Process suggestions to apply Empty or Filter filters
-                const filteredSuggestions = suggestionResponse.suggestions
-                    // Empty suggestion filter
-                    .filter(suggestion => {
-                        if (suggestion.content === '') {
-                            session.setSuggestionState(suggestion.itemId, 'Empty')
-                            return false
-                        }
-
-                        return true
-                    })
-                    // References setting filter
-                    .filter(suggestion => {
-                        // State to track whether code with references should be included in
-                        // the response. No locking or concurrency controls, filtering is done
-                        // right before returning and is only guaranteed to be consistent within
-                        // the context of a single response.
-                        const { includeSuggestionsWithCodeReferences } = amazonQServiceManager.getConfiguration()
-                        if (includeSuggestionsWithCodeReferences) {
-                            return true
-                        }
-
-                        if (suggestion.references == null || suggestion.references.length === 0) {
-                            return true
-                        }
-
-                        // Filter out suggestions that have references when includeSuggestionsWithCodeReferences setting is true
-                        session.setSuggestionState(suggestion.itemId, 'Filter')
-                        return false
-                    })
-
-                if (suggestionResponse.suggestionType === SuggestionType.COMPLETION) {
-                    const { includeImportsWithSuggestions } = amazonQServiceManager.getConfiguration()
-                    const suggestionsWithRightContext = mergeSuggestionsWithRightContext(
-                        session.requestContext.fileContext.rightFileContent,
-                        filteredSuggestions,
-                        includeImportsWithSuggestions,
-                        selectionRange
-                    ).filter(suggestion => {
-                        // Discard suggestions that have empty string insertText after right context merge and can't be displayed anymore
-                        if (suggestion.insertText === '') {
-                            session.setSuggestionState(suggestion.itemId, 'Discard')
-                            return false
-                        }
-
-                        return true
-                    })
-
-                    suggestionsWithRightContext.forEach(suggestion => {
-                        const cachedSuggestion = session.suggestions.find(s => s.itemId === suggestion.itemId)
-                        if (cachedSuggestion) cachedSuggestion.insertText = suggestion.insertText.toString()
-                    })
-
-                    // TODO: need dedupe after right context merging but I don't see one
-                    session.suggestionsAfterRightContextMerge.push(...suggestionsWithRightContext)
-
-                    session.codewhispererSuggestionImportCount =
-                        session.codewhispererSuggestionImportCount +
-                        suggestionsWithRightContext.reduce((total, suggestion) => {
-                            return total + (suggestion.mostRelevantMissingImports?.length || 0)
-                        }, 0)
-
-                    // If after all server-side filtering no suggestions can be displayed, and there is no nextToken
-                    // close session and return empty results
-                    if (
-                        session.suggestionsAfterRightContextMerge.length === 0 &&
-                        !suggestionResponse.responseContext.nextToken
-                    ) {
-                        completionSessionManager.closeSession(session)
-                        await emitUserTriggerDecisionTelemetry(
-                            telemetry,
-                            telemetryService,
-                            session,
-                            timeSinceLastUserModification
+                if (params.partialResultToken && currentSession) {
+                    // subsequent paginated requests for current session
+                    try {
+                        logging.debug(`[INLINE_COMPLETION] API call - generateSuggestions (pagination)`)
+                        const suggestionResponse = await codeWhispererService.generateSuggestions({
+                            ...currentSession.requestContext,
+                            fileContext: {
+                                ...currentSession.requestContext.fileContext,
+                            },
+                            nextToken: `${params.partialResultToken}`,
+                        })
+                        logging.debug(`[INLINE_COMPLETION] Pagination request completed`)
+                        return await processSuggestionResponse(
+                            suggestionResponse,
+                            currentSession,
+                            false,
+                            params.context.selectedCompletionInfo?.range
                         )
-
+                    } catch (error) {
+                        logging.debug(`[INLINE_COMPLETION] Pagination error: ${error}`)
+                        return handleSuggestionsErrors(error as Error, currentSession)
+                    }
+                } else {
+                    // request for new session
+                    if (!textDocument) {
+                        logging.debug(`[INLINE_COMPLETION] Document not found: ${params.textDocument.uri}`)
                         return EMPTY_RESULT
                     }
 
-                    return {
-                        items: suggestionsWithRightContext,
-                        sessionId: session.id,
-                        partialResultToken: suggestionResponse.responseContext.nextToken,
+                    const inferredLanguageId = getSupportedLanguageId(textDocument)
+                    if (!inferredLanguageId) {
+                        logging.debug(`[INLINE_COMPLETION] Unsupported language: ${textDocument.languageId}`)
+                        return EMPTY_RESULT
                     }
-                } else {
-                    return {
-                        items: suggestionResponse.suggestions
-                            .map(suggestion => {
-                                // Check if this suggestion is similar to a previously rejected edit
-                                const isSimilarToRejected = rejectedEditTracker.isSimilarToRejected(
-                                    suggestion.content,
-                                    textDocument?.uri || ''
-                                )
+                    logging.debug(`[INLINE_COMPLETION] New session - language: ${inferredLanguageId}`)
 
-                                if (isSimilarToRejected) {
-                                    // Mark as rejected in the session
-                                    session.setSuggestionState(suggestion.itemId, 'Reject')
-                                    logging.debug(
-                                        `[EDIT_PREDICTION] Filtered out suggestion similar to previously rejected edit`
-                                    )
-                                    // Return empty item that will be filtered out
-                                    return {
-                                        insertText: '',
-                                        isInlineEdit: true,
-                                        itemId: suggestion.itemId,
-                                    }
-                                }
-
-                                return {
-                                    insertText: suggestion.content,
-                                    isInlineEdit: true,
-                                    itemId: suggestion.itemId,
-                                }
-                            })
-                            .filter(item => item.insertText !== ''),
-                        sessionId: session.id,
-                        partialResultToken: suggestionResponse.responseContext.nextToken,
-                    }
-                }
-            }
-
-            const handleSuggestionsErrors = (
-                error: Error,
-                session: CodeWhispererSession
-            ): InlineCompletionListWithReferences => {
-                logging.log('Recommendation failure: ' + error)
-                logging.debug(`[INLINE_SUGGESTION] handleSuggestionsErrors call`)
-
-                // Add specific handling for IAM-related errors
-                if (isUsingIAMAuth(credentialsProvider)) {
-                    if (error.message?.includes('not authorized') || error.message?.includes('AccessDenied')) {
-                        logging.error(
-                            `[IAM AUTH ERROR] IAM authentication error: User not authorized. Check IAM permissions for CodeWhisperer.`
-                        )
-                    } else if (error.message?.includes('invalid parameter')) {
-                        logging.error(
-                            `[IAM AUTH ERROR] IAM authentication error: Invalid request parameters for IAM client`
-                        )
-                    } else if (error.message?.includes('credentials')) {
-                        logging.error(`[IAM AUTH ERROR] IAM authentication error: Invalid or missing credentials`)
-                    }
-
-                    // Log detailed information about the request context
-                    logging.error(`[IAM AUTH ERROR] Request context: ${JSON.stringify(session.requestContext)}`)
-                }
-
-                emitServiceInvocationFailure(telemetry, session, error)
-
-                completionSessionManager.closeSession(session)
-
-                let translatedError = error
-
-                if (hasConnectionExpired(error)) {
-                    translatedError = new AmazonQServiceConnectionExpiredError(getErrorMessage(error))
-                }
-
-                if (translatedError instanceof AmazonQError) {
-                    throw new ResponseError(
-                        LSPErrorCodes.RequestFailed,
-                        translatedError.message || 'Error processing suggestion requests',
-                        {
-                            awsErrorCode: translatedError.code,
-                        }
-                    )
-                }
-
-                return EMPTY_RESULT
-            }
-
-            // Schedule tracker for UserModification Telemetry event
-            const enqueueCodeDiffEntry = (
-                session: CodeWhispererSession,
-                acceptedSuggestion: Suggestion,
-                addedCharactersForEdit?: string
-            ) => {
-                const endPosition = getEndPositionForAcceptedSuggestion(acceptedSuggestion.content, session.startPosition)
-                // use the addedCharactersForEdit if it is EDIT suggestion type
-                const originalString = addedCharactersForEdit ? addedCharactersForEdit : acceptedSuggestion.content
-
-                codeDiffTracker.enqueue({
-                    sessionId: session.codewhispererSessionId || '',
-                    requestId: session.responseContext?.requestId || '',
-                    fileUrl: session.document.uri,
-                    languageId: session.language,
-                    time: Date.now(),
-                    originalString: originalString,
-                    startPosition: session.startPosition,
-                    endPosition: endPosition,
-                    customizationArn: session.customizationArn,
-                    completionType: getCompletionType(acceptedSuggestion),
-                    triggerType: session.triggerType,
-                    credentialStartUrl: session.credentialStartUrl,
-                })
-            }
-
-            const onLogInlineCompletionSessionResultsHandler = async (params: LogInlineCompletionSessionResultsParams) => {
-                const {
-                    sessionId,
-                    completionSessionResult,
-                    firstCompletionDisplayLatency,
-                    totalSessionDisplayTime,
-                    typeaheadLength,
-                    isInlineEdit,
-                    addedDiagnostics,
-                    removedDiagnostics,
-                } = params
-
-                const sessionManager = params.isInlineEdit ? editSessionManager : completionSessionManager
-
-                const session = sessionManager.getSessionById(sessionId)
-                if (!session) {
-                    logging.log(`ERROR: Session ID ${sessionId} was not found`)
-                    return
-                }
-
-                if (session.state !== 'ACTIVE') {
-                    logging.log(`ERROR: Trying to record trigger decision for not-active session ${sessionId}`)
-                    return
-                }
-
-                const acceptedItemId = Object.keys(params.completionSessionResult).find(
-                    k => params.completionSessionResult[k].accepted
-                )
-                const isAccepted = acceptedItemId ? true : false
-                const acceptedSuggestion = session.suggestions.find(s => s.itemId === acceptedItemId)
-                let addedLengthForEdits = 0
-                let deletedLengthForEdits = 0
-                if (acceptedSuggestion) {
-                    codePercentageTracker.countSuccess(session.language)
-                    if (session.suggestionType === SuggestionType.EDIT && acceptedSuggestion.content) {
-                        // [acceptedSuggestion.insertText] will be undefined for NEP suggestion. Use [acceptedSuggestion.content] instead.
-                        // Since [acceptedSuggestion.content] is in the form of a diff, transform the content into addedCharacters and deletedCharacters.
-                        const { addedLines, deletedLines } = getAddedAndDeletedLines(acceptedSuggestion.content)
-                        const charDiffResult = getCharacterDifferences(addedLines, deletedLines)
-                        addedLengthForEdits = charDiffResult.charactersAdded
-                        deletedLengthForEdits = charDiffResult.charactersRemoved
-
-                        codePercentageTracker.countAcceptedTokensUsingCount(
-                            session.language,
-                            charDiffResult.charactersAdded
-                        )
-                        codePercentageTracker.addTotalTokensForEdits(session.language, charDiffResult.charactersAdded)
-                        enqueueCodeDiffEntry(session, acceptedSuggestion, addedLines.join('\n'))
-                    } else if (acceptedSuggestion.insertText) {
-                        codePercentageTracker.countAcceptedTokens(session.language, acceptedSuggestion.insertText)
-                        codePercentageTracker.countTotalTokens(session.language, acceptedSuggestion.insertText, true)
-
-                        enqueueCodeDiffEntry(session, acceptedSuggestion)
-                    }
-                }
-
-                // Handle rejected edit predictions
-                if (isInlineEdit && !isAccepted) {
-                    // Find all rejected suggestions in this session
-                    const rejectedSuggestions = session.suggestions.filter(suggestion => {
-                        const result = completionSessionResult[suggestion.itemId]
-                        return result && result.seen && !result.accepted
+                    // Build request context
+                    const isAutomaticLspTriggerKind =
+                        params.context.triggerKind == InlineCompletionTriggerKind.Automatic
+                    const maxResults = isAutomaticLspTriggerKind ? 1 : 5
+                    const selectionRange = params.context.selectedCompletionInfo?.range
+                    const fileContext = getFileContext({
+                        textDocument,
+                        inferredLanguageId,
+                        position: params.position,
+                        workspaceFolder: workspace.getWorkspaceFolder(textDocument.uri),
                     })
 
-                    // Record each rejected edit
-                    for (const rejectedSuggestion of rejectedSuggestions) {
-                        if (rejectedSuggestion.content) {
-                            rejectedEditTracker.recordRejectedEdit({
-                                content: rejectedSuggestion.content,
-                                timestamp: Date.now(),
-                                documentUri: session.document.uri,
-                                position: session.startPosition,
+                    const workspaceState = WorkspaceFolderManager.getInstance()?.getWorkspaceState()
+                    const workspaceId = workspaceState?.webSocketClient?.isConnected()
+                        ? workspaceState.workspaceId
+                        : undefined
+
+                    const previousSession = completionSessionManager.getPreviousSession()
+                    const previousDecision = previousSession?.getAggregatedUserTriggerDecision() ?? ''
+                    logging.debug(`[INLINE_COMPLETION] Previous decision: ${previousDecision}`)
+                    let ideCategory: string | undefined = ''
+                    const initializeParams = lsp.getClientInitializeParams()
+                    if (initializeParams !== undefined) {
+                        ideCategory = getIdeCategory(initializeParams)
+                    }
+
+                    // auto trigger code path
+                    let codewhispererAutoTriggerType = undefined
+                    let triggerCharacters = ''
+                    let autoTriggerResult = undefined
+
+                    if (isAutomaticLspTriggerKind) {
+                        logging.debug(`[INLINE_COMPLETION] Auto-trigger evaluation started`)
+                        // Reference: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/classifierTrigger.ts#L477
+                        if (
+                            params.documentChangeParams?.contentChanges &&
+                            params.documentChangeParams.contentChanges.length > 0 &&
+                            params.documentChangeParams.contentChanges[0].text !== undefined
+                        ) {
+                            triggerCharacters = params.documentChangeParams.contentChanges[0].text
+                            codewhispererAutoTriggerType = getAutoTriggerType(
+                                params.documentChangeParams.contentChanges
+                            )
+                        } else {
+                            // if the client does not emit document change for the trigger, use left most character.
+                            triggerCharacters = fileContext.leftFileContent.trim().at(-1) ?? ''
+                            codewhispererAutoTriggerType = triggerType(fileContext)
+                        }
+                        // See: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/keyStrokeHandler.ts#L132
+                        // In such cases, do not auto trigger.
+                        if (codewhispererAutoTriggerType === undefined) {
+                            return EMPTY_RESULT
+                        }
+
+                        autoTriggerResult = autoTrigger(
+                            {
+                                fileContext, // The left/right file context and programming language
+                                lineNum: params.position.line, // the line number of the invocation, this is the line of the cursor
+                                char: triggerCharacters, // Add the character just inserted, if any, before the invication position
+                                ide: ideCategory ?? '',
+                                os: getNormalizeOsName(),
+                                previousDecision, // The last decision by the user on the previous invocation
+                                triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
+                            },
+                            logging
+                        )
+
+                        if (
+                            codewhispererAutoTriggerType === 'Classifier' &&
+                            !autoTriggerResult.shouldTrigger &&
+                            !(editsEnabled && codeWhispererService instanceof CodeWhispererServiceToken)
+                        ) {
+                            // There is still potentially a Edit trigger without Completion if NEP is enabled (current only BearerTokenClient)
+                            logging.debug(`[INLINE_COMPLETION] Auto-trigger declined by classifier`)
+                            return EMPTY_RESULT
+                        }
+                        logging.debug(`[INLINE_COMPLETION] Auto-trigger approved: ${codewhispererAutoTriggerType}`)
+                    }
+
+                    // Get supplemental context from recent edits if available.
+                    let supplementalContextFromEdits = undefined
+
+                    let requestContext: GenerateSuggestionsRequest = {
+                        fileContext,
+                        maxResults,
+                    }
+
+                    logging.debug(
+                        `[INLINE_COMPLETION] Fetching supplemental context - auth: ${codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'}`
+                    )
+
+                    const supplementalContext = await codeWhispererService.constructSupplementalContext(
+                        textDocument,
+                        params.position,
+                        workspace,
+                        recentEditTracker,
+                        logging,
+                        token,
+                        params.openTabFilepaths,
+                        { includeRecentEdits: false }
+                    )
+                    // TODO: logging
+                    if (codeWhispererService instanceof CodeWhispererServiceToken) {
+                        const tokenRequestContext = requestContext as GenerateTokenSuggestionsRequest
+                        const supplementalContextItems = supplementalContext?.items || []
+                        tokenRequestContext.supplementalContexts = [
+                            ...supplementalContextItems.map(v => ({
+                                content: v.content,
+                                filePath: v.filePath,
+                            })),
+                        ]
+
+                        if (editsEnabled) {
+                            const predictionTypes: string[][] = []
+
+                            /**
+                             * Manual trigger - should always have 'Completions'
+                             * Auto trigger
+                             *  - Classifier - should have 'Completions' when classifier evalualte to true given the editor's states
+                             *  - Others - should always have 'Completions'
+                             */
+                            if (
+                                !isAutomaticLspTriggerKind ||
+                                (isAutomaticLspTriggerKind && codewhispererAutoTriggerType !== 'Classifier') ||
+                                (isAutomaticLspTriggerKind &&
+                                    codewhispererAutoTriggerType === 'Classifier' &&
+                                    autoTriggerResult?.shouldTrigger)
+                            ) {
+                                predictionTypes.push(['COMPLETIONS'])
+                            }
+
+                            const editPredictionAutoTriggerResult = editPredictionAutoTrigger({
+                                fileContext: fileContext,
+                                lineNum: params.position.line,
+                                char: triggerCharacters,
+                                previousDecision: previousDecision,
+                                cursorHistory: cursorTracker,
+                                recentEdits: recentEditTracker,
                             })
 
-                            logging.debug(
-                                `[EDIT_PREDICTION] Recorded rejected edit: ${rejectedSuggestion.content.substring(0, 20)}...`
+                            if (editPredictionAutoTriggerResult.shouldTrigger) {
+                                predictionTypes.push(['EDITS'])
+                            }
+
+                            if (predictionTypes.length === 0) {
+                                return EMPTY_RESULT
+                            }
+
+                            // Step 0: Determine if we have "Recent Edit context"
+                            if (recentEditTracker) {
+                                supplementalContextFromEdits =
+                                    await recentEditTracker.generateEditBasedContext(textDocument)
+                            }
+
+                            // Step 1: Recent Edits context
+                            const supplementalContextItemsForEdits =
+                                supplementalContextFromEdits?.supplementalContextItems || []
+
+                            tokenRequestContext.supplementalContexts.push(
+                                ...supplementalContextItemsForEdits.map(v => ({
+                                    content: v.content,
+                                    filePath: v.filePath,
+                                    type: 'PreviousEditorState',
+                                    metadata: {
+                                        previousEditorStateMetadata: {
+                                            timeOffset: 1000,
+                                        },
+                                    },
+                                }))
                             )
+
+                            // Step 2: Prediction type COMPLETION, Edits or both
+                            tokenRequestContext.predictionTypes = predictionTypes.flat()
+
+                            // Step 3: Current Editor/Cursor state
+                            tokenRequestContext.editorState = {
+                                document: {
+                                    relativeFilePath: textDocument.uri,
+                                    programmingLanguage: {
+                                        languageName: requestContext.fileContext.programmingLanguage.languageName,
+                                    },
+                                    text: textDocument.getText(),
+                                },
+                                cursorState: {
+                                    position: {
+                                        line: params.position.line,
+                                        character: params.position.character,
+                                    },
+                                },
+                            }
+                        }
+                        requestContext = tokenRequestContext
+                    }
+
+                    // Close ACTIVE session and record Discard trigger decision immediately
+                    if (currentSession && currentSession.state === 'ACTIVE') {
+                        if (editsEnabled && currentSession.suggestionType === SuggestionType.EDIT) {
+                            const mergedSuggestions = mergeEditSuggestionsWithFileContext(
+                                currentSession,
+                                textDocument,
+                                fileContext
+                            )
+
+                            if (mergedSuggestions.length > 0) {
+                                return {
+                                    items: mergedSuggestions,
+                                    sessionId: currentSession.id,
+                                }
+                            }
+                        }
+                        // Emit user trigger decision at session close time for active session
+                        completionSessionManager.discardSession(currentSession)
+                        const streakLength = editsEnabled ? completionSessionManager.getAndUpdateStreakLength(false) : 0
+                        await emitUserTriggerDecisionTelemetry(
+                            telemetry,
+                            telemetryService,
+                            currentSession,
+                            timeSinceLastUserModification,
+                            0,
+                            0,
+                            [],
+                            [],
+                            streakLength
+                        )
+                    }
+
+                    // Get supplemental context for metadata
+
+                    const supplementalMetadata = supplementalContext?.supContextData
+
+                    const newSession = completionSessionManager.createSession({
+                        document: textDocument,
+                        startPosition: params.position,
+                        triggerType: isAutomaticLspTriggerKind ? 'AutoTrigger' : 'OnDemand',
+                        language: inferredLanguageId,
+                        requestContext: requestContext,
+                        autoTriggerType: isAutomaticLspTriggerKind ? codewhispererAutoTriggerType : undefined,
+                        triggerCharacter: triggerCharacters,
+                        classifierResult: autoTriggerResult?.classifierResult,
+                        classifierThreshold: autoTriggerResult?.classifierThreshold,
+                        credentialStartUrl: credentialsProvider.getConnectionMetadata?.()?.sso?.startUrl ?? undefined,
+                        supplementalMetadata: supplementalMetadata,
+                        customizationArn: textUtils.undefinedIfEmpty(codeWhispererService.customizationArn),
+                    })
+
+                    // Add extra context to request context
+                    const { extraContext } = amazonQServiceManager.getConfiguration().inlineSuggestions
+                    if (extraContext) {
+                        requestContext.fileContext.leftFileContent =
+                            extraContext + '\n' + requestContext.fileContext.leftFileContent
+                    }
+
+                    // Prepare the request with normalized file content
+                    const normalizedFileContext = {
+                        ...requestContext.fileContext,
+                        leftFileContent: requestContext.fileContext.leftFileContent
+                            .slice(-CONTEXT_CHARACTERS_LIMIT)
+                            .replaceAll('\r\n', '\n'),
+                        rightFileContent: requestContext.fileContext.rightFileContent
+                            .slice(0, CONTEXT_CHARACTERS_LIMIT)
+                            .replaceAll('\r\n', '\n'),
+                    }
+
+                    // Create the appropriate request based on service type
+                    let generateCompletionReq: BaseGenerateSuggestionsRequest
+
+                    if (codeWhispererService instanceof CodeWhispererServiceToken) {
+                        const tokenRequest = requestContext as GenerateTokenSuggestionsRequest
+                        logging.debug(
+                            `[INLINE_COMPLETION] Final token request - predictionTypes: ${tokenRequest.predictionTypes?.join(',') || 'none'}`
+                        )
+                        generateCompletionReq = {
+                            ...tokenRequest,
+                            fileContext: normalizedFileContext,
+                            ...(workspaceId ? { workspaceId } : {}),
+                        }
+                    } else {
+                        const iamRequest = requestContext as GenerateIAMSuggestionsRequest
+                        logging.debug(`[INLINE_COMPLETION] Final IAM request - maxResults: ${iamRequest.maxResults}`)
+                        generateCompletionReq = {
+                            ...iamRequest,
+                            fileContext: normalizedFileContext,
                         }
                     }
+
+                    try {
+                        const authType = codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'
+                        logging.debug(`[INLINE_COMPLETION] API call - generateSuggestions (new session, ${authType})`)
+                        const suggestionResponse = await codeWhispererService.generateSuggestions(generateCompletionReq)
+                        return await processSuggestionResponse(suggestionResponse, newSession, true, selectionRange)
+                    } catch (error) {
+                        return handleSuggestionsErrors(error as Error, newSession)
+                    }
                 }
+            } finally {
+                isOnInlineCompletionHandlerInProgress = false
+            }
+        }
 
-                session.setClientResultData(
-                    completionSessionResult,
-                    firstCompletionDisplayLatency,
-                    totalSessionDisplayTime,
-                    typeaheadLength
+        const processSuggestionResponse = async (
+            suggestionResponse: GenerateSuggestionsResponse,
+            session: CodeWhispererSession,
+            isNewSession: boolean,
+            selectionRange?: Range,
+            textDocument?: TextDocument
+        ): Promise<InlineCompletionListWithReferences> => {
+            codePercentageTracker.countInvocation(session.language)
+            logging.debug(
+                `[INLINE_COMPLETION] Processing response - suggestions: ${suggestionResponse.suggestions.length}, new: ${isNewSession}`
+            )
+
+            userWrittenCodeTracker?.recordUsageCount(session.language)
+            session.includeImportsWithSuggestions =
+                amazonQServiceManager.getConfiguration().includeImportsWithSuggestions
+
+            if (isNewSession) {
+                // Populate the session with information from codewhisperer response
+                session.suggestions = suggestionResponse.suggestions
+                session.responseContext = suggestionResponse.responseContext
+                session.codewhispererSessionId = suggestionResponse.responseContext.codewhispererSessionId
+                session.timeToFirstRecommendation = new Date().getTime() - session.startTime
+                session.suggestionType = suggestionResponse.suggestionType
+                logging.debug(
+                    `[INLINE_COMPLETION] New session initialized - sessionId: ${session.codewhispererSessionId}`
                 )
+            } else {
+                session.suggestions = [...session.suggestions, ...suggestionResponse.suggestions]
+            }
 
-                if (firstCompletionDisplayLatency) emitPerceivedLatencyTelemetry(telemetry, session)
+            // Emit service invocation telemetry for every request sent to backend
+            emitServiceInvocationTelemetry(telemetry, session, suggestionResponse.responseContext.requestId)
 
-                // Always emit user trigger decision at session close
-                sessionManager.closeSession(session)
-                const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(isAccepted) : 0
+            // Discard previous inflight API response due to new trigger
+            if (session.discardInflightSessionOnNewInvocation) {
+                session.discardInflightSessionOnNewInvocation = false
+                completionSessionManager.discardSession(session)
+                const streakLength = editsEnabled ? completionSessionManager.getAndUpdateStreakLength(false) : 0
                 await emitUserTriggerDecisionTelemetry(
                     telemetry,
                     telemetryService,
                     session,
                     timeSinceLastUserModification,
-                    addedLengthForEdits,
-                    deletedLengthForEdits,
-                    addedDiagnostics,
-                    removedDiagnostics,
-                    streakLength,
-                    Object.keys(params.completionSessionResult)[0]
+                    0,
+                    0,
+                    [],
+                    [],
+                    streakLength
                 )
             }
 
-            const updateConfiguration = (updatedConfig: AmazonQWorkspaceConfig) => {
-                logging.debug('Updating configuration of inline complete server.')
-
-                const { customizationArn, optOutTelemetryPreference, sendUserWrittenCodeMetrics } = updatedConfig
-
-                codePercentageTracker.customizationArn = customizationArn
-                if (sendUserWrittenCodeMetrics) {
-                    userWrittenCodeTracker = UserWrittenCodeTracker.getInstance(telemetryService)
-                }
-                if (userWrittenCodeTracker) {
-                    userWrittenCodeTracker.customizationArn = customizationArn
-                }
-                logging.debug(`CodePercentageTracker customizationArn updated to ${customizationArn}`)
-                /*
-                    The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
-                    configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
-                */
-                // const enableTelemetryEventsToDestination = true
-                // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
-                telemetryService.updateOptOutPreference(optOutTelemetryPreference)
-                logging.debug(`TelemetryService OptOutPreference updated to ${optOutTelemetryPreference}`)
+            // session was closed by user already made decisions consequent completion request before new paginated API response was received
+            if (
+                session.suggestionType !== SuggestionType.EDIT && // TODO: this is a shorterm fix to allow Edits tabtabtab experience, however the real solution is to manage such sessions correctly
+                (session.state === 'CLOSED' || session.state === 'DISCARD')
+            ) {
+                return EMPTY_RESULT
             }
 
-            const onInitializedHandler = async () => {
-                try {
-                    logging.log('[DEBUG] Starting Amazon Q service initialization...')
-                    const usingIAM = isUsingIAMAuth(credentialsProvider)
-                    logging.log(`[DEBUG] Authentication type: ${usingIAM ? 'IAM' : 'Bearer Token'}`)
-                    logging.log(`[DEBUG] Using IAM auth: ${usingIAM}`)
+            // API response was recieved, we can activate session now
+            completionSessionManager.activateSession(session)
 
-                    // Log authentication details
-                    try {
-                        const iamCreds = credentialsProvider.getCredentials('iam')
-                        logging.log(`[DEBUG] IAM credentials available: ${!!iamCreds}`)
-                        if (iamCreds) {
-                            // Safely log credential info without exposing secrets
-                            logging.log(`[DEBUG] IAM credentials type: ${typeof iamCreds}`)
-                            logging.log(`[DEBUG] IAM credentials has accessKeyId`)
-                            logging.log(`[DEBUG] IAM credentials expiration: `)
-                        }
-                    } catch (credError) {
-                        logging.error(`[DEBUG] Error accessing IAM credentials: ${credError}`)
+            // Process suggestions to apply Empty or Filter filters
+            const filteredSuggestions = suggestionResponse.suggestions
+                // Empty suggestion filter
+                .filter(suggestion => {
+                    if (suggestion.content === '') {
+                        session.setSuggestionState(suggestion.itemId, 'Empty')
+                        return false
                     }
 
-                    try {
-                        const bearerCreds = credentialsProvider.getCredentials('bearer')
-                        logging.log(`[DEBUG] Bearer credentials available: ${!!bearerCreds}`)
-                        if (bearerCreds) {
-                            logging.log(`[DEBUG] Bearer token exists`)
-                        }
-                    } catch (credError) {
-                        logging.error(`[DEBUG] Error accessing bearer credentials: ${credError}`)
+                    return true
+                })
+                // References setting filter
+                .filter(suggestion => {
+                    // State to track whether code with references should be included in
+                    // the response. No locking or concurrency controls, filtering is done
+                    // right before returning and is only guaranteed to be consistent within
+                    // the context of a single response.
+                    const { includeSuggestionsWithCodeReferences } = amazonQServiceManager.getConfiguration()
+                    if (includeSuggestionsWithCodeReferences) {
+                        return true
                     }
 
-                    // Create service manager
-                    logging.log('[DEBUG] Creating service manager...')
-                    amazonQServiceManager = serviceManager()
-                    logging.log('[DEBUG] Service manager created successfully')
-
-                    // Log service manager details
-                    logging.log(`[DEBUG] Service manager type: ${amazonQServiceManager.constructor.name}`)
-
-                    // Get CodeWhisperer service
-                    try {
-                        const codeWhispererService = amazonQServiceManager.getCodewhispererService()
-                        logging.log(`[DEBUG] CodeWhisperer service created: ${!!codeWhispererService}`)
-                        logging.log(`[DEBUG] CodeWhisperer service type: ${codeWhispererService.constructor.name}`)
-                        logging.log(
-                            `[DEBUG] CodeWhisperer service credentials type: ${codeWhispererService.getCredentialsType()}`
-                        )
-                    } catch (serviceError) {
-                        logging.error(`[DEBUG] Error getting CodeWhisperer service: ${serviceError}`)
+                    if (suggestion.references == null || suggestion.references.length === 0) {
+                        return true
                     }
 
-                    const clientParams = safeGet(
-                        lsp.getClientInitializeParams(),
-                        new AmazonQServiceInitializationError(
-                            'TelemetryService initialized before LSP connection was initialized.'
-                        )
-                    )
-
-                    logging.log(`[DEBUG] Client initialization params: ${JSON.stringify(clientParams)}`)
-                    editsEnabled =
-                        clientParams?.initializationOptions?.aws?.awsClientCapabilities?.textDocument
-                            ?.inlineCompletionWithReferences?.inlineEditSupport ?? false
-                    logging.log(`[DEBUG] Edits enabled: ${editsEnabled}`)
-
-                    logging.log('[DEBUG] Creating telemetry service...')
-                    telemetryService = new TelemetryService(amazonQServiceManager, credentialsProvider, telemetry, logging)
-                    telemetryService.updateUserContext(makeUserContextObject(clientParams, runtime.platform, 'INLINE'))
-                    logging.log('[DEBUG] Telemetry service created successfully')
-
-                    logging.log('[DEBUG] Creating code percentage tracker...')
-                    codePercentageTracker = new CodePercentageTracker(telemetryService)
-                    logging.log('[DEBUG] Creating code diff tracker...')
-                    codeDiffTracker = new CodeDiffTracker(
-                        workspace,
-                        logging,
-                        async (entry: AcceptedInlineSuggestionEntry, percentage, unmodifiedAcceptedCharacterCount) => {
-                            await telemetryService.emitUserModificationEvent(
-                                {
-                                    sessionId: entry.sessionId,
-                                    requestId: entry.requestId,
-                                    languageId: entry.languageId,
-                                    customizationArn: entry.customizationArn,
-                                    timestamp: new Date(),
-                                    acceptedCharacterCount: entry.originalString.length,
-                                    modificationPercentage: percentage,
-                                    unmodifiedAcceptedCharacterCount: unmodifiedAcceptedCharacterCount,
-                                },
-                                {
-                                    completionType: entry.completionType || 'LINE',
-                                    triggerType: entry.triggerType || 'OnDemand',
-                                    credentialStartUrl: entry.credentialStartUrl,
-                                }
-                            )
-                        }
-                    )
-
-                    const periodicLoggingEnabled = process.env.LOG_EDIT_TRACKING === 'true'
-                    logging.log(
-                        `[SERVER] Initialized telemetry-dependent components: CodePercentageTracker, CodeDiffTracker, periodicLogging=${periodicLoggingEnabled}`
-                    )
-
-                    logging.log('[DEBUG] Adding configuration change listener...')
-                    await amazonQServiceManager.addDidChangeConfigurationListener(updateConfiguration)
-
-                    editCompletionHandler = new EditCompletionHandler(
-                        logging,
-                        clientParams,
-                        workspace,
-                        amazonQServiceManager,
-                        editSessionManager,
-                        cursorTracker,
-                        recentEditTracker,
-                        rejectedEditTracker,
-                        documentChangedListener,
-                        telemetry,
-                        telemetryService,
-                        credentialsProvider
-                    )
-
-                    logging.log('[DEBUG] Amazon Q service initialization completed successfully')
-                } catch (error) {
-                    logging.error(`[DEBUG] CRITICAL ERROR initializing Amazon Q service: ${error}`)
-                    if (error instanceof Error) {
-                        logging.error(`[DEBUG] Error stack: ${error.stack}`)
-                    }
-                    throw error
-                }
-            }
-
-            const onEditCompletion = async (
-                param: InlineCompletionWithReferencesParams,
-                token: CancellationToken
-            ): Promise<InlineCompletionListWithReferences> => {
-                return await editCompletionHandler.onEditCompletion(param, token)
-            }
-
-            // Register event handlers
-            lsp.extensions.onInlineCompletionWithReferences(onInlineCompletionHandler)
-            lsp.extensions.onEditCompletion(onEditCompletion)
-            lsp.extensions.onLogInlineCompletionSessionResults(onLogInlineCompletionSessionResultsHandler)
-            lsp.onInitialized(onInitializedHandler)
-
-            lsp.onDidChangeTextDocument(async p => {
-                const textDocument = await workspace.getTextDocument(p.textDocument.uri)
-                const languageId = getSupportedLanguageId(textDocument)
-
-                if (!textDocument || !languageId) {
-                    return
-                }
-
-                p.contentChanges.forEach(change => {
-                    codePercentageTracker.countTotalTokens(languageId, change.text, false)
-
-                    const { sendUserWrittenCodeMetrics } = amazonQServiceManager.getConfiguration()
-                    if (!sendUserWrittenCodeMetrics) {
-                        return
-                    }
-                    // exclude cases that the document change is from Q suggestions
-                    const currentSession = completionSessionManager.getCurrentSession()
-                    if (
-                        !currentSession?.suggestions.some(
-                            suggestion => suggestion?.insertText && suggestion.insertText === change.text
-                        )
-                    ) {
-                        userWrittenCodeTracker?.countUserWrittenTokens(languageId, change.text)
-                    }
+                    // Filter out suggestions that have references when includeSuggestionsWithCodeReferences setting is true
+                    session.setSuggestionState(suggestion.itemId, 'Filter')
+                    return false
                 })
 
-                // Record last user modification time for any document
-                if (lastUserModificationTime) {
-                    timeSinceLastUserModification = new Date().getTime() - lastUserModificationTime
+            if (suggestionResponse.suggestionType === SuggestionType.COMPLETION) {
+                const { includeImportsWithSuggestions } = amazonQServiceManager.getConfiguration()
+                const suggestionsWithRightContext = mergeSuggestionsWithRightContext(
+                    session.requestContext.fileContext.rightFileContent,
+                    filteredSuggestions,
+                    includeImportsWithSuggestions,
+                    selectionRange
+                ).filter(suggestion => {
+                    // Discard suggestions that have empty string insertText after right context merge and can't be displayed anymore
+                    if (suggestion.insertText === '') {
+                        session.setSuggestionState(suggestion.itemId, 'Discard')
+                        return false
+                    }
+
+                    return true
+                })
+
+                suggestionsWithRightContext.forEach(suggestion => {
+                    const cachedSuggestion = session.suggestions.find(s => s.itemId === suggestion.itemId)
+                    if (cachedSuggestion) cachedSuggestion.insertText = suggestion.insertText.toString()
+                })
+
+                // TODO: need dedupe after right context merging but I don't see one
+                session.suggestionsAfterRightContextMerge.push(...suggestionsWithRightContext)
+
+                session.codewhispererSuggestionImportCount =
+                    session.codewhispererSuggestionImportCount +
+                    suggestionsWithRightContext.reduce((total, suggestion) => {
+                        return total + (suggestion.mostRelevantMissingImports?.length || 0)
+                    }, 0)
+
+                // If after all server-side filtering no suggestions can be displayed, and there is no nextToken
+                // close session and return empty results
+                if (
+                    session.suggestionsAfterRightContextMerge.length === 0 &&
+                    !suggestionResponse.responseContext.nextToken
+                ) {
+                    completionSessionManager.closeSession(session)
+                    await emitUserTriggerDecisionTelemetry(
+                        telemetry,
+                        telemetryService,
+                        session,
+                        timeSinceLastUserModification
+                    )
+
+                    return EMPTY_RESULT
                 }
-                lastUserModificationTime = new Date().getTime()
 
-                documentChangedListener.onDocumentChanged(p)
-                editCompletionHandler.documentChanged()
-
-                // Process document changes with RecentEditTracker.
-                if (editsEnabled && recentEditTracker) {
-                    await recentEditTracker.handleDocumentChange({
-                        uri: p.textDocument.uri,
-                        languageId: textDocument.languageId,
-                        version: textDocument.version,
-                        text: textDocument.getText(),
-                    })
+                return {
+                    items: suggestionsWithRightContext,
+                    sessionId: session.id,
+                    partialResultToken: suggestionResponse.responseContext.nextToken,
                 }
-            })
+            } else {
+                return {
+                    items: suggestionResponse.suggestions
+                        .map(suggestion => {
+                            // Check if this suggestion is similar to a previously rejected edit
+                            const isSimilarToRejected = rejectedEditTracker.isSimilarToRejected(
+                                suggestion.content,
+                                textDocument?.uri || ''
+                            )
 
-            lsp.onDidOpenTextDocument(p => {
-                logging.log(`Document opened: ${p.textDocument.uri}`)
+                            if (isSimilarToRejected) {
+                                // Mark as rejected in the session
+                                session.setSuggestionState(suggestion.itemId, 'Reject')
+                                logging.debug(
+                                    `[EDIT_PREDICTION] Filtered out suggestion similar to previously rejected edit`
+                                )
+                                // Return empty item that will be filtered out
+                                return {
+                                    insertText: '',
+                                    isInlineEdit: true,
+                                    itemId: suggestion.itemId,
+                                }
+                            }
 
-                // Track document opening with RecentEditTracker
-                if (recentEditTracker) {
-                    logging.log(`[SERVER] Tracking document open with RecentEditTracker: ${p.textDocument.uri}`)
-                    recentEditTracker.handleDocumentOpen({
-                        uri: p.textDocument.uri,
-                        languageId: p.textDocument.languageId,
-                        version: p.textDocument.version,
-                        text: p.textDocument.text,
-                    })
+                            return {
+                                insertText: suggestion.content,
+                                isInlineEdit: true,
+                                itemId: suggestion.itemId,
+                            }
+                        })
+                        .filter(item => item.insertText !== ''),
+                    sessionId: session.id,
+                    partialResultToken: suggestionResponse.responseContext.nextToken,
                 }
-            })
-
-            lsp.onDidCloseTextDocument(p => {
-                logging.log(`Document closed: ${p.textDocument.uri}`)
-
-                // Track document closing with RecentEditTracker
-                if (recentEditTracker) {
-                    logging.log(`[SERVER] Tracking document close with RecentEditTracker: ${p.textDocument.uri}`)
-                    recentEditTracker.handleDocumentClose(p.textDocument.uri)
-                }
-
-                if (cursorTracker) {
-                    cursorTracker.clearHistory(p.textDocument.uri)
-                }
-            })
-
-            logging.log('Amazon Q Inline Suggestion server has been initialised')
-
-            return async () => {
-                // Dispose all trackers in reverse order of initialization
-                if (codePercentageTracker) codePercentageTracker.dispose()
-                if (userWrittenCodeTracker) userWrittenCodeTracker?.dispose()
-                if (codeDiffTracker) await codeDiffTracker.shutdown()
-                if (recentEditTracker) recentEditTracker.dispose()
-                if (cursorTracker) cursorTracker.dispose()
-                if (rejectedEditTracker) rejectedEditTracker.dispose()
-
-                logging.log('Amazon Q Inline Suggestion server has been shut down')
             }
         }
+
+        const handleSuggestionsErrors = (
+            error: Error,
+            session: CodeWhispererSession
+        ): InlineCompletionListWithReferences => {
+            logging.log('Recommendation failure: ' + error)
+            logging.debug(`[INLINE_SUGGESTION] handleSuggestionsErrors call`)
+
+            // Add specific handling for IAM-related errors
+            if (isUsingIAMAuth(credentialsProvider)) {
+                if (error.message?.includes('not authorized') || error.message?.includes('AccessDenied')) {
+                    logging.error(
+                        `[IAM AUTH ERROR] IAM authentication error: User not authorized. Check IAM permissions for CodeWhisperer.`
+                    )
+                } else if (error.message?.includes('invalid parameter')) {
+                    logging.error(
+                        `[IAM AUTH ERROR] IAM authentication error: Invalid request parameters for IAM client`
+                    )
+                } else if (error.message?.includes('credentials')) {
+                    logging.error(`[IAM AUTH ERROR] IAM authentication error: Invalid or missing credentials`)
+                }
+
+                // Log detailed information about the request context
+                logging.error(`[IAM AUTH ERROR] Request context: ${JSON.stringify(session.requestContext)}`)
+            }
+
+            emitServiceInvocationFailure(telemetry, session, error)
+
+            completionSessionManager.closeSession(session)
+
+            let translatedError = error
+
+            if (hasConnectionExpired(error)) {
+                translatedError = new AmazonQServiceConnectionExpiredError(getErrorMessage(error))
+            }
+
+            if (translatedError instanceof AmazonQError) {
+                throw new ResponseError(
+                    LSPErrorCodes.RequestFailed,
+                    translatedError.message || 'Error processing suggestion requests',
+                    {
+                        awsErrorCode: translatedError.code,
+                    }
+                )
+            }
+
+            return EMPTY_RESULT
+        }
+
+        // Schedule tracker for UserModification Telemetry event
+        const enqueueCodeDiffEntry = (
+            session: CodeWhispererSession,
+            acceptedSuggestion: Suggestion,
+            addedCharactersForEdit?: string
+        ) => {
+            const endPosition = getEndPositionForAcceptedSuggestion(acceptedSuggestion.content, session.startPosition)
+            // use the addedCharactersForEdit if it is EDIT suggestion type
+            const originalString = addedCharactersForEdit ? addedCharactersForEdit : acceptedSuggestion.content
+
+            codeDiffTracker.enqueue({
+                sessionId: session.codewhispererSessionId || '',
+                requestId: session.responseContext?.requestId || '',
+                fileUrl: session.document.uri,
+                languageId: session.language,
+                time: Date.now(),
+                originalString: originalString,
+                startPosition: session.startPosition,
+                endPosition: endPosition,
+                customizationArn: session.customizationArn,
+                completionType: getCompletionType(acceptedSuggestion),
+                triggerType: session.triggerType,
+                credentialStartUrl: session.credentialStartUrl,
+            })
+        }
+
+        const onLogInlineCompletionSessionResultsHandler = async (params: LogInlineCompletionSessionResultsParams) => {
+            const {
+                sessionId,
+                completionSessionResult,
+                firstCompletionDisplayLatency,
+                totalSessionDisplayTime,
+                typeaheadLength,
+                isInlineEdit,
+                addedDiagnostics,
+                removedDiagnostics,
+            } = params
+
+            const sessionManager = params.isInlineEdit ? editSessionManager : completionSessionManager
+
+            const session = sessionManager.getSessionById(sessionId)
+            if (!session) {
+                logging.log(`ERROR: Session ID ${sessionId} was not found`)
+                return
+            }
+
+            if (session.state !== 'ACTIVE') {
+                logging.log(`ERROR: Trying to record trigger decision for not-active session ${sessionId}`)
+                return
+            }
+
+            const acceptedItemId = Object.keys(params.completionSessionResult).find(
+                k => params.completionSessionResult[k].accepted
+            )
+            const isAccepted = acceptedItemId ? true : false
+            const acceptedSuggestion = session.suggestions.find(s => s.itemId === acceptedItemId)
+            let addedLengthForEdits = 0
+            let deletedLengthForEdits = 0
+            if (acceptedSuggestion) {
+                codePercentageTracker.countSuccess(session.language)
+                if (session.suggestionType === SuggestionType.EDIT && acceptedSuggestion.content) {
+                    // [acceptedSuggestion.insertText] will be undefined for NEP suggestion. Use [acceptedSuggestion.content] instead.
+                    // Since [acceptedSuggestion.content] is in the form of a diff, transform the content into addedCharacters and deletedCharacters.
+                    const { addedLines, deletedLines } = getAddedAndDeletedLines(acceptedSuggestion.content)
+                    const charDiffResult = getCharacterDifferences(addedLines, deletedLines)
+                    addedLengthForEdits = charDiffResult.charactersAdded
+                    deletedLengthForEdits = charDiffResult.charactersRemoved
+
+                    codePercentageTracker.countAcceptedTokensUsingCount(
+                        session.language,
+                        charDiffResult.charactersAdded
+                    )
+                    codePercentageTracker.addTotalTokensForEdits(session.language, charDiffResult.charactersAdded)
+                    enqueueCodeDiffEntry(session, acceptedSuggestion, addedLines.join('\n'))
+                } else if (acceptedSuggestion.insertText) {
+                    codePercentageTracker.countAcceptedTokens(session.language, acceptedSuggestion.insertText)
+                    codePercentageTracker.countTotalTokens(session.language, acceptedSuggestion.insertText, true)
+
+                    enqueueCodeDiffEntry(session, acceptedSuggestion)
+                }
+            }
+
+            // Handle rejected edit predictions
+            if (isInlineEdit && !isAccepted) {
+                // Find all rejected suggestions in this session
+                const rejectedSuggestions = session.suggestions.filter(suggestion => {
+                    const result = completionSessionResult[suggestion.itemId]
+                    return result && result.seen && !result.accepted
+                })
+
+                // Record each rejected edit
+                for (const rejectedSuggestion of rejectedSuggestions) {
+                    if (rejectedSuggestion.content) {
+                        rejectedEditTracker.recordRejectedEdit({
+                            content: rejectedSuggestion.content,
+                            timestamp: Date.now(),
+                            documentUri: session.document.uri,
+                            position: session.startPosition,
+                        })
+
+                        logging.debug(
+                            `[EDIT_PREDICTION] Recorded rejected edit: ${rejectedSuggestion.content.substring(0, 20)}...`
+                        )
+                    }
+                }
+            }
+
+            session.setClientResultData(
+                completionSessionResult,
+                firstCompletionDisplayLatency,
+                totalSessionDisplayTime,
+                typeaheadLength
+            )
+
+            if (firstCompletionDisplayLatency) emitPerceivedLatencyTelemetry(telemetry, session)
+
+            // Always emit user trigger decision at session close
+            sessionManager.closeSession(session)
+            const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(isAccepted) : 0
+            await emitUserTriggerDecisionTelemetry(
+                telemetry,
+                telemetryService,
+                session,
+                timeSinceLastUserModification,
+                addedLengthForEdits,
+                deletedLengthForEdits,
+                addedDiagnostics,
+                removedDiagnostics,
+                streakLength,
+                Object.keys(params.completionSessionResult)[0]
+            )
+        }
+
+        const updateConfiguration = (updatedConfig: AmazonQWorkspaceConfig) => {
+            logging.debug('Updating configuration of inline complete server.')
+
+            const { customizationArn, optOutTelemetryPreference, sendUserWrittenCodeMetrics } = updatedConfig
+
+            codePercentageTracker.customizationArn = customizationArn
+            if (sendUserWrittenCodeMetrics) {
+                userWrittenCodeTracker = UserWrittenCodeTracker.getInstance(telemetryService)
+            }
+            if (userWrittenCodeTracker) {
+                userWrittenCodeTracker.customizationArn = customizationArn
+            }
+            logging.debug(`CodePercentageTracker customizationArn updated to ${customizationArn}`)
+            /*
+                        The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
+                        configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
+                    */
+            // const enableTelemetryEventsToDestination = true
+            // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
+            telemetryService.updateOptOutPreference(optOutTelemetryPreference)
+            logging.debug(`TelemetryService OptOutPreference updated to ${optOutTelemetryPreference}`)
+        }
+
+        const onInitializedHandler = async () => {
+            try {
+                logging.log('[DEBUG] Starting Amazon Q service initialization...')
+                const usingIAM = isUsingIAMAuth(credentialsProvider)
+                logging.log(`[DEBUG] Authentication type: ${usingIAM ? 'IAM' : 'Bearer Token'}`)
+                logging.log(`[DEBUG] Using IAM auth: ${usingIAM}`)
+
+                // Log authentication details
+                try {
+                    const iamCreds = credentialsProvider.getCredentials('iam')
+                    logging.log(`[DEBUG] IAM credentials available: ${!!iamCreds}`)
+                    if (iamCreds) {
+                        // Safely log credential info without exposing secrets
+                        logging.log(`[DEBUG] IAM credentials type: ${typeof iamCreds}`)
+                        logging.log(`[DEBUG] IAM credentials has accessKeyId`)
+                        logging.log(`[DEBUG] IAM credentials expiration: `)
+                    }
+                } catch (credError) {
+                    logging.error(`[DEBUG] Error accessing IAM credentials: ${credError}`)
+                }
+
+                try {
+                    const bearerCreds = credentialsProvider.getCredentials('bearer')
+                    logging.log(`[DEBUG] Bearer credentials available: ${!!bearerCreds}`)
+                    if (bearerCreds) {
+                        logging.log(`[DEBUG] Bearer token exists`)
+                    }
+                } catch (credError) {
+                    logging.error(`[DEBUG] Error accessing bearer credentials: ${credError}`)
+                }
+
+                // Create service manager
+                logging.log('[DEBUG] Creating service manager...')
+                amazonQServiceManager = serviceManager()
+                logging.log('[DEBUG] Service manager created successfully')
+
+                // Log service manager details
+                logging.log(`[DEBUG] Service manager type: ${amazonQServiceManager.constructor.name}`)
+
+                // Get CodeWhisperer service
+                try {
+                    const codeWhispererService = amazonQServiceManager.getCodewhispererService()
+                    logging.log(`[DEBUG] CodeWhisperer service created: ${!!codeWhispererService}`)
+                    logging.log(`[DEBUG] CodeWhisperer service type: ${codeWhispererService.constructor.name}`)
+                    logging.log(
+                        `[DEBUG] CodeWhisperer service credentials type: ${codeWhispererService.getCredentialsType()}`
+                    )
+                } catch (serviceError) {
+                    logging.error(`[DEBUG] Error getting CodeWhisperer service: ${serviceError}`)
+                }
+
+                const clientParams = safeGet(
+                    lsp.getClientInitializeParams(),
+                    new AmazonQServiceInitializationError(
+                        'TelemetryService initialized before LSP connection was initialized.'
+                    )
+                )
+
+                logging.log(`[DEBUG] Client initialization params: ${JSON.stringify(clientParams)}`)
+                editsEnabled =
+                    clientParams?.initializationOptions?.aws?.awsClientCapabilities?.textDocument
+                        ?.inlineCompletionWithReferences?.inlineEditSupport ?? false
+                logging.log(`[DEBUG] Edits enabled: ${editsEnabled}`)
+
+                logging.log('[DEBUG] Creating telemetry service...')
+                telemetryService = new TelemetryService(amazonQServiceManager, credentialsProvider, telemetry, logging)
+                telemetryService.updateUserContext(makeUserContextObject(clientParams, runtime.platform, 'INLINE'))
+                logging.log('[DEBUG] Telemetry service created successfully')
+
+                logging.log('[DEBUG] Creating code percentage tracker...')
+                codePercentageTracker = new CodePercentageTracker(telemetryService)
+                logging.log('[DEBUG] Creating code diff tracker...')
+                codeDiffTracker = new CodeDiffTracker(
+                    workspace,
+                    logging,
+                    async (entry: AcceptedInlineSuggestionEntry, percentage, unmodifiedAcceptedCharacterCount) => {
+                        await telemetryService.emitUserModificationEvent(
+                            {
+                                sessionId: entry.sessionId,
+                                requestId: entry.requestId,
+                                languageId: entry.languageId,
+                                customizationArn: entry.customizationArn,
+                                timestamp: new Date(),
+                                acceptedCharacterCount: entry.originalString.length,
+                                modificationPercentage: percentage,
+                                unmodifiedAcceptedCharacterCount: unmodifiedAcceptedCharacterCount,
+                            },
+                            {
+                                completionType: entry.completionType || 'LINE',
+                                triggerType: entry.triggerType || 'OnDemand',
+                                credentialStartUrl: entry.credentialStartUrl,
+                            }
+                        )
+                    }
+                )
+
+                const periodicLoggingEnabled = process.env.LOG_EDIT_TRACKING === 'true'
+                logging.log(
+                    `[SERVER] Initialized telemetry-dependent components: CodePercentageTracker, CodeDiffTracker, periodicLogging=${periodicLoggingEnabled}`
+                )
+
+                logging.log('[DEBUG] Adding configuration change listener...')
+                await amazonQServiceManager.addDidChangeConfigurationListener(updateConfiguration)
+
+                editCompletionHandler = new EditCompletionHandler(
+                    logging,
+                    clientParams,
+                    workspace,
+                    amazonQServiceManager,
+                    editSessionManager,
+                    cursorTracker,
+                    recentEditTracker,
+                    rejectedEditTracker,
+                    documentChangedListener,
+                    telemetry,
+                    telemetryService,
+                    credentialsProvider
+                )
+
+                logging.log('[DEBUG] Amazon Q service initialization completed successfully')
+            } catch (error) {
+                logging.error(`[DEBUG] CRITICAL ERROR initializing Amazon Q service: ${error}`)
+                if (error instanceof Error) {
+                    logging.error(`[DEBUG] Error stack: ${error.stack}`)
+                }
+                throw error
+            }
+        }
+
+        const onEditCompletion = async (
+            param: InlineCompletionWithReferencesParams,
+            token: CancellationToken
+        ): Promise<InlineCompletionListWithReferences> => {
+            return await editCompletionHandler.onEditCompletion(param, token)
+        }
+
+        // Register event handlers
+        lsp.extensions.onInlineCompletionWithReferences(onInlineCompletionHandler)
+        lsp.extensions.onEditCompletion(onEditCompletion)
+        lsp.extensions.onLogInlineCompletionSessionResults(onLogInlineCompletionSessionResultsHandler)
+        lsp.onInitialized(onInitializedHandler)
+
+        lsp.onDidChangeTextDocument(async p => {
+            const textDocument = await workspace.getTextDocument(p.textDocument.uri)
+            const languageId = getSupportedLanguageId(textDocument)
+
+            if (!textDocument || !languageId) {
+                return
+            }
+
+            p.contentChanges.forEach(change => {
+                codePercentageTracker.countTotalTokens(languageId, change.text, false)
+
+                const { sendUserWrittenCodeMetrics } = amazonQServiceManager.getConfiguration()
+                if (!sendUserWrittenCodeMetrics) {
+                    return
+                }
+                // exclude cases that the document change is from Q suggestions
+                const currentSession = completionSessionManager.getCurrentSession()
+                if (
+                    !currentSession?.suggestions.some(
+                        suggestion => suggestion?.insertText && suggestion.insertText === change.text
+                    )
+                ) {
+                    userWrittenCodeTracker?.countUserWrittenTokens(languageId, change.text)
+                }
+            })
+
+            // Record last user modification time for any document
+            if (lastUserModificationTime) {
+                timeSinceLastUserModification = new Date().getTime() - lastUserModificationTime
+            }
+            lastUserModificationTime = new Date().getTime()
+
+            documentChangedListener.onDocumentChanged(p)
+            editCompletionHandler.documentChanged()
+
+            // Process document changes with RecentEditTracker.
+            if (editsEnabled && recentEditTracker) {
+                await recentEditTracker.handleDocumentChange({
+                    uri: p.textDocument.uri,
+                    languageId: textDocument.languageId,
+                    version: textDocument.version,
+                    text: textDocument.getText(),
+                })
+            }
+        })
+
+        lsp.onDidOpenTextDocument(p => {
+            logging.log(`Document opened: ${p.textDocument.uri}`)
+
+            // Track document opening with RecentEditTracker
+            if (recentEditTracker) {
+                logging.log(`[SERVER] Tracking document open with RecentEditTracker: ${p.textDocument.uri}`)
+                recentEditTracker.handleDocumentOpen({
+                    uri: p.textDocument.uri,
+                    languageId: p.textDocument.languageId,
+                    version: p.textDocument.version,
+                    text: p.textDocument.text,
+                })
+            }
+        })
+
+        lsp.onDidCloseTextDocument(p => {
+            logging.log(`Document closed: ${p.textDocument.uri}`)
+
+            // Track document closing with RecentEditTracker
+            if (recentEditTracker) {
+                logging.log(`[SERVER] Tracking document close with RecentEditTracker: ${p.textDocument.uri}`)
+                recentEditTracker.handleDocumentClose(p.textDocument.uri)
+            }
+
+            if (cursorTracker) {
+                cursorTracker.clearHistory(p.textDocument.uri)
+            }
+        })
+
+        logging.log('Amazon Q Inline Suggestion server has been initialised')
+
+        return async () => {
+            // Dispose all trackers in reverse order of initialization
+            if (codePercentageTracker) codePercentageTracker.dispose()
+            if (userWrittenCodeTracker) userWrittenCodeTracker?.dispose()
+            if (codeDiffTracker) await codeDiffTracker.shutdown()
+            if (recentEditTracker) recentEditTracker.dispose()
+            if (cursorTracker) cursorTracker.dispose()
+            if (rejectedEditTracker) rejectedEditTracker.dispose()
+
+            logging.log('Amazon Q Inline Suggestion server has been shut down')
+        }
+    }
 
 export const CodeWhispererServerIAM = CodewhispererServerFactory(getOrThrowBaseIAMServiceManager)
 export const CodeWhispererServerToken = CodewhispererServerFactory(getOrThrowBaseTokenServiceManager)

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -6,7 +6,6 @@ import {
     InlineCompletionTriggerKind,
     InlineCompletionWithReferencesParams,
     LogInlineCompletionSessionResultsParams,
-    Position,
     Range,
     Server,
     TextDocument,
@@ -15,6 +14,10 @@ import {
 } from '@aws/language-server-runtimes/server-interface'
 import { autoTrigger, getAutoTriggerType, getNormalizeOsName, triggerType } from './auto-trigger/autoTrigger'
 import {
+    BaseGenerateSuggestionsRequest,
+    CodeWhispererServiceToken,
+    GenerateIAMSuggestionsRequest,
+    GenerateTokenSuggestionsRequest,
     GenerateSuggestionsRequest,
     GenerateSuggestionsResponse,
     getFileContext,
@@ -41,7 +44,6 @@ import { AmazonQWorkspaceConfig } from '../../shared/amazonQServiceManager/confi
 import { hasConnectionExpired } from '../../shared/utils'
 import { getOrThrowBaseIAMServiceManager } from '../../shared/amazonQServiceManager/AmazonQIAMServiceManager'
 import { WorkspaceFolderManager } from '../workspaceContext/workspaceFolderManager'
-import path = require('path')
 import { UserWrittenCodeTracker } from '../../shared/userWrittenCodeTracker'
 import { RecentEditTracker, RecentEditTrackerDefaultConfig } from './tracker/codeEditTracker'
 import { CursorTracker } from './tracker/cursorTracker'
@@ -58,6 +60,10 @@ import { EditCompletionHandler } from './editCompletionHandler'
 import { EMPTY_RESULT, ABAP_EXTENSIONS } from './constants'
 import { IdleWorkspaceManager } from '../workspaceContext/IdleWorkspaceManager'
 import { URI } from 'vscode-uri'
+import { isUsingIAMAuth } from '../../shared/utils'
+const { editPredictionAutoTrigger } = require('./auto-trigger/editPredictionAutoTrigger')
+
+export const CONTEXT_CHARACTERS_LIMIT = 10240
 
 const mergeSuggestionsWithRightContext = (
     rightFileContext: string,
@@ -144,9 +150,11 @@ export const CodewhispererServerFactory =
             // when one handler is at the API call stage, it has not yet update the session state
             // but another request can start, causing the state to be incorrect.
             IdleWorkspaceManager.recordActivityTimestamp()
-
+            logging.debug(
+                `[INLINE_COMPLETION] Handler started - uri: ${params.textDocument.uri}, pos: ${params.position.line}:${params.position.character}`
+            )
             if (isOnInlineCompletionHandlerInProgress) {
-                logging.log(`Skip concurrent inline completion`)
+                logging.debug(`[INLINE_COMPLETION] Skipping concurrent request`)
                 return EMPTY_RESULT
             }
             isOnInlineCompletionHandlerInProgress = true
@@ -154,9 +162,11 @@ export const CodewhispererServerFactory =
             try {
                 // On every new completion request close current inflight session.
                 const currentSession = completionSessionManager.getCurrentSession()
+                logging.debug(`[INLINE_COMPLETION] Current session state: ${currentSession?.state || 'none'}`)
                 if (currentSession && currentSession.state == 'REQUESTING' && !params.partialResultToken) {
                     // this REQUESTING state only happens when the session is initialized, which is rare
                     currentSession.discardInflightSessionOnNewInvocation = true
+                    logging.debug(`[INLINE_COMPLETION] Marked session for discard`)
                 }
 
                 if (cursorTracker) {
@@ -165,9 +175,14 @@ export const CodewhispererServerFactory =
                 const textDocument = await getTextDocument(params.textDocument.uri, workspace, logging)
 
                 const codeWhispererService = amazonQServiceManager.getCodewhispererService()
+                const authType = codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'
+                logging.debug(
+                    `[INLINE_COMPLETION] Service ready - auth: ${authType}, partial token: ${!!params.partialResultToken}`
+                )
                 if (params.partialResultToken && currentSession) {
                     // subsequent paginated requests for current session
                     try {
+                        logging.debug(`[INLINE_COMPLETION] API call - generateSuggestions (pagination)`)
                         const suggestionResponse = await codeWhispererService.generateSuggestions({
                             ...currentSession.requestContext,
                             fileContext: {
@@ -175,6 +190,7 @@ export const CodewhispererServerFactory =
                             },
                             nextToken: `${params.partialResultToken}`,
                         })
+                        logging.debug(`[INLINE_COMPLETION] Pagination request completed`)
                         return await processSuggestionResponse(
                             suggestionResponse,
                             currentSession,
@@ -182,22 +198,22 @@ export const CodewhispererServerFactory =
                             params.context.selectedCompletionInfo?.range
                         )
                     } catch (error) {
+                        logging.debug(`[INLINE_COMPLETION] Pagination error: ${error}`)
                         return handleSuggestionsErrors(error as Error, currentSession)
                     }
                 } else {
                     // request for new session
                     if (!textDocument) {
-                        logging.log(`textDocument [${params.textDocument.uri}] not found`)
+                        logging.debug(`[INLINE_COMPLETION] Document not found: ${params.textDocument.uri}`)
                         return EMPTY_RESULT
                     }
 
                     const inferredLanguageId = getSupportedLanguageId(textDocument)
                     if (!inferredLanguageId) {
-                        logging.log(
-                            `textDocument [${params.textDocument.uri}] with languageId [${textDocument.languageId}] not supported`
-                        )
+                        logging.debug(`[INLINE_COMPLETION] Unsupported language: ${textDocument.languageId}`)
                         return EMPTY_RESULT
                     }
+                    logging.debug(`[INLINE_COMPLETION] New session - language: ${inferredLanguageId}`)
 
                     // Build request context
                     const isAutomaticLspTriggerKind =
@@ -218,6 +234,7 @@ export const CodewhispererServerFactory =
 
                     const previousSession = completionSessionManager.getPreviousSession()
                     const previousDecision = previousSession?.getAggregatedUserTriggerDecision() ?? ''
+                    logging.debug(`[INLINE_COMPLETION] Previous decision: ${previousDecision}`)
                     let ideCategory: string | undefined = ''
                     const initializeParams = lsp.getClientInitializeParams()
                     if (initializeParams !== undefined) {
@@ -230,6 +247,7 @@ export const CodewhispererServerFactory =
                     let autoTriggerResult = undefined
 
                     if (isAutomaticLspTriggerKind) {
+                        logging.debug(`[INLINE_COMPLETION] Auto-trigger evaluation started`)
                         // Reference: https://github.com/aws/aws-toolkit-vscode/blob/amazonq/v1.74.0/packages/core/src/codewhisperer/service/classifierTrigger.ts#L477
                         if (
                             params.documentChangeParams?.contentChanges &&
@@ -264,15 +282,29 @@ export const CodewhispererServerFactory =
                             logging
                         )
 
-                        if (codewhispererAutoTriggerType === 'Classifier' && !autoTriggerResult.shouldTrigger) {
+                        if (
+                            codewhispererAutoTriggerType === 'Classifier' &&
+                            !autoTriggerResult.shouldTrigger &&
+                            !(editsEnabled && codeWhispererService instanceof CodeWhispererServiceToken)
+                        ) {
+                            // There is still potentially a Edit trigger without Completion if NEP is enabled (current only BearerTokenClient)
+                            logging.debug(`[INLINE_COMPLETION] Auto-trigger declined by classifier`)
                             return EMPTY_RESULT
                         }
+                        logging.debug(`[INLINE_COMPLETION] Auto-trigger approved: ${codewhispererAutoTriggerType}`)
                     }
+
+                    // Get supplemental context from recent edits if available.
+                    let supplementalContextFromEdits = undefined
 
                     let requestContext: GenerateSuggestionsRequest = {
                         fileContext,
                         maxResults,
                     }
+
+                    logging.debug(
+                        `[INLINE_COMPLETION] Fetching supplemental context - auth: ${codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'}`
+                    )
 
                     const supplementalContext = await codeWhispererService.constructSupplementalContext(
                         textDocument,
@@ -284,9 +316,97 @@ export const CodewhispererServerFactory =
                         params.openTabFilepaths,
                         { includeRecentEdits: false }
                     )
+                    // TODO: logging
+                    if (codeWhispererService instanceof CodeWhispererServiceToken) {
+                        const tokenRequestContext = requestContext as GenerateTokenSuggestionsRequest
+                        const supplementalContextItems = supplementalContext?.items || []
+                        tokenRequestContext.supplementalContexts = [
+                            ...supplementalContextItems.map(v => ({
+                                content: v.content,
+                                filePath: v.filePath,
+                            })),
+                        ]
 
-                    if (supplementalContext?.items) {
-                        requestContext.supplementalContexts = supplementalContext.items
+                        if (editsEnabled) {
+                            const predictionTypes: string[][] = []
+
+                            /**
+                             * Manual trigger - should always have 'Completions'
+                             * Auto trigger
+                             *  - Classifier - should have 'Completions' when classifier evalualte to true given the editor's states
+                             *  - Others - should always have 'Completions'
+                             */
+                            if (
+                                !isAutomaticLspTriggerKind ||
+                                (isAutomaticLspTriggerKind && codewhispererAutoTriggerType !== 'Classifier') ||
+                                (isAutomaticLspTriggerKind &&
+                                    codewhispererAutoTriggerType === 'Classifier' &&
+                                    autoTriggerResult?.shouldTrigger)
+                            ) {
+                                predictionTypes.push(['COMPLETIONS'])
+                            }
+
+                            const editPredictionAutoTriggerResult = editPredictionAutoTrigger({
+                                fileContext: fileContext,
+                                lineNum: params.position.line,
+                                char: triggerCharacters,
+                                previousDecision: previousDecision,
+                                cursorHistory: cursorTracker,
+                                recentEdits: recentEditTracker,
+                            })
+
+                            if (editPredictionAutoTriggerResult.shouldTrigger) {
+                                predictionTypes.push(['EDITS'])
+                            }
+
+                            if (predictionTypes.length === 0) {
+                                return EMPTY_RESULT
+                            }
+
+                            // Step 0: Determine if we have "Recent Edit context"
+                            if (recentEditTracker) {
+                                supplementalContextFromEdits =
+                                    await recentEditTracker.generateEditBasedContext(textDocument)
+                            }
+
+                            // Step 1: Recent Edits context
+                            const supplementalContextItemsForEdits =
+                                supplementalContextFromEdits?.supplementalContextItems || []
+
+                            tokenRequestContext.supplementalContexts.push(
+                                ...supplementalContextItemsForEdits.map(v => ({
+                                    content: v.content,
+                                    filePath: v.filePath,
+                                    type: 'PreviousEditorState',
+                                    metadata: {
+                                        previousEditorStateMetadata: {
+                                            timeOffset: 1000,
+                                        },
+                                    },
+                                }))
+                            )
+
+                            // Step 2: Prediction type COMPLETION, Edits or both
+                            tokenRequestContext.predictionTypes = predictionTypes.flat()
+
+                            // Step 3: Current Editor/Cursor state
+                            tokenRequestContext.editorState = {
+                                document: {
+                                    relativeFilePath: textDocument.uri,
+                                    programmingLanguage: {
+                                        languageName: requestContext.fileContext.programmingLanguage.languageName,
+                                    },
+                                    text: textDocument.getText(),
+                                },
+                                cursorState: {
+                                    position: {
+                                        line: params.position.line,
+                                        character: params.position.character,
+                                    },
+                                },
+                            }
+                        }
+                        requestContext = tokenRequestContext
                     }
 
                     // Close ACTIVE session and record Discard trigger decision immediately
@@ -321,13 +441,15 @@ export const CodewhispererServerFactory =
                         )
                     }
 
+                    // Get supplemental context for metadata
+
                     const supplementalMetadata = supplementalContext?.supContextData
 
                     const newSession = completionSessionManager.createSession({
                         document: textDocument,
                         startPosition: params.position,
                         triggerType: isAutomaticLspTriggerKind ? 'AutoTrigger' : 'OnDemand',
-                        language: fileContext.programmingLanguage.languageName,
+                        language: inferredLanguageId,
                         requestContext: requestContext,
                         autoTriggerType: isAutomaticLspTriggerKind ? codewhispererAutoTriggerType : undefined,
                         triggerCharacter: triggerCharacters,
@@ -345,11 +467,42 @@ export const CodewhispererServerFactory =
                             extraContext + '\n' + requestContext.fileContext.leftFileContent
                     }
 
-                    const generateCompletionReq = {
-                        ...requestContext,
-                        ...(workspaceId ? { workspaceId: workspaceId } : {}),
+                    // Prepare the request with normalized file content
+                    const normalizedFileContext = {
+                        ...requestContext.fileContext,
+                        leftFileContent: requestContext.fileContext.leftFileContent
+                            .slice(-CONTEXT_CHARACTERS_LIMIT)
+                            .replaceAll('\r\n', '\n'),
+                        rightFileContent: requestContext.fileContext.rightFileContent
+                            .slice(0, CONTEXT_CHARACTERS_LIMIT)
+                            .replaceAll('\r\n', '\n'),
                     }
+
+                    // Create the appropriate request based on service type
+                    let generateCompletionReq: BaseGenerateSuggestionsRequest
+
+                    if (codeWhispererService instanceof CodeWhispererServiceToken) {
+                        const tokenRequest = requestContext as GenerateTokenSuggestionsRequest
+                        logging.debug(
+                            `[INLINE_COMPLETION] Final token request - predictionTypes: ${tokenRequest.predictionTypes?.join(',') || 'none'}`
+                        )
+                        generateCompletionReq = {
+                            ...tokenRequest,
+                            fileContext: normalizedFileContext,
+                            ...(workspaceId ? { workspaceId } : {}),
+                        }
+                    } else {
+                        const iamRequest = requestContext as GenerateIAMSuggestionsRequest
+                        logging.debug(`[INLINE_COMPLETION] Final IAM request - maxResults: ${iamRequest.maxResults}`)
+                        generateCompletionReq = {
+                            ...iamRequest,
+                            fileContext: normalizedFileContext,
+                        }
+                    }
+
                     try {
+                        const authType = codeWhispererService instanceof CodeWhispererServiceToken ? 'token' : 'iam'
+                        logging.debug(`[INLINE_COMPLETION] API call - generateSuggestions (new session, ${authType})`)
                         const suggestionResponse = await codeWhispererService.generateSuggestions(generateCompletionReq)
                         return await processSuggestionResponse(suggestionResponse, newSession, true, selectionRange)
                     } catch (error) {
@@ -369,6 +522,9 @@ export const CodewhispererServerFactory =
             textDocument?: TextDocument
         ): Promise<InlineCompletionListWithReferences> => {
             codePercentageTracker.countInvocation(session.language)
+            logging.debug(
+                `[INLINE_COMPLETION] Processing response - suggestions: ${suggestionResponse.suggestions.length}, new: ${isNewSession}`
+            )
 
             userWrittenCodeTracker?.recordUsageCount(session.language)
             session.includeImportsWithSuggestions =
@@ -381,6 +537,9 @@ export const CodewhispererServerFactory =
                 session.codewhispererSessionId = suggestionResponse.responseContext.codewhispererSessionId
                 session.timeToFirstRecommendation = new Date().getTime() - session.startTime
                 session.suggestionType = suggestionResponse.suggestionType
+                logging.debug(
+                    `[INLINE_COMPLETION] New session initialized - sessionId: ${session.codewhispererSessionId}`
+                )
             } else {
                 session.suggestions = [...session.suggestions, ...suggestionResponse.suggestions]
             }
@@ -543,6 +702,26 @@ export const CodewhispererServerFactory =
             session: CodeWhispererSession
         ): InlineCompletionListWithReferences => {
             logging.log('Recommendation failure: ' + error)
+            logging.debug(`[INLINE_SUGGESTION] handleSuggestionsErrors call`)
+
+            // Add specific handling for IAM-related errors
+            if (isUsingIAMAuth(credentialsProvider)) {
+                if (error.message?.includes('not authorized') || error.message?.includes('AccessDenied')) {
+                    logging.error(
+                        `[IAM AUTH ERROR] IAM authentication error: User not authorized. Check IAM permissions for CodeWhisperer.`
+                    )
+                } else if (error.message?.includes('invalid parameter')) {
+                    logging.error(
+                        `[IAM AUTH ERROR] IAM authentication error: Invalid request parameters for IAM client`
+                    )
+                } else if (error.message?.includes('credentials')) {
+                    logging.error(`[IAM AUTH ERROR] IAM authentication error: Invalid or missing credentials`)
+                }
+
+                // Log detailed information about the request context
+                logging.error(`[IAM AUTH ERROR] Request context: ${JSON.stringify(session.requestContext)}`)
+            }
+
             emitServiceInvocationFailure(telemetry, session, error)
 
             completionSessionManager.closeSession(session)
@@ -728,72 +907,6 @@ export const CodewhispererServerFactory =
             logging.debug(`TelemetryService OptOutPreference updated to ${optOutTelemetryPreference}`)
         }
 
-        const onInitializedHandler = async () => {
-            amazonQServiceManager = serviceManager()
-
-            const clientParams = safeGet(
-                lsp.getClientInitializeParams(),
-                new AmazonQServiceInitializationError(
-                    'TelemetryService initialized before LSP connection was initialized.'
-                )
-            )
-
-            logging.log(`Client initialization params: ${JSON.stringify(clientParams)}`)
-            editsEnabled =
-                clientParams?.initializationOptions?.aws?.awsClientCapabilities?.textDocument
-                    ?.inlineCompletionWithReferences?.inlineEditSupport ?? false
-
-            telemetryService = new TelemetryService(amazonQServiceManager, credentialsProvider, telemetry, logging)
-            telemetryService.updateUserContext(makeUserContextObject(clientParams, runtime.platform, 'INLINE'))
-
-            codePercentageTracker = new CodePercentageTracker(telemetryService)
-            codeDiffTracker = new CodeDiffTracker(
-                workspace,
-                logging,
-                async (entry: AcceptedInlineSuggestionEntry, percentage, unmodifiedAcceptedCharacterCount) => {
-                    await telemetryService.emitUserModificationEvent(
-                        {
-                            sessionId: entry.sessionId,
-                            requestId: entry.requestId,
-                            languageId: entry.languageId,
-                            customizationArn: entry.customizationArn,
-                            timestamp: new Date(),
-                            acceptedCharacterCount: entry.originalString.length,
-                            modificationPercentage: percentage,
-                            unmodifiedAcceptedCharacterCount: unmodifiedAcceptedCharacterCount,
-                        },
-                        {
-                            completionType: entry.completionType || 'LINE',
-                            triggerType: entry.triggerType || 'OnDemand',
-                            credentialStartUrl: entry.credentialStartUrl,
-                        }
-                    )
-                }
-            )
-
-            const periodicLoggingEnabled = process.env.LOG_EDIT_TRACKING === 'true'
-            logging.log(
-                `[SERVER] Initialized telemetry-dependent components: CodePercentageTracker, CodeDiffTracker, periodicLogging=${periodicLoggingEnabled}`
-            )
-
-            await amazonQServiceManager.addDidChangeConfigurationListener(updateConfiguration)
-
-            editCompletionHandler = new EditCompletionHandler(
-                logging,
-                clientParams,
-                workspace,
-                amazonQServiceManager,
-                editSessionManager,
-                cursorTracker,
-                recentEditTracker,
-                rejectedEditTracker,
-                documentChangedListener,
-                telemetry,
-                telemetryService,
-                credentialsProvider
-            )
-        }
-
         const onEditCompletion = async (
             param: InlineCompletionWithReferencesParams,
             token: CancellationToken
@@ -801,6 +914,136 @@ export const CodewhispererServerFactory =
             return await editCompletionHandler.onEditCompletion(param, token)
         }
 
+        const onInitializedHandler = async () => {
+            try {
+                logging.log('[DEBUG] Starting Amazon Q service initialization...')
+                const usingIAM = isUsingIAMAuth(credentialsProvider)
+                logging.log(`[DEBUG] Authentication type: ${usingIAM ? 'IAM' : 'Bearer Token'}`)
+                logging.log(`[DEBUG] Using IAM auth: ${usingIAM}`)
+
+                // Log authentication details
+                try {
+                    const iamCreds = credentialsProvider.getCredentials('iam')
+                    logging.log(`[DEBUG] IAM credentials available: ${!!iamCreds}`)
+                    if (iamCreds) {
+                        // Safely log credential info without exposing secrets
+                        logging.log(`[DEBUG] IAM credentials type: ${typeof iamCreds}`)
+                        logging.log(`[DEBUG] IAM credentials has accessKeyId`)
+                        logging.log(`[DEBUG] IAM credentials expiration: `)
+                    }
+                } catch (credError) {
+                    logging.error(`[DEBUG] Error accessing IAM credentials: ${credError}`)
+                }
+
+                try {
+                    const bearerCreds = credentialsProvider.getCredentials('bearer')
+                    logging.log(`[DEBUG] Bearer credentials available: ${!!bearerCreds}`)
+                    if (bearerCreds) {
+                        logging.log(`[DEBUG] Bearer token exists`)
+                    }
+                } catch (credError) {
+                    logging.error(`[DEBUG] Error accessing bearer credentials: ${credError}`)
+                }
+
+                // Create service manager
+                logging.log('[DEBUG] Creating service manager...')
+                amazonQServiceManager = serviceManager()
+                logging.log('[DEBUG] Service manager created successfully')
+
+                // Log service manager details
+                logging.log(`[DEBUG] Service manager type: ${amazonQServiceManager.constructor.name}`)
+
+                // Get CodeWhisperer service
+                try {
+                    const codeWhispererService = amazonQServiceManager.getCodewhispererService()
+                    logging.log(`[DEBUG] CodeWhisperer service created: ${!!codeWhispererService}`)
+                    logging.log(`[DEBUG] CodeWhisperer service type: ${codeWhispererService.constructor.name}`)
+                    logging.log(
+                        `[DEBUG] CodeWhisperer service credentials type: ${codeWhispererService.getCredentialsType()}`
+                    )
+                } catch (serviceError) {
+                    logging.error(`[DEBUG] Error getting CodeWhisperer service: ${serviceError}`)
+                }
+
+                const clientParams = safeGet(
+                    lsp.getClientInitializeParams(),
+                    new AmazonQServiceInitializationError(
+                        'TelemetryService initialized before LSP connection was initialized.'
+                    )
+                )
+
+                logging.log(`[DEBUG] Client initialization params: ${JSON.stringify(clientParams)}`)
+                editsEnabled =
+                    clientParams?.initializationOptions?.aws?.awsClientCapabilities?.textDocument
+                        ?.inlineCompletionWithReferences?.inlineEditSupport ?? false
+                logging.log(`[DEBUG] Edits enabled: ${editsEnabled}`)
+
+                logging.log('[DEBUG] Creating telemetry service...')
+                telemetryService = new TelemetryService(amazonQServiceManager, credentialsProvider, telemetry, logging)
+                telemetryService.updateUserContext(makeUserContextObject(clientParams, runtime.platform, 'INLINE'))
+                logging.log('[DEBUG] Telemetry service created successfully')
+
+                logging.log('[DEBUG] Creating code percentage tracker...')
+                codePercentageTracker = new CodePercentageTracker(telemetryService)
+                logging.log('[DEBUG] Creating code diff tracker...')
+                codeDiffTracker = new CodeDiffTracker(
+                    workspace,
+                    logging,
+                    async (entry: AcceptedInlineSuggestionEntry, percentage, unmodifiedAcceptedCharacterCount) => {
+                        await telemetryService.emitUserModificationEvent(
+                            {
+                                sessionId: entry.sessionId,
+                                requestId: entry.requestId,
+                                languageId: entry.languageId,
+                                customizationArn: entry.customizationArn,
+                                timestamp: new Date(),
+                                acceptedCharacterCount: entry.originalString.length,
+                                modificationPercentage: percentage,
+                                unmodifiedAcceptedCharacterCount: unmodifiedAcceptedCharacterCount,
+                            },
+                            {
+                                completionType: entry.completionType || 'LINE',
+                                triggerType: entry.triggerType || 'OnDemand',
+                                credentialStartUrl: entry.credentialStartUrl,
+                            }
+                        )
+                    }
+                )
+
+                const periodicLoggingEnabled = process.env.LOG_EDIT_TRACKING === 'true'
+                logging.log(
+                    `[SERVER] Initialized telemetry-dependent components: CodePercentageTracker, CodeDiffTracker, periodicLogging=${periodicLoggingEnabled}`
+                )
+
+                logging.log('[DEBUG] Adding configuration change listener...')
+                await amazonQServiceManager.addDidChangeConfigurationListener(updateConfiguration)
+
+                editCompletionHandler = new EditCompletionHandler(
+                    logging,
+                    clientParams,
+                    workspace,
+                    amazonQServiceManager,
+                    editSessionManager,
+                    cursorTracker,
+                    recentEditTracker,
+                    rejectedEditTracker,
+                    documentChangedListener,
+                    telemetry,
+                    telemetryService,
+                    credentialsProvider
+                )
+
+                logging.log('[DEBUG] Amazon Q service initialization completed successfully')
+            } catch (error) {
+                logging.error(`[DEBUG] CRITICAL ERROR initializing Amazon Q service: ${error}`)
+                if (error instanceof Error) {
+                    logging.error(`[DEBUG] Error stack: ${error.stack}`)
+                }
+                throw error
+            }
+        }
+
+        // Register event handlers
         lsp.extensions.onInlineCompletionWithReferences(onInlineCompletionHandler)
         lsp.extensions.onEditCompletion(onEditCompletion)
         lsp.extensions.onLogInlineCompletionSessionResults(onLogInlineCompletionSessionResultsHandler)

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -55,7 +55,9 @@ import {
 } from './telemetry'
 import { DocumentChangedListener } from './documentChangedListener'
 import { EditCompletionHandler } from './editCompletionHandler'
-import { EMPTY_RESULT } from './constants'
+import { EMPTY_RESULT, ABAP_EXTENSIONS } from './constants'
+import { IdleWorkspaceManager } from '../workspaceContext/IdleWorkspaceManager'
+import { URI } from 'vscode-uri'
 
 const mergeSuggestionsWithRightContext = (
     rightFileContext: string,
@@ -141,6 +143,8 @@ export const CodewhispererServerFactory =
             // 2. it is not designed to handle concurrent changes to these state variables.
             // when one handler is at the API call stage, it has not yet update the session state
             // but another request can start, causing the state to be incorrect.
+            IdleWorkspaceManager.recordActivityTimestamp()
+
             if (isOnInlineCompletionHandlerInProgress) {
                 logging.log(`Skip concurrent inline completion`)
                 return EMPTY_RESULT
@@ -158,7 +162,7 @@ export const CodewhispererServerFactory =
                 if (cursorTracker) {
                     cursorTracker.trackPosition(params.textDocument.uri, params.position)
                 }
-                const textDocument = await workspace.getTextDocument(params.textDocument.uri)
+                const textDocument = await getTextDocument(params.textDocument.uri, workspace, logging)
 
                 const codeWhispererService = amazonQServiceManager.getCodewhispererService()
                 if (params.partialResultToken && currentSession) {
@@ -498,7 +502,6 @@ export const CodewhispererServerFactory =
                     partialResultToken: suggestionResponse.responseContext.nextToken,
                 }
             } else {
-                session.hasEditsPending = suggestionResponse.responseContext.nextToken ? true : false
                 return {
                     items: suggestionResponse.suggestions
                         .map(suggestion => {
@@ -687,14 +690,8 @@ export const CodewhispererServerFactory =
             if (firstCompletionDisplayLatency) emitPerceivedLatencyTelemetry(telemetry, session)
 
             // Always emit user trigger decision at session close
-            // Close session unless Edit suggestion was accepted with more pending
-            const shouldKeepSessionOpen =
-                session.suggestionType === SuggestionType.EDIT && isAccepted && session.hasEditsPending
-
-            if (!shouldKeepSessionOpen) {
-                completionSessionManager.closeSession(session)
-            }
-            const streakLength = editsEnabled ? completionSessionManager.getAndUpdateStreakLength(isAccepted) : 0
+            sessionManager.closeSession(session)
+            const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(isAccepted) : 0
             await emitUserTriggerDecisionTelemetry(
                 telemetry,
                 telemetryService,
@@ -722,10 +719,9 @@ export const CodewhispererServerFactory =
                 userWrittenCodeTracker.customizationArn = customizationArn
             }
             logging.debug(`CodePercentageTracker customizationArn updated to ${customizationArn}`)
-            /*
-                The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
-                configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
-            */
+
+            // The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
+            // configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
             // const enableTelemetryEventsToDestination = true
             // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
             telemetryService.updateOptOutPreference(optOutTelemetryPreference)
@@ -902,3 +898,27 @@ export const CodewhispererServerFactory =
 
 export const CodeWhispererServerIAM = CodewhispererServerFactory(getOrThrowBaseIAMServiceManager)
 export const CodeWhispererServerToken = CodewhispererServerFactory(getOrThrowBaseTokenServiceManager)
+
+const getLanguageIdFromUri = (uri: string, logging?: any): string => {
+    try {
+        const extension = uri.split('.').pop()?.toLowerCase()
+        return ABAP_EXTENSIONS.has(extension || '') ? 'abap' : ''
+    } catch (err) {
+        logging?.log(`Error parsing URI to determine language: ${uri}: ${err}`)
+        return ''
+    }
+}
+
+const getTextDocument = async (uri: string, workspace: any, logging: any): Promise<TextDocument | undefined> => {
+    let textDocument = await workspace.getTextDocument(uri)
+    if (!textDocument) {
+        try {
+            const content = await workspace.fs.readFile(URI.parse(uri).fsPath)
+            const languageId = getLanguageIdFromUri(uri)
+            textDocument = TextDocument.create(uri, languageId, 0, content)
+        } catch (err) {
+            logging.log(`Unable to load from ${uri}: ${err}`)
+        }
+    }
+    return textDocument
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -895,20 +895,14 @@ export const CodewhispererServerFactory =
                     userWrittenCodeTracker.customizationArn = customizationArn
                 }
                 logging.debug(`CodePercentageTracker customizationArn updated to ${customizationArn}`)
-
-                // The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
-                // configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
+                /*
+                    The flag enableTelemetryEventsToDestination is set to true temporarily. It's value will be determined through destination
+                    configuration post all events migration to STE. It'll be replaced by qConfig['enableTelemetryEventsToDestination'] === true
+                */
                 // const enableTelemetryEventsToDestination = true
                 // telemetryService.updateEnableTelemetryEventsToDestination(enableTelemetryEventsToDestination)
                 telemetryService.updateOptOutPreference(optOutTelemetryPreference)
                 logging.debug(`TelemetryService OptOutPreference updated to ${optOutTelemetryPreference}`)
-            }
-
-            const onEditCompletion = async (
-                param: InlineCompletionWithReferencesParams,
-                token: CancellationToken
-            ): Promise<InlineCompletionListWithReferences> => {
-                return await editCompletionHandler.onEditCompletion(param, token)
             }
 
             const onInitializedHandler = async () => {
@@ -1038,6 +1032,13 @@ export const CodewhispererServerFactory =
                     }
                     throw error
                 }
+            }
+
+            const onEditCompletion = async (
+                param: InlineCompletionWithReferencesParams,
+                token: CancellationToken
+            ): Promise<InlineCompletionListWithReferences> => {
+                return await editCompletionHandler.onEditCompletion(param, token)
             }
 
             // Register event handlers

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -866,6 +866,7 @@ export const CodewhispererServerFactory =
 
                 // Always emit user trigger decision at session close
                 sessionManager.closeSession(session)
+
                 const streakLength = editsEnabled ? sessionManager.getAndUpdateStreakLength(isAccepted) : 0
                 await emitUserTriggerDecisionTelemetry(
                     telemetry,

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/constants.ts
@@ -4,3 +4,28 @@ export const CONTEXT_CHARACTERS_LIMIT = 10240
 export const EMPTY_RESULT = { sessionId: '', items: [] }
 export const EDIT_DEBOUNCE_INTERVAL_MS = 500
 export const EDIT_STALE_RETRY_COUNT = 3
+// ABAP ADT extensions commonly used with Eclipse
+export const ABAP_EXTENSIONS = new Set([
+    'asprog',
+    'aclass',
+    'asinc',
+    'aint',
+    'assrvds',
+    'asbdef',
+    'asddls',
+    'astablds',
+    'astabldt',
+    'amdp',
+    'apack',
+    'asrv',
+    'aobj',
+    'aexit',
+    'abdef',
+    'acinc',
+    'asfugr',
+    'apfugr',
+    'asfunc',
+    'asfinc',
+    'apfunc',
+    'apfinc',
+])

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
@@ -80,7 +80,6 @@ export class CodeWhispererSession {
     includeImportsWithSuggestions?: boolean
     codewhispererSuggestionImportCount: number = 0
     suggestionType?: string
-    hasEditsPending?: boolean = false
     // Track the most recent itemId for paginated Edit suggestions
 
     constructor(data: SessionData) {

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/telemetry.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/telemetry.ts
@@ -147,13 +147,7 @@ export const emitUserTriggerDecisionTelemetry = async (
         streakLength
     )
 
-    // Mark telemetry as complete unless Edit suggestion was accepted with more pending
-    const hasPendingEditTelemetry =
-        session.suggestionType === SuggestionType.EDIT && session.acceptedSuggestionId && session.hasEditsPending
-
-    if (!hasPendingEditTelemetry) {
-        session.reportedUserDecision = true
-    }
+    session.reportedUserDecision = true
 }
 
 export const emitAggregatedUserTriggerDecisionTelemetry = (

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/IdleWorkspaceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/IdleWorkspaceManager.test.ts
@@ -1,0 +1,75 @@
+import { IdleWorkspaceManager } from './IdleWorkspaceManager'
+import { WorkspaceFolderManager } from './workspaceFolderManager'
+import sinon, { stubInterface, StubbedInstance } from 'ts-sinon'
+
+describe('IdleWorkspaceManager', () => {
+    let clock: sinon.SinonFakeTimers
+    let mockWorkspaceFolderManager: StubbedInstance<WorkspaceFolderManager>
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers()
+        mockWorkspaceFolderManager = stubInterface<WorkspaceFolderManager>()
+        sinon.stub(WorkspaceFolderManager, 'getInstance').returns(mockWorkspaceFolderManager)
+        sinon.stub(console, 'error')
+    })
+
+    afterEach(() => {
+        clock.restore()
+        sinon.restore()
+    })
+
+    describe('isSessionIdle', () => {
+        it('should return false when session is not idle', () => {
+            IdleWorkspaceManager.recordActivityTimestamp()
+
+            const result = IdleWorkspaceManager.isSessionIdle()
+
+            expect(result).toBe(false)
+        })
+
+        it('should return true when session exceeds idle threshold', () => {
+            IdleWorkspaceManager.recordActivityTimestamp()
+            clock.tick(31 * 60 * 1000) // 31 minutes
+
+            const result = IdleWorkspaceManager.isSessionIdle()
+
+            expect(result).toBe(true)
+        })
+    })
+
+    describe('recordActivityTimestamp', () => {
+        it('should update activity timestamp', async () => {
+            IdleWorkspaceManager.recordActivityTimestamp()
+
+            expect(IdleWorkspaceManager.isSessionIdle()).toBe(false)
+        })
+
+        it('should not trigger workspace check when session was not idle', async () => {
+            mockWorkspaceFolderManager.isContinuousMonitoringStopped.returns(false)
+
+            IdleWorkspaceManager.recordActivityTimestamp()
+
+            sinon.assert.notCalled(mockWorkspaceFolderManager.checkRemoteWorkspaceStatusAndReact)
+        })
+
+        it('should trigger workspace check when session was idle and monitoring is active', async () => {
+            // Make session idle first
+            clock.tick(31 * 60 * 1000)
+            mockWorkspaceFolderManager.isContinuousMonitoringStopped.returns(false)
+            mockWorkspaceFolderManager.checkRemoteWorkspaceStatusAndReact.resolves()
+
+            IdleWorkspaceManager.recordActivityTimestamp()
+
+            sinon.assert.calledOnce(mockWorkspaceFolderManager.checkRemoteWorkspaceStatusAndReact)
+        })
+
+        it('should not trigger workspace check when session was idle but monitoring is stopped', async () => {
+            clock.tick(31 * 60 * 1000)
+            mockWorkspaceFolderManager.isContinuousMonitoringStopped.returns(true)
+
+            IdleWorkspaceManager.recordActivityTimestamp()
+
+            sinon.assert.notCalled(mockWorkspaceFolderManager.checkRemoteWorkspaceStatusAndReact)
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/IdleWorkspaceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/IdleWorkspaceManager.ts
@@ -1,0 +1,38 @@
+import { WorkspaceFolderManager } from './workspaceFolderManager'
+
+export class IdleWorkspaceManager {
+    private static readonly idleThreshold = 30 * 60 * 1000 // 30 minutes
+    private static lastActivityTimestamp = 0 // treat session as idle as the start
+
+    private constructor() {}
+
+    /**
+     * Records activity timestamp and triggers workspace status check if session was idle.
+     *
+     * When transitioning from idle to active, proactively checks remote workspace status
+     * (if continuous monitoring is enabled) without blocking the current operation.
+     */
+    public static recordActivityTimestamp(): void {
+        try {
+            const wasSessionIdle = IdleWorkspaceManager.isSessionIdle()
+            IdleWorkspaceManager.lastActivityTimestamp = Date.now()
+
+            const workspaceFolderManager = WorkspaceFolderManager.getInstance()
+            if (workspaceFolderManager && wasSessionIdle && !workspaceFolderManager.isContinuousMonitoringStopped()) {
+                // Proactively check the remote workspace status instead of waiting for the next scheduled check
+                // Fire and forget - don't await to avoid blocking
+                workspaceFolderManager.checkRemoteWorkspaceStatusAndReact().catch(err => {
+                    // ignore errors
+                })
+            }
+        } catch (err) {
+            // ignore errors
+        }
+    }
+
+    public static isSessionIdle(): boolean {
+        const currentTime = Date.now()
+        const timeSinceLastActivity = currentTime - IdleWorkspaceManager.lastActivityTimestamp
+        return timeSinceLastActivity > IdleWorkspaceManager.idleThreshold
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyDiscoverer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/dependency/dependencyDiscoverer.ts
@@ -191,7 +191,8 @@ export class DependencyDiscoverer {
         }
     }
 
-    public resetFromDisposal(): void {
+    public disposeAndReset(): void {
+        this.dispose()
         this.sharedState.isDisposed = false
         this.sharedState.dependencyUploadedSizeSum = 0
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -221,7 +221,6 @@ export const WorkspaceContextServer = (): Server => features => {
             isLoggedInUsingBearerToken(credentialsProvider) &&
             abTestingEnabled &&
             !workspaceFolderManager.getOptOutStatus() &&
-            !workspaceFolderManager.getServiceQuotaExceededStatus() &&
             workspaceIdentifier
         )
     }
@@ -303,17 +302,15 @@ export const WorkspaceContextServer = (): Server => features => {
                     await evaluateABTesting()
                     isWorkflowInitialized = true
 
-                    workspaceFolderManager.resetAdminOptOutAndServiceQuotaStatus()
+                    workspaceFolderManager.resetAdminOptOutStatus()
                     if (!isUserEligibleForWorkspaceContext()) {
                         return
                     }
 
                     fileUploadJobManager.startFileUploadJobConsumer()
                     dependencyEventBundler.startDependencyEventBundler()
-                    await Promise.all([
-                        workspaceFolderManager.initializeWorkspaceStatusMonitor(),
-                        workspaceFolderManager.processNewWorkspaceFolders(workspaceFolders),
-                    ])
+
+                    workspaceFolderManager.initializeWorkspaceStatusMonitor()
                     logging.log(`Workspace context workflow initialized`)
                 } else if (!isLoggedIn) {
                     if (isWorkflowInitialized) {

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceFolderManager.ts
@@ -20,6 +20,7 @@ import { AmazonQTokenServiceManager } from '../../shared/amazonQServiceManager/A
 import { URI } from 'vscode-uri'
 import path = require('path')
 import { isAwsError } from '../../shared/utils'
+import { IdleWorkspaceManager } from './IdleWorkspaceManager'
 
 interface WorkspaceState {
     remoteWorkspaceState: WorkspaceStatus
@@ -54,8 +55,8 @@ export class WorkspaceFolderManager {
     private optOutMonitorInterval: NodeJS.Timeout | undefined
     private messageQueueConsumerInterval: NodeJS.Timeout | undefined
     private isOptedOut: boolean = false
-    // Tracks if the user has reached their maximum allowed remote workspaces quota
-    private isServiceQuotaExceeded: boolean = false
+    private isCheckingRemoteWorkspaceStatus: boolean = false
+    private isArtifactUploadedToRemoteWorkspace: boolean = false
 
     static createInstance(
         serviceManager: AmazonQTokenServiceManager,
@@ -138,13 +139,8 @@ export class WorkspaceFolderManager {
         return this.isOptedOut
     }
 
-    getServiceQuotaExceededStatus(): boolean {
-        return this.isServiceQuotaExceeded
-    }
-
-    resetAdminOptOutAndServiceQuotaStatus(): void {
+    resetAdminOptOutStatus(): void {
         this.isOptedOut = false
-        this.isServiceQuotaExceeded = false
     }
 
     getWorkspaceState(): WorkspaceState {
@@ -324,14 +320,13 @@ export class WorkspaceFolderManager {
         this.workspaceState.webSocketClient = webSocketClient
     }
 
-    async initializeWorkspaceStatusMonitor() {
+    initializeWorkspaceStatusMonitor() {
         this.logging.log(`Initializing workspace status check for workspace [${this.workspaceIdentifier}]`)
 
         // Reset workspace ID to force operations to wait for new remote workspace information
         this.resetRemoteWorkspaceId()
 
-        this.artifactManager.resetFromDisposal()
-        this.dependencyDiscoverer.resetFromDisposal()
+        this.isArtifactUploadedToRemoteWorkspace = false
 
         // Set up message queue consumer
         if (this.messageQueueConsumerInterval === undefined) {
@@ -350,12 +345,8 @@ export class WorkspaceFolderManager {
             }, this.MESSAGE_PUBLISH_INTERVAL)
         }
 
-        // Perform a one-time checkRemoteWorkspaceStatusAndReact first
-        // Pass skipUploads as true since it would be handled by processNewWorkspaceFolders
-        await this.checkRemoteWorkspaceStatusAndReact(true)
-
         // Set up continuous monitoring which periodically invokes checkRemoteWorkspaceStatusAndReact
-        if (!this.isOptedOut && !this.isServiceQuotaExceeded && this.continuousMonitorInterval === undefined) {
+        if (!this.isOptedOut && this.continuousMonitorInterval === undefined) {
             this.logging.log(`Starting continuous monitor for workspace [${this.workspaceIdentifier}]`)
             this.continuousMonitorInterval = setInterval(async () => {
                 try {
@@ -427,61 +418,92 @@ export class WorkspaceFolderManager {
         })
     }
 
-    private async checkRemoteWorkspaceStatusAndReact(skipUploads: boolean = false) {
-        if (this.workspaceFolders.length === 0) {
-            this.logging.log(`No workspace folders added, skipping workspace status check`)
+    public async checkRemoteWorkspaceStatusAndReact() {
+        if (this.isCheckingRemoteWorkspaceStatus) {
+            // Skip checking remote workspace if a previous check is still in progress
             return
         }
+        this.isCheckingRemoteWorkspaceStatus = true
+        try {
+            if (IdleWorkspaceManager.isSessionIdle()) {
+                this.resetWebSocketClient()
+                this.logging.log('Session is idle, skipping remote workspace status check')
+                return
+            }
 
-        this.logging.log(`Checking remote workspace status for workspace [${this.workspaceIdentifier}]`)
-        const { metadata, optOut, error } = await this.listWorkspaceMetadata(this.workspaceIdentifier)
+            if (this.workspaceFolders.length === 0) {
+                this.logging.log(`No workspace folders added, skipping workspace status check`)
+                return
+            }
 
-        if (optOut) {
-            this.logging.log('User opted out, clearing all resources and starting opt-out monitor')
-            this.isOptedOut = true
-            this.clearAllWorkspaceResources()
-            this.startOptOutMonitor()
-            return
-        }
+            this.logging.log(`Checking remote workspace status for workspace [${this.workspaceIdentifier}]`)
+            const { metadata, optOut, error } = await this.listWorkspaceMetadata(this.workspaceIdentifier)
 
-        if (error) {
-            // Do not do anything if we received an exception but not caused by optOut
-            return
-        }
+            if (optOut) {
+                this.logging.log('User opted out, clearing all resources and starting opt-out monitor')
+                this.isOptedOut = true
+                this.clearAllWorkspaceResources()
+                this.startOptOutMonitor()
+                return
+            }
 
-        if (!metadata) {
-            // Workspace no longer exists, Recreate it.
-            this.resetRemoteWorkspaceId() // workspaceId would change if remote record is gone
-            await this.handleWorkspaceCreatedState(skipUploads)
-            return
-        }
+            if (error) {
+                // Do not do anything if we received an exception but not caused by optOut
+                return
+            }
 
-        this.workspaceState.remoteWorkspaceState = metadata.workspaceStatus
-        if (this.workspaceState.workspaceId === undefined) {
-            this.setRemoteWorkspaceId(metadata.workspaceId)
-        }
+            if (!metadata) {
+                // Workspace no longer exists, Recreate it.
+                this.resetRemoteWorkspaceId() // workspaceId would change if remote record is gone
+                await this.handleWorkspaceCreatedState()
+                return
+            }
 
-        switch (metadata.workspaceStatus) {
-            case 'READY':
-                // Check if connection exists
-                const client = this.workspaceState.webSocketClient
-                if (!client || !client.isConnected()) {
-                    this.logging.log(
-                        `Workspace is ready but no connection exists or connection lost. Re-establishing connection...`
-                    )
-                    await this.establishConnection(metadata)
-                }
-                break
-            case 'PENDING':
-                // Schedule an initial connection when pending
-                await this.waitForInitialConnection()
-                break
-            case 'CREATED':
-                // Workspace has no environment, Recreate it.
-                await this.handleWorkspaceCreatedState(skipUploads)
-                break
-            default:
-                this.logging.warn(`Unknown workspace status: ${metadata.workspaceStatus}`)
+            this.workspaceState.remoteWorkspaceState = metadata.workspaceStatus
+            if (this.workspaceState.workspaceId === undefined) {
+                this.setRemoteWorkspaceId(metadata.workspaceId)
+            }
+
+            switch (metadata.workspaceStatus) {
+                case 'READY':
+                    // Check if connection exists
+                    const client = this.workspaceState.webSocketClient
+                    if (!client || !client.isConnected()) {
+                        this.logging.log(
+                            `Workspace is ready but no connection exists or connection lost. Re-establishing connection...`
+                        )
+                        let uploadArtifactsPromise: Promise<void> | undefined
+                        if (!this.isArtifactUploadedToRemoteWorkspace) {
+                            uploadArtifactsPromise = this.uploadAllArtifactsToRemoteWorkspace()
+                        }
+                        await this.establishConnection(metadata)
+                        if (uploadArtifactsPromise) {
+                            await uploadArtifactsPromise
+                        }
+                    }
+                    break
+                case 'PENDING':
+                    // Schedule an initial connection when pending
+                    let uploadArtifactsPromise: Promise<void> | undefined
+                    if (!this.isArtifactUploadedToRemoteWorkspace) {
+                        uploadArtifactsPromise = this.uploadAllArtifactsToRemoteWorkspace()
+                    }
+                    await this.waitForInitialConnection()
+                    if (uploadArtifactsPromise) {
+                        await uploadArtifactsPromise
+                    }
+                    break
+                case 'CREATED':
+                    // Workspace has no environment, Recreate it.
+                    await this.handleWorkspaceCreatedState()
+                    break
+                default:
+                    this.logging.warn(`Unknown workspace status: ${metadata.workspaceStatus}`)
+            }
+        } catch (error) {
+            this.logging.error(`Error checking remote workspace status: ${error}`)
+        } finally {
+            this.isCheckingRemoteWorkspaceStatus = false
         }
     }
 
@@ -515,9 +537,7 @@ export class WorkspaceFolderManager {
                         )
                         clearInterval(intervalId)
                         this.optOutMonitorInterval = undefined
-                        this.initializeWorkspaceStatusMonitor().catch(error => {
-                            this.logging.error(`Error while initializing workspace status monitoring: ${error}`)
-                        })
+                        this.initializeWorkspaceStatusMonitor()
                         this.processNewWorkspaceFolders(this.workspaceFolders).catch(error => {
                             this.logging.error(`Error while processing workspace folders: ${error}`)
                         })
@@ -530,25 +550,18 @@ export class WorkspaceFolderManager {
         }
     }
 
-    private async handleWorkspaceCreatedState(skipUploads: boolean = false): Promise<void> {
+    private async handleWorkspaceCreatedState(): Promise<void> {
         this.logging.log(`No READY / PENDING remote workspace found, creating a new one`)
         // If remote state is CREATED, call create API to create a new workspace
-        if (this.workspaceState.webSocketClient) {
-            this.workspaceState.webSocketClient.destroyClient()
-            this.workspaceState.webSocketClient = undefined
-        }
+        this.resetWebSocketClient()
         const initialResult = await this.createNewWorkspace()
 
         // If creation succeeds, establish connection
         if (initialResult.response) {
             this.logging.log(`Workspace [${this.workspaceIdentifier}] created successfully, establishing connection`)
+            const uploadArtifactsPromise = this.uploadAllArtifactsToRemoteWorkspace()
             await this.waitForInitialConnection()
-            if (!skipUploads) {
-                await this.syncSourceCodesToS3(this.workspaceFolders)
-                this.dependencyDiscoverer.reSyncDependenciesToS3(this.workspaceFolders).catch(e => {
-                    this.logging.warn(`Error during re-syncing dependencies: ${e}`)
-                })
-            }
+            await uploadArtifactsPromise
             return
         }
 
@@ -570,13 +583,27 @@ export class WorkspaceFolderManager {
         }
 
         this.logging.log(`Retry succeeded for workspace creation, establishing connection`)
+        const uploadArtifactsPromise = this.uploadAllArtifactsToRemoteWorkspace()
         await this.waitForInitialConnection()
-        if (!skipUploads) {
-            await this.syncSourceCodesToS3(this.workspaceFolders)
-            this.dependencyDiscoverer.reSyncDependenciesToS3(this.workspaceFolders).catch(e => {
-                this.logging.warn(`Error during re-syncing dependencies: ${e}`)
-            })
-        }
+        await uploadArtifactsPromise
+    }
+
+    private async uploadAllArtifactsToRemoteWorkspace() {
+        // initialize source codes
+        this.artifactManager.resetFromDisposal()
+        await this.syncSourceCodesToS3(this.workspaceFolders)
+
+        // initialize dependencies
+        this.dependencyDiscoverer.disposeAndReset()
+        this.dependencyDiscoverer.searchDependencies(this.workspaceFolders).catch(e => {
+            this.logging.warn(`Error during dependency discovery: ${e}`)
+        })
+
+        this.isArtifactUploadedToRemoteWorkspace = true
+    }
+
+    public isContinuousMonitoringStopped(): boolean {
+        return this.continuousMonitorInterval === undefined
     }
 
     private stopContinuousMonitoring() {
@@ -602,15 +629,15 @@ export class WorkspaceFolderManager {
         }
     }
 
+    private resetWebSocketClient() {
+        if (this.workspaceState.webSocketClient) {
+            this.workspaceState.webSocketClient.destroyClient()
+            this.workspaceState.webSocketClient = undefined
+        }
+    }
+
     private async createNewWorkspace() {
         const createWorkspaceResult = await this.createWorkspace(this.workspaceIdentifier)
-
-        this.isServiceQuotaExceeded = createWorkspaceResult.isServiceQuotaExceeded
-        if (this.isServiceQuotaExceeded) {
-            // Stop continuous monitor and all actions
-            this.clearAllWorkspaceResources()
-        }
-
         const workspaceDetails = createWorkspaceResult.response
         if (!workspaceDetails) {
             this.logging.warn(`Failed to create remote workspace for [${this.workspaceIdentifier}]`)

--- a/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.test.ts
@@ -269,6 +269,7 @@ describe('CodeWhispererService', function () {
             it('should call client.generateRecommendations and process response', async function () {
                 const mockRequest: GenerateSuggestionsRequest = {
                     fileContext: {
+                        fileUri: 'file:///test.js',
                         filename: 'test.js',
                         programmingLanguage: { languageName: 'javascript' },
                         leftFileContent: 'const x = ',
@@ -289,6 +290,7 @@ describe('CodeWhispererService', function () {
 
                 const mockRequest: GenerateSuggestionsRequest = {
                     fileContext: {
+                        fileUri: 'file:///test.js',
                         filename: 'test.js',
                         programmingLanguage: { languageName: 'javascript' },
                         leftFileContent: 'const x = ',
@@ -366,6 +368,7 @@ describe('CodeWhispererService', function () {
             it('should call client.generateCompletions and process response', async function () {
                 const mockRequest: GenerateSuggestionsRequest = {
                     fileContext: {
+                        fileUri: 'file:///test.js',
                         filename: 'test.js',
                         programmingLanguage: { languageName: 'javascript' },
                         leftFileContent: 'const x = ',
@@ -387,6 +390,7 @@ describe('CodeWhispererService', function () {
 
                 const mockRequest: GenerateSuggestionsRequest = {
                     fileContext: {
+                        fileUri: 'file:///test.js',
                         filename: 'test.js',
                         programmingLanguage: { languageName: 'javascript' },
                         leftFileContent: 'const x = ',
@@ -404,6 +408,7 @@ describe('CodeWhispererService', function () {
             it('should process profile ARN with withProfileArn method', async function () {
                 const mockRequest: GenerateSuggestionsRequest = {
                     fileContext: {
+                        fileUri: 'file:///test.js',
                         filename: 'test.js',
                         programmingLanguage: { languageName: 'javascript' },
                         leftFileContent: 'const x = ',

--- a/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
@@ -135,23 +135,33 @@ describe('getClientName', () => {
 })
 
 describe('getOriginFromClientInfo', () => {
-    it('returns MD_IDE for SMUS-IDE client name', () => {
+    it('returns MD_IDE for client names starting with SMUS-IDE prefix', () => {
         const result = getOriginFromClientInfo('AmazonQ-For-SMUS-IDE-1.0.0')
         assert.strictEqual(result, 'MD_IDE')
     })
 
-    it('returns MD_IDE for SMUS-CE client name', () => {
+    it('returns MD_IDE for client names starting with SMUS-CE prefix', () => {
         const result = getOriginFromClientInfo('AmazonQ-For-SMUS-CE-1.0.0')
         assert.strictEqual(result, 'MD_IDE')
     })
 
-    it('returns MD_IDE for client names starting with SMUS-IDE prefix', () => {
+    it('returns MD_IDE for client names starting with SMAI-CE prefix', () => {
+        const result = getOriginFromClientInfo('AmazonQ-For-SMAI-CE-1.0.0')
+        assert.strictEqual(result, 'MD_IDE')
+    })
+
+    it('returns MD_IDE for SMUS-IDE client name', () => {
         const result = getOriginFromClientInfo('AmazonQ-For-SMUS-IDE')
         assert.strictEqual(result, 'MD_IDE')
     })
 
-    it('returns MD_IDE for client names starting with SMUS-CE prefix', () => {
+    it('returns MD_IDE for SMUS-CE client name', () => {
         const result = getOriginFromClientInfo('AmazonQ-For-SMUS-CE')
+        assert.strictEqual(result, 'MD_IDE')
+    })
+
+    it('returns MD_IDE for SMAI-CE client name', () => {
+        const result = getOriginFromClientInfo('AmazonQ-For-SMAI-CE')
         assert.strictEqual(result, 'MD_IDE')
     })
 

--- a/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
@@ -27,6 +27,7 @@ import {
     getClientName,
     sanitizeInput,
     sanitizeRequestInput,
+    isUsingIAMAuth,
 } from './utils'
 import { promises as fsPromises } from 'fs'
 
@@ -172,6 +173,87 @@ describe('getOriginFromClientInfo', () => {
     it('returns IDE for client names that do not match SMUS patterns', () => {
         const result = getOriginFromClientInfo('AmazonQ-For-Other-IDE')
         assert.strictEqual(result, 'IDE')
+    })
+
+    it('returns MD_IDE for SMUS Code Editor client name', () => {
+        const result = getOriginFromClientInfo('AmazonQ-For-SMUS-CE-1.0.0')
+        assert.strictEqual(result, 'MD_IDE')
+    })
+})
+
+describe('isUsingIAMAuth', () => {
+    let originalEnv: string | undefined
+
+    beforeEach(() => {
+        originalEnv = process.env.USE_IAM_AUTH
+        delete process.env.USE_IAM_AUTH
+    })
+
+    afterEach(() => {
+        if (originalEnv !== undefined) {
+            process.env.USE_IAM_AUTH = originalEnv
+        } else {
+            delete process.env.USE_IAM_AUTH
+        }
+    })
+
+    it('should return true when USE_IAM_AUTH environment variable is "true"', () => {
+        process.env.USE_IAM_AUTH = 'true'
+        assert.strictEqual(isUsingIAMAuth(), true)
+    })
+
+    it('should return false when USE_IAM_AUTH environment variable is not set', () => {
+        assert.strictEqual(isUsingIAMAuth(), false)
+    })
+
+    it('should return true when only IAM credentials are available', () => {
+        const mockProvider: CredentialsProvider = {
+            hasCredentials: sinon.stub().returns(true),
+            getCredentials: sinon
+                .stub()
+                .withArgs('iam')
+                .returns({ accessKeyId: 'AKIA...', secretAccessKey: 'secret' })
+                .withArgs('bearer')
+                .returns(null),
+            getConnectionMetadata: sinon.stub(),
+            getConnectionType: sinon.stub(),
+            onCredentialsDeleted: sinon.stub(),
+        }
+
+        assert.strictEqual(isUsingIAMAuth(mockProvider), true)
+    })
+
+    it('should return false when bearer credentials are available', () => {
+        const mockProvider: CredentialsProvider = {
+            hasCredentials: sinon.stub().returns(true),
+            getCredentials: sinon
+                .stub()
+                .withArgs('iam')
+                .returns({ accessKeyId: 'AKIA...', secretAccessKey: 'secret' })
+                .withArgs('bearer')
+                .returns({ token: 'bearer-token' }),
+            getConnectionMetadata: sinon.stub(),
+            getConnectionType: sinon.stub(),
+            onCredentialsDeleted: sinon.stub(),
+        }
+
+        assert.strictEqual(isUsingIAMAuth(mockProvider), false)
+    })
+
+    it('should return false when credential access fails', () => {
+        const mockProvider: CredentialsProvider = {
+            hasCredentials: sinon.stub().returns(true),
+            getCredentials: sinon.stub().throws(new Error('Access failed')),
+            getConnectionMetadata: sinon.stub(),
+            getConnectionType: sinon.stub(),
+            onCredentialsDeleted: sinon.stub(),
+        }
+
+        assert.strictEqual(isUsingIAMAuth(mockProvider), false)
+    })
+
+    it('should return false when credentialsProvider is undefined', () => {
+        assert.strictEqual(isUsingIAMAuth(undefined), false)
     })
 })
 

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -381,7 +381,12 @@ export function getClientName(lspParams: InitializeParams | undefined): string |
 }
 
 export function getOriginFromClientInfo(clientName: string | undefined): Origin {
-    if (clientName?.startsWith('AmazonQ-For-SMUS-IDE') || clientName?.startsWith('AmazonQ-For-SMUS-CE')) {
+    // TODO: Update with a new origin for SMAI case, as a short-term solution Sagemaker AI CE is using same origin as that of Sagemaker Unified Studio's IDE and CE
+    if (
+        clientName?.startsWith('AmazonQ-For-SMUS-IDE') ||
+        clientName?.startsWith('AmazonQ-For-SMUS-CE') ||
+        clientName?.startsWith('AmazonQ-For-SMAI-CE')
+    ) {
         return 'MD_IDE'
     }
     return 'IDE'

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -387,8 +387,40 @@ export function getOriginFromClientInfo(clientName: string | undefined): Origin 
     return 'IDE'
 }
 
-export function isUsingIAMAuth(): boolean {
-    return process.env.USE_IAM_AUTH === 'true'
+export function isUsingIAMAuth(credentialsProvider?: CredentialsProvider): boolean {
+    // Environment variable check first
+    console.log(`[IAM_AUTH_CHECK] USE_IAM_AUTH env: ${process.env.USE_IAM_AUTH}`)
+    if (process.env.USE_IAM_AUTH === 'true') {
+        console.log(`[IAM_AUTH_CHECK] Using IAM auth - environment variable set`)
+        return true
+    }
+
+    // CRITICAL: Add credential-based detection as fallback
+    if (credentialsProvider) {
+        try {
+            const iamCreds = credentialsProvider.getCredentials('iam')
+            const bearerCreds = credentialsProvider.getCredentials('bearer')
+
+            console.log(`[IAM_AUTH_CHECK] IAM creds available: ${!!iamCreds}`)
+            console.log(`[IAM_AUTH_CHECK] Bearer creds available: ${!!bearerCreds}`)
+            console.log(`[IAM_AUTH_CHECK] Bearer token available: ${!!(bearerCreds as any)?.token}`)
+
+            // If only IAM creds available, use IAM
+            if (iamCreds && !(bearerCreds as any)?.token) {
+                console.log(`[IAM_AUTH_CHECK] Using IAM auth - IAM creds present, no bearer token`)
+                return true
+            }
+
+            console.log(`[IAM_AUTH_CHECK] Using Token auth - bearer token available or no IAM creds`)
+        } catch (error) {
+            // If credential access fails, default to bearer
+            console.log(`[IAM_AUTH_CHECK] Credential access failed: ${error}, defaulting to bearer`)
+            return false
+        }
+    }
+
+    console.log(`[IAM_AUTH_CHECK] Using Token auth - no credentials provider`)
+    return false
 }
 
 export const flattenMetric = (obj: any, prefix = '') => {


### PR DESCRIPTION
## Problem
- Currently IAM Auth support is missing in flare for InlineSuggestions, which is mainly used in Sagemaker instances
## Solution
- Changes are test branch only and safe to merge
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
