### PR TITLE
fix(amazonq): fix for mcp permissions read/write inconsistencies

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/agentPermissionManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/agentPermissionManager.test.ts
@@ -19,7 +19,12 @@ describe('AgentPermissionManager', () => {
             tools: [],
             allowedTools: [],
         }
-        manager = new AgentPermissionManager(agentConfig)
+        manager = new AgentPermissionManager(
+            agentConfig,
+            undefined, // getAvailableTools
+            undefined, // getAllAvailableServers
+            undefined // getAllBuiltinTools
+        )
     })
 
     describe('matchesPattern', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/agentPermissionManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/agentPermissionManager.ts
@@ -9,7 +9,12 @@ import { AgentConfig, McpPermissionType } from './mcpTypes'
  * Manages agent tool permissions with wildcard support for reading and simple patterns for writing
  */
 export class AgentPermissionManager {
-    constructor(private agentConfig: AgentConfig) {}
+    constructor(
+        private agentConfig: AgentConfig,
+        private getAvailableTools?: (serverName: string) => string[],
+        private getAllAvailableServers?: () => string[],
+        private getAllBuiltinTools?: () => string[]
+    ) {}
 
     /**
      * Check if a tool matches a pattern using glob-style wildcards
@@ -36,19 +41,29 @@ export class AgentPermissionManager {
         const toolId = serverName ? `@${serverName}/${toolName}` : toolName
         const serverPrefix = serverName ? `@${serverName}` : ''
 
-        // Check exact matches first
+        // Check exact matches first (exact matches take precedence)
         if (this.agentConfig.tools.includes(toolId)) return true
         if (serverPrefix && this.agentConfig.tools.includes(serverPrefix)) return true
+
+        // Check for global wildcard
+        if (this.agentConfig.tools.includes('*')) return true
+
+        // Check for @builtin pattern (built-in tools only)
+        if (!serverName && this.agentConfig.tools.includes('@builtin')) return true
 
         // Check wildcard patterns
         for (const tool of this.agentConfig.tools) {
             if (tool.includes('*') || tool.includes('?')) {
+                // For server patterns like @*-mcp, match against server prefix
+                if (serverName && tool.startsWith('@') && !tool.includes('/')) {
+                    if (this.matchesPattern(serverPrefix, tool)) return true
+                }
+                // For full tool patterns
                 if (this.matchesPattern(toolId, tool)) return true
             }
         }
 
-        // Check for global wildcard
-        return this.agentConfig.tools.includes('*')
+        return false
     }
 
     /**
@@ -76,66 +91,77 @@ export class AgentPermissionManager {
      * Get permission type for a tool
      */
     getToolPermission(serverName: string, toolName: string): McpPermissionType {
-        const isEnabled = this.isToolEnabled(serverName, toolName)
-        const isAlwaysAllowed = this.isToolAlwaysAllowed(serverName, toolName)
+        const toolId = serverName ? `@${serverName}/${toolName}` : toolName
+        const serverPrefix = serverName ? `@${serverName}` : ''
 
-        // If tool is always allowed, it's implicitly enabled
-        if (isAlwaysAllowed) {
+        // Check exact matches first (exact matches take precedence over patterns)
+        const exactInTools = this.agentConfig.tools.includes(toolId)
+        const exactInAllowed = this.agentConfig.allowedTools.includes(toolId)
+        const serverInTools = serverPrefix && this.agentConfig.tools.includes(serverPrefix)
+        const serverInAllowed = serverPrefix && this.agentConfig.allowedTools.includes(serverPrefix)
+
+        // If exact match in allowedTools or server-wide in allowedTools
+        if (exactInAllowed || serverInAllowed) {
             return McpPermissionType.alwaysAllow
         }
 
-        // If tool is enabled but not always allowed, ask for permission
+        // If exact match in tools, check if also in allowedTools patterns
+        if (exactInTools) {
+            const isAlwaysAllowed = this.isToolAlwaysAllowed(serverName, toolName)
+            return isAlwaysAllowed ? McpPermissionType.alwaysAllow : McpPermissionType.ask
+        }
+
+        // If server-wide in tools, check if also in allowedTools patterns
+        if (serverInTools) {
+            const isAlwaysAllowed = this.isToolAlwaysAllowed(serverName, toolName)
+            return isAlwaysAllowed ? McpPermissionType.alwaysAllow : McpPermissionType.ask
+        }
+
+        // Fall back to pattern matching
+        const isEnabled = this.isToolEnabled(serverName, toolName)
+        const isAlwaysAllowed = this.isToolAlwaysAllowed(serverName, toolName)
+
+        // Tool must be enabled first before it can be always allowed
+        if (isEnabled && isAlwaysAllowed) {
+            return McpPermissionType.alwaysAllow
+        }
+
         if (isEnabled) {
             return McpPermissionType.ask
         }
 
-        // Tool is not enabled and not always allowed
         return McpPermissionType.deny
     }
 
     /**
-     * Set permission for a tool (uses simple patterns for writing)
+     * Set permission for a tool - removes conflicting wildcards and replaces with explicit tools
      */
     setToolPermission(serverName: string, toolName: string, permission: McpPermissionType): void {
         const toolId = serverName ? `@${serverName}/${toolName}` : toolName
         const serverPrefix = serverName ? `@${serverName}` : ''
 
-        // Remove conflicting wildcards that would affect this tool
-        this.removeConflictingWildcards(toolId)
-
         switch (permission) {
             case McpPermissionType.deny:
-                this.removeTool(toolId, serverPrefix)
-                this.removeFromAllowedTools(toolId, serverPrefix)
+                this.removeConflictingWildcardsForDeny(serverName, toolName)
+                this.removeConflictingAllowedWildcardsForDeny(serverName, toolName)
                 break
 
             case McpPermissionType.ask:
-                this.addTool(toolId)
-                this.removeFromAllowedTools(toolId, serverPrefix)
+                this.removeConflictingAllowedWildcardsForAsk(serverName, toolName)
+                if (!this.isToolEnabled(serverName, toolName)) {
+                    this.addTool(toolId)
+                }
                 break
 
             case McpPermissionType.alwaysAllow:
-                this.addTool(toolId)
-                this.addToAllowedTools(toolId)
+                if (!this.isToolEnabled(serverName, toolName)) {
+                    this.addTool(toolId)
+                }
+                if (!this.isToolAlwaysAllowed(serverName, toolName)) {
+                    this.addToAllowedTools(toolId)
+                }
                 break
         }
-    }
-
-    /**
-     * Remove wildcards that would conflict with specific tool permission
-     */
-    private removeConflictingWildcards(toolId: string): void {
-        // Remove wildcards from tools array that would match this tool
-        this.agentConfig.tools = this.agentConfig.tools.filter(tool => {
-            if (!tool.includes('*') && !tool.includes('?')) return true
-            return !this.matchesPattern(toolId, tool)
-        })
-
-        // Remove wildcards from allowedTools array that would match this tool
-        this.agentConfig.allowedTools = this.agentConfig.allowedTools.filter(tool => {
-            if (!tool.includes('*') && !tool.includes('?')) return true
-            return !this.matchesPattern(toolId, tool)
-        })
     }
 
     /**
@@ -164,7 +190,7 @@ export class AgentPermissionManager {
     }
 
     /**
-     * Remove tool from allowedTools array
+     * Remove tool from allowedTools array (only exact matches)
      */
     private removeFromAllowedTools(toolId: string, serverPrefix?: string): void {
         this.agentConfig.allowedTools = this.agentConfig.allowedTools.filter(
@@ -200,6 +226,270 @@ export class AgentPermissionManager {
                 this.addToAllowedTools(serverPrefix)
                 break
         }
+    }
+
+    /**
+     * Convert server-wide permission to individual tools, excluding the denied tool
+     */
+    private convertServerWideToIndividualTools(serverName: string, deniedToolName: string): void {
+        const serverPrefix = `@${serverName}`
+
+        // Remove server-wide permission
+        this.agentConfig.tools = this.agentConfig.tools.filter(tool => tool !== serverPrefix)
+
+        // If we have a callback to get available tools, add them individually
+        if (this.getAvailableTools) {
+            const availableTools = this.getAvailableTools(serverName)
+            for (const toolName of availableTools) {
+                if (toolName !== deniedToolName) {
+                    const toolId = `@${serverName}/${toolName}`
+                    this.addTool(toolId)
+                }
+            }
+        }
+        // If no callback, we just remove server-wide permission (limitation)
+    }
+
+    /**
+     * Remove conflicting wildcards from tools when denying a tool
+     */
+    private removeConflictingWildcardsForDeny(serverName: string, toolName: string): void {
+        const toolId = serverName ? `@${serverName}/${toolName}` : toolName
+        const serverPrefix = serverName ? `@${serverName}` : ''
+
+        // Handle global wildcard (*)
+        if (this.agentConfig.tools.includes('*')) {
+            this.expandGlobalWildcard(serverName, toolName)
+        }
+
+        // Handle server-wide wildcard (@server)
+        if (serverPrefix && this.agentConfig.tools.includes(serverPrefix)) {
+            this.convertServerWideToIndividualTools(serverName, toolName)
+        }
+
+        // Handle @builtin wildcard
+        if (!serverName && this.agentConfig.tools.includes('@builtin')) {
+            this.expandBuiltinWildcard(toolName)
+        }
+
+        // Handle pattern wildcards
+        this.removeMatchingPatternWildcards(serverName, toolName)
+
+        // Remove explicit tool entry
+        this.removeTool(toolId, serverPrefix)
+    }
+
+    /**
+     * Remove conflicting wildcards from allowedTools when denying a tool
+     */
+    private removeConflictingAllowedWildcardsForDeny(serverName: string, toolName: string): void {
+        const toolId = serverName ? `@${serverName}/${toolName}` : toolName
+        const serverPrefix = serverName ? `@${serverName}` : ''
+
+        // Remove exact matches
+        this.agentConfig.allowedTools = this.agentConfig.allowedTools.filter(
+            tool => tool !== toolId && tool !== serverPrefix
+        )
+
+        // Remove matching wildcards and expand them
+        const toRemove: string[] = []
+        for (const allowedTool of this.agentConfig.allowedTools) {
+            if (allowedTool.includes('*') || allowedTool.includes('?')) {
+                if (this.matchesPattern(toolId, allowedTool)) {
+                    toRemove.push(allowedTool)
+                }
+            }
+        }
+
+        for (const pattern of toRemove) {
+            this.expandAllowedPatternWildcard(pattern, serverName, toolName)
+        }
+    }
+
+    /**
+     * Remove conflicting wildcards from allowedTools when setting to ask
+     */
+    private removeConflictingAllowedWildcardsForAsk(serverName: string, toolName: string): void {
+        const toolId = serverName ? `@${serverName}/${toolName}` : toolName
+        const serverPrefix = serverName ? `@${serverName}` : ''
+
+        // Remove exact matches
+        this.agentConfig.allowedTools = this.agentConfig.allowedTools.filter(
+            tool => tool !== toolId && tool !== serverPrefix
+        )
+
+        // Remove matching wildcards and expand them (excluding the tool being set to ask)
+        const toRemove: string[] = []
+        for (const allowedTool of this.agentConfig.allowedTools) {
+            if (allowedTool.includes('*') || allowedTool.includes('?')) {
+                if (this.matchesPattern(toolId, allowedTool)) {
+                    toRemove.push(allowedTool)
+                }
+            }
+        }
+
+        for (const pattern of toRemove) {
+            this.expandAllowedPatternWildcard(pattern, serverName, toolName)
+        }
+    }
+
+    /**
+     * Expand global wildcard (*) to all available tools except the denied one
+     */
+    private expandGlobalWildcard(deniedServerName: string, deniedToolName: string): void {
+        this.agentConfig.tools = this.agentConfig.tools.filter(tool => tool !== '*')
+
+        if (this.getAvailableTools) {
+            // Get all available servers (this should be provided by the manager)
+            const allServers = this.getAvailableServers()
+            for (const serverName of allServers) {
+                const tools = this.getAvailableTools(serverName)
+                for (const toolName of tools) {
+                    if (!(serverName === deniedServerName && toolName === deniedToolName)) {
+                        this.addTool(`@${serverName}/${toolName}`)
+                    }
+                }
+            }
+
+            // Add builtin tools (except denied one)
+            const builtinTools = this.getBuiltinTools()
+            for (const toolName of builtinTools) {
+                if (!(deniedServerName === '' && toolName === deniedToolName)) {
+                    this.addTool(toolName)
+                }
+            }
+        }
+    }
+
+    /**
+     * Expand @builtin wildcard to all builtin tools except the denied one
+     */
+    private expandBuiltinWildcard(deniedToolName: string): void {
+        this.agentConfig.tools = this.agentConfig.tools.filter(tool => tool !== '@builtin')
+
+        const builtinTools = this.getBuiltinTools()
+        for (const toolName of builtinTools) {
+            if (toolName !== deniedToolName) {
+                this.addTool(toolName)
+            }
+        }
+    }
+
+    /**
+     * Remove pattern wildcards that match the tool and expand them
+     */
+    private removeMatchingPatternWildcards(serverName: string, toolName: string): void {
+        const toolId = serverName ? `@${serverName}/${toolName}` : toolName
+        const serverPrefix = serverName ? `@${serverName}` : ''
+
+        const toRemove: string[] = []
+        for (const tool of this.agentConfig.tools) {
+            if (tool.includes('*') || tool.includes('?')) {
+                if (serverName && tool.startsWith('@') && !tool.includes('/')) {
+                    if (this.matchesPattern(serverPrefix, tool)) {
+                        toRemove.push(tool)
+                    }
+                } else if (this.matchesPattern(toolId, tool)) {
+                    toRemove.push(tool)
+                }
+            }
+        }
+
+        for (const pattern of toRemove) {
+            this.expandPatternWildcard(pattern, serverName, toolName)
+        }
+    }
+
+    /**
+     * Expand a pattern wildcard to individual tools except the denied one
+     */
+    private expandPatternWildcard(pattern: string, deniedServerName: string, deniedToolName: string): void {
+        this.agentConfig.tools = this.agentConfig.tools.filter(tool => tool !== pattern)
+
+        if (!this.getAvailableTools) return
+
+        if (pattern.startsWith('@') && !pattern.includes('/')) {
+            // Server pattern like @*-mcp
+            const allServers = this.getAvailableServers()
+            for (const serverName of allServers) {
+                const serverPrefix = `@${serverName}`
+                if (this.matchesPattern(serverPrefix, pattern)) {
+                    const tools = this.getAvailableTools(serverName)
+                    for (const toolName of tools) {
+                        if (!(serverName === deniedServerName && toolName === deniedToolName)) {
+                            this.addTool(`@${serverName}/${toolName}`)
+                        }
+                    }
+                }
+            }
+        } else {
+            // Tool pattern like @fs/read_*
+            const allServers = this.getAvailableServers()
+            for (const serverName of allServers) {
+                const tools = this.getAvailableTools(serverName)
+                for (const toolName of tools) {
+                    const toolId = `@${serverName}/${toolName}`
+                    if (this.matchesPattern(toolId, pattern)) {
+                        if (!(serverName === deniedServerName && toolName === deniedToolName)) {
+                            this.addTool(toolId)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Expand allowedTools pattern wildcard except the denied tool
+     */
+    private expandAllowedPatternWildcard(pattern: string, deniedServerName: string, deniedToolName: string): void {
+        this.agentConfig.allowedTools = this.agentConfig.allowedTools.filter(tool => tool !== pattern)
+
+        if (!this.getAvailableTools) return
+
+        if (pattern.startsWith('@') && !pattern.includes('/')) {
+            // Server pattern like @git
+            const allServers = this.getAvailableServers()
+            for (const serverName of allServers) {
+                const serverPrefix = `@${serverName}`
+                if (this.matchesPattern(serverPrefix, pattern)) {
+                    const tools = this.getAvailableTools(serverName)
+                    for (const toolName of tools) {
+                        if (!(serverName === deniedServerName && toolName === deniedToolName)) {
+                            this.addToAllowedTools(`@${serverName}/${toolName}`)
+                        }
+                    }
+                }
+            }
+        } else {
+            // Tool pattern like @fs/*
+            const allServers = this.getAvailableServers()
+            for (const serverName of allServers) {
+                const tools = this.getAvailableTools(serverName)
+                for (const toolName of tools) {
+                    const toolId = `@${serverName}/${toolName}`
+                    if (this.matchesPattern(toolId, pattern)) {
+                        if (!(serverName === deniedServerName && toolName === deniedToolName)) {
+                            this.addToAllowedTools(toolId)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Get all available servers
+     */
+    private getAvailableServers(): string[] {
+        return this.getAllAvailableServers?.() || []
+    }
+
+    /**
+     * Get all builtin tools
+     */
+    private getBuiltinTools(): string[] {
+        return this.getAllBuiltinTools?.() || []
     }
 
     /**

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpEventHandler.test.ts
@@ -49,6 +49,17 @@ describe('McpEventHandler error handling', () => {
             },
             agent: {
                 getTools: sinon.stub().returns([]),
+                getBuiltInToolNames: sinon
+                    .stub()
+                    .returns([
+                        'fsRead',
+                        'fsWrite',
+                        'executeBash',
+                        'listDirectory',
+                        'fileSearch',
+                        'codeReview',
+                        'displayFindings',
+                    ]),
             },
             lsp: {},
             telemetry: {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -28,7 +28,25 @@ const fakeWorkspace = {
     getUserHomeDir: () => '',
     getAllWorkspaceFolders: () => [{ uri: '/fake/workspace' }],
 }
-const features = { logging: fakeLogging, workspace: fakeWorkspace, lsp: {} } as any
+const features = {
+    logging: fakeLogging,
+    workspace: fakeWorkspace,
+    lsp: {},
+    telemetry: { emitMetric: () => {} },
+    credentialsProvider: { getConnectionMetadata: () => ({}) },
+    runtime: { serverInfo: { version: '1.0.0' } },
+    agent: {
+        getBuiltInToolNames: () => [
+            'fsRead',
+            'fsWrite',
+            'executeBash',
+            'listDirectory',
+            'fileSearch',
+            'codeReview',
+            'displayFindings',
+        ],
+    },
+} as any
 
 function stubAgentConfig(): sinon.SinonStub {
     return sinon.stub(mcpUtils, 'loadAgentConfig').resolves({

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpTool.test.ts
@@ -25,9 +25,20 @@ describe('McpTool', () => {
         },
         telemetry: { record: () => {}, emitMetric: () => {} },
         runtime: { serverInfo: { version: '1.0.0' } },
+        agent: {
+            getBuiltInToolNames: () => [
+                'fsRead',
+                'fsWrite',
+                'executeBash',
+                'listDirectory',
+                'fileSearch',
+                'codeReview',
+                'displayFindings',
+            ],
+        },
     } as unknown as Pick<
         import('@aws/language-server-runtimes/server-interface/server').Features,
-        'logging' | 'workspace' | 'lsp' | 'credentialsProvider' | 'telemetry' | 'runtime'
+        'logging' | 'workspace' | 'lsp' | 'credentialsProvider' | 'telemetry' | 'runtime' | 'agent'
     >
 
     const definition: McpToolDefinition = {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -684,22 +684,7 @@ export function convertPersonaToAgent(
     mcpServers: Record<string, MCPServerConfig>,
     featureAgent: Agent
 ): AgentConfig {
-    const agent: AgentConfig = {
-        name: 'q_ide_default',
-        description: 'Default agent configuration',
-        prompt: '',
-        mcpServers: {},
-        tools: [],
-        toolAliases: {},
-        allowedTools: [],
-        toolsSettings: {},
-        resources: [],
-        hooks: {
-            agentSpawn: [],
-            userPromptSubmit: [],
-        },
-        useLegacyMcpJson: true,
-    }
+    const agent: AgentConfig = JSON.parse(DEFAULT_AGENT_RAW)
 
     // Include all servers from MCP config
     Object.entries(mcpServers).forEach(([name, config]) => {
@@ -1023,16 +1008,7 @@ export async function saveServerSpecificAgentConfig(
             existingConfig = JSON.parse(raw.toString())
         } catch {
             // If file doesn't exist, create minimal config
-            existingConfig = {
-                name: 'q_ide_default',
-                description: 'Agent configuration',
-                mcpServers: {},
-                tools: [],
-                allowedTools: [],
-                toolsSettings: {},
-                includedFiles: [],
-                resources: [],
-            }
+            existingConfig = JSON.parse(DEFAULT_AGENT_RAW)
         }
 
         // Remove existing server tools from arrays

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -348,6 +348,7 @@ export const McpToolsServer: Server = ({
                 telemetry,
                 credentialsProvider,
                 runtime,
+                agent,
             })
 
             McpManager.instance.clearToolNameMapping()


### PR DESCRIPTION
## Problem

Seeing MCP permission read/write inconsistencies.

## Solution

1. Permission Precedence Logic
• Fixed inconsistent behavior where exact matches weren't properly prioritized over wildcard patterns
• Resolved cases where allowedTools patterns could override explicit tools configurations
• Ensured that exact tool matches take precedence over server-wide or wildcard patterns

2. Enhanced Constructor Dependencies
• Added optional callback functions to AgentPermissionManager constructor:
  • getAvailableTools: Retrieves available tools for a specific server
  • getAllAvailableServers: Gets all available MCP servers
  • getAllBuiltinTools: Returns built-in tool names
• These dependencies enable more accurate permission resolution by providing runtime context

3. Improved Wildcard Handling
• Enhanced pattern matching for server-level wildcards (e.g., @*-mcp)
• Added support for @builtin pattern to match built-in tools specifically
• Fixed global wildcard (*) behavior to work consistently across all scenarios

4. Refined Permission Setting Logic
• Improved setToolPermission method to handle conflicting wildcards more intelligently
• Added proper validation to ensure tools are enabled before being marked as always allowed
• Enhanced conflict resolution when switching between permission types


https://github.com/user-attachments/assets/815bb8fd-4ef2-4298-8f56-513a2860306f



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
