### PR TITLE
chore(amazonq): add more tests for inline completion codes

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/handler/editCompletionHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/handler/editCompletionHandler.ts
@@ -22,7 +22,7 @@ import { CodeWhispererSession, SessionManager } from '../session/sessionManager'
 import { CursorTracker } from '../tracker/cursorTracker'
 import { CodewhispererLanguage, getSupportedLanguageId } from '../../../shared/languageDetection'
 import { WorkspaceFolderManager } from '../../workspaceContext/workspaceFolderManager'
-import { shouldTriggerEdits } from '../trigger'
+import { shouldTriggerEdits } from '../utils/triggerUtils'
 import {
     emitEmptyUserTriggerDecisionTelemetry,
     emitServiceInvocationFailure,

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/utils/diffUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/utils/diffUtils.test.ts
@@ -1,0 +1,85 @@
+import * as assert from 'assert'
+import { getAddedAndDeletedLines, getCharacterDifferences, generateDiffContexts } from './diffUtils'
+
+describe('diffUtils', () => {
+    describe('getAddedAndDeletedLines', () => {
+        const SAMPLE_UNIFIED_DIFF = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+ line1
+-old line
++new line
+ line3`
+        it('should extract added and deleted lines from unified diff', () => {
+            const result = getAddedAndDeletedLines(SAMPLE_UNIFIED_DIFF)
+
+            assert.deepEqual(result.addedLines, ['new line'])
+            assert.deepEqual(result.deletedLines, ['old line'])
+        })
+
+        it('should handle empty diff', () => {
+            const result = getAddedAndDeletedLines('')
+            assert.deepEqual(result.addedLines, [])
+            assert.deepEqual(result.deletedLines, [])
+        })
+    })
+
+    describe('getCharacterDifferences', () => {
+        const ADDED_LINES = ['hello world']
+        const DELETED_LINES = ['hello there']
+        it('should calculate character differences using LCS', () => {
+            const result = getCharacterDifferences(ADDED_LINES, DELETED_LINES)
+
+            assert.equal(result.charactersAdded, 4)
+            assert.equal(result.charactersRemoved, 4)
+        })
+
+        it('should handle empty added lines', () => {
+            const result = getCharacterDifferences([], DELETED_LINES)
+
+            assert.equal(result.charactersAdded, 0)
+            assert.equal(result.charactersRemoved, 11) // 'hello there' = 11 chars
+        })
+
+        it('should handle empty deleted lines', () => {
+            const result = getCharacterDifferences(ADDED_LINES, [])
+
+            assert.equal(result.charactersAdded, 11) // 'hello world' = 11 chars
+            assert.equal(result.charactersRemoved, 0)
+        })
+    })
+
+    describe('generateDiffContexts', () => {
+        const TEST_FILE_PATH = '/test/file.ts'
+        const CURRENT_CONTENT = 'current content'
+        const OLD_CONTENT = 'old content'
+        const MAX_CONTEXTS = 5
+        const SNAPSHOT_CONTENTS = [
+            {
+                filePath: TEST_FILE_PATH,
+                content: OLD_CONTENT,
+                timestamp: Date.now() - 1000,
+            },
+        ]
+        it('should generate diff contexts from snapshots', () => {
+            const result = generateDiffContexts(TEST_FILE_PATH, CURRENT_CONTENT, SNAPSHOT_CONTENTS, MAX_CONTEXTS)
+
+            assert.equal(result.isUtg, false)
+            assert.equal(result.isProcessTimeout, false)
+            assert.equal(result.strategy, 'recentEdits')
+            assert.equal(typeof result.latency, 'number')
+            assert.equal(typeof result.contentsLength, 'number')
+        })
+
+        it('should return empty context for no snapshots', () => {
+            const result = generateDiffContexts(TEST_FILE_PATH, 'content', [], MAX_CONTEXTS)
+
+            assert.equal(result.isUtg, false)
+            assert.equal(result.isProcessTimeout, false)
+            assert.equal(result.supplementalContextItems.length, 0)
+            assert.equal(result.contentsLength, 0)
+            assert.equal(result.latency, 0)
+            assert.equal(result.strategy, 'recentEdits')
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/utils/mergeRightUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/utils/mergeRightUtils.test.ts
@@ -1,74 +1,185 @@
-import { getPrefixOverlapLastIndex, getPrefixSuffixOverlap, truncateOverlapWithRightContext } from './mergeRightUtils'
+import * as assert from 'assert'
+import {
+    getPrefixSuffixOverlap,
+    truncateOverlapWithRightContext,
+    mergeSuggestionsWithRightContext,
+} from './mergeRightUtils'
+import { Suggestion } from '../../../shared/codeWhispererService'
 import { HELLO_WORLD_IN_CSHARP, HELLO_WORLD_WITH_WINDOWS_ENDING } from '../../../shared/testUtils'
-import assert = require('assert')
 
-describe('Merge Right Utils', () => {
-    const HELLO_WORLD = `Console.WriteLine("Hello World!");`
+describe('mergeRightUtils', () => {
+    describe('getPrefixSuffixOverlap', () => {
+        it('should find overlap between suffix and prefix', () => {
+            const result = getPrefixSuffixOverlap('adwg31', '31ggrs')
+            assert.equal(result, '31')
+        })
 
-    it('get prefix suffix overlap works as expected', () => {
-        const result = getPrefixSuffixOverlap('adwg31', '31ggrs')
-        assert.deepEqual(result, '31')
+        it('should return empty string when no overlap', () => {
+            const result = getPrefixSuffixOverlap('hello', 'world')
+            assert.equal(result, '')
+        })
+
+        it('should handle empty strings', () => {
+            const result = getPrefixSuffixOverlap('', 'test')
+            assert.equal(result, '')
+        })
+
+        it('should find full overlap when second string is prefix of first', () => {
+            const result = getPrefixSuffixOverlap('hello', 'hello world')
+            assert.equal(result, 'hello')
+        })
     })
 
-    it('get prefix prefix overlap index works as expected', () => {
-        const result1 = getPrefixOverlapLastIndex('static void', 'static')
-        assert.deepEqual(result1, 6)
-        const result2 = getPrefixOverlapLastIndex('static void', 'void')
-        assert.deepEqual(result2, 11)
-        const result3 = getPrefixOverlapLastIndex('static void', 'staic')
-        assert.deepEqual(result3, 3)
+    describe('truncateOverlapWithRightContext', () => {
+        const HELLO_WORLD = 'Console.WriteLine("Hello World!");'
+        it('should truncate overlap with right context', () => {
+            const rightContext = '");'
+            const result = truncateOverlapWithRightContext(rightContext, HELLO_WORLD)
+            assert.equal(result, 'Console.WriteLine("Hello World!')
+        })
+
+        it('should return original suggestion when no overlap', () => {
+            const rightContext = 'different content'
+            const result = truncateOverlapWithRightContext(rightContext, HELLO_WORLD)
+            assert.equal(result, HELLO_WORLD)
+        })
+
+        it('should handle right context with leading whitespace', () => {
+            const suggestion = 'const x = 1;'
+            const rightContext = '    ; // comment'
+            const result = truncateOverlapWithRightContext(rightContext, suggestion)
+            assert.equal(result, 'const x = 1')
+        })
+
+        it('should return empty suggestion when right context equals line content ', () => {
+            const result1 = truncateOverlapWithRightContext(HELLO_WORLD, HELLO_WORLD)
+            assert.deepEqual(result1, '')
+            // Without trimStart, this test would fail because the function doesn't trim leading new line from right context
+            const result2 = truncateOverlapWithRightContext(HELLO_WORLD_IN_CSHARP.trimStart(), HELLO_WORLD_IN_CSHARP)
+            assert.deepEqual(result2, '')
+        })
+
+        it('should not handle the case where right context fully matches suggestion but starts with a newline ', () => {
+            const result = truncateOverlapWithRightContext('\n' + HELLO_WORLD_IN_CSHARP, HELLO_WORLD_IN_CSHARP)
+            // Even though right context and suggestion are equal, the newline of right context doesn't get trimmed while the newline of suggestion gets trimmed
+            // As a result, we end up with no overlap
+            assert.deepEqual(result, HELLO_WORLD_IN_CSHARP)
+        })
+
+        it('should return truncated suggestion when right context matches end of the suggestion', () => {
+            // File contents will be `nsole.WriteLine("Hello World!");`
+            // Suggestion will be the full HELLO_WORLD
+            // Final truncated result should be the first two letters of HELLO_WORLD
+            const result = truncateOverlapWithRightContext(HELLO_WORLD.substring(2), HELLO_WORLD)
+
+            assert.deepEqual(result, HELLO_WORLD.substring(0, 2))
+        })
+
+        it('should trim right-context tabs and whitespaces until first newline', () => {
+            const suggestion = '{\n            return a + b;\n        }'
+            const rightContent = '       \n        }\n\n    }\n}'
+            const expected_result = '{\n            return a + b;'
+            const result = truncateOverlapWithRightContext(rightContent, suggestion)
+
+            assert.deepEqual(result, expected_result)
+        })
+
+        it('should handle different line endings', () => {
+            const suggestion = '{\n            return a + b;\n        }'
+            const rightContent = '\r\n        }\r\n}\r\n}'
+            const expected_result = '{\n            return a + b;'
+            const result = truncateOverlapWithRightContext(rightContent, suggestion)
+
+            assert.deepEqual(result, expected_result)
+        })
+
+        it('should handle windows line endings for files', () => {
+            const result = truncateOverlapWithRightContext(
+                HELLO_WORLD_WITH_WINDOWS_ENDING,
+                HELLO_WORLD_WITH_WINDOWS_ENDING.replaceAll('\r', '')
+            )
+            assert.deepEqual(result, '')
+        })
     })
 
-    it('should return empty suggestion when right context equals line content ', () => {
-        const result = truncateOverlapWithRightContext(HELLO_WORLD, HELLO_WORLD)
-        assert.deepEqual(result, '')
-    })
+    describe('mergeSuggestionsWithRightContext', () => {
+        const mockSuggestions: Suggestion[] = [
+            {
+                itemId: 'item1',
+                content: 'console.log("test");',
+                references: [
+                    {
+                        licenseName: 'MIT',
+                        url: 'https://example.com',
+                        repository: 'test-repo',
+                        recommendationContentSpan: { start: 0, end: 10 },
+                    },
+                ],
+                mostRelevantMissingImports: [
+                    {
+                        statement: 'import { test } from "test"',
+                    },
+                ],
+            },
+        ]
 
-    it('should return empty suggestion when right context equals file content', () => {
-        // Without trimStart, this test would fail because the function doesn't trim leading new line from right context
-        const result = truncateOverlapWithRightContext(HELLO_WORLD_IN_CSHARP.trimStart(), HELLO_WORLD_IN_CSHARP)
-        assert.deepEqual(result, '')
-    })
+        it('should merge suggestions with right context', () => {
+            const rightContext = '");'
+            const result = mergeSuggestionsWithRightContext(rightContext, mockSuggestions, false)
 
-    it('should not handle the case where right context fully matches suggestion but starts with a newline ', () => {
-        const result = truncateOverlapWithRightContext('\n' + HELLO_WORLD_IN_CSHARP, HELLO_WORLD_IN_CSHARP)
-        // Even though right context and suggestion are equal, the newline of right context doesn't get trimmed while the newline of suggestion gets trimmed
-        // As a result, we end up with no overlap
-        assert.deepEqual(result, HELLO_WORLD_IN_CSHARP)
-    })
+            assert.equal(result.length, 1)
+            assert.equal(result[0].itemId, 'item1')
+            assert.equal(result[0].insertText, 'console.log("test')
+            assert.equal(result[0].mostRelevantMissingImports, undefined)
+        })
 
-    it('should return truncated suggestion when right context matches end of the suggestion', () => {
-        // File contents will be `nsole.WriteLine("Hello World!");`
-        // Suggestion will be the full HELLO_WORLD
-        // Final truncated result should be the first two letters of HELLO_WORLD
-        const result = truncateOverlapWithRightContext(HELLO_WORLD.substring(2), HELLO_WORLD)
+        it('should include imports when enabled', () => {
+            const rightContext = ''
+            const result = mergeSuggestionsWithRightContext(rightContext, mockSuggestions, true)
 
-        assert.deepEqual(result, HELLO_WORLD.substring(0, 2))
-    })
+            assert.equal(result[0].mostRelevantMissingImports?.length, 1)
+            assert.equal(result[0].mostRelevantMissingImports?.[0].statement, 'import { test } from "test"')
+        })
 
-    it('should trim right-context tabs and whitespaces until first newline', () => {
-        const suggestion = '{\n            return a + b;\n        }'
-        const rightContent = '       \n        }\n\n    }\n}'
-        const expected_result = '{\n            return a + b;'
-        const result = truncateOverlapWithRightContext(rightContent, suggestion)
+        it('should filter references based on insert text length', () => {
+            const suggestions: Suggestion[] = [
+                {
+                    itemId: 'item1',
+                    content: 'short',
+                    references: [
+                        {
+                            licenseName: 'MIT',
+                            url: 'https://example.com',
+                            repository: 'test-repo',
+                            recommendationContentSpan: { start: 10, end: 20 }, // start > insertText.length
+                        },
+                    ],
+                },
+            ]
 
-        assert.deepEqual(result, expected_result)
-    })
+            const result = mergeSuggestionsWithRightContext('', suggestions, false)
 
-    it('should handle different line endings', () => {
-        const suggestion = '{\n            return a + b;\n        }'
-        const rightContent = '\r\n        }\r\n}\r\n}'
-        const expected_result = '{\n            return a + b;'
-        const result = truncateOverlapWithRightContext(rightContent, suggestion)
+            assert.equal(result[0].references, undefined)
+        })
 
-        assert.deepEqual(result, expected_result)
-    })
+        it('should include range when provided', () => {
+            const range = { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } }
+            const result = mergeSuggestionsWithRightContext('', mockSuggestions, false, range)
 
-    it('should handle windows line endings for files', () => {
-        const result = truncateOverlapWithRightContext(
-            HELLO_WORLD_WITH_WINDOWS_ENDING,
-            HELLO_WORLD_WITH_WINDOWS_ENDING.replaceAll('\r', '')
-        )
-        assert.deepEqual(result, '')
+            assert.deepEqual(result[0].range, range)
+        })
+
+        it('should handle suggestions with no references', () => {
+            const suggestions: Suggestion[] = [
+                {
+                    itemId: 'item1',
+                    content: 'test content',
+                },
+            ]
+
+            const result = mergeSuggestionsWithRightContext('', suggestions, false)
+
+            assert.equal(result[0].references, undefined)
+        })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/utils/mergeRightUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/utils/mergeRightUtils.ts
@@ -16,49 +16,17 @@ export function getPrefixSuffixOverlap(firstString: string, secondString: string
     return secondString.slice(0, i)
 }
 
-/**
- * Returns the last index of the longest overlap between the first string and the second string
- * @param targetString the target string
- * @param searchString the search string
- * @returns last index of the longest overlap between the first string and the second string
- * @example getPrefixOverlapLastIndex("public static void", "static") = 13
- */
-export function getPrefixOverlapLastIndex(targetString: string, searchString: string) {
-    let i = searchString.length
-    let idx = -1
-    while (i > 0) {
-        idx = targetString.indexOf(searchString.slice(0, i))
-        if (idx != -1) {
-            return idx + i
-        }
-        i--
-    }
-    return idx
-}
-
-export function truncateOverlapWithRightContext(
-    rightFileContent: string,
-    suggestion: string,
-    userEdit?: string
-): string {
+export function truncateOverlapWithRightContext(rightFileContent: string, suggestion: string): string {
     const trimmedSuggestion = suggestion.trim()
     // limit of 5000 for right context matching
     const rightContext = rightFileContent
         .substring(0, 5000)
         .replaceAll('\r\n', '\n')
         .replace(/^[^\S\n]+/, '') // remove leading tabs and whitespaces
-    let prefixOverlapLastIndex = 0
-    if (userEdit) {
-        const trimmpedUserEdit = userEdit.trim()
-        prefixOverlapLastIndex = getPrefixOverlapLastIndex(trimmedSuggestion, trimmpedUserEdit)
-        if (prefixOverlapLastIndex == -1) {
-            return ''
-        }
-    }
-    const prefixSuffixOverlap = getPrefixSuffixOverlap(trimmedSuggestion, rightContext)
-    const prefixSuffixOverlapIndex = suggestion.lastIndexOf(prefixSuffixOverlap)
-    if (prefixSuffixOverlapIndex >= 0) {
-        const truncated = suggestion.slice(prefixOverlapLastIndex, prefixSuffixOverlapIndex)
+    const overlap = getPrefixSuffixOverlap(trimmedSuggestion, rightContext)
+    const overlapIndex = suggestion.lastIndexOf(overlap)
+    if (overlapIndex >= 0) {
+        const truncated = suggestion.slice(0, overlapIndex)
         return truncated.trim().length ? truncated : ''
     } else {
         return suggestion

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/utils/triggerUtils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/utils/triggerUtils.test.ts
@@ -1,0 +1,178 @@
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import { shouldTriggerEdits, NepTrigger } from './triggerUtils'
+import { SessionManager } from '../session/sessionManager'
+import { CursorTracker } from '../tracker/cursorTracker'
+import { RecentEditTracker } from '../tracker/codeEditTracker'
+import {
+    CodeWhispererServiceToken,
+    CodeWhispererServiceIAM,
+    ClientFileContext,
+} from '../../../shared/codeWhispererService'
+import * as editPredictionAutoTrigger from '../auto-trigger/editPredictionAutoTrigger'
+import { InlineCompletionWithReferencesParams } from '@aws/language-server-runtimes/server-interface'
+
+describe('triggerUtils', () => {
+    let service: sinon.SinonStubbedInstance<CodeWhispererServiceToken>
+    let iamService: sinon.SinonStubbedInstance<CodeWhispererServiceIAM>
+    let cursorTracker: sinon.SinonStubbedInstance<CursorTracker>
+    let recentEditsTracker: sinon.SinonStubbedInstance<RecentEditTracker>
+    let sessionManager: sinon.SinonStubbedInstance<SessionManager>
+    let editPredictionAutoTriggerStub: sinon.SinonStub
+
+    const fileContext = {
+        leftFileContent: 'const x = 1;',
+        rightFileContent: '',
+        filename: 'test.ts',
+        programmingLanguage: { languageName: 'typescript' },
+    } as ClientFileContext
+
+    const inlineParams = {
+        textDocument: { uri: 'file:///test.ts' },
+        position: { line: 0, character: 12 },
+        context: { triggerKind: 1 },
+        documentChangeParams: {
+            contentChanges: [{ text: ';' }],
+        },
+    } as InlineCompletionWithReferencesParams
+
+    beforeEach(() => {
+        service = sinon.createStubInstance(CodeWhispererServiceToken)
+        iamService = sinon.createStubInstance(CodeWhispererServiceIAM)
+        cursorTracker = sinon.createStubInstance(CursorTracker)
+        recentEditsTracker = sinon.createStubInstance(RecentEditTracker)
+        sessionManager = sinon.createStubInstance(SessionManager)
+        editPredictionAutoTriggerStub = sinon.stub(editPredictionAutoTrigger, 'editPredictionAutoTrigger')
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('shouldTriggerEdits', () => {
+        it('should return undefined when edits not enabled', () => {
+            const result = shouldTriggerEdits(
+                service,
+                fileContext,
+                inlineParams,
+                cursorTracker,
+                recentEditsTracker,
+                sessionManager,
+                false
+            )
+
+            assert.equal(result, undefined)
+        })
+
+        it('should return undefined when service is not token-based', () => {
+            const result = shouldTriggerEdits(
+                iamService,
+                fileContext,
+                inlineParams,
+                cursorTracker,
+                recentEditsTracker,
+                sessionManager,
+                true
+            )
+
+            assert.equal(result, undefined)
+        })
+
+        it('should return NepTrigger when auto trigger returns shouldTrigger true', () => {
+            editPredictionAutoTriggerStub.returns({ shouldTrigger: true })
+            sessionManager.getPreviousSession.returns(undefined)
+
+            const result = shouldTriggerEdits(
+                service,
+                fileContext,
+                inlineParams,
+                cursorTracker,
+                recentEditsTracker,
+                sessionManager,
+                true
+            )
+
+            assert.ok(result instanceof NepTrigger)
+            sinon.assert.calledWith(editPredictionAutoTriggerStub, {
+                fileContext,
+                lineNum: 0,
+                char: ';',
+                previousDecision: '',
+                cursorHistory: cursorTracker,
+                recentEdits: recentEditsTracker,
+            })
+        })
+
+        it('should return undefined when auto trigger returns shouldTrigger false', () => {
+            editPredictionAutoTriggerStub.returns({ shouldTrigger: false })
+            sessionManager.getPreviousSession.returns(undefined)
+
+            const result = shouldTriggerEdits(
+                service,
+                fileContext,
+                inlineParams,
+                cursorTracker,
+                recentEditsTracker,
+                sessionManager,
+                true
+            )
+
+            assert.equal(result, undefined)
+        })
+
+        it('should use last character from file content when no document change', () => {
+            const paramsWithoutDocChange = {
+                ...inlineParams,
+                documentChangeParams: undefined,
+            }
+            editPredictionAutoTriggerStub.returns({ shouldTrigger: true })
+            sessionManager.getPreviousSession.returns(undefined)
+
+            shouldTriggerEdits(
+                service,
+                fileContext,
+                paramsWithoutDocChange,
+                cursorTracker,
+                recentEditsTracker,
+                sessionManager,
+                true
+            )
+
+            sinon.assert.calledWith(editPredictionAutoTriggerStub, {
+                fileContext,
+                lineNum: 0,
+                char: ';',
+                previousDecision: '',
+                cursorHistory: cursorTracker,
+                recentEdits: recentEditsTracker,
+            })
+        })
+
+        it('should use previous session decision when available', () => {
+            const mockSession = {
+                getAggregatedUserTriggerDecision: sinon.stub().returns('Accept'),
+            }
+            sessionManager.getPreviousSession.returns(mockSession as any)
+            editPredictionAutoTriggerStub.returns({ shouldTrigger: true })
+
+            shouldTriggerEdits(
+                service,
+                fileContext,
+                inlineParams,
+                cursorTracker,
+                recentEditsTracker,
+                sessionManager,
+                true
+            )
+
+            sinon.assert.calledWith(editPredictionAutoTriggerStub, {
+                fileContext,
+                lineNum: 0,
+                char: ';',
+                previousDecision: 'Accept',
+                cursorHistory: cursorTracker,
+                recentEdits: recentEditsTracker,
+            })
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/inline-completion/utils/triggerUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/inline-completion/utils/triggerUtils.ts
@@ -1,13 +1,13 @@
-import { SessionManager } from './session/sessionManager'
+import { SessionManager } from '../session/sessionManager'
 import { InlineCompletionWithReferencesParams } from '@aws/language-server-runtimes/protocol'
-import { editPredictionAutoTrigger } from './auto-trigger/editPredictionAutoTrigger'
-import { CursorTracker } from './tracker/cursorTracker'
-import { RecentEditTracker } from './tracker/codeEditTracker'
+import { editPredictionAutoTrigger } from '../auto-trigger/editPredictionAutoTrigger'
+import { CursorTracker } from '../tracker/cursorTracker'
+import { RecentEditTracker } from '../tracker/codeEditTracker'
 import {
     CodeWhispererServiceBase,
     CodeWhispererServiceToken,
     ClientFileContext,
-} from '../../shared/codeWhispererService'
+} from '../../../shared/codeWhispererService'
 
 export class NepTrigger {}
 


### PR DESCRIPTION
## Problem

add tests for inline utils files

## Solution

add tests for inline utils files and remove unused files

Coverage should go to 85% after this change: https://app.codecov.io/gh/aws/language-servers/commit/b91f1a0de8b711cd1ce24a7389b64daf15e06f72/tree/server/aws-lsp-codewhisperer/src/language-server?dropdown=coverage

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
