### PR TITLE
feat(amazonq): env var change for JupyterLab conversation history on refresh support

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.test.ts
@@ -15,6 +15,8 @@ import { ChatHistoryActionType } from '../../shared/telemetry/types'
 import { TelemetryService } from '../../shared/telemetry/telemetryService'
 import { URI } from 'vscode-uri'
 
+const JUPYTERLAB_APP_TYPE_VALUE = 'jupyterlab'
+
 describe('TabBarController', () => {
     let testFeatures: TestFeatures
     let chatHistoryDb: ChatDatabase
@@ -50,7 +52,7 @@ describe('TabBarController', () => {
     afterEach(() => {
         sinon.restore()
         clock.restore()
-        delete process.env.JUPYTER_LAB // Clean up JupyterLab environment variables
+        delete process.env.SAGEMAKER_APP_TYPE_LOWERCASE // Clean up JupyterLab environment variables
         testFeatures.dispose()
     })
 
@@ -563,7 +565,7 @@ describe('TabBarController', () => {
 
         it('should allow multiple loads in JupyterLab environment', async () => {
             // Set JupyterLab environment
-            process.env.JUPYTER_LAB = 'true'
+            process.env.SAGEMAKER_APP_TYPE_LOWERCASE = JUPYTERLAB_APP_TYPE_VALUE
 
             const mockTabs = [{ historyId: 'history1', conversations: [{ messages: [] }] }] as unknown as Tab[]
             ;(chatHistoryDb.getOpenTabs as sinon.SinonStub).returns(mockTabs)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tabBarController.ts
@@ -22,6 +22,7 @@ import { ChatHistoryActionType } from '../../shared/telemetry/types'
 import { CancellationError } from '@aws/lsp-core'
 
 const MaxRestoredHistoryMessages = 250
+const JUPYTERLAB_APP_TYPE_VALUE = 'jupyterlab'
 
 /**
  * Controller for managing chat history and export functionality.
@@ -344,9 +345,9 @@ export class TabBarController {
      */
     private isJupyterLabEnvironment(): boolean {
         try {
-            return process.env.JUPYTER_LAB === 'true'
+            return process.env.SAGEMAKER_APP_TYPE_LOWERCASE === JUPYTERLAB_APP_TYPE_VALUE
         } catch (error) {
-            this.#features.logging.error(`Failed to read JUPYTER_LAB environment variable: ${error}`)
+            this.#features.logging.error(`Failed to read SAGEMAKER_APP_TYPE_LOWERCASE environment variable: ${error}`)
             return false
         }
     }


### PR DESCRIPTION
**Description**
Team has decided to use `SAGEMAKER_APP_TYPE_LOWERCASE` env var to support conversation history on refresh for JupterLab. 

**Testing Done**
- npm test
- Build server bundle and tested in a SMUS space

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
