### PR TITLE
feat(amazonq): adding amzn-mcp server to the internal amazon users

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -40,6 +40,7 @@ import { URI } from 'vscode-uri'
 import { sanitizeInput } from '../../../../shared/utils'
 import { ProfileStatusMonitor } from './profileStatusMonitor'
 import { OAuthClient } from './mcpOauthClient'
+import { INTERNAL_USER_START_URL } from '../../../../shared/constants'
 
 export const MCP_SERVER_STATUS_CHANGED = 'mcpServerStatusChanged'
 export const AGENT_TOOLS_CHANGED = 'agentToolsChanged'
@@ -172,8 +173,17 @@ export class McpManager {
      * Load configurations and initialize each enabled server.
      */
     private async discoverAllServers(): Promise<void> {
+        // Check if user is internal
+        const startUrl = this.features.credentialsProvider?.getConnectionMetadata()?.sso?.startUrl
+        const isInternalUser = startUrl === INTERNAL_USER_START_URL
+
         // Load agent config
-        const result = await loadAgentConfig(this.features.workspace, this.features.logging, this.agentPaths)
+        const result = await loadAgentConfig(
+            this.features.workspace,
+            this.features.logging,
+            this.agentPaths,
+            isInternalUser
+        )
 
         // Extract agent config and other data
         this.agentConfig = result.agentConfig


### PR DESCRIPTION
## Problem

Internal amazon users need amzn-mcp server added by default

## Solution
- Added amazon mcp server by default for internal users.


https://github.com/user-attachments/assets/22ab27ac-e8fa-4831-ae7e-3a4239d5e7a1



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
