### PR TITLE
fix: set resolveProvider to false json and yaml server

### DIFF
--- a/server/aws-lsp-json/src/language-server/jsonServer.ts
+++ b/server/aws-lsp-json/src/language-server/jsonServer.ts
@@ -36,7 +36,7 @@ export const JsonServerFactory =
         const onInitializeHandler = () => {
             return {
                 capabilities: {
-                    completionProvider: { resolveProvider: true },
+                    completionProvider: { resolveProvider: false },
                     hoverProvider: true,
                     documentFormattingProvider: true,
                     textDocumentSync: {

--- a/server/aws-lsp-yaml/src/language-server/yamlServer.ts
+++ b/server/aws-lsp-yaml/src/language-server/yamlServer.ts
@@ -36,7 +36,7 @@ export const YamlServerFactory =
         const onInitializeHandler = () => {
             return {
                 capabilities: {
-                    completionProvider: { resolveProvider: true },
+                    completionProvider: { resolveProvider: false },
                     hoverProvider: true,
                     documentFormattingProvider: true,
                     textDocumentSync: {


### PR DESCRIPTION
## Problem

Currently, both the JSON and YAML generic language servers respond with `resolveProvider: true` in their initialization response. This signals to clients that these language servers support completion item resolve requests, which these servers don't actually support, resulting in errors when clients send resolve requests.

## Solution

This updates `resolveProvider` to `false` to accurately describe the capabilities of these language servers.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
