### PR TITLE
fix(amazonq): fix to add filewatcher for mcp config files

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.ts
@@ -12,7 +12,14 @@ import {
     Status,
 } from '@aws/language-server-runtimes/protocol'
 
-import { getGlobalAgentConfigPath, getWorkspaceAgentConfigPaths, sanitizeName, normalizePathFromUri } from './mcpUtils'
+import {
+    getGlobalAgentConfigPath,
+    getWorkspaceAgentConfigPaths,
+    sanitizeName,
+    normalizePathFromUri,
+    getWorkspaceMcpConfigPaths,
+    getGlobalMcpConfigPath,
+} from './mcpUtils'
 import {
     McpPermissionType,
     MCPServerConfig,
@@ -1472,13 +1479,15 @@ export class McpEventHandler {
             this.#features.logging.warn(`Failed to get user home directory: ${e}`)
         }
 
-        // Only watch agent config files
+        // Watch both agent config files and MCP config files
         const agentPaths = [
             ...getWorkspaceAgentConfigPaths(wsUris),
             ...(homeDir ? [getGlobalAgentConfigPath(homeDir)] : []),
         ]
 
-        const allPaths = [...agentPaths]
+        const mcpPaths = [...getWorkspaceMcpConfigPaths(wsUris), ...(homeDir ? [getGlobalMcpConfigPath(homeDir)] : [])]
+
+        const allPaths = [...agentPaths, ...mcpPaths]
 
         this.#fileWatcher.watchPaths(allPaths, () => {
             // Store the current programmatic state when the event is triggered

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -1003,7 +1003,8 @@ export class McpManager {
                     null, // Don't save server config to agent file for legacy servers
                     serverTools,
                     serverAllowedTools,
-                    agentPath
+                    agentPath,
+                    isLegacyMcpServer
                 )
             }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -1010,7 +1010,8 @@ export async function saveServerSpecificAgentConfig(
     serverConfig: any,
     serverTools: string[],
     serverAllowedTools: string[],
-    configPath: string
+    configPath: string,
+    isLegacyMcpServer: boolean = false
 ): Promise<void> {
     try {
         await workspace.fs.mkdir(path.dirname(configPath), { recursive: true })
@@ -1043,12 +1044,14 @@ export async function saveServerSpecificAgentConfig(
             tool => tool !== serverPrefix && !tool.startsWith(`${serverPrefix}/`)
         )
 
-        if (serverConfig === null) {
-            // Remove server entirely
-            delete existingConfig.mcpServers[serverName]
-        } else {
-            // Update or add server
-            existingConfig.mcpServers[serverName] = serverConfig
+        if (!isLegacyMcpServer) {
+            if (serverConfig === null) {
+                // Remove server entirely
+                delete existingConfig.mcpServers[serverName]
+            } else {
+                // Update or add server
+                existingConfig.mcpServers[serverName] = serverConfig
+            }
         }
 
         // Add new server tools


### PR DESCRIPTION
## Problem
Filewatchers needs to be attached to mcp config as well

## Solution
- Added filewatchers as well

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
