### PR TITLE
fix: emit error code on failed user messages

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -3479,7 +3479,8 @@ export class AgenticChatController implements ChatHandlers {
         metric.metric.requestIds = [requestID]
         metric.metric.cwsprChatMessageId = errorMessageId
         metric.metric.cwsprChatConversationId = conversationId
-        await this.#telemetryController.emitAddMessageMetric(tabId, metric.metric, 'Failed', errorMessage)
+        const errorCode = err.code ?? ''
+        await this.#telemetryController.emitAddMessageMetric(tabId, metric.metric, 'Failed', errorMessage, errorCode)
 
         if (isUsageLimitError(err)) {
             if (this.#paidTierMode !== 'paidtier') {

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -298,7 +298,8 @@ export class ChatTelemetryController {
         tabId: string,
         metric: Partial<CombinedConversationEvent>,
         result?: string,
-        errorMessage?: string
+        errorMessage?: string,
+        errorCode?: string
     ) {
         const conversationId = this.getConversationId(tabId)
         // Store the customization value associated with the message
@@ -355,6 +356,7 @@ export class ChatTelemetryController {
                 experimentName: metric.experimentName,
                 userVariation: metric.userVariation,
                 errorMessage: errorMessage,
+                errorCode: errorCode,
             }
         )
     }

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.test.ts
@@ -860,6 +860,7 @@ describe('TelemetryService', () => {
                     cwsprChatPinnedFolderContextCount: undefined,
                     cwsprChatPinnedPromptContextCount: undefined,
                     errorMessage: undefined,
+                    errorCode: undefined,
                 },
             })
         })

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -566,6 +566,7 @@ export class TelemetryService {
             experimentName?: string
             userVariation?: string
             errorMessage?: string
+            errorCode?: string
         }>
     ) {
         const timeBetweenChunks = params.timeBetweenChunks?.slice(0, 100)
@@ -620,6 +621,7 @@ export class TelemetryService {
                     experimentName: additionalParams.experimentName,
                     userVariation: additionalParams.userVariation,
                     errorMessage: additionalParams.errorMessage,
+                    errorCode: additionalParams.errorCode,
                 },
             })
         }


### PR DESCRIPTION
## Problem
In cloudwatch, we use the errorMessage as the dimension. For faults (5xx), the errorMessage value does not seem particularly useful to use as a label in cloudwatch.

Some examples: 
`Encountered an unexpected error when processing the request, please try again.`
```
Unexpected token '<', "<html>
<h"... is not valid JSON
  Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
```
## Solution
- We may actually want to use the `err.code` as the errorMessage dimension value for faults (5xx). Sending this data to kibana as a preliminary way to check. If this is the case, I will follow up to update how we process this in cloudwatch.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
