### PR TITLE
fix: move amazonq-ui.js from clients.zip to servers.zip

### DIFF
--- a/.github/workflows/agentic-prerelease-release-notes.md
+++ b/.github/workflows/agentic-prerelease-release-notes.md
@@ -10,9 +10,8 @@ Depending on your IDE plugin, you may have the following options available to yo
 
 ### Sideload a build into the plugin
 Download the bundle, then configure your plugin to use the downloaded build.
-- download clients.zip, and unzip it to a `clients` folder
 - download the servers zip for your platform, and unzip it to a `servers` folder
-- configure your plugin to use your downloaded client and server
+- configure your plugin to use your downloaded server (UI files are now included in the server bundle)
 
 ### Override the artifact manifest
 Configure your plugin to download and install the build linked to this release.

--- a/.github/workflows/create-agent-standalone.yml
+++ b/.github/workflows/create-agent-standalone.yml
@@ -34,8 +34,7 @@ jobs:
                   npm run ci:generate:agent-standalone -w app/aws-lsp-codewhisperer-runtimes
                   npm run ci:generate:agentic:attribution
 
-            # We "flatten" out each clients.zip-servers.zip pairing so that the
-            # downloadable artifacts are nicely organized, one per platform.
+            # Prepare and upload artifacts for each platform
             - name: Prepare and upload artifacts
               run: |
                   platforms=("linux-arm64" "linux-x64" "mac-arm64" "mac-x64" "win-x64")
@@ -43,22 +42,8 @@ jobs:
                     echo "Preparing artifacts for $platform"
                     mkdir -p "_artifacts/$platform"
 
-                    cp "app/aws-lsp-codewhisperer-runtimes/build/archives/shared/clients.zip" "_artifacts/$platform/"
                     cp "app/aws-lsp-codewhisperer-runtimes/build/archives/agent-standalone/$platform/servers.zip" "_artifacts/$platform/"
                   done
-                  mkdir -p "_artifacts/clients"
-                  unzip "app/aws-lsp-codewhisperer-runtimes/build/archives/shared/clients.zip" -d _artifacts/clients
-
-            # GitHub Actions zips the archive, so we upload the folder used to
-            # produce clients.zip. Otherwise we have a clients.zip artifact
-            # that contains our clients.zip file.
-            # app/aws-lsp-codewhisperer-runtimes/build/archives/shared/clients.zip
-            - name: Upload clients.zip
-              uses: actions/upload-artifact@v4
-              with:
-                  name: clients
-                  path: _artifacts/clients/
-                  if-no-files-found: error
 
             - name: Upload linux-arm64
               uses: actions/upload-artifact@v4

--- a/.github/workflows/create-agentic-github-prerelease.yml
+++ b/.github/workflows/create-agentic-github-prerelease.yml
@@ -128,9 +128,6 @@ jobs:
                     cp downloaded-artifacts/$platform/servers.zip _release-artifacts/$platform-servers.zip
                   done
 
-                  # clients.zip : just pick one of the platforms, they're all the same file
-                  cp downloaded-artifacts/linux-x64/clients.zip _release-artifacts/clients.zip
-
                   # THIRD_PARTY_LICENSES
                   cp downloaded-artifacts/THIRD_PARTY_LICENSES/THIRD_PARTY_LICENSES _release-artifacts/THIRD_PARTY_LICENSES
 

--- a/app/aws-lsp-codewhisperer-runtimes/scripts/create-repo-manifest.ts
+++ b/app/aws-lsp-codewhisperer-runtimes/scripts/create-repo-manifest.ts
@@ -55,7 +55,6 @@ interface Params {
 }
 
 const serversZipName = 'servers.zip'
-const clientsZipName = 'clients.zip'
 
 /**
  * Updates the manifest file with new version information or performs rollback operations.
@@ -70,7 +69,7 @@ const clientsZipName = 'clients.zip'
  *
  * @description
  * This function performs the following operations:
- * 1. Calculates SHA384 checksums and file sizes for clients.zip and servers.zip files.
+ * 1. Calculates SHA384 checksums and file sizes for servers.zip files.
  * 2. Generates a new manifest entry with the provided and calculated information.
  * 3. Produces a manifest file, containing only this one version.
  * 4. Saves the updated manifest to a file.
@@ -93,18 +92,6 @@ export async function updateManifest(
         const bytes = await run(`wc -c < ${serverZipPath}`)
         return {
             url: getGitHubReleaseDownloadUrl(path.basename(serverZipPath)),
-            hash: sha,
-            bytes: bytes,
-        }
-    }
-
-    const clientZipPath = path.join(releaseArtifactsPath, clientsZipName)
-
-    async function getClientZipFileInfo() {
-        const sha = await run(`sha384sum ${clientZipPath} | awk '{print $1}'`)
-        const bytes = await run(`wc -c < ${clientZipPath}`)
-        return {
-            url: getGitHubReleaseDownloadUrl(clientsZipName),
             hash: sha,
             bytes: bytes,
         }
@@ -137,7 +124,7 @@ export async function updateManifest(
                 arm64: await getServerZipFileInfo('mac', 'arm64'),
             },
         },
-        clientZip: await getClientZipFileInfo(),
+
         licensesURL,
     })
 
@@ -170,16 +157,11 @@ interface EntryParameters {
             arm64: FileInfo
         }
     }
-    clientZip: FileInfo
+
     licensesURL: string
 }
 
-function generateNewEntry({
-    version,
-    serverZips,
-    clientZip,
-    licensesURL,
-}: EntryParameters): ManifestServerVersionEntry {
+function generateNewEntry({ version, serverZips, licensesURL }: EntryParameters): ManifestServerVersionEntry {
     return {
         serverVersion: version.server,
         isDelisted: false,
@@ -199,12 +181,6 @@ function generateNewEntry({
                         hashes: [`sha384:${serverZips.win.x64.hash}`],
                         bytes: parseInt(serverZips.win.x64.bytes),
                     },
-                    {
-                        filename: clientsZipName,
-                        url: clientZip.url,
-                        hashes: [`sha384:${clientZip.hash}`],
-                        bytes: parseInt(clientZip.bytes),
-                    },
                 ],
             },
             {
@@ -216,12 +192,6 @@ function generateNewEntry({
                         url: serverZips.win.arm64.url,
                         hashes: [`sha384:${serverZips.win.arm64.hash}`],
                         bytes: parseInt(serverZips.win.arm64.bytes),
-                    },
-                    {
-                        filename: clientsZipName,
-                        url: clientZip.url,
-                        hashes: [`sha384:${clientZip.hash}`],
-                        bytes: parseInt(clientZip.bytes),
                     },
                 ],
             },
@@ -235,12 +205,6 @@ function generateNewEntry({
                         hashes: [`sha384:${serverZips.linux!.x64.hash}`],
                         bytes: parseInt(serverZips.linux!.x64.bytes),
                     },
-                    {
-                        filename: clientsZipName,
-                        url: clientZip.url,
-                        hashes: [`sha384:${clientZip.hash}`],
-                        bytes: parseInt(clientZip.bytes),
-                    },
                 ],
             },
             {
@@ -252,12 +216,6 @@ function generateNewEntry({
                         url: serverZips.linux!.arm64.url,
                         hashes: [`sha384:${serverZips.linux!.arm64.hash}`],
                         bytes: parseInt(serverZips.linux!.arm64.bytes),
-                    },
-                    {
-                        filename: clientsZipName,
-                        url: clientZip.url,
-                        hashes: [`sha384:${clientZip.hash}`],
-                        bytes: parseInt(clientZip.bytes),
                     },
                 ],
             },
@@ -271,12 +229,6 @@ function generateNewEntry({
                         hashes: [`sha384:${serverZips.mac!.x64.hash}`],
                         bytes: parseInt(serverZips.mac!.x64.bytes),
                     },
-                    {
-                        filename: clientsZipName,
-                        url: clientZip.url,
-                        hashes: [`sha384:${clientZip.hash}`],
-                        bytes: parseInt(clientZip.bytes),
-                    },
                 ],
             },
             {
@@ -288,12 +240,6 @@ function generateNewEntry({
                         url: serverZips.mac!.arm64.url,
                         hashes: [`sha384:${serverZips.mac!.arm64.hash}`],
                         bytes: parseInt(serverZips.mac!.arm64.bytes),
-                    },
-                    {
-                        filename: clientsZipName,
-                        url: clientZip.url,
-                        hashes: [`sha384:${clientZip.hash}`],
-                        bytes: parseInt(clientZip.bytes),
                     },
                 ],
             },

--- a/app/aws-lsp-codewhisperer-runtimes/scripts/package.sh
+++ b/app/aws-lsp-codewhisperer-runtimes/scripts/package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script collects all of the files needed for bundling and packages them
-# into clients.zip and one servers.zip file per platform.
+# into one servers.zip file per platform.
 # Bundled outputs are placed in
 # - build/archives/agent-standalone/(platform)-(architecture)
 # - build/archives/shared
@@ -18,10 +18,8 @@ TARGET_BUILD_DIR=./build/private/bundle/client
 mkdir -p $TARGET_BUILD_DIR
 cp -r $CHAT_CLIENT_BUNDLE_DIR/* $TARGET_BUILD_DIR
 
-# ZIP client files
+# Create archives directory
 ARCHIVES_DIR=./build/archives
-mkdir -p $ARCHIVES_DIR/shared
-zip -j $ARCHIVES_DIR/shared/clients.zip $TARGET_BUILD_DIR/*
 
 # Create tempdir for unzipped qcontext files
 TEMP_DIR=$(mktemp -d)
@@ -68,35 +66,35 @@ for config in "${configs[@]}"; do
 
     # Win x64
     zip -j $ARCHIVES_DIR/${config}/win-x64/servers.zip \
-        ./build/private/assets/win-x64/*
+        ./build/private/assets/win-x64/* $TARGET_BUILD_DIR/amazonq-ui.js
     if [ "$config" = "agent-standalone" ]; then
         (cd $TEMP_DIR/win-x64 && zip -r $OLDPWD/$ARCHIVES_DIR/${config}/win-x64/servers.zip indexing ripgrep/rg.exe)
     fi
 
     # Linux x64
     zip -j $ARCHIVES_DIR/${config}/linux-x64/servers.zip \
-        ./build/private/assets/linux-x64/*
+        ./build/private/assets/linux-x64/* $TARGET_BUILD_DIR/amazonq-ui.js
     if [ "$config" = "agent-standalone" ]; then
         (cd $TEMP_DIR/linux-x64 && zip -r $OLDPWD/$ARCHIVES_DIR/${config}/linux-x64/servers.zip indexing ripgrep/rg)
     fi
 
     # Mac x64
     zip -j $ARCHIVES_DIR/${config}/mac-x64/servers.zip \
-        ./build/private/assets/mac-x64/*
+        ./build/private/assets/mac-x64/* $TARGET_BUILD_DIR/amazonq-ui.js
     if [ "$config" = "agent-standalone" ]; then
         (cd $TEMP_DIR/mac-x64 && zip -r $OLDPWD/$ARCHIVES_DIR/${config}/mac-x64/servers.zip indexing ripgrep/rg)
     fi
 
     # Linux ARM64
     zip -j $ARCHIVES_DIR/${config}/linux-arm64/servers.zip \
-        ./build/private/assets/linux-arm64/*
+        ./build/private/assets/linux-arm64/* $TARGET_BUILD_DIR/amazonq-ui.js
     if [ "$config" = "agent-standalone" ]; then
         (cd $TEMP_DIR/linux-arm64 && zip -r $OLDPWD/$ARCHIVES_DIR/${config}/linux-arm64/servers.zip indexing ripgrep/rg)
     fi
 
     # Mac ARM64
     zip -j $ARCHIVES_DIR/${config}/mac-arm64/servers.zip \
-        ./build/private/assets/mac-arm64/*
+        ./build/private/assets/mac-arm64/* $TARGET_BUILD_DIR/amazonq-ui.js
     if [ "$config" = "agent-standalone" ]; then
         (cd $TEMP_DIR/mac-arm64 && zip -r $OLDPWD/$ARCHIVES_DIR/${config}/mac-arm64/servers.zip indexing ripgrep/rg)
     fi


### PR DESCRIPTION
## Problem
Windows Defender occasionally, incorrectly flags the Amazon Q Developer plugin for malicious code. In particular, the `clients.zip` folder downloaded as part of the language server bundle is falsely flagged with the following errors:

<img width="1197" height="930" alt="Screenshot 2025-09-03 at 1 37 30 PM" src="https://github.com/user-attachments/assets/83efd590-6e4d-446c-a9a1-e62244308ea0" />


```
Activity details :
•   'Wacatac' malware was detected
Suspicious Files observed :
•   File Path: aws\toolkits\language-servers\AmazonQ\1.27.0\clients.zip

```

```
Trojan:Script/Wacatac.H!ml
Alert level: Severe
Status: Active
Date: 8/12/2025 9:15 AM
Category: Trojan
Details: This program is dangerous and executes commands from an
attacker.
Learn more
Affected items:
file: C:\Users\username\AppData\Local\aws\toolkits\language-servers\AmazonQ\1.27.0\clients.zip
```

## Solution
Bundle the single `amazonq-ui.js` file contained in clients.zip in the servers.zip instead

- `package.sh` - Modified to include `amazonq-ui.js` in `servers.zip` instead of creating `clients.zip`

- `create-repo-manifest.ts` - Removed all clients.zip references from manifest generation

- `create-agent-standalone.yml` - Removed clients.zip upload steps from workflow - [Test Run](https://github.com/tsmithsz/language-servers/actions/runs/17472277267)

- `agentic-prerelease-release-notes.md` - Updated installation instructions

These changes eliminate the Windows Defender flagging issue by moving the large JavaScript file from a separate `clients.zip` to the platform-specific `servers.zip` files.


## Testing

Tested on Windows Defender, VirusTotal and Microsoft Security Intelligence



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
