### PR TITLE
fix(amazonq): status message update for mcp tool permission acceptance

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2607,7 +2607,7 @@ export class AgenticChatController implements ChatHandlers {
                                 status: {
                                     status: isAccept ? 'success' : 'error',
                                     icon: isAccept ? 'ok' : 'cancel',
-                                    text: isAccept ? 'Completed' : 'Rejected',
+                                    text: isAccept ? 'Accepted' : 'Rejected',
                                 },
                                 fileList: undefined,
                             },


### PR DESCRIPTION
## Problem
When an MCP tools is accpeted, it shows completed as status.

## Solution
- Updated it to `Accepted`

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
