### PR TITLE
fix(amazonq): fix for delete mcp for mcp config

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -107,14 +107,20 @@ export async function loadMcpServerConfigs(
                 configErrors.set(`${name}_timeout`, errorMsg)
             }
             const cfg: MCPServerConfig = {
-                url: entry.url,
-                headers: typeof entry.headers === 'object' && entry.headers !== null ? entry.headers : undefined,
-                command: entry.command,
-                args: Array.isArray(entry.args) ? entry.args.map(String) : [],
-                env: typeof entry.env === 'object' && entry.env !== null ? entry.env : {},
+                command: (entry as any).command,
+                url: (entry as any).url,
+                args: Array.isArray((entry as any).args) ? (entry as any).args.map(String) : [],
+                env: typeof (entry as any).env === 'object' && (entry as any).env !== null ? (entry as any).env : {},
+                headers:
+                    typeof (entry as any).headers === 'object' && (entry as any).headers !== null
+                        ? (entry as any).headers
+                        : undefined,
                 initializationTimeout:
-                    typeof entry.initializationTimeout === 'number' ? entry.initializationTimeout : undefined,
-                timeout: typeof entry.timeout === 'number' ? entry.timeout : undefined,
+                    typeof (entry as any).initializationTimeout === 'number'
+                        ? (entry as any).initializationTimeout
+                        : undefined,
+                timeout: typeof (entry as any).timeout === 'number' ? (entry as any).timeout : undefined,
+                disabled: typeof (entry as any).disabled === 'boolean' ? (entry as any).disabled : false,
                 __configPath__: fsPath,
             }
 
@@ -1074,10 +1080,6 @@ export async function migrateAgentConfigToCLIFormat(
             config.toolAliases = {}
             updated = true
         }
-        if (!config.hasOwnProperty('useLegacyMcpJson')) {
-            config.useLegacyMcpJson = true
-            updated = true
-        }
 
         // Remove deprecated fields
         if (config.hasOwnProperty('version')) {
@@ -1115,6 +1117,9 @@ export async function migrateAgentConfigToCLIFormat(
                 updated = true
             }
         }
+
+        config.useLegacyMcpJson = true
+        updated = true
 
         if (updated) {
             await workspace.fs.writeFile(configPath, JSON.stringify(config, null, 2))


### PR DESCRIPTION
## Problem

Fixing bugs for mcp config support

## Solution
- `useLegacyMcpJson` will be set to true by default
- agent config file will be created for mcp config at their level
- delete workflow fix
- disable workflow fix
- refresh for discover mcps from config file at workspace level.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
