### PR TITLE
fix: fix to add disk caching for mcp admin state

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.test.ts
@@ -169,8 +169,8 @@ describe('ProfileStatusMonitor', () => {
                 mockOnMcpEnabled
             )
 
-            // Initially undefined
-            expect(ProfileStatusMonitor.getMcpState()).to.be.undefined
+            // Initially true (default value)
+            expect(ProfileStatusMonitor.getMcpState()).to.be.true
 
             // Set through internal mechanism (simulating state change)
             ;(ProfileStatusMonitor as any).lastMcpState = false

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/profileStatusMonitor.ts
@@ -28,6 +28,7 @@ export class ProfileStatusMonitor {
     private static readonly MCP_CACHE_DIR = path.join(os.homedir(), '.aws', 'amazonq', 'mcpAdmin')
     private static readonly MCP_CACHE_FILE = path.join(ProfileStatusMonitor.MCP_CACHE_DIR, 'mcp-state.json')
     private static eventEmitter = new EventEmitter()
+    private static logging?: Logging
 
     constructor(
         private credentialsProvider: CredentialsProvider,
@@ -37,6 +38,7 @@ export class ProfileStatusMonitor {
         private onMcpDisabled: () => void,
         private onMcpEnabled?: () => void
     ) {
+        ProfileStatusMonitor.logging = logging
         ProfileStatusMonitor.loadMcpStateFromDisk()
 
         // Listen for auth success events
@@ -142,7 +144,7 @@ export class ProfileStatusMonitor {
                 ProfileStatusMonitor.lastMcpState = parsed.enabled ?? true
             }
         } catch (error) {
-            // Ignore errors and use default value
+            ProfileStatusMonitor.logging?.debug(`Failed to load MCP state from disk: ${error}`)
         }
         ProfileStatusMonitor.setMcpState(ProfileStatusMonitor.lastMcpState)
     }
@@ -155,7 +157,7 @@ export class ProfileStatusMonitor {
                 JSON.stringify({ enabled: ProfileStatusMonitor.lastMcpState })
             )
         } catch (error) {
-            // Ignore write errors
+            ProfileStatusMonitor.logging?.debug(`Failed to save MCP state to disk: ${error}`)
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -33,6 +33,7 @@ import { getAmazonQRegionAndEndpoint } from './configurationUtils'
 import { getUserAgent } from '../telemetryUtils'
 import { StreamingClientServiceToken } from '../streamingClientService'
 import { parse } from '@aws-sdk/util-arn-parser'
+import { ProfileStatusMonitor } from '../../language-server/agenticChat/tools/mcp/profileStatusMonitor'
 
 /**
  * AmazonQTokenServiceManager manages state and provides centralized access to
@@ -152,6 +153,9 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
         this.resetCodewhispererService()
         this.connectionType = 'none'
         this.state = 'PENDING_CONNECTION'
+
+        // Reset MCP state cache when auth changes
+        ProfileStatusMonitor.resetMcpState()
     }
 
     public async handleOnUpdateConfiguration(params: UpdateConfigurationParams, _token: CancellationToken) {
@@ -245,6 +249,9 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
             this.state = 'INITIALIZED'
             this.log('Initialized Amazon Q service with builderId connection')
 
+            // Emit auth success event
+            ProfileStatusMonitor.emitAuthSuccess()
+
             return
         }
 
@@ -266,6 +273,9 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
             this.createCodewhispererServiceInstances('identityCenter', undefined, endpointOverride)
             this.state = 'INITIALIZED'
             this.log('Initialized Amazon Q service with identityCenter connection')
+
+            // Emit auth success event
+            ProfileStatusMonitor.emitAuthSuccess()
 
             return
         }
@@ -375,6 +385,9 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
                 `Initialized identityCenter connection to region ${newProfile.identityDetails.region} for profile ${newProfile.arn}`
             )
 
+            // Emit auth success event
+            ProfileStatusMonitor.emitAuthSuccess()
+
             return
         }
 
@@ -384,6 +397,9 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
             this.log(`Profile selection did not change, active profile is ${this.activeIdcProfile.arn}`)
             this.activeIdcProfile = newProfile
             this.state = 'INITIALIZED'
+
+            // Emit auth success event
+            ProfileStatusMonitor.emitAuthSuccess()
 
             return
         }
@@ -427,6 +443,9 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
             this.endpointOverride()
         )
         this.state = 'INITIALIZED'
+
+        // Emit auth success event
+        ProfileStatusMonitor.emitAuthSuccess()
 
         return
     }


### PR DESCRIPTION
## Problem
mcp admin state needs disk caching
Auth change needs to also do the mcp state check

## Solution
- Added disk caching for mcp admin state
- Added mcp state check for auth change with event

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
