### PR TITLE
fix(amazonq): fix for mcp servers operations to edit server config only

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -1061,9 +1061,11 @@ describe('listServersAndTools()', () => {
 
 describe('updateServerPermission()', () => {
     let saveAgentConfigStub: sinon.SinonStub
+    let saveServerSpecificAgentConfigStub: sinon.SinonStub
 
     beforeEach(() => {
         saveAgentConfigStub = sinon.stub(mcpUtils, 'saveAgentConfig').resolves()
+        saveServerSpecificAgentConfigStub = sinon.stub(mcpUtils, 'saveServerSpecificAgentConfig').resolves()
     })
 
     afterEach(async () => {
@@ -1112,8 +1114,8 @@ describe('updateServerPermission()', () => {
             __configPath__: '/p',
         })
 
-        // Verify saveAgentConfig was called
-        expect(saveAgentConfigStub.calledOnce).to.be.true
+        // Verify saveServerSpecificAgentConfig was called
+        expect(saveServerSpecificAgentConfigStub.calledOnce).to.be.true
 
         // Verify the tool permission was updated
         expect(mgr.requiresApproval('srv', 'tool1')).to.be.false

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -239,12 +239,12 @@ describe('callTool()', () => {
 describe('addServer()', () => {
     let loadStub: sinon.SinonStub
     let initOneStub: sinon.SinonStub
-    let saveAgentConfigStub: sinon.SinonStub
+    let saveServerSpecificAgentConfigStub: sinon.SinonStub
 
     beforeEach(() => {
         loadStub = stubAgentConfig()
         initOneStub = stubInitOneServer()
-        saveAgentConfigStub = sinon.stub(mcpUtils, 'saveAgentConfig').resolves()
+        saveServerSpecificAgentConfigStub = sinon.stub(mcpUtils, 'saveServerSpecificAgentConfig').resolves()
     })
 
     afterEach(async () => {
@@ -268,7 +268,7 @@ describe('addServer()', () => {
 
         await mgr.addServer('newS', newCfg, 'path.json')
 
-        expect(saveAgentConfigStub.calledOnce).to.be.true
+        expect(saveServerSpecificAgentConfigStub.calledOnce).to.be.true
         expect(initOneStub.calledOnceWith('newS', sinon.match(newCfg))).to.be.true
     })
 
@@ -301,14 +301,14 @@ describe('addServer()', () => {
 
         await mgr.addServer('httpSrv', httpCfg, 'http.json')
 
-        expect(saveAgentConfigStub.calledOnce).to.be.true
+        expect(saveServerSpecificAgentConfigStub.calledOnce).to.be.true
         expect(initOneStub.calledOnceWith('httpSrv', sinon.match(httpCfg))).to.be.true
     })
 })
 
 describe('removeServer()', () => {
     let loadStub: sinon.SinonStub
-    let saveAgentConfigStub: sinon.SinonStub
+    let saveServerSpecificAgentConfigStub: sinon.SinonStub
     let existsStub: sinon.SinonStub
     let readFileStub: sinon.SinonStub
     let writeFileStub: sinon.SinonStub
@@ -318,7 +318,7 @@ describe('removeServer()', () => {
 
     beforeEach(() => {
         loadStub = stubAgentConfig()
-        saveAgentConfigStub = sinon.stub(mcpUtils, 'saveAgentConfig').resolves()
+        saveServerSpecificAgentConfigStub = sinon.stub(mcpUtils, 'saveServerSpecificAgentConfig').resolves()
         existsStub = sinon.stub(fakeWorkspace.fs, 'exists').resolves(true)
         readFileStub = sinon
             .stub(fakeWorkspace.fs, 'readFile')
@@ -364,7 +364,7 @@ describe('removeServer()', () => {
         }
 
         await mgr.removeServer('x')
-        expect(saveAgentConfigStub.calledOnce).to.be.true
+        expect(saveServerSpecificAgentConfigStub.calledOnce).to.be.true
         expect((mgr as any).clients.has('x')).to.be.false
     })
 
@@ -395,8 +395,8 @@ describe('removeServer()', () => {
 
         await mgr.removeServer('x')
 
-        // Verify that saveAgentConfig was called
-        expect(saveAgentConfigStub.calledOnce).to.be.true
+        // Verify that saveServerSpecificAgentConfig was called
+        expect(saveServerSpecificAgentConfigStub.calledOnce).to.be.true
         expect((mgr as any).clients.has('x')).to.be.false
 
         // Verify server was removed from agent config
@@ -472,11 +472,11 @@ describe('mutateConfigFile()', () => {
 describe('updateServer()', () => {
     let loadStub: sinon.SinonStub
     let initOneStub: sinon.SinonStub
-    let saveAgentConfigStub: sinon.SinonStub
+    let saveServerSpecificAgentConfigStub: sinon.SinonStub
 
     beforeEach(() => {
         initOneStub = stubInitOneServer()
-        saveAgentConfigStub = sinon.stub(mcpUtils, 'saveAgentConfig').resolves()
+        saveServerSpecificAgentConfigStub = sinon.stub(mcpUtils, 'saveServerSpecificAgentConfig').resolves()
     })
 
     afterEach(async () => {
@@ -519,11 +519,11 @@ describe('updateServer()', () => {
 
         const closeStub = sinon.stub(fakeClient, 'close').resolves()
         initOneStub.resetHistory()
-        saveAgentConfigStub.resetHistory()
+        saveServerSpecificAgentConfigStub.resetHistory()
 
         await mgr.updateServer('u1', { timeout: 999 }, 'u.json')
 
-        expect(saveAgentConfigStub.calledOnce).to.be.true
+        expect(saveServerSpecificAgentConfigStub.calledOnce).to.be.true
         expect(closeStub.calledOnce).to.be.true
         expect(initOneStub.calledOnceWith('u1', sinon.match.has('timeout', 999))).to.be.true
     })
@@ -559,11 +559,11 @@ describe('updateServer()', () => {
         const mgr = McpManager.instance
 
         initOneStub.resetHistory()
-        saveAgentConfigStub.resetHistory()
+        saveServerSpecificAgentConfigStub.resetHistory()
 
         await mgr.updateServer('srv', { command: undefined, url: 'https://new.host/mcp' }, 'z.json')
 
-        expect(saveAgentConfigStub.calledOnce).to.be.true
+        expect(saveServerSpecificAgentConfigStub.calledOnce).to.be.true
         expect(initOneStub.calledOnceWith('srv', sinon.match({ url: 'https://new.host/mcp' }))).to.be.true
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -1136,12 +1136,6 @@ export class McpManager {
                 )
             }
 
-            // Update mcpServerPermissions map
-            this.mcpServerPermissions.set(serverName, {
-                enabled: perm.enabled,
-                toolPerms: perm.toolPerms || {},
-            })
-
             // enable/disable server
             if (this.isServerDisabled(serverName)) {
                 const client = this.clients.get(serverName)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -1247,11 +1247,14 @@ export class McpManager {
                     return true
                 })
 
-                // Save agent config
-                await saveAgentConfig(
+                // Save server removal to agent config
+                await saveServerSpecificAgentConfig(
                     this.features.workspace,
                     this.features.logging,
-                    this.agentConfig,
+                    unsanitizedName,
+                    null, // null indicates server should be removed
+                    [],
+                    [],
                     cfg.__configPath__
                 )
             }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -26,6 +26,7 @@ import {
     isEmptyEnv,
     loadAgentConfig,
     saveAgentConfig,
+    saveServerSpecificAgentConfig,
     sanitizeName,
     getGlobalAgentConfigPath,
     getWorkspaceMcpConfigPaths,
@@ -730,8 +731,23 @@ export class McpManager {
                 this.agentConfig.tools.push(serverPrefix)
             }
 
-            // Save agent config once with all changes
-            await saveAgentConfig(this.features.workspace, this.features.logging, this.agentConfig, agentPath)
+            // Save server-specific changes to agent config
+            const serverTools = this.agentConfig.tools.filter(
+                tool => tool === serverPrefix || tool.startsWith(`${serverPrefix}/`)
+            )
+            const serverAllowedTools = this.agentConfig.allowedTools.filter(
+                tool => tool === serverPrefix || tool.startsWith(`${serverPrefix}/`)
+            )
+
+            await saveServerSpecificAgentConfig(
+                this.features.workspace,
+                this.features.logging,
+                serverName,
+                serverConfig,
+                serverTools,
+                serverAllowedTools,
+                agentPath
+            )
 
             // Add server tools to tools list after initialization
             await this.initOneServer(sanitizedName, newCfg, AuthIntent.Interactive)
@@ -794,8 +810,16 @@ export class McpManager {
                 return true
             })
 
-            // Save agent config
-            await saveAgentConfig(this.features.workspace, this.features.logging, this.agentConfig, cfg.__configPath__)
+            // Save server removal to agent config
+            await saveServerSpecificAgentConfig(
+                this.features.workspace,
+                this.features.logging,
+                unsanitizedName,
+                null, // null indicates server should be removed
+                [],
+                [],
+                cfg.__configPath__
+            )
         }
 
         this.mcpServers.delete(serverName)
@@ -853,8 +877,24 @@ export class McpManager {
                 }
                 this.agentConfig.mcpServers[unsanitizedServerName] = updatedConfig
 
-                // Save agent config
-                await saveAgentConfig(this.features.workspace, this.features.logging, this.agentConfig, agentPath)
+                // Save server-specific changes to agent config
+                const serverPrefix = `@${unsanitizedServerName}`
+                const serverTools = this.agentConfig.tools.filter(
+                    tool => tool === serverPrefix || tool.startsWith(`${serverPrefix}/`)
+                )
+                const serverAllowedTools = this.agentConfig.allowedTools.filter(
+                    tool => tool === serverPrefix || tool.startsWith(`${serverPrefix}/`)
+                )
+
+                await saveServerSpecificAgentConfig(
+                    this.features.workspace,
+                    this.features.logging,
+                    unsanitizedServerName,
+                    updatedConfig,
+                    serverTools,
+                    serverAllowedTools,
+                    agentPath
+                )
             }
 
             const newCfg: MCPServerConfig = {
@@ -1057,6 +1097,12 @@ export class McpManager {
                 }
             }
 
+            // Update mcpServerPermissions map immediately to reflect changes
+            this.mcpServerPermissions.set(serverName, {
+                enabled: perm.enabled,
+                toolPerms: perm.toolPerms || {},
+            })
+
             // Update server enabled/disabled state in agent config
             if (this.agentConfig.mcpServers[unsanitizedServerName]) {
                 this.agentConfig.mcpServers[unsanitizedServerName].disabled = !perm.enabled
@@ -1067,10 +1113,27 @@ export class McpManager {
                 serverConfig.disabled = !perm.enabled
             }
 
-            // Save agent config
+            // Save only server-specific changes to agent config
             const agentPath = perm.__configPath__
             if (agentPath) {
-                await saveAgentConfig(this.features.workspace, this.features.logging, this.agentConfig, agentPath)
+                // Collect server-specific tools and allowedTools
+                const serverPrefix = `@${unsanitizedServerName}`
+                const serverTools = this.agentConfig.tools.filter(
+                    tool => tool === serverPrefix || tool.startsWith(`${serverPrefix}/`)
+                )
+                const serverAllowedTools = this.agentConfig.allowedTools.filter(
+                    tool => tool === serverPrefix || tool.startsWith(`${serverPrefix}/`)
+                )
+
+                await saveServerSpecificAgentConfig(
+                    this.features.workspace,
+                    this.features.logging,
+                    unsanitizedServerName,
+                    this.agentConfig.mcpServers[unsanitizedServerName],
+                    serverTools,
+                    serverAllowedTools,
+                    agentPath
+                )
             }
 
             // Update mcpServerPermissions map


### PR DESCRIPTION
## Problem

MCP server operations in config are inconsistent for all operations like add, remove, disable and edit tool permissions. This is happening due to entire agent config overwrite which is union of local and workspace level configs.

## Solution
- We edit the agent configs only for the servers and do not touch the rest of the agent config.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
