### PR TITLE
ci: generation of builds action can be triggered manually

### DIFF
--- a/.github/workflows/create-agent-standalone.yml
+++ b/.github/workflows/create-agent-standalone.yml
@@ -3,10 +3,12 @@ name: Create agent-standalone bundles
 on:
     push:
         branches: [main, feature/*, release/agentic/*]
+    workflow_dispatch:
 
 jobs:
     build:
         runs-on: ubuntu-latest
+        if: github.event_name == 'push' || github.actor_id == github.repository_owner_id
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
## Problem

## Solution
Add the ability to trigger the GitHub action manually for code owners.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
