### PR TITLE
feat: upgrade node version from 18 to 24

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/scripts/download-node.sh
+++ b/app/aws-lsp-codewhisperer-runtimes/scripts/download-node.sh
@@ -5,7 +5,7 @@
 # by src/scripts/copy-node-assets.ts, to produce the final bundle.
 
 set -e
-NODE_VERSION="18"
+NODE_VERSION="24"
 BASE_URL="https://nodejs.org/download/release/latest-v${NODE_VERSION}.x"
 SHASUMS_FILE="SHASUMS256.txt"
 ASSETS_DIR="build/node-assets"


### PR DESCRIPTION
## Problem
- Existing node version 18 is at EOL.
## Solution
- Upgrading node version from 18 to 24.
<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
