### PR TITLE
fix(amazonq): fix to add warning for number of tools exceeding limit

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
@@ -17,7 +17,7 @@ export const GENERATE_ASSISTANT_RESPONSE_INPUT_LIMIT = 500_000
 export const DEFAULT_MODEL_ID = BedrockModel.CLAUDE_SONNET_4_20250514_V1_0
 
 // MCP Constants
-export const MAX_MCP_TOOLS_LIMIT = 40
+export const MCP_TOOLS_CONTEXT_WINDOW_THRESHOLD = 0.2 // 20% of context window
 
 // Compaction
 export const COMPACTION_BODY = (threshold: number) =>


### PR DESCRIPTION
## Problem

MCP tools reaching high numbers would decrease context window and would affect user experience.

## Solution
- Added a warning to MCP tools exceeding a currently agreed limit of 40.

<img width="451" height="856" alt="Screenshot 2025-08-28 at 12 40 14 AM" src="https://github.com/user-attachments/assets/b5b55d87-ea7b-4f9d-b880-2051665829bc" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
