### PR TITLE
fix(amazonq): disable typewriter animation

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -27,7 +27,7 @@
         "@aws/chat-client-ui-types": "^0.1.56",
         "@aws/language-server-runtimes": "^0.2.127",
         "@aws/language-server-runtimes-types": "^0.1.50",
-        "@aws/mynah-ui": "^4.36.4"
+        "@aws/mynah-ui": "^4.36.5"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -827,6 +827,7 @@ export const createMynahUi = (
             // if we want to max user input as 500000, need to configure the maxUserInput as 500096
             maxUserInput: 500096,
             userInputLengthWarningThreshold: 450000,
+            disableTypewriterAnimation: true,
         },
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,7 +257,7 @@
                 "@aws/chat-client-ui-types": "^0.1.56",
                 "@aws/language-server-runtimes": "^0.2.127",
                 "@aws/language-server-runtimes-types": "^0.1.50",
-                "@aws/mynah-ui": "^4.36.4"
+                "@aws/mynah-ui": "^4.36.5"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4203,9 +4203,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.36.4",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.36.4.tgz",
-            "integrity": "sha512-vGW4wlNindpr2Ep9x3iuKbrZTXe5KrE8vWpg15DjkN3qK42KMuMEQ67Pqtfgl5EseNYC1ukZm4HIQIMmt+vevA==",
+            "version": "4.36.5",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.36.5.tgz",
+            "integrity": "sha512-HMXqvSpZT84mpY67ChzRDrd73Y9AFZVZ8RcOJ/rNWIXR44uryfNFg2nrvoP4GSn2P+kU8WIPGChHGmyX9N0UgA==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {


### PR DESCRIPTION
## Problem

When larger responses are being streamed, the typewriter animation logic can cause significant delays in text rendering (perceived latency) and also causes the UI to lag.

## Solution

Disable typewriter animation. Chunks are added immediately to the UI as soon as they are streamed in, and all remaining content is flushed as soon as the stream completes.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
