### PR TITLE
ci: remove condition preventing manual trigger of build actions

### DIFF
--- a/.github/workflows/create-agent-standalone.yml
+++ b/.github/workflows/create-agent-standalone.yml
@@ -8,7 +8,6 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
-        if: github.event_name == 'push' || github.actor_id == github.repository_owner_id
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
## Problem
The `create-agent-standalone.yml` workflow requires empty commits to trigger builds on release branches because the job condition `github.actor_id == github.repository_owner_id` fails for collaborators with write access (only works for admin users).

## Solution
Remove the redundant if condition and rely on GitHub's built-in permissions. GitHub automatically restricts workflow triggers to users with appropriate repository permissions. This eliminates the need for workaround empty commits while maintaining security through GitHub's native access controls.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
