### PR TITLE
fix: quick fix for repeated logging from squashed commit

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/artifactManager.ts
@@ -182,10 +182,6 @@ export class ArtifactManager {
                         //if can't generate hash then file copy failed previously
                         continue
                     }
-                    if (contentHash.length == 0) {
-                        //if can't generate hash then file copy failed previously
-                        continue
-                    }
                     const relativePath = this.normalizeSourceFileRelativePath(request.SolutionRootPath, filePath)
                     codeFiles.push({
                         contentMd5Hash: contentHash,
@@ -331,15 +327,6 @@ export class ArtifactManager {
         if (failedCopies.length > 0) {
             this.logging.log(`Files - ${failedCopies.join(',')} - could not be copied.`)
         }
-        this.logging.log(
-            `Files with extensions ${filteredExtensions.join(', ')} are not zipped, as they are not necessary for transformation`
-        )
-        this.logging.log(
-            `Files in directories ${filteredDirectories.join(', ')} are not zipped, as they are not necessary for transformation`
-        )
-        if (failedCopies.length > 0) {
-            this.logging.log(`Files - ${failedCopies.join(',')} - could not be copied.`)
-        }
         const zipPath = path.join(this.workspacePath, zipFileName)
         this.logging.log('Zipping files to ' + zipPath)
         await this.zipDirectory(folderPath, zipPath)
@@ -439,8 +426,6 @@ export class ArtifactManager {
                 fs.copyFile(sourceFilePath, destFilePath, err => {
                     if (err) {
                         this.logging.log(`Failed to copy from ${sourceFilePath} and error is ${err}`)
-                        failedCopies.push(sourceFilePath)
-                        resolve()
                         failedCopies.push(sourceFilePath)
                         resolve()
                     } else {


### PR DESCRIPTION
## Problem

There are some repeat logging statements as a result of multiple commits from this [merged PR](https://github.com/aws/language-servers/pull/2233/files). **This issue is not breaking, as overall functionality has been tested successfully.**

## Solution

Removal of the repeated code logs, to only log the information once. 

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
