### PR TITLE
fix: optimize memory bank token usage and add new tab support

### DIFF
--- a/chat-client/src/client/features/rules.test.ts
+++ b/chat-client/src/client/features/rules.test.ts
@@ -16,6 +16,9 @@ describe('rules', () => {
         mynahUi = {
             openTopBarButtonOverlay: sinon.stub(),
             showCustomForm: sinon.stub(),
+            getAllTabs: sinon.stub().returns({}),
+            updateStore: sinon.stub().returns('new-tab-id'),
+            notify: sinon.stub(),
         } as unknown as MynahUI
         openTopBarButtonOverlayStub = mynahUi.openTopBarButtonOverlay as sinon.SinonStub
         showCustomFormStub = mynahUi.showCustomForm as sinon.SinonStub
@@ -23,6 +26,7 @@ describe('rules', () => {
         messager = {
             onRuleClick: sinon.stub(),
             onChatPrompt: sinon.stub(),
+            onTabAdd: sinon.stub(),
         } as unknown as Messager
 
         rulesList = new RulesList(mynahUi, messager)
@@ -151,12 +155,17 @@ describe('rules', () => {
 
             onItemClick(createMemoryBankItem)
 
-            // Should send a chat prompt
+            // Should create new tab and send chat prompt
+            sinon.assert.calledOnce(messager.onTabAdd as sinon.SinonStub)
             sinon.assert.calledOnce(messager.onChatPrompt as sinon.SinonStub)
+
+            const tabAddArgs = (messager.onTabAdd as sinon.SinonStub).getCall(0).args[0]
+            assert.equal(tabAddArgs, 'new-tab-id')
 
             const chatPromptArgs = (messager.onChatPrompt as sinon.SinonStub).getCall(0).args[0]
             assert.equal(chatPromptArgs.prompt.prompt, 'Generate a Memory Bank for this project')
             assert.equal(chatPromptArgs.prompt.escapedPrompt, 'Generate a Memory Bank for this project')
+            assert.equal(chatPromptArgs.tabId, 'new-tab-id')
         })
 
         it('calls messager when regular rule is clicked', () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
@@ -81,6 +81,16 @@ The summary should have following main sections:
 </example_output>
 `
 
+// FsRead limits
+export const FSREAD_MAX_PER_FILE = 200_000
+export const FSREAD_MAX_TOTAL = 400_000
+export const FSREAD_MEMORY_BANK_MAX_PER_FILE = 20_000
+export const FSREAD_MEMORY_BANK_MAX_TOTAL = 100_000
+
+// Memory Bank constants
+// Temporarily reduced from recommended 20 to 5 for token optimization
+export const MAX_NUMBER_OF_FILES_FOR_MEMORY_BANK_RANKING = 5
+
 // shortcut constant
 export const DEFAULT_MACOS_RUN_SHORTCUT = '&#8679; &#8984; &#8629;'
 export const DEFAULT_WINDOW_RUN_SHORTCUT = 'Ctrl + &#8679; + &#8629;'

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -41,6 +41,7 @@ export class ChatSessionService {
     public pairProgrammingMode: boolean = true
     public contextListSent: boolean = false
     public modelId: string | undefined
+    public isMemoryBankGeneration: boolean = false
     #lsp?: Features['lsp']
     #abortController?: AbortController
     #currentPromptId?: string


### PR DESCRIPTION
## Problem
Amazon Q IDE is encountering issues where conversation history is unexpectedly cleared due to exceeding token limits. This leads to a poor user experience and loss of context in ongoing conversations. We need to implement strategies to prevent hitting these limits and handle cases where we do exceed them more gracefully.

## Solution
- Reduced memory bank file processing from 10 to 5 files with custom fsRead limits (20K per file, 100K total vs standard 200K/400K)
- Memory bank generation now automatically opens in a dedicated new tab, keeping original conversations clean (Note/

### TODO/Callouts: 

- We need to open new tabs when memory bank is triggered by the prompt rather than the explicit button. It still runs in the current chat window for this case)
- We don't currently de-dupe the Memory Bank tabs (similar to \transform). We can take a product call on whether or not we want to do this.


## Testing

- Tested on VSCode repository where it always fails due to context exceeded:



https://github.com/user-attachments/assets/815a530d-b41d-4865-893a-26accbc2473c



- Too many tabs case:


https://github.com/user-attachments/assets/0207b344-0482-4192-9fc8-bcd34f3f5fd1


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
