### PR TITLE
chore: remove old ignore entries

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 **/node_modules/**
 **/out/**
-server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperersigv4client.d.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,5 @@ node_modules/
 out/
 **/bin/
 **/obj/
-server/aws-lsp-codewhisperer/src/client/sigv4/codewhisperersigv4client.d.ts
 **/*.md
 **/antlr-generated/


### PR DESCRIPTION
## Problem

Old client type definition files are referenced but they have been removed in favor of v3 clients.

## Solution

Remove old ignore entries.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
