### PR TITLE
fix: reduce auto trigger frequency for VSC

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
@@ -229,7 +229,12 @@ export const autoTrigger = (
 
     const triggerTypeCoefficient = coefficients.triggerTypeCoefficient[triggerType] ?? 0
     const osCoefficient = coefficients.osCoefficient[os] ?? 0
-    const charCoefficient = coefficients.charCoefficient[char] ?? 0
+    let charCoefficient = coefficients.charCoefficient[char] ?? 0
+    // this is a temporary change to lower the auto trigger frequency
+    if (ide === 'VSCODE') {
+        charCoefficient = 0
+    }
+
     const keyWordCoefficient = coefficients.charCoefficient[keyword] ?? 0
 
     const languageCoefficient = coefficients.languageCoefficient[fileContext.programmingLanguage.languageName] ?? 0


### PR DESCRIPTION
## Problem
1. Auto trigger is too aggressive.
2. In pre LS VSC Amazon Q, the charCoefficient was accidentally set to 0.

## Solution
Set charCoefficient to 0 for VSC

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
