### PR TITLE
fix: auto trigger should only respect previous decisions in the past 2mins

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/auto-trigger/autoTrigger.ts
@@ -177,7 +177,7 @@ type AutoTriggerParams = {
     char: string
     triggerType: string // Left as String intentionally to support future and unknown trigger types
     os: string
-    previousDecision: string
+    previousDecision: string | undefined
     ide: string
     lineNum: number
 }
@@ -235,12 +235,19 @@ export const autoTrigger = (
     const languageCoefficient = coefficients.languageCoefficient[fileContext.programmingLanguage.languageName] ?? 0
 
     let previousDecisionCoefficient = 0
-    if (previousDecision === 'Accept') {
-        previousDecisionCoefficient = coefficients.prevDecisionAcceptCoefficient
-    } else if (previousDecision === 'Reject') {
-        previousDecisionCoefficient = coefficients.prevDecisionRejectCoefficient
-    } else if (previousDecision === 'Discard' || previousDecision === 'Empty') {
-        previousDecisionCoefficient = coefficients.prevDecisionOtherCoefficient
+    switch (previousDecision) {
+        case 'Accept':
+            previousDecisionCoefficient = coefficients.prevDecisionAcceptCoefficient
+            break
+        case 'Reject':
+            previousDecisionCoefficient = coefficients.prevDecisionRejectCoefficient
+            break
+        case 'Discard':
+        case 'Empty':
+            previousDecisionCoefficient = coefficients.prevDecisionOtherCoefficient
+            break
+        default:
+            break
     }
 
     const ideCoefficient = coefficients.ideCoefficient[ide] ?? 0

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/codeWhispererServer.ts
@@ -239,7 +239,11 @@ export const CodewhispererServerFactory =
                         : undefined
 
                     const previousSession = completionSessionManager.getPreviousSession()
-                    const previousDecision = previousSession?.getAggregatedUserTriggerDecision() ?? ''
+                    // Only refer to decisions in the past 2 mins
+                    const previousDecisionClassifier =
+                        previousSession && performance.now() - previousSession.decisionMadeTimestamp <= 2 * 60 * 1000
+                            ? previousSession.getAggregatedUserTriggerDecision()
+                            : undefined
                     let ideCategory: string | undefined = ''
                     const initializeParams = lsp.getClientInitializeParams()
                     if (initializeParams !== undefined) {
@@ -280,7 +284,7 @@ export const CodewhispererServerFactory =
                                 char: triggerCharacters, // Add the character just inserted, if any, before the invication position
                                 ide: ideCategory ?? '',
                                 os: getNormalizeOsName(),
-                                previousDecision, // The last decision by the user on the previous invocation
+                                previousDecision: previousDecisionClassifier, // The last decision by the user on the previous invocation
                                 triggerType: codewhispererAutoTriggerType, // The 2 trigger types currently influencing the Auto-Trigger are SpecialCharacter and Enter
                             },
                             logging

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/session/sessionManager.ts
@@ -60,6 +60,13 @@ export class CodeWhispererSession {
     suggestions: CachedSuggestion[] = []
     suggestionsAfterRightContextMerge: InlineCompletionItemWithReferences[] = []
     suggestionsStates = new Map<string, UserDecision>()
+    private _DecisionTimestamp = 0
+    get decisionMadeTimestamp() {
+        return this._DecisionTimestamp
+    }
+    set decisionMadeTimestamp(time: number) {
+        this._DecisionTimestamp = time
+    }
     acceptedSuggestionId?: string = undefined
     responseContext?: ResponseContext
     triggerType: CodewhispererTriggerType

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -199,6 +199,7 @@ export class TelemetryService {
         removedIdeDiagnostics?: IdeDiagnostic[],
         streakLength?: number
     ) {
+        session.decisionMadeTimestamp = performance.now()
         if (this.enableTelemetryEventsToDestination) {
             const data: CodeWhispererUserTriggerDecisionEvent = {
                 codewhispererSessionId: session.codewhispererSessionId || '',


### PR DESCRIPTION
…

## Problem
Original implementation only use decisions in the past 2mins

https://github.com/aws/aws-toolkit-vscode/blob/e7341f2a55e47733ed519545bde6d6ea3e4b973c/packages/core/src/codewhisperer/util/telemetryHelper.ts#L480-L484

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
