### PR TITLE
fix: inline UTD telemetry empty cases dont differentiate Edit and Completion

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts
@@ -519,7 +519,11 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
                 authType: 'token' as const,
             }
 
-            const r = this.mapCodeWhispererApiResponseToSuggestion(response, responseContext)
+            const r = this.mapCodeWhispererApiResponseToSuggestion(
+                response,
+                tokenRequest.predictionTypes,
+                responseContext
+            )
             const firstSuggestionLogstr = r.suggestions.length > 0 ? `\n${r.suggestions[0].content}` : 'No suggestion'
 
             logstr += `@@response metadata@@
@@ -543,7 +547,7 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
 
     private mapCodeWhispererApiResponseToSuggestion(
         apiResponse: GenerateCompletionsResponse,
-        request: GenerateTokenSuggestionsRequest,
+        requestPredictionType: CodeWhispererTokenClient.PredictionTypes | undefined,
         responseContext: ResponseContext
     ): GenerateSuggestionsResponse {
         // "Predictions" will be returned if clients speicifed predictionType in the generateCompletion request, otherwise "Completions" will be returned for the backward compatibility
@@ -563,7 +567,6 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
                     responseContext,
                 }
             } else if (apiResponse.predictions.length === 0) {
-                const requestPredictionType = request.predictionTypes
                 const suggestionType =
                     requestPredictionType && requestPredictionType.includes('EDITS')
                         ? SuggestionType.EDIT


### PR DESCRIPTION
## Problem

suggestionType is inferred by the statements
https://github.com/aws/language-servers/blob/main/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts#L544-L572

specifically
```
if (apiResponse?.predictions && apiResponse.predictions.length > 0) {
            const suggestionType = apiResponse.predictions[0].edit ? SuggestionType.EDIT : SuggestionType.COMPLETION
            const predictionType = suggestionType === SuggestionType.COMPLETION ? 'completion' : 'edit'

            return {
                suggestions: apiResponse.predictions.map(prediction => ({
                    content: prediction[predictionType]?.content ?? '',
                    references: prediction[predictionType]?.references ?? [],
                    itemId: this.generateItemId(),
                })),
                suggestionType,
                responseContext,
            }
        }
```
so if it's an Edit request and service returns empty suggestion then it will be determined as "Completion".


## Solution
If no suggestion, use client specified predictionType as suggestion type.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
