### PR TITLE
fix: should send classifier score after taking sigmoid

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
@@ -229,7 +229,9 @@ export const autoTrigger = (
 
     const triggerTypeCoefficient = coefficients.triggerTypeCoefficient[triggerType] ?? 0
     const osCoefficient = coefficients.osCoefficient[os] ?? 0
+
     const charCoefficient = coefficients.charCoefficient[char] ?? 0
+
     const keyWordCoefficient = coefficients.charCoefficient[keyword] ?? 0
 
     const languageCoefficient = coefficients.languageCoefficient[fileContext.programmingLanguage.languageName] ?? 0
@@ -274,11 +276,13 @@ export const autoTrigger = (
         previousDecisionCoefficient +
         languageCoefficient +
         leftContextLengthCoefficient
-    const shouldTrigger = sigmoid(classifierResult) > TRIGGER_THRESHOLD
+
+    const r = sigmoid(classifierResult)
+    const shouldTrigger = r > TRIGGER_THRESHOLD
 
     return {
         shouldTrigger,
-        classifierResult,
+        classifierResult: r,
         classifierThreshold: TRIGGER_THRESHOLD,
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/userTriggerDecision.test.ts
@@ -145,7 +145,7 @@ describe('Telemetry', () => {
             },
         }
         const EMPTY_RESULT = { items: [], sessionId: '' }
-        const classifierResult = getNormalizeOsName() !== 'Linux' ? 0.4114381148145918 : 0.46733811481459187
+        const classifierResult = getNormalizeOsName() !== 'Linux' ? 0.6014326616203989 : 0.61475353067264
 
         let features: TestFeatures
         let server: Server
@@ -1251,7 +1251,7 @@ describe('Telemetry', () => {
                     triggerType: 'AutoTrigger',
                     autoTriggerType: 'SpecialCharacters',
                     triggerCharacter: '(',
-                    classifierResult: getNormalizeOsName() === 'Linux' ? 0.30173811481459184 : 0.2458381148145919,
+                    classifierResult: getNormalizeOsName() === 'Linux' ? 0.5748673583477094 : 0.5611518554232429,
                     classifierThreshold: 0.43,
                     language: 'csharp',
                     requestContext: {


### PR DESCRIPTION
## Problem
for the classifier score, we are supposed to send the score after taking sigmoid but current the raw score is sent.

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
