### PR TITLE
feat(amazonq): add auto compaction feature

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/errors.ts
@@ -61,6 +61,27 @@ export function isInputTooLongError(error: unknown): boolean {
     return false
 }
 
+/**
+ * Detects context window overflow errors that can be resolved by compacting conversation history.
+ * Covers various error patterns from different backends and API versions.
+ */
+export function isContextWindowOverflow(error: unknown): boolean {
+    if (isInputTooLongError(error)) {
+        return true
+    }
+
+    const message = (error as Error)?.message?.toLowerCase() ?? ''
+    const name = (error as Error)?.name ?? ''
+    return (
+        name === 'ContextWindowOverflowException' ||
+        message.includes('improperly formed request') ||
+        message.includes('prompt is too long') ||
+        message.includes('context window') ||
+        message.includes('token limit') ||
+        message.includes('maximum context')
+    )
+}
+
 export function isRequestAbortedError(error: unknown): boolean {
     if (error instanceof AgenticChatError && error.code === 'RequestAborted') {
         return true

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatSessionService.ts
@@ -31,6 +31,7 @@ export class ChatSessionService {
     public pairProgrammingMode: boolean = true
     public contextListSent: boolean = false
     public isMemoryBankGeneration: boolean = false
+    public didAutoCompactOnOverflow: boolean = false
     #modelId: string | undefined
     #lsp?: Features['lsp']
     #abortController?: AbortController


### PR DESCRIPTION
## Problem
When the context window is exceeded during agentic chat, users see an "Improperly formed request" or "Input is too long" error and must manually run `/compact` then re-ask their question.

## Solution
Automatically detect context window overflow errors and run compaction + retry transparently, using a single boolean flag (`didAutoCompactOnOverflow`) to allow __one__ automatic compaction per user turn (preventing infinite loops).

Auto-compaction is handled at two levels:

1. __Mid-loop (inside `#runAgentLoop`)__: When `getChatResponse()` throws a context overflow error, the agent loop compacts conversation history and `continue`s from the current iteration — preserving in-progress state and tool execution context.

2. __Outer catch (in `onChatPrompt`)__: Catches overflow errors from request preparation, compaction itself, or result handling. Compacts and retries the full `onChatPrompt` call.

The flag is reset at the start of each new user message, so:

- First overflow → auto-compact + retry (flag: `false` → `true`)
- Second overflow in same turn → shows error to user (already `true`)
- New user message → flag reset to `false`

###

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
