### PR TITLE
fix: compile errors from merge conflicts

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts
@@ -26,6 +26,7 @@ import {
     UserModificationEvent,
     CompletionType,
     InlineChatUserDecision,
+    AgenticChatEventStatus,
 } from '@amzn/codewhisperer-runtime'
 import { getCompletionType, getSsoConnectionType, isServiceException } from '../utils'
 import {
@@ -182,7 +183,7 @@ export class TelemetryService {
                 request.modelId = this.modelId
             }
             const r = await this.getService().sendTelemetryEvent(request)
-            this.logging.log(`SendTelemetryEvent succeeded, requestId: ${r.$response.requestId}`)
+            this.logging.log(`SendTelemetryEvent succeeded, requestId: ${r.$metadata.requestId}`)
         } catch (error) {
             this.logSendTelemetryEventFailure(error)
         }


### PR DESCRIPTION
## Problem

There are compilation errors on this branch after auto merges

```
server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts:185:76 - error TS2339: Property '$response' does not exist on type 'SendTelemetryEventCommandOutput'.

185             this.logging.log(`SendTelemetryEvent succeeded, requestId: ${r.$response.requestId}`)
                                                                               ~~~~~~~~~

server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts:650:54 - error TS2304: Cannot find name 'AgenticChatEventStatus'.

650             result: (params.result?.toUpperCase() ?? AgenticChatEventStatus.Succeeded) as AgenticChatEventStatus,
                                                         ~~~~~~~~~~~~~~~~~~~~~~

server/aws-lsp-codewhisperer/src/shared/telemetry/telemetryService.ts:650:91 - error TS2304: Cannot find name 'AgenticChatEventStatus'.

650             result: (params.result?.toUpperCase() ?? AgenticChatEventStatus.Succeeded) as AgenticChatEventStatus,
                                                                                              ~~~~~~~~~~~~~~~~~~~~~~
```

## Solution

Fix compilation errors

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
