### PR TITLE
chore: bump agentic version: 1.37.0

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/src/version.json
+++ b/app/aws-lsp-codewhisperer-runtimes/src/version.json
@@ -1,3 +1,3 @@
 {
-    "agenticChat": "1.36.0"
+    "agenticChat": "1.37.0"
 }


### PR DESCRIPTION
This merges the released changes for 1.37.0 into main.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
