### PR TITLE
fix: trim new line when emitting error message

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -3473,7 +3473,7 @@ export class AgenticChatController implements ChatHandlers {
         metric: Metric<CombinedConversationEvent>,
         agenticCodingMode: boolean
     ): Promise<ChatResult | ResponseError<ChatResult>> {
-        const errorMessage = getErrorMsg(err) ?? GENERIC_ERROR_MS
+        const errorMessage = (getErrorMsg(err) ?? GENERIC_ERROR_MS).replace(/[\r\n]+/g, ' ') // replace new lines with empty space
         const requestID = getRequestID(err) ?? ''
         metric.setDimension('cwsprChatResponseCode', getHttpStatusCode(err) ?? 0)
         metric.setDimension('languageServerVersion', this.#features.runtime.serverInfo.version)


### PR DESCRIPTION
## Problem
There are instances of newlines in the errorMessage value. 

The errorMessage value (dimension value) is used as the label name in Cloudwatch. However Cloudwatch does not support dimension values having newlines: `ASCII control characters are not supported as part of dimension values.`
- https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html

Therefore, the data where errorMessage value was not being logged to Cloudwatch.

## Solution
Remove new lines when emitting error message

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
