### PR TITLE
fix: emit acceptedLineCount metric and AgenticCodeAccepted interaction type

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2076,6 +2076,19 @@ export class AgenticChatController implements ChatHandlers {
                             this.#abTestingAllocation?.experimentName,
                             this.#abTestingAllocation?.userVariation
                         )
+                        // Emit acceptedLineCount when write tool is used and code changes are accepted
+                        const beforeLines = cachedToolUse?.fileChange?.before?.split('\n').length ?? 0
+                        const afterLines = doc?.getText()?.split('\n').length ?? 0
+                        const acceptedLineCount = afterLines - beforeLines
+                        await this.#telemetryController.emitInteractWithMessageMetric(
+                            tabId,
+                            {
+                                cwsprChatMessageId: chatResult.messageId ?? toolUse.toolUseId,
+                                cwsprChatInteractionType: ChatInteractionType.AgenticCodeAccepted,
+                                codewhispererCustomizationArn: this.#customizationArn,
+                            },
+                            acceptedLineCount
+                        )
                         await chatResultStream.writeResultBlock(chatResult)
                         break
                     case CodeReview.toolName:

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -421,10 +421,12 @@ export class ChatTelemetryController {
 
     public emitInteractWithMessageMetric(
         tabId: string,
-        metric: Omit<InteractWithMessageEvent, 'cwsprChatConversationId'>
+        metric: Omit<InteractWithMessageEvent, 'cwsprChatConversationId'>,
+        acceptedLineCount?: number
     ) {
         return this.#telemetryService.emitChatInteractWithMessage(metric, {
             conversationId: this.getConversationId(tabId),
+            acceptedLineCount,
         })
     }
 

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -66,6 +66,7 @@ export class TelemetryService {
         [ChatInteractionType.Upvote]: 'UPVOTE',
         [ChatInteractionType.Downvote]: 'DOWNVOTE',
         [ChatInteractionType.ClickBodyLink]: 'CLICK_BODY_LINK',
+        [ChatInteractionType.AgenticCodeAccepted]: 'AGENTIC_CODE_ACCEPTED',
     }
 
     constructor(

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -429,6 +429,7 @@ export enum ChatInteractionType {
     Upvote = 'upvote',
     Downvote = 'downvote',
     ClickBodyLink = 'clickBodyLink',
+    AgenticCodeAccepted = 'agenticCodeAccepted',
 }
 
 export enum ChatHistoryActionType {


### PR DESCRIPTION
## Problem
We need to emit the number of accepted lines of code generated by the agentic chat

## Solution
A new interaction type for `AGENTIC_CODE_ACCEPTED` was added to our backend. Add `AGENTIC_CODE_ACCEPTED` telemetry event to track when users accept code changes from agentic write tools. Emit telemetry with net line count difference (after - before) when `FS_WRITE`/`FS_REPLACE` tools are executed.


## Testing
Tested in RTS alpha:

IDE local log:
```
[Info  - 12:16:39 PM] [2025-08-27T19:16:39.232Z] lserver: Invoking SendTelemetryEvent:ChatInteractWithMessageEvent with:
            "interactionType": AGENTIC_CODE_ACCEPTED
            "acceptedLineCount": 4
```


Local RTS Server Logs:

```
 [java] 2025-08-27T22:09:05,293 [DEBUG] 5e271ff1-4c2a-4436-bf59-c65bbbca012e (coral-orchestrator-13) com.amazon.aws.vector.consolas.runtimeservice.component.SendTelemetryEventBaseComponent: Request id: [5e271ff1-4c2a-4436-bf59-c65bbbca012e] has sent telemetry event: [TelemetryEvent(chatInteractWithMessageEvent=ChatInteractWithMessageEvent(conversationId=92ef2402-800e-4762-9d66-d10b81cc9b8c, messageId=tooluse_KADpLeK_Rom_g77oJ9i1gA, customizationArn=null, interactionType=AGENTIC_CODE_ACCEPTED, interactionTarget=null, acceptedCharacterCount=null, acceptedLineCount=38, acceptedSnippetHasReference=false, hasProjectLevelContext=false, userIntent=null, addedIdeDiagnostics=null, removedIdeDiagnostics=null))] and userContext: [UserContext(ideCategory=VSCODE, operatingSystem=MAC, product=CHAT, clientId=2334a77f-feeb-4649-842c-8b176c091b78, ideVersion=ide=1.103.2;plugin=testPluginVersion;lsp=1.29.0, pluginVersion=null, lspVersion=null)]
 ```
 
RTS Alpha Service Metrics:
```
InteractionType=AGENTIC_CODE_ACCEPTED
.
.
.
TelemetryEvent=ChatInteractWithMessageEvent
```


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
