### PR TITLE
fix: multiple fixes on auth flow edge cases

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpOauthClient.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpOauthClient.test.ts
@@ -113,7 +113,9 @@ describe('OAuthClient getValidAccessToken()', () => {
 
         stubFileSystem(cachedToken, cachedReg)
 
-        const token = await OAuthClient.getValidAccessToken(new URL('https://api.example.com/mcp'))
+        const token = await OAuthClient.getValidAccessToken(new URL('https://api.example.com/mcp'), {
+            interactive: true,
+        })
         expect(token).to.equal('cached_access')
         expect((http.createServer as any).calledOnce).to.be.true
     })


### PR DESCRIPTION
## Problem
Some Issues edge cases in PKCE auth flow
## Solution
* Added timeout for PKCE flow.
* Fixed issue when Auth Failed, UI stuck in "activating" page, now error will be catched and displayed on add/edit view
* Fixed issue when Auth failed, UI always jump back to list server view
* Fixed Windows path

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
