### PR TITLE
fix: emit errorMessage in addMessage

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -3371,7 +3371,7 @@ export class AgenticChatController implements ChatHandlers {
         metric: Metric<CombinedConversationEvent>,
         agenticCodingMode: boolean
     ): Promise<ChatResult | ResponseError<ChatResult>> {
-        const errorMessage = getErrorMsg(err)
+        const errorMessage = getErrorMsg(err) ?? GENERIC_ERROR_MS
         const requestID = getRequestID(err) ?? ''
         metric.setDimension('cwsprChatResponseCode', getHttpStatusCode(err) ?? 0)
         metric.setDimension('languageServerVersion', this.#features.runtime.serverInfo.version)
@@ -3381,7 +3381,7 @@ export class AgenticChatController implements ChatHandlers {
         metric.metric.requestIds = [requestID]
         metric.metric.cwsprChatMessageId = errorMessageId
         metric.metric.cwsprChatConversationId = conversationId
-        await this.#telemetryController.emitAddMessageMetric(tabId, metric.metric, 'Failed')
+        await this.#telemetryController.emitAddMessageMetric(tabId, metric.metric, 'Failed', errorMessage)
 
         if (isUsageLimitError(err)) {
             if (this.#paidTierMode !== 'paidtier') {
@@ -3426,7 +3426,7 @@ export class AgenticChatController implements ChatHandlers {
                 tabId,
                 metric.metric,
                 requestID,
-                errorMessage ?? GENERIC_ERROR_MS,
+                errorMessage,
                 agenticCodingMode
             )
         }

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -294,7 +294,12 @@ export class ChatTelemetryController {
         })
     }
 
-    public emitAddMessageMetric(tabId: string, metric: Partial<CombinedConversationEvent>, result?: string) {
+    public emitAddMessageMetric(
+        tabId: string,
+        metric: Partial<CombinedConversationEvent>,
+        result?: string,
+        errorMessage?: string
+    ) {
         const conversationId = this.getConversationId(tabId)
         // Store the customization value associated with the message
         if (metric.cwsprChatMessageId && metric.codewhispererCustomizationArn) {
@@ -349,6 +354,7 @@ export class ChatTelemetryController {
                 requestIds: metric.requestIds,
                 experimentName: metric.experimentName,
                 userVariation: metric.userVariation,
+                errorMessage: errorMessage,
             }
         )
     }

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -859,6 +859,7 @@ describe('TelemetryService', () => {
                     cwsprChatPinnedFileContextCount: undefined,
                     cwsprChatPinnedFolderContextCount: undefined,
                     cwsprChatPinnedPromptContextCount: undefined,
+                    errorMessage: undefined,
                 },
             })
         })

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -564,6 +564,7 @@ export class TelemetryService {
             requestIds?: string[]
             experimentName?: string
             userVariation?: string
+            errorMessage?: string
         }>
     ) {
         const timeBetweenChunks = params.timeBetweenChunks?.slice(0, 100)
@@ -617,6 +618,7 @@ export class TelemetryService {
                     requestIds: truncatedRequestIds,
                     experimentName: additionalParams.experimentName,
                     userVariation: additionalParams.userVariation,
+                    errorMessage: additionalParams.errorMessage,
                 },
             })
         }


### PR DESCRIPTION
## Problem
CW dashboard requires errorMessage to be in addMessage

## Solution
emit errorMessage in addMessage

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
