### PR TITLE
fix: configure CI to run on release branches

### DIFF
--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -1,9 +1,9 @@
 name: Language Server CI
 on:
     push:
-        branches: [main, dev, feature/*]
+        branches: [main, dev, feature/*, release/agentic/*]
     pull_request:
-        branches: [main, dev, feature/*]
+        branches: [main, dev, feature/*, release/agentic/*]
 
 jobs:
     test:

--- a/.github/workflows/npm-packaging.yaml
+++ b/.github/workflows/npm-packaging.yaml
@@ -1,9 +1,9 @@
 name: NPM Packaging
 on:
     push:
-        branches: [main, dev, feature/*]
+        branches: [main, dev, feature/*, release/agentic/*]
     pull_request:
-        branches: [main, dev, feature/*]
+        branches: [main, dev, feature/*, release/agentic/*]
 
 jobs:
     build:


### PR DESCRIPTION
## Description
Currently release/agentic/* branches used in our release process have rules that require CI to be run. However the corresponding workflows do not actually trigger for release branches. This change ensures no manual overrides are required in the release process and CI mapped with the branch actually runs.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
