### PR TITLE
fix: multiple fixes for agentconfig change regression

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -178,57 +178,11 @@ export class McpManager {
 
         // Reset permissions map
         this.mcpServerPermissions.clear()
-
-        // Initialize permissions for servers from agent config
+        // Create init state
         for (const [sanitizedName, _] of this.mcpServers.entries()) {
-            const name = this.serverNameMapping.get(sanitizedName) || sanitizedName
-
             // Set server status to UNINITIALIZED initially
             this.setState(sanitizedName, McpServerStatus.UNINITIALIZED, 0)
-
-            // Initialize permissions for this server
-            const serverPrefix = `@${name}`
-
-            // Extract tool permissions from agent config
-            const toolPerms: Record<string, McpPermissionType> = {}
-
-            // Check if the server is enabled as a whole (@server) or just specific tools (@server/tool)
-            const isWholeServerEnabled = this.agentConfig.tools.includes(serverPrefix)
-
-            if (isWholeServerEnabled) {
-                // Check for specific tools in allowedTools
-                this.agentConfig.allowedTools.forEach(allowedTool => {
-                    if (allowedTool.startsWith(serverPrefix + '/')) {
-                        const toolName = allowedTool.substring(serverPrefix.length + 1)
-                        if (toolName) {
-                            // This specific tool is in allowedTools
-                            toolPerms[toolName] = McpPermissionType.alwaysAllow
-                        }
-                    }
-                })
-            } else {
-                // Only specific tools are enabled
-                this.agentConfig.tools.forEach(tool => {
-                    if (tool.startsWith(serverPrefix + '/')) {
-                        const toolName = tool.substring(serverPrefix.length + 1)
-                        if (toolName) {
-                            // Check if tool is in allowedTools
-                            if (this.agentConfig.allowedTools.includes(tool)) {
-                                toolPerms[toolName] = McpPermissionType.alwaysAllow
-                            } else {
-                                toolPerms[toolName] = McpPermissionType.ask
-                            }
-                        }
-                    }
-                })
-            }
-
-            this.mcpServerPermissions.set(sanitizedName, {
-                enabled: true,
-                toolPerms,
-            })
         }
-
         // Get all servers that need to be initialized
         const serversToInit: Array<[string, MCPServerConfig]> = []
 
@@ -263,6 +217,65 @@ export class McpManager {
             }
 
             this.features.logging.info(`MCP: completed initialization of ${totalServers} servers`)
+        }
+
+        for (const [sanitizedName, _] of this.mcpServers.entries()) {
+            const name = this.serverNameMapping.get(sanitizedName) || sanitizedName
+            // Initialize permissions for this server
+            const serverPrefix = `@${name}`
+
+            // Extract tool permissions from agent config
+            const toolPerms: Record<string, McpPermissionType> = {}
+
+            // Check if the server is enabled as a whole (@server) or just specific tools (@server/tool)
+            const isWholeServerEnabled = this.agentConfig.tools.includes(serverPrefix)
+
+            if (isWholeServerEnabled) {
+                // Check for specific tools in allowedTools
+                this.agentConfig.allowedTools.forEach(allowedTool => {
+                    if (allowedTool.startsWith(serverPrefix + '/')) {
+                        const toolName = allowedTool.substring(serverPrefix.length + 1)
+                        if (toolName) {
+                            // This specific tool is in allowedTools
+                            toolPerms[toolName] = McpPermissionType.alwaysAllow
+                        }
+                    }
+                })
+            } else {
+                // Only specific tools are enabled
+                // get allTools of this server, if it's not in tools --> it's denied
+                // have to move the logic after all servers finish init, because that's when we have list of tools
+                const deniedTools = new Set(
+                    this.getAllTools()
+                        .filter(tool => tool.serverName === name)
+                        .map(tool => tool.toolName)
+                )
+                this.agentConfig.tools.forEach(tool => {
+                    if (tool.startsWith(serverPrefix + '/')) {
+                        // remove this from deniedTools
+                        const toolName = tool.substring(serverPrefix.length + 1)
+                        deniedTools.delete(toolName)
+                        if (toolName) {
+                            // Check if tool is in allowedTools
+                            if (this.agentConfig.allowedTools.includes(tool)) {
+                                toolPerms[toolName] = McpPermissionType.alwaysAllow
+                            } else {
+                                toolPerms[toolName] = McpPermissionType.ask
+                            }
+                        }
+                    }
+                })
+
+                // update permission to deny for rest of the tools
+                deniedTools.forEach(tool => {
+                    toolPerms[tool] = McpPermissionType.deny
+                })
+            }
+
+            this.mcpServerPermissions.set(sanitizedName, {
+                enabled: true,
+                toolPerms,
+            })
         }
     }
 
@@ -658,13 +671,7 @@ export class McpManager {
             }
 
             // Save agent config once with all changes
-            await saveAgentConfig(
-                this.features.workspace,
-                this.features.logging,
-                this.agentConfig,
-                agentPath,
-                serverName
-            )
+            await saveAgentConfig(this.features.workspace, this.features.logging, this.agentConfig, agentPath)
 
             // Add server tools to tools list after initialization
             await this.initOneServer(sanitizedName, newCfg)
@@ -728,13 +735,7 @@ export class McpManager {
             })
 
             // Save agent config
-            await saveAgentConfig(
-                this.features.workspace,
-                this.features.logging,
-                this.agentConfig,
-                cfg.__configPath__,
-                unsanitizedName
-            )
+            await saveAgentConfig(this.features.workspace, this.features.logging, this.agentConfig, cfg.__configPath__)
 
             // Get all config paths and delete the server from each one
             const wsUris = this.features.workspace.getAllWorkspaceFolders()?.map(f => f.uri) ?? []
@@ -817,13 +818,7 @@ export class McpManager {
                 this.agentConfig.mcpServers[unsanitizedServerName] = updatedConfig
 
                 // Save agent config
-                await saveAgentConfig(
-                    this.features.workspace,
-                    this.features.logging,
-                    this.agentConfig,
-                    agentPath,
-                    unsanitizedServerName
-                )
+                await saveAgentConfig(this.features.workspace, this.features.logging, this.agentConfig, agentPath)
             }
 
             const newCfg: MCPServerConfig = {
@@ -1035,13 +1030,7 @@ export class McpManager {
             // Save agent config
             const agentPath = perm.__configPath__
             if (agentPath) {
-                await saveAgentConfig(
-                    this.features.workspace,
-                    this.features.logging,
-                    this.agentConfig,
-                    agentPath,
-                    unsanitizedServerName
-                )
+                await saveAgentConfig(this.features.workspace, this.features.logging, this.agentConfig, agentPath)
             }
 
             // Update mcpServerPermissions map
@@ -1059,7 +1048,7 @@ export class McpManager {
                 }
                 this.setState(serverName, McpServerStatus.DISABLED, 0)
             } else {
-                if (!this.clients.has(serverName)) {
+                if (!this.clients.has(serverName) && serverName !== 'Built-in') {
                     await this.initOneServer(serverName, this.mcpServers.get(serverName)!)
                 }
             }
@@ -1085,6 +1074,13 @@ export class McpManager {
         const unsanitizedServerName = this.serverNameMapping.get(server) || server
         const toolId = `@${unsanitizedServerName}/${tool}`
         return !this.agentConfig.allowedTools.includes(toolId)
+    }
+
+    /**
+     * get server's tool permission
+     */
+    public getMcpServerPermissions(serverName: string): MCPServerPermission | undefined {
+        return this.mcpServerPermissions.get(serverName)
     }
 
     /**
@@ -1152,8 +1148,7 @@ export class McpManager {
                     this.features.workspace,
                     this.features.logging,
                     this.agentConfig,
-                    cfg.__configPath__,
-                    unsanitizedName
+                    cfg.__configPath__
                 )
             }
         } catch (err) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -958,61 +958,13 @@ export async function saveAgentConfig(
     workspace: Workspace,
     logging: Logger,
     config: AgentConfig,
-    configPath: string,
-    serverName?: string
+    configPath: string
 ): Promise<void> {
     try {
         await workspace.fs.mkdir(path.dirname(configPath), { recursive: true })
-
-        if (!serverName) {
-            // Save the whole config
-            await workspace.fs.writeFile(configPath, JSON.stringify(config, null, 2))
-            logging.info(`Saved agent config to ${configPath}`)
-            return
-        }
-
-        // Read existing config if it exists, otherwise use default
-        let existingConfig: any
-        try {
-            const configExists = await workspace.fs.exists(configPath)
-            if (configExists) {
-                const raw = (await workspace.fs.readFile(configPath)).toString().trim()
-                existingConfig = raw ? JSON.parse(raw) : JSON.parse(DEFAULT_AGENT_RAW)
-            } else {
-                existingConfig = JSON.parse(DEFAULT_AGENT_RAW)
-            }
-        } catch (err) {
-            logging.warn(`Failed to read existing config at ${configPath}: ${err}`)
-            existingConfig = JSON.parse(DEFAULT_AGENT_RAW)
-        }
-
-        // Update only the specific server's config
-        if (config.mcpServers[serverName]) {
-            existingConfig.mcpServers[serverName] = config.mcpServers[serverName]
-        }
-
-        // Remove existing tools for this server
-        const serverToolPattern = `@${serverName}`
-        existingConfig.tools = existingConfig.tools.filter(
-            (tool: string) => tool !== serverToolPattern && !tool.startsWith(`${serverToolPattern}/`)
-        )
-        existingConfig.allowedTools = existingConfig.allowedTools.filter(
-            (tool: string) => tool !== serverToolPattern && !tool.startsWith(`${serverToolPattern}/`)
-        )
-
-        // Add only tools for this server
-        const serverTools = config.tools.filter(
-            tool => tool === serverToolPattern || tool.startsWith(`${serverToolPattern}/`)
-        )
-        const serverAllowedTools = config.allowedTools.filter(
-            tool => tool === serverToolPattern || tool.startsWith(`${serverToolPattern}/`)
-        )
-
-        existingConfig.tools.push(...serverTools)
-        existingConfig.allowedTools.push(...serverAllowedTools)
-
-        await workspace.fs.writeFile(configPath, JSON.stringify(existingConfig, null, 2))
-        logging.info(`Saved agent config for server ${serverName} to ${configPath}`)
+        // Save the whole config
+        await workspace.fs.writeFile(configPath, JSON.stringify(config, null, 2))
+        logging.info(`Saved agent config to ${configPath}`)
     } catch (err: any) {
         logging.error(`Failed to save agent config to ${configPath}: ${err.message}`)
         throw err


### PR DESCRIPTION
## Problem

2. Deleted server not persist in config file and re-appear in UI after refresh
3. Called initServer on built-in server when updateServerPermission that could lead to regression in the future
4. if one if a tool permission is changed to deny, enable/disable a server will lose it because an empty perm object is used for updateServerPermission.
5. if a tool permission is changed to deny, restarting IDE then open the UI again, the tool permission shows Ask instead of Deny because It's currently not store deny permission into the cache --> on start-up, it has no deny set so it will be default as Ask. Then when getToolPerm is called to get the permission to display, it has no deny stored in cache so it will return Ask as default value
6. If a tool permission of a server is changed to Deny, restarting IDE, open the UI again, disable or enable that server will lose Deny permission of that tool in config file. Same cause as 4.

## Solution

1. Update new logic to process #pendingPermissionConfig and remove filtering logic in saveAgentConfig
2.Make sure to exclude serverName === 'Built-in' in that process
3. Instead of using an empty perm object, use McpManager.mcpServerPermissions, which is a cache for storing tools permissions
4. Correctly set permission of tools in permission cache (mcpServerPermissions) on start-up by moving setting permission logic to the end of discoverAllServers to get all tools to include deny permission as an option.
5. The previous fix resolves this too

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
