### PR TITLE
chore: bump runtimes to 0.2.126

### DIFF
--- a/app/aws-lsp-antlr4-runtimes/package.json
+++ b/app/aws-lsp-antlr4-runtimes/package.json
@@ -12,7 +12,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-antlr4": "*",
         "antlr4-c3": "^3.4.1",
         "antlr4ng": "^3.0.4"

--- a/app/aws-lsp-buildspec-runtimes/package.json
+++ b/app/aws-lsp-buildspec-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-buildspec": "^0.0.1"
     }
 }

--- a/app/aws-lsp-cloudformation-runtimes/package.json
+++ b/app/aws-lsp-cloudformation-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-cloudformation": "^0.0.1"
     }
 }

--- a/app/aws-lsp-codewhisperer-runtimes/package.json
+++ b/app/aws-lsp-codewhisperer-runtimes/package.json
@@ -23,7 +23,7 @@
         "local-build": "node scripts/local-build.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-codewhisperer": "*",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",

--- a/app/aws-lsp-identity-runtimes/package.json
+++ b/app/aws-lsp-identity-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-identity": "^0.0.1"
     }
 }

--- a/app/aws-lsp-json-runtimes/package.json
+++ b/app/aws-lsp-json-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-json": "*"
     },
     "devDependencies": {

--- a/app/aws-lsp-notification-runtimes/package.json
+++ b/app/aws-lsp-notification-runtimes/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-notification": "^0.0.1"
     }
 }

--- a/app/aws-lsp-s3-runtimes/package.json
+++ b/app/aws-lsp-s3-runtimes/package.json
@@ -10,7 +10,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-s3": "^0.0.1"
     }
 }

--- a/app/aws-lsp-yaml-json-webworker/package.json
+++ b/app/aws-lsp-yaml-json-webworker/package.json
@@ -11,7 +11,7 @@
         "serve:webpack": "NODE_ENV=development webpack serve"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*"
     },

--- a/app/aws-lsp-yaml-runtimes/package.json
+++ b/app/aws-lsp-yaml-runtimes/package.json
@@ -11,7 +11,7 @@
         "webpack": "webpack"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-yaml": "*"
     },
     "devDependencies": {

--- a/app/hello-world-lsp-runtimes/package.json
+++ b/app/hello-world-lsp-runtimes/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@aws/hello-world-lsp": "^0.0.1",
-        "@aws/language-server-runtimes": "^0.2.125"
+        "@aws/language-server-runtimes": "^0.2.126"
     },
     "devDependencies": {
         "@types/chai": "^4.3.5",

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@aws/chat-client-ui-types": "^0.1.56",
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/language-server-runtimes-types": "^0.1.50",
         "@aws/mynah-ui": "^4.36.4"
     },

--- a/client/vscode/package.json
+++ b/client/vscode/package.json
@@ -352,7 +352,7 @@
         "@aws-sdk/credential-providers": "^3.731.1",
         "@aws-sdk/types": "^3.734.0",
         "@aws/chat-client-ui-types": "^0.1.56",
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@types/uuid": "^9.0.8",
         "@types/vscode": "^1.98.0",
         "jose": "^5.2.4",

--- a/core/aws-lsp-core/package.json
+++ b/core/aws-lsp-core/package.json
@@ -28,7 +28,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@gerhobbelt/gitignore-parser": "^0.2.0-9",
         "cross-spawn": "7.0.6",
         "jose": "^5.2.4",

--- a/integration-tests/q-agentic-chat-server/package.json
+++ b/integration-tests/q-agentic-chat-server/package.json
@@ -9,7 +9,7 @@
         "test-integ": "npm run compile && mocha --timeout 30000 \"./out/**/*.test.js\" --retries 2"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-core": "*"
     },
     "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
             "name": "@aws/lsp-antlr4-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-antlr4": "*",
                 "antlr4-c3": "^3.4.1",
                 "antlr4ng": "^3.0.4"
@@ -71,7 +71,7 @@
             "name": "@aws/lsp-buildspec-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-buildspec": "^0.0.1"
             }
         },
@@ -79,7 +79,7 @@
             "name": "@aws/lsp-cloudformation-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-cloudformation": "^0.0.1"
             }
         },
@@ -87,7 +87,7 @@
             "name": "@aws/lsp-codewhisperer-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-codewhisperer": "*",
                 "copyfiles": "^2.4.1",
                 "cross-env": "^7.0.3",
@@ -120,7 +120,7 @@
             "name": "@aws/lsp-identity-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-identity": "^0.0.1"
             }
         },
@@ -128,7 +128,7 @@
             "name": "@aws/lsp-json-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-json": "*"
             },
             "devDependencies": {
@@ -148,7 +148,7 @@
             "name": "@aws/lsp-notification-runtimes",
             "version": "0.1.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-notification": "^0.0.1"
             }
         },
@@ -181,7 +181,7 @@
             "name": "@aws/lsp-s3-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-s3": "^0.0.1"
             },
             "bin": {
@@ -192,7 +192,7 @@
             "name": "@aws/lsp-yaml-json-webworker",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*"
             },
@@ -212,7 +212,7 @@
             "name": "@aws/lsp-yaml-runtimes",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-yaml": "*"
             },
             "devDependencies": {
@@ -234,7 +234,7 @@
             "version": "0.0.1",
             "dependencies": {
                 "@aws/hello-world-lsp": "^0.0.1",
-                "@aws/language-server-runtimes": "^0.2.125"
+                "@aws/language-server-runtimes": "^0.2.126"
             },
             "devDependencies": {
                 "@types/chai": "^4.3.5",
@@ -255,7 +255,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/chat-client-ui-types": "^0.1.56",
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/language-server-runtimes-types": "^0.1.50",
                 "@aws/mynah-ui": "^4.36.4"
             },
@@ -280,7 +280,7 @@
                 "@aws-sdk/credential-providers": "^3.731.1",
                 "@aws-sdk/types": "^3.734.0",
                 "@aws/chat-client-ui-types": "^0.1.56",
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@types/uuid": "^9.0.8",
                 "@types/vscode": "^1.98.0",
                 "jose": "^5.2.4",
@@ -296,7 +296,7 @@
             "version": "0.0.13",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@gerhobbelt/gitignore-parser": "^0.2.0-9",
                 "cross-spawn": "7.0.6",
                 "jose": "^5.2.4",
@@ -327,7 +327,7 @@
             "name": "@aws/q-agentic-chat-server-integration-tests",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-core": "*"
             },
             "devDependencies": {
@@ -4036,9 +4036,9 @@
             "link": true
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.2.125",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.125.tgz",
-            "integrity": "sha512-tjXJEagZ6rm09fcgJGu1zbFNzi0+7R1mdNFa6zCIv68c76xq5JHjc++Hne9aOgp61O6BM9uNnX3KR57v9/0E1g==",
+            "version": "0.2.126",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.2.126.tgz",
+            "integrity": "sha512-dUIKTL6+AOxdberwHLvigSJcbhFv6oUS3POhZWoNlBV9XJZRWwzNW9gkjkUsI03YTVshqMuVHT/HaoRW/hDkIA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.1.56",
@@ -28608,7 +28608,7 @@
             "version": "0.1.17",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-core": "^0.0.13"
             },
             "devDependencies": {
@@ -28650,7 +28650,7 @@
             "name": "@aws/lsp-buildspec",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-json": "*",
                 "@aws/lsp-yaml": "*",
                 "vscode-languageserver": "^9.0.1",
@@ -28661,7 +28661,7 @@
             "name": "@aws/lsp-cloudformation",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-core": "*",
                 "@aws/lsp-json": "*",
                 "vscode-languageserver": "^9.0.1",
@@ -28683,7 +28683,7 @@
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "^0.1.56",
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-core": "^0.0.13",
                 "@modelcontextprotocol/sdk": "^1.15.0",
                 "@smithy/node-http-handler": "^2.5.0",
@@ -28823,7 +28823,7 @@
             "dependencies": {
                 "@aws-sdk/client-sso-oidc": "^3.616.0",
                 "@aws-sdk/token-providers": "^3.744.0",
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-core": "^0.0.12",
                 "@smithy/node-http-handler": "^3.2.5",
                 "@smithy/shared-ini-file-loader": "^4.0.1",
@@ -28888,7 +28888,7 @@
             "version": "0.1.17",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-core": "^0.0.13",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -28905,7 +28905,7 @@
             "version": "0.0.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-core": "^0.0.12",
                 "vscode-languageserver": "^9.0.1"
             },
@@ -28966,7 +28966,7 @@
             "version": "0.0.16",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "antlr4-c3": "3.4.2",
                 "antlr4ng": "3.0.14",
                 "web-tree-sitter": "0.22.6"
@@ -28988,7 +28988,7 @@
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.623.0",
                 "@aws-sdk/types": "^3.734.0",
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-core": "^0.0.12",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8"
@@ -29019,7 +29019,7 @@
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "@aws/lsp-core": "^0.0.13",
                 "vscode-languageserver": "^9.0.1",
                 "vscode-languageserver-textdocument": "^1.0.8",
@@ -29033,7 +29033,7 @@
             "name": "@amzn/device-sso-auth-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {
@@ -29044,7 +29044,7 @@
             "name": "@aws/hello-world-lsp",
             "version": "0.0.1",
             "dependencies": {
-                "@aws/language-server-runtimes": "^0.2.125",
+                "@aws/language-server-runtimes": "^0.2.126",
                 "vscode-languageserver": "^9.0.1"
             },
             "devDependencies": {

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf node_modules"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-core": "^0.0.13"
     },
     "peerDependencies": {

--- a/server/aws-lsp-buildspec/package.json
+++ b/server/aws-lsp-buildspec/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-json": "*",
         "@aws/lsp-yaml": "*",
         "vscode-languageserver": "^9.0.1",

--- a/server/aws-lsp-cloudformation/package.json
+++ b/server/aws-lsp-cloudformation/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-core": "*",
         "@aws/lsp-json": "*",
         "vscode-languageserver": "^9.0.1",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -36,7 +36,7 @@
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "^0.1.56",
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-core": "^0.0.13",
         "@modelcontextprotocol/sdk": "^1.15.0",
         "@smithy/node-http-handler": "^2.5.0",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@aws-sdk/client-sso-oidc": "^3.616.0",
         "@aws-sdk/token-providers": "^3.744.0",
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-core": "^0.0.12",
         "@smithy/node-http-handler": "^3.2.5",
         "@smithy/shared-ini-file-loader": "^4.0.1",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -26,7 +26,7 @@
         "prepack": "shx cp ../../LICENSE ../../NOTICE ../../SECURITY.md ."
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-core": "^0.0.13",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -22,7 +22,7 @@
         "coverage:report": "c8 report --reporter=html --reporter=text"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-core": "^0.0.12",
         "vscode-languageserver": "^9.0.1"
     },

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -24,7 +24,7 @@
         "out"
     ],
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "antlr4-c3": "3.4.2",
         "antlr4ng": "3.0.14",
         "web-tree-sitter": "0.22.6"

--- a/server/aws-lsp-s3/package.json
+++ b/server/aws-lsp-s3/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "^3.623.0",
         "@aws-sdk/types": "^3.734.0",
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-core": "^0.0.12",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8"

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -26,7 +26,7 @@
         "postinstall": "node patchYamlPackage.js"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "@aws/lsp-core": "^0.0.13",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.8",

--- a/server/device-sso-auth-lsp/package.json
+++ b/server/device-sso-auth-lsp/package.json
@@ -7,7 +7,7 @@
         "compile": "tsc --build"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {

--- a/server/hello-world-lsp/package.json
+++ b/server/hello-world-lsp/package.json
@@ -13,7 +13,7 @@
         "coverage:report": "c8 report --reporter=html --reporter=text"
     },
     "dependencies": {
-        "@aws/language-server-runtimes": "^0.2.125",
+        "@aws/language-server-runtimes": "^0.2.126",
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem
New runtimes version is available: https://github.com/aws/language-server-runtimes/pull/665

## Solution
Bump runtimes to 0.2.126

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
