### PR TITLE
fix: fix calculation for num-lines contributed by the LLM

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -166,6 +166,7 @@ import { FsWrite, FsWriteParams } from './tools/fsWrite'
 import { ExecuteBash, ExecuteBashParams } from './tools/executeBash'
 import { ExplanatoryParams, InvokeOutput, ToolApprovalException } from './tools/toolShared'
 import { validatePathBasic, validatePathExists, validatePaths as validatePathsSync } from './utils/pathValidation'
+import { calculateModifiedLines } from './utils/fileModificationMetrics'
 import { GrepSearch, SanitizedRipgrepOutput } from './tools/grepSearch'
 import { FileSearch, FileSearchParams, isFileSearchParams } from './tools/fileSearch'
 import { FsReplace, FsReplaceParams } from './tools/fsReplace'
@@ -2077,9 +2078,7 @@ export class AgenticChatController implements ChatHandlers {
                             this.#abTestingAllocation?.userVariation
                         )
                         // Emit acceptedLineCount when write tool is used and code changes are accepted
-                        const beforeLines = cachedToolUse?.fileChange?.before?.split('\n').length ?? 0
-                        const afterLines = doc?.getText()?.split('\n').length ?? 0
-                        const acceptedLineCount = afterLines - beforeLines
+                        const acceptedLineCount = calculateModifiedLines(toolUse, doc?.getText())
                         await this.#telemetryController.emitInteractWithMessageMetric(
                             tabId,
                             {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/utils/fileModificationMetrics.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/utils/fileModificationMetrics.test.ts
@@ -1,0 +1,139 @@
+import { calculateModifiedLines } from './fileModificationMetrics'
+import { ToolUse } from '@amzn/codewhisperer-streaming'
+import { FS_WRITE, FS_REPLACE } from '../constants/toolConstants'
+import * as assert from 'assert'
+
+describe('calculateModifiedLines', () => {
+    describe('FS_WRITE', () => {
+        it('should count lines for create command', () => {
+            const toolUse: ToolUse = {
+                toolUseId: 'test-1',
+                name: FS_WRITE,
+                input: {
+                    command: 'create',
+                    path: '/test/file.txt',
+                    fileText: 'line1\nline2\nline3',
+                },
+            }
+            const afterContent = 'line1\nline2\nline3'
+
+            assert.strictEqual(calculateModifiedLines(toolUse, afterContent), 3)
+        })
+
+        it('should count lines for append command', () => {
+            const toolUse: ToolUse = {
+                toolUseId: 'test-2',
+                name: FS_WRITE,
+                input: {
+                    command: 'append',
+                    path: '/test/file.txt',
+                    fileText: 'line4\nline5',
+                },
+            }
+
+            assert.strictEqual(calculateModifiedLines(toolUse), 2)
+        })
+
+        it('should handle empty content', () => {
+            const toolUse: ToolUse = {
+                toolUseId: 'test-3',
+                name: FS_WRITE,
+                input: {
+                    command: 'create',
+                    path: '/test/file.txt',
+                    fileText: '',
+                },
+            }
+
+            assert.strictEqual(calculateModifiedLines(toolUse, ''), 0)
+        })
+    })
+
+    describe('FS_REPLACE', () => {
+        it('should count replaced lines correctly (double counting)', () => {
+            const toolUse: ToolUse = {
+                toolUseId: 'test-4',
+                name: FS_REPLACE,
+                input: {
+                    path: '/test/file.txt',
+                    diffs: [
+                        {
+                            oldStr: 'old line 1\nold line 2\nold line 3',
+                            newStr: 'new line 1\nnew line 2\nnew line 3',
+                        },
+                    ],
+                },
+            }
+
+            assert.strictEqual(calculateModifiedLines(toolUse), 6)
+        })
+
+        it('should count pure deletions', () => {
+            const toolUse: ToolUse = {
+                toolUseId: 'test-5',
+                name: FS_REPLACE,
+                input: {
+                    path: '/test/file.txt',
+                    diffs: [
+                        {
+                            oldStr: 'line to delete 1\nline to delete 2',
+                            newStr: '',
+                        },
+                    ],
+                },
+            }
+
+            assert.strictEqual(calculateModifiedLines(toolUse), 2)
+        })
+
+        it('should count pure insertions', () => {
+            const toolUse: ToolUse = {
+                toolUseId: 'test-6',
+                name: FS_REPLACE,
+                input: {
+                    path: '/test/file.txt',
+                    diffs: [
+                        {
+                            oldStr: '',
+                            newStr: 'new line 1\nnew line 2',
+                        },
+                    ],
+                },
+            }
+
+            assert.strictEqual(calculateModifiedLines(toolUse), 2)
+        })
+
+        it('should handle multiple diffs', () => {
+            const toolUse: ToolUse = {
+                toolUseId: 'test-7',
+                name: FS_REPLACE,
+                input: {
+                    path: '/test/file.txt',
+                    diffs: [
+                        {
+                            oldStr: 'old line 1',
+                            newStr: 'new line 1',
+                        },
+                        {
+                            oldStr: 'delete this line',
+                            newStr: '',
+                        },
+                    ],
+                },
+            }
+
+            assert.strictEqual(calculateModifiedLines(toolUse), 3)
+        })
+    })
+
+    it('should return 0 for unknown tools', () => {
+        const toolUse: ToolUse = {
+            toolUseId: 'test-8',
+            name: 'unknownTool',
+            input: {},
+        }
+
+        assert.strictEqual(calculateModifiedLines(toolUse), 0)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/utils/fileModificationMetrics.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/utils/fileModificationMetrics.ts
@@ -1,0 +1,58 @@
+import { ToolUse } from '@amzn/codewhisperer-streaming'
+import { diffLines } from 'diff'
+import { FsWriteParams } from '../tools/fsWrite'
+import { FsReplaceParams } from '../tools/fsReplace'
+import { FS_WRITE, FS_REPLACE } from '../constants/toolConstants'
+
+/**
+ * Counts the number of lines in text, handling different line endings
+ * @param text The text to count lines in
+ * @returns The number of lines
+ */
+function countLines(text?: string): number {
+    if (!text) return 0
+    const parts = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n')
+    return parts.length && parts[parts.length - 1] === '' ? parts.length - 1 : parts.length
+}
+
+/**
+ * Calculates the actual lines modified by analyzing file modification tools.
+ * @param toolUse The tool use object
+ * @param afterContent The content after the tool execution (for FS_WRITE create operations)
+ * @returns The total number of lines modified (added + removed)
+ */
+export function calculateModifiedLines(toolUse: ToolUse, afterContent?: string): number {
+    if (toolUse.name === FS_WRITE) {
+        const input = toolUse.input as unknown as FsWriteParams
+
+        if (input.command === 'create') {
+            return countLines(afterContent ?? '')
+        } else if (input.command === 'append') {
+            return countLines(input.fileText)
+        }
+    }
+
+    if (toolUse.name === FS_REPLACE) {
+        const input = toolUse.input as unknown as FsReplaceParams
+        let linesAdded = 0
+        let linesRemoved = 0
+
+        for (const diff of input.diffs || []) {
+            const oldStr = diff.oldStr ?? ''
+            const newStr = diff.newStr ?? ''
+
+            const changes = diffLines(oldStr, newStr)
+
+            for (const change of changes) {
+                if (change.added) {
+                    linesAdded += countLines(change.value)
+                } else if (change.removed) {
+                    linesRemoved += countLines(change.value)
+                }
+            }
+        }
+
+        return linesAdded + linesRemoved
+    }
+    return 0
+}


### PR DESCRIPTION
## Problem
This metric name `acceptedLineCount ` is misleading for our usecase. We want to emit the number of lines modified by the LLM.

## Solution
- Implemented calculateModifiedLines(): Uses diffLines to analyze changes in FsReplaceParams.diffs.
	- Counts pure adds/deletes independently.
- Handled multiple operations:
	- create: Counts all new lines as added.
	- append: Counts appended lines only.
	- replace: Sums added + removed lines for accurate contribution tracking.

The key change is using `linesAdded` + `linesRemoved` instead of trying to avoid double-counting, matching the CLI's approach for consistent metrics across platforms:

- https://github.com/aws/amazon-q-developer-cli/pull/2738


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
