### PR TITLE
revert: "deps: update indexing bundle to 042c98e6 (#2174)"

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-darwin-arm64.zip
+++ b/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-darwin-arm64.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4fbd67484ea48363077bbfaa576154196558a4048a862abac84d496fec6b636
-size 96644452
+oid sha256:5f651f5364b2417df24d40cbd2d34d69f8b338f3f00aca9c5afd5b4f9ea3d22d
+size 96647490

--- a/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-darwin-x64.zip
+++ b/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-darwin-x64.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bcfa7697a0ecdc4ff43f84d1a8c8b7840c144080e51b921dd7c5d3478613a82
-size 98325089
+oid sha256:03ef43ac80e2a16e8c842e92a3f3285d5424f2ea99bba167b9cbb9dabb751262
+size 98328127

--- a/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-linux-arm64.zip
+++ b/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-linux-arm64.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f644daa198d026a091ac87a33fa54b7c1faf1e929ce8ef3ab7e25b7510335e7
-size 102586773
+oid sha256:33bf50f87b67a330b3dc28f9a2fb1678f5c9cd6eb33beb964b6b068790b05b6c
+size 102589811

--- a/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-linux-x64.zip
+++ b/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-linux-x64.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f6add24d8ae6d1248e3ff8281a8c9e8b402370fd00fcc8bf65c553457715f27
-size 114549102
+oid sha256:ec71aea47b7cb08c13e94fe4ca284b3656d23266bcdd728a3525abd7939730f0
+size 114552140

--- a/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-win32-x64.zip
+++ b/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-win32-x64.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5949d0c3d13d02c31f6bf06ea7a0339a851be1824f90c81d48e66c48c79e4930
-size 113887210
+oid sha256:cd8190acad1f1c2b37a818fcf606cc3d2fa4e1929c82ef967ac360b7345864b4
+size 113890248


### PR DESCRIPTION
This reverts commit 28567e3ab06a38e13d23df98f0000d62f43293f6.

indexing bundle contains a crypto polyfill that is needed for some reason

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
