### PR TITLE
Model selection for code review tool

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
+++ b/server/aws-lsp-codewhisperer/src/client/token/bearer-token-service.json
@@ -4822,6 +4822,12 @@
                 },
                 "profileArn": {
                     "shape": "ProfileArn"
+                },
+                "languageModelId": {
+                    "shape": "ModelId"
+                },
+                "clientType": {
+                    "shape": "Origin"
                 }
             }
         },

--- a/server/aws-lsp-codewhisperer/src/client/token/codewhispererbearertokenclient.d.ts
+++ b/server/aws-lsp-codewhisperer/src/client/token/codewhispererbearertokenclient.d.ts
@@ -1539,6 +1539,8 @@ declare namespace CodeWhispererBearerTokenClient {
     codeScanName?: CodeScanName;
     codeDiffMetadata?: CodeDiffMetadata;
     profileArn?: ProfileArn;
+    languageModelId?: ModelId;
+    clientType?: Origin;
   }
   export type StartCodeAnalysisRequestClientTokenString = string;
   export interface StartCodeAnalysisResponse {
@@ -2186,4 +2188,4 @@ declare namespace CodeWhispererBearerTokenClient {
 }
 export = CodeWhispererBearerTokenClient;
 
-  
+    

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -1988,6 +1988,7 @@ export class AgenticChatController implements ChatHandlers {
                                 .filter(c => c.type === 'rule')
                                 .map(c => ({ path: c.path }))
                         }
+                        initialInput['modelId'] = session.modelId
                         toolUse.input = initialInput
                     } catch (e) {
                         this.#features.logging.warn(`could not parse CodeReview tool input: ${e}`)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReview.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReview.test.ts
@@ -104,6 +104,7 @@ describe('CodeReview', () => {
                 folderLevelArtifacts: [],
                 ruleArtifacts: [],
                 scopeOfReview: FULL_REVIEW,
+                modelId: 'claude-4-sonnet',
             }
         })
 
@@ -199,56 +200,6 @@ describe('CodeReview', () => {
             expect(callArgs).to.have.property('scope', 'AGENTIC')
         })
 
-        it('should execute successfully with undefined modelId and still pass clientType', async () => {
-            const inputWithoutModelId = {
-                ...validInput,
-                modelId: undefined,
-            }
-
-            // Setup mocks for successful execution
-            mockCodeWhispererClient.createUploadUrl.resolves({
-                uploadUrl: 'https://upload.com',
-                uploadId: 'upload-456',
-                requestHeaders: {},
-            })
-
-            mockCodeWhispererClient.startCodeAnalysis.resolves({
-                jobId: 'job-456',
-                status: 'Pending',
-            })
-
-            mockCodeWhispererClient.getCodeAnalysis.resolves({
-                status: 'Completed',
-            })
-
-            mockCodeWhispererClient.listCodeAnalysisFindings.resolves({
-                codeAnalysisFindings: '[]',
-                nextToken: undefined,
-            })
-
-            sandbox.stub(CodeReviewUtils, 'uploadFileToPresignedUrl').resolves()
-            sandbox.stub(codeReview as any, 'prepareFilesAndFoldersForUpload').resolves({
-                zipBuffer: Buffer.from('test'),
-                md5Hash: 'hash456',
-                isCodeDiffPresent: false,
-                programmingLanguages: new Set(['javascript']),
-            })
-            sandbox.stub(codeReview as any, 'parseFindings').returns([])
-
-            const result = await codeReview.execute(inputWithoutModelId, context)
-
-            expect(result.output.success).to.be.true
-            expect(result.output.kind).to.equal('json')
-
-            // Verify that startCodeAnalysis was called with the correct parameters
-            expect(mockCodeWhispererClient.startCodeAnalysis.calledOnce).to.be.true
-            const startAnalysisCall = mockCodeWhispererClient.startCodeAnalysis.getCall(0)
-            const callArgs = startAnalysisCall.args[0]
-
-            expect(callArgs).to.have.property('languageModelId', undefined)
-            expect(callArgs).to.have.property('clientType', Origin.IDE)
-        })
-
         it('should handle missing client error', async () => {
             context.codeWhispererClient = undefined
 
@@ -266,6 +217,7 @@ describe('CodeReview', () => {
                 folderLevelArtifacts: [],
                 ruleArtifacts: [],
                 scopeOfReview: FULL_REVIEW,
+                modelId: 'claude-4-sonnet',
             }
 
             try {
@@ -385,6 +337,7 @@ describe('CodeReview', () => {
                 folderLevelArtifacts: [],
                 ruleArtifacts: [],
                 scopeOfReview: FULL_REVIEW,
+                modelId: 'claude-4-sonnet',
             }
 
             const context = {
@@ -409,6 +362,7 @@ describe('CodeReview', () => {
                 folderLevelArtifacts: [{ path: '/test/folder' }],
                 ruleArtifacts: [],
                 scopeOfReview: CODE_DIFF_REVIEW,
+                modelId: 'claude-4-sonnet',
             }
 
             const context = {
@@ -720,6 +674,7 @@ describe('CodeReview', () => {
                 folderLevelArtifacts: [],
                 ruleArtifacts: [],
                 scopeOfReview: FULL_REVIEW,
+                modelId: 'claude-4-sonnet',
             }
 
             // Make prepareFilesAndFoldersForUpload throw an error

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReview.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReview.ts
@@ -31,6 +31,7 @@ import {
     SuccessMetricName,
 } from './codeReviewTypes'
 import { CancellationError } from '@aws/lsp-core'
+import { Origin } from '@amzn/codewhisperer-streaming'
 
 export class CodeReview {
     private static readonly CUSTOMER_CODE_BASE_PATH = 'customerCodeBaseFolder'
@@ -158,6 +159,7 @@ export class CodeReview {
         const fileArtifacts = validatedInput.fileLevelArtifacts || []
         const folderArtifacts = validatedInput.folderLevelArtifacts || []
         const ruleArtifacts = validatedInput.ruleArtifacts || []
+        const modelId = validatedInput.modelId
 
         if (fileArtifacts.length === 0 && folderArtifacts.length === 0) {
             CodeReviewUtils.emitMetric(
@@ -182,7 +184,7 @@ export class CodeReview {
         const programmingLanguage = 'java'
         const scanName = 'Standard-' + randomUUID()
 
-        this.logging.info(`Agentic scan name: ${scanName}`)
+        this.logging.info(`Agentic scan name: ${scanName} selectedModel: ${modelId}`)
 
         return {
             fileArtifacts,
@@ -192,6 +194,7 @@ export class CodeReview {
             programmingLanguage,
             scanName,
             ruleArtifacts,
+            modelId,
         }
     }
 
@@ -274,6 +277,8 @@ export class CodeReview {
             codeScanName: setup.scanName,
             scope: CodeReview.SCAN_SCOPE,
             codeDiffMetadata: uploadResult.isCodeDiffPresent ? { codeDiffPath: '/code_artifact/codeDiff/' } : undefined,
+            languageModelId: setup.modelId,
+            clientType: Origin.IDE,
         })
 
         if (!createResponse.jobId) {
@@ -293,6 +298,7 @@ export class CodeReview {
                         customRules: setup.ruleArtifacts.length,
                         programmingLanguages: Array.from(uploadResult.programmingLanguages),
                         scope: setup.isFullReviewRequest ? FULL_REVIEW : CODE_DIFF_REVIEW,
+                        modelId: setup.modelId,
                     },
                 },
                 this.logging,
@@ -349,6 +355,7 @@ export class CodeReview {
                             programmingLanguages: Array.from(uploadResult.programmingLanguages),
                             scope: setup.isFullReviewRequest ? FULL_REVIEW : CODE_DIFF_REVIEW,
                             status: status,
+                            modelId: setup.modelId,
                         },
                     },
                     this.logging,
@@ -382,6 +389,7 @@ export class CodeReview {
                         programmingLanguages: Array.from(uploadResult.programmingLanguages),
                         scope: setup.isFullReviewRequest ? FULL_REVIEW : CODE_DIFF_REVIEW,
                         status: status,
+                        modelId: setup.modelId,
                     },
                 },
                 this.logging,
@@ -426,6 +434,7 @@ export class CodeReview {
                     programmingLanguages: Array.from(uploadResult.programmingLanguages),
                     scope: setup.isFullReviewRequest ? FULL_REVIEW : CODE_DIFF_REVIEW,
                     latency: Date.now() - this.toolStartTime,
+                    modelId: setup.modelId,
                 },
             },
             this.logging,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReviewSchemas.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReviewSchemas.ts
@@ -113,6 +113,7 @@ export const Z_CODE_REVIEW_INPUT_SCHEMA = z.object({
             })
         )
         .optional(),
+    modelId: z.string().optional(),
 })
 
 /**

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReviewSchemas.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReviewSchemas.ts
@@ -113,7 +113,7 @@ export const Z_CODE_REVIEW_INPUT_SCHEMA = z.object({
             })
         )
         .optional(),
-    modelId: z.string().optional(),
+    modelId: z.string(),
 })
 
 /**

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReviewTypes.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReviewTypes.ts
@@ -21,6 +21,7 @@ export type ValidateInputAndSetupResult = {
     programmingLanguage: string
     scanName: string
     ruleArtifacts: RuleArtifacts
+    modelId?: string
 }
 
 export type PrepareAndUploadArtifactsResult = {


### PR DESCRIPTION
## Problem
Currently for code review tool , the selected model data is not sent to the RTS requests.


## Solution
Hence adding additional attributes to send the selected model Id and origin related data

Tested in alpha (used RTS alpha to initiate a new scan)
modelId and origin is saved in scanMetadata table 
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
