### PR TITLE
chore: update STE userContext version metadata

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/qAgenticChatServer.ts
@@ -110,7 +110,7 @@ export const QAgenticChatServer =
                 )
             )
 
-            const userContext = makeUserContextObject(clientParams, runtime.platform, 'CHAT')
+            const userContext = makeUserContextObject(clientParams, runtime.platform, 'CHAT', amazonQServiceManager.serverInfo)
             telemetryService.updateUserContext(userContext)
 
             chatController = new AgenticChatController(

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/qChatServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/qChatServer.ts
@@ -59,7 +59,9 @@ export const QChatServerFactory =
                     'TelemetryService initialized before LSP connection was initialized.'
                 )
             )
-            telemetryService.updateUserContext(makeUserContextObject(clientParams, runtime.platform, 'CHAT'))
+            telemetryService.updateUserContext(
+                makeUserContextObject(clientParams, runtime.platform, 'CHAT', amazonQServiceManager.serverInfo)
+            )
 
             chatController = new ChatController(
                 chatSessionManagementService,

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -723,7 +723,9 @@ export const CodewhispererServerFactory =
                     ?.inlineCompletionWithReferences?.inlineEditSupport ?? false
 
             telemetryService = new TelemetryService(amazonQServiceManager, credentialsProvider, telemetry, logging)
-            telemetryService.updateUserContext(makeUserContextObject(clientParams, runtime.platform, 'INLINE'))
+            telemetryService.updateUserContext(
+                makeUserContextObject(clientParams, runtime.platform, 'INLINE', amazonQServiceManager.serverInfo)
+            )
 
             codePercentageTracker = new CodePercentageTracker(telemetryService)
             codeDiffTracker = new CodeDiffTracker(

--- a/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/workspaceContext/workspaceContextServer.ts
@@ -188,7 +188,12 @@ export const WorkspaceContextServer = (): Server => features => {
                 abTestingEnabled = true
             } else {
                 const clientParams = safeGet(lsp.getClientInitializeParams())
-                const userContext = makeUserContextObject(clientParams, runtime.platform, 'CodeWhisperer') ?? {
+                const userContext = makeUserContextObject(
+                    clientParams,
+                    runtime.platform,
+                    'CodeWhisperer',
+                    amazonQServiceManager.serverInfo
+                ) ?? {
                     ideCategory: 'VSCODE',
                     operatingSystem: 'MAC',
                     product: 'CodeWhisperer',

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/BaseAmazonQServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/BaseAmazonQServiceManager.ts
@@ -17,6 +17,7 @@ import {
 } from './configurationUtils'
 import { AmazonQServiceInitializationError } from './errors'
 import { StreamingClientServiceBase } from '../streamingClientService'
+import { UserContext } from '../../client/token/codewhispererbearertokenclient'
 
 export interface QServiceManagerFeatures {
     lsp: Lsp
@@ -85,6 +86,10 @@ export abstract class BaseAmazonQServiceManager<
 
     abstract getCodewhispererService(): C
     abstract getStreamingClient(): S
+
+    get serverInfo() {
+        return this.features.runtime.serverInfo
+    }
 
     public getConfiguration(): Readonly<AmazonQWorkspaceConfig> {
         return this.configurationCache.getConfig()

--- a/server/aws-lsp-codewhisperer/src/shared/telemetryUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetryUtils.ts
@@ -89,15 +89,20 @@ const getOperatingSystem = (platform: Platform) => {
 export const makeUserContextObject = (
     initializeParams: InitializeParams,
     platform: Platform,
-    product: string
+    product: string,
+    serverInfo: ServerInfo
 ): UserContext | undefined => {
+    const ide = getIdeCategory(initializeParams)
+    const ideVersion =
+        initializeParams.initializationOptions?.aws?.clientInfo?.version || initializeParams.clientInfo?.version
+    const pluginVersion = initializeParams.initializationOptions?.aws?.clientInfo?.extension?.version || ''
+    const lspVersion = serverInfo.version ?? ''
     const userContext: UserContext = {
-        ideCategory: getIdeCategory(initializeParams),
+        ideCategory: ide,
         operatingSystem: getOperatingSystem(platform),
         product: product,
         clientId: initializeParams.initializationOptions?.aws?.clientInfo?.clientId,
-        ideVersion:
-            initializeParams.initializationOptions?.aws?.clientInfo?.version || initializeParams.clientInfo?.version,
+        ideVersion: `ide=${ideVersion};plugin=${pluginVersion};lsp=${lspVersion}`,
     }
 
     if (userContext.ideCategory === 'UNKNOWN' || userContext.operatingSystem === 'UNKNOWN') {


### PR DESCRIPTION
## Problem
our telemetry doesnt have enough infomation
1. plugin version
2. lsp version

`{ideCategory: 'VSCODE', operatingSystem: 'MAC', product: 'INLINE', clientId: 'foo', ideVersion: 'ide=testPluginVersion;plugin=testPluginVersion;lsp=1.27.0'}`

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
