### PR TITLE
[internal review]feat: add custom_transformation folder support to artifact.zip

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -22,16 +22,19 @@ const zipFileName = 'artifact.zip'
 const sourceCodeFolderName = 'sourceCode'
 const packagesFolderName = 'packages'
 const thirdPartyPackageFolderName = 'thirdpartypackages'
+const customTransformationFolderName = 'custom_transformation'
 
 export class ArtifactManager {
     private workspace: Workspace
     private logging: Logging
     private workspacePath: string
+    private solutionRootPath: string
 
-    constructor(workspace: Workspace, logging: Logging, workspacePath: string) {
+    constructor(workspace: Workspace, logging: Logging, workspacePath: string, solutionRootPath: string) {
         this.workspace = workspace
         this.logging = logging
         this.workspacePath = workspacePath
+        this.solutionRootPath = solutionRootPath
     }
 
     async createZip(request: StartTransformRequest): Promise<string> {
@@ -282,6 +285,14 @@ export class ArtifactManager {
             this.logging.log('Cannot find artifacts folder')
             return ''
         }
+
+        const customTransformationPath = path.join(this.solutionRootPath, customTransformationFolderName)
+        if (fs.existsSync(customTransformationPath)) {
+            this.logging.log(`Adding custom transformation folder to artifact: ${customTransformationPath}`)
+            const artifactCustomTransformationPath = path.join(folderPath, customTransformationFolderName)
+            fs.cpSync(customTransformationPath, artifactCustomTransformationPath, { recursive: true })
+        }
+
         const zipPath = path.join(this.workspacePath, zipFileName)
         this.logging.log('Zipping files to ' + zipPath)
         await this.zipDirectory(folderPath, zipPath)

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/artifactManager.createTransformationPreferencesContent.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/artifactManager.createTransformationPreferencesContent.test.ts
@@ -14,7 +14,7 @@ describe('ArtifactManager - createTransformationPreferencesContent', () => {
     beforeEach(() => {
         workspace = stubInterface<Workspace>()
         mockedLogging = stubInterface<Logging>()
-        artifactManager = new ArtifactManager(workspace, mockedLogging, '')
+        artifactManager = new ArtifactManager(workspace, mockedLogging, '', '')
 
         // Create a clean base request for each test
         baseRequest = {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/artifactManager.processPrivatePackages.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/artifactManager.processPrivatePackages.test.ts
@@ -17,7 +17,7 @@ describe('ArtifactManager - processPrivatePackages', () => {
     beforeEach(() => {
         workspace = stubInterface<Workspace>()
         // Create new instance of ArtifactManager before each test
-        artifactManager = new ArtifactManager(workspace, mockedLogging, '')
+        artifactManager = new ArtifactManager(workspace, mockedLogging, '', '')
 
         // Mock internal methods that might be called
         artifactManager.copyFile = async (source: string, destination: string) => {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/transformHandler.ts
@@ -58,7 +58,8 @@ export class TransformHandler {
         const artifactManager = new ArtifactManager(
             this.workspace,
             this.logging,
-            this.getWorkspacePath(userInputrequest.SolutionRootPath)
+            this.getWorkspacePath(userInputrequest.SolutionRootPath),
+            userInputrequest.SolutionRootPath
         )
         try {
             const payloadFilePath = await this.zipCodeAsync(userInputrequest, artifactManager)


### PR DESCRIPTION
## Summary
Adds support for including a `custom_transformation` folder from the solution root into the artifact.zip for .NET transformations.

## Changes
- Add `custom_transformation` folder detection and inclusion in artifact creation
- Update ArtifactManager constructor to accept solution root path
- Update tests to match new constructor signature

## Testing
- Existing tests updated and passing
- Custom transformation folder is only included if it exists in solution root

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
