### PR TITLE
fix: compact UI is not updated correctly when multiple nudges are displayed

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -2707,6 +2707,7 @@ export class AgenticChatController implements ChatHandlers {
         session.setDeferredToolExecution(messageId, deferred.resolve, deferred.reject)
         this.#log(`Prompting for compaction approval for messageId: ${messageId}`)
         await deferred.promise
+        session.removeDeferredToolExecution(messageId)
         // Note: we want to overwrite the button block because it already exists in the stream.
         await resultStream.overwriteResultBlock(this.#getUpdateCompactConfirmResult(messageId), promptBlockId)
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -78,8 +78,15 @@ export class ChatSessionService {
     public getDeferredToolExecution(messageId: string): DeferredHandler | undefined {
         return this.#deferredToolExecution[messageId]
     }
+
     public setDeferredToolExecution(messageId: string, resolve: any, reject: any) {
         this.#deferredToolExecution[messageId] = { resolve, reject }
+    }
+
+    public removeDeferredToolExecution(messageId: string) {
+        if (messageId in this.#deferredToolExecution) {
+            delete this.#deferredToolExecution[messageId]
+        }
     }
 
     public getAllDeferredCompactMessageIds(): string[] {


### PR DESCRIPTION
## Problem
- The first accepted compaction nudge is being updated by newer nudge action

## Solution
- Fixed the bug

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
