### PR TITLE
fix(amazonq): make modelId optional in CodeReview

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReviewSchemas.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/qCodeAnalysis/codeReviewSchemas.ts
@@ -113,7 +113,7 @@ export const Z_CODE_REVIEW_INPUT_SCHEMA = z.object({
             })
         )
         .optional(),
-    modelId: z.string(),
+    modelId: z.string().optional(),
 })
 
 /**


### PR DESCRIPTION
## Problem
There are some cases where the session.modelId field is empty. When this happens, code review tool was failing unnecessarily. If modelId is null for us, then there is no issue

## Solution
mark modelId as optional in schema

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
