### PR TITLE
fix(amazonq): fix to update MCP servers list when last server removed

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -231,6 +231,9 @@ export class McpManager {
             }
 
             this.features.logging.info(`MCP: completed initialization of ${totalServers} servers`)
+        } else {
+            // Emit event to refresh MCP list page when no servers are configured
+            this.setState('no-servers', McpServerStatus.UNINITIALIZED, 0)
         }
 
         for (const [sanitizedName, _] of this.mcpServers.entries()) {


### PR DESCRIPTION
## Problem

when all servers all manually removed from agent config, we do not refresh/update MCP list.

## Solution
- fix to update MCP servers list when last server removed by sending an no-servers state event.


https://github.com/user-attachments/assets/0d0f06f0-1dff-488c-a927-66560f007b97



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
