### PR TITLE
feat: disable pkce flow during plugin load

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -11,6 +11,7 @@ type AgenticChatErrorCode =
     | 'MCPServerInitTimeout' // mcp server failed to start within allowed time
     | 'MCPToolExecTimeout' // mcp tool call failed to complete within allowed time
     | 'MCPServerConnectionFailed' // mcp server failed to connect
+    | 'MCPServerAuthFailed' // mcp server failed to complete auth flow
     | 'RequestAborted' // request was aborted by the user
     | 'RequestThrottled' // request was aborted by the user
 


### PR DESCRIPTION
## Problem
If MCP server failed to init with auth issue, PKCE flow shouldn't be launched in browser.

## Solution
Disable pkce flow during plugin load

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
