### PR TITLE
fix: remove @workspace from context commands menu

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -183,7 +183,7 @@ export class ContextCommandsProvider implements Disposable {
             description: 'Reference all code in workspace',
             disabledText: this.workspacePending ? 'pending' : undefined,
         }
-        const commands = [workspaceCmd, folderCmdGroup, fileCmdGroup, codeCmdGroup, promptCmdGroup]
+        const commands = [folderCmdGroup, fileCmdGroup, codeCmdGroup, promptCmdGroup]
 
         if (imageContextEnabled) {
             commands.push(imageCmdGroup)


### PR DESCRIPTION
## Problem
`@workspace` uses vector/semantic search (ONNX + faiss + CodeSage model) has been broken. Even if it is enabled, there are major performance issues with it.

## Solution
After checking metrics, we can remove `@workspace` from the context commands menu so it's no longer shown to users which means that they are not able to use it anymore

## Follow up
Dead code cleanup here: https://github.com/aws/language-servers/pull/2670