### PR TITLE
revert(amazonq): fix to add opt-out header to streaming client

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -38,6 +38,7 @@ type DeferredHandler = {
     reject: (err: Error) => void
 }
 export class ChatSessionService {
+    public shareCodeWhispererContentWithAWS = false
     public pairProgrammingMode: boolean = true
     public contextListSent: boolean = false
     public modelId: string | undefined

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQIAMServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQIAMServiceManager.ts
@@ -74,9 +74,6 @@ export class AmazonQIAMServiceManager extends BaseAmazonQServiceManager<
                 this.region,
                 this.endpoint
             )
-            this.cachedStreamingClient.shareCodeWhispererContentWithAWS = this.configurationCache.getProperty(
-                'shareCodeWhispererContentWithAWS'
-            )
         }
         return this.cachedStreamingClient
     }

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -584,9 +584,6 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
             this.getCustomUserAgent()
         )
         streamingClient.profileArn = this.activeIdcProfile?.arn
-        streamingClient.shareCodeWhispererContentWithAWS = this.configurationCache.getProperty(
-            'shareCodeWhispererContentWithAWS'
-        )
 
         this.logging.debug(`Created streaming client instance region=${region}, endpoint=${endpoint}`)
         return streamingClient

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/BaseAmazonQServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/BaseAmazonQServiceManager.ts
@@ -157,17 +157,6 @@ export abstract class BaseAmazonQServiceManager<
             )
             this.cachedCodewhispererService.shareCodeWhispererContentWithAWS = shareCodeWhispererContentWithAWS
         }
-
-        if (this.cachedStreamingClient) {
-            const shareCodeWhispererContentWithAWS = this.configurationCache.getProperty(
-                'shareCodeWhispererContentWithAWS'
-            )
-            this.logging.debug(
-                'Update shareCodeWhispererContentWithAWS setting on cachedStreamingClient to ' +
-                    shareCodeWhispererContentWithAWS
-            )
-            this.cachedStreamingClient.shareCodeWhispererContentWithAWS = shareCodeWhispererContentWithAWS
-        }
     }
 
     private async notifyDidChangeConfigurationListeners(): Promise<void> {

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.test.ts
@@ -12,8 +12,6 @@ import {
 } from '@amzn/codewhisperer-streaming'
 import { QDeveloperStreaming } from '@amzn/amazon-q-developer-streaming-client'
 import { rejects } from 'assert'
-import { initBaseTestServiceManager, TestAmazonQServiceManager } from './amazonQServiceManager/testUtils'
-import { stubCodeWhispererService } from './testUtils'
 
 const TIME_TO_ADVANCE_MS = 100
 
@@ -113,33 +111,6 @@ describe('StreamingClientServiceToken', () => {
 
         sinon.assert.calledOnce(sendMessageStub)
         sinon.assert.match(sendMessageStub.firstCall.firstArg, expectedRequest)
-    })
-
-    it('creates client with shareCodeWhispererContentWithAWS parameter', () => {
-        const streamingClientServiceWithOptout = new StreamingClientServiceToken(
-            features.credentialsProvider,
-            features.sdkInitializator,
-            features.logging,
-            DEFAULT_AWS_Q_REGION,
-            DEFAULT_AWS_Q_ENDPOINT_URL,
-            'some-user-agent'
-        )
-        streamingClientServiceWithOptout.shareCodeWhispererContentWithAWS = false
-
-        expect(streamingClientServiceWithOptout['shareCodeWhispererContentWithAWS']).to.equal(false)
-    })
-
-    it('creates client without shareCodeWhispererContentWithAWS parameter', () => {
-        const streamingClientServiceDefault = new StreamingClientServiceToken(
-            features.credentialsProvider,
-            features.sdkInitializator,
-            features.logging,
-            DEFAULT_AWS_Q_REGION,
-            DEFAULT_AWS_Q_ENDPOINT_URL,
-            'some-user-agent'
-        )
-
-        expect(streamingClientServiceDefault['shareCodeWhispererContentWithAWS']).to.be.undefined
     })
 
     describe('generateAssistantResponse', () => {
@@ -346,80 +317,5 @@ describe('StreamingClientServiceIAM', () => {
         // Verify expiration is set to current date to force refresh when not provided in credentials
         expect(credentials.expiration).to.be.instanceOf(Date)
         expect(credentials.expiration.getTime()).to.be.closeTo(Date.now(), 1000)
-    })
-
-    it('creates client with shareCodeWhispererContentWithAWS parameter', () => {
-        const streamingClientServiceWithOptout = new StreamingClientServiceIAM(
-            features.credentialsProvider,
-            features.sdkInitializator,
-            features.logging,
-            DEFAULT_AWS_Q_REGION,
-            DEFAULT_AWS_Q_ENDPOINT_URL
-        )
-        streamingClientServiceWithOptout.shareCodeWhispererContentWithAWS = false
-
-        expect(streamingClientServiceWithOptout['shareCodeWhispererContentWithAWS']).to.equal(false)
-    })
-
-    it('creates client without shareCodeWhispererContentWithAWS parameter', () => {
-        const streamingClientServiceDefault = new StreamingClientServiceIAM(
-            features.credentialsProvider,
-            features.sdkInitializator,
-            features.logging,
-            DEFAULT_AWS_Q_REGION,
-            DEFAULT_AWS_Q_ENDPOINT_URL
-        )
-
-        expect(streamingClientServiceDefault['shareCodeWhispererContentWithAWS']).to.be.undefined
-    })
-})
-
-describe('BaseAmazonQServiceManager streaming client cache updates', () => {
-    let features: TestFeatures
-    let serviceManager: TestAmazonQServiceManager
-    let streamingClientMock: StreamingClientServiceToken
-
-    beforeEach(() => {
-        features = new TestFeatures()
-        const serviceStub = stubCodeWhispererService()
-
-        streamingClientMock = Object.assign(sinon.createStubInstance(StreamingClientServiceToken), {
-            region: DEFAULT_AWS_Q_REGION,
-            endpoint: DEFAULT_AWS_Q_ENDPOINT_URL,
-        }) as unknown as StreamingClientServiceToken
-        serviceManager = initBaseTestServiceManager(features, serviceStub, streamingClientMock)
-    })
-
-    afterEach(() => {
-        sinon.restore()
-        TestAmazonQServiceManager.resetInstance()
-    })
-
-    it('updates shareCodeWhispererContentWithAWS on cached streaming client when configuration changes', async () => {
-        // Set initial configuration
-        features.lsp.workspace.getConfiguration.resolves({ shareCodeWhispererContentWithAWS: true })
-
-        await serviceManager.handleDidChangeConfiguration()
-
-        expect(streamingClientMock.shareCodeWhispererContentWithAWS).to.equal(true)
-
-        // Change configuration
-        features.lsp.workspace.getConfiguration.resolves({ shareCodeWhispererContentWithAWS: false })
-
-        await serviceManager.handleDidChangeConfiguration()
-
-        expect(streamingClientMock.shareCodeWhispererContentWithAWS).to.equal(false)
-    })
-
-    it('does not update streaming client when no cached client exists', async () => {
-        TestAmazonQServiceManager.resetInstance()
-        const serviceManagerWithoutClient = initBaseTestServiceManager(features, stubCodeWhispererService())
-
-        features.lsp.workspace.getConfiguration.resolves({ shareCodeWhispererContentWithAWS: false })
-
-        // Should not throw when no cached streaming client exists
-        await serviceManagerWithoutClient.handleDidChangeConfiguration()
-
-        expect(serviceManagerWithoutClient['cachedStreamingClient']).to.be.undefined
     })
 })

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -39,7 +39,6 @@ export type ChatCommandOutput = SendMessageCommandOutput | GenerateAssistantResp
 export abstract class StreamingClientServiceBase {
     protected readonly region
     protected readonly endpoint
-    public shareCodeWhispererContentWithAWS?: boolean
 
     inflightRequests: Set<AbortController> = new Set()
 
@@ -66,7 +65,6 @@ export abstract class StreamingClientServiceBase {
 export class StreamingClientServiceToken extends StreamingClientServiceBase {
     client: CodeWhispererStreaming
     public profileArn?: string
-
     constructor(
         credentialsProvider: CredentialsProvider,
         sdkInitializator: SDKInitializator,
@@ -76,7 +74,6 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
         customUserAgent: string
     ) {
         super(region, endpoint)
-
         const tokenProvider = async () => {
             const token = getBearerTokenFromProvider(credentialsProvider)
             // without setting expiration, the tokenProvider will only be called once
@@ -98,15 +95,11 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
         })
 
         this.client.middlewareStack.add(
-            (next, context) => (args: any) => {
+            (next, context) => args => {
                 if (credentialsProvider.getConnectionType() === 'external_idp') {
+                    // @ts-ignore
                     args.request.headers['TokenType'] = 'EXTERNAL_IDP'
                 }
-                if (this.shareCodeWhispererContentWithAWS !== undefined) {
-                    args.request.headers['x-amzn-codewhisperer-optout'] = `${!this.shareCodeWhispererContentWithAWS}`
-                }
-                // Log headers for debugging
-                logging.debug(`StreamingClient headers: ${JSON.stringify(args.request.headers)}`)
                 return next(args)
             },
             {
@@ -220,18 +213,6 @@ export class StreamingClientServiceIAM extends StreamingClientServiceBase {
             credentials: iamCredentialProvider,
             retryStrategy: new ConfiguredRetryStrategy(0, (attempt: number) => 500 + attempt ** 10),
         })
-
-        this.client.middlewareStack.add(
-            (next, context) => (args: any) => {
-                if (this.shareCodeWhispererContentWithAWS !== undefined) {
-                    args.request.headers['x-amzn-codewhisperer-optout'] = `${!this.shareCodeWhispererContentWithAWS}`
-                }
-                return next(args)
-            },
-            {
-                step: 'build',
-            }
-        )
     }
 
     public async sendMessage(


### PR DESCRIPTION
## Problem
We need to revert the opt-out commit from main for release.

## Solution
This PR reverts PR #2365 

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
