### PR TITLE
fix: clean up @workspace dead code after removing from context menu

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -257,11 +257,7 @@ describe('AgenticChatController', () => {
         } as any // Using 'as any' to prevent type errors when the Agent interface is updated with new methods
 
         additionalContextProviderStub = sinon.stub(AdditionalContextProvider.prototype, 'getAdditionalContext')
-        additionalContextProviderStub.callsFake(async (triggerContext, _, context: ContextCommand[]) => {
-            // When @workspace is in the context, set hasWorkspace flag
-            if (context && context.some(item => item.command === '@workspace')) {
-                triggerContext.hasWorkspace = true
-            }
+        additionalContextProviderStub.callsFake(async () => {
             return []
         })
         // @ts-ignore
@@ -1343,60 +1339,6 @@ describe('AgenticChatController', () => {
 
             afterEach(() => {
                 extractDocumentContextStub.restore()
-            })
-
-            it('parses relevant document and includes as requestInput if @workspace context is included', async () => {
-                const localProjectContextController = new LocalProjectContextController('client-name', [], logging)
-                const mockRelevantDocs = [
-                    { filePath: '/test/1.ts', content: 'text', id: 'id-1', index: 0, vec: [1] },
-                    { filePath: '/test/2.ts', content: 'text2', id: 'id-2', index: 0, vec: [1] },
-                ]
-
-                sinon.stub(LocalProjectContextController, 'getInstance').resolves(localProjectContextController)
-                sinon.stub(localProjectContextController, 'isIndexingEnabled').returns(true)
-                sinon.stub(localProjectContextController, 'queryVectorIndex').resolves(mockRelevantDocs)
-
-                await chatController.onChatPrompt(
-                    {
-                        tabId: 'tab',
-                        prompt: {
-                            prompt: '@workspace help me understand this code',
-                            escapedPrompt: '@workspace help me understand this code',
-                        },
-                        context: [{ command: '@workspace' }],
-                    },
-                    mockCancellationToken
-                )
-
-                const calledRequestInput: GenerateAssistantResponseCommandInput =
-                    generateAssistantResponseStub.firstCall.firstArg
-
-                assert.deepStrictEqual(
-                    calledRequestInput.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
-                        ?.editorState,
-                    {
-                        workspaceFolders: [],
-                        relevantDocuments: [
-                            {
-                                endLine: -1,
-                                path: '/test/1.ts',
-                                relativeFilePath: '1.ts',
-                                startLine: -1,
-                                text: 'text',
-                                type: ContentType.WORKSPACE,
-                            },
-                            {
-                                endLine: -1,
-                                path: '/test/2.ts',
-                                relativeFilePath: '2.ts',
-                                startLine: -1,
-                                text: 'text2',
-                                type: ContentType.WORKSPACE,
-                            },
-                        ],
-                        useRelevantDocuments: true,
-                    }
-                )
             })
 
             it('leaves cursorState as undefined if cursorState is not passed', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -3535,7 +3535,6 @@ export class AgenticChatController implements ChatHandlers {
         if (triggerContext.contextInfo) {
             metric.mergeWith({
                 cwsprChatHasContextList: triggerContext.documentReference?.filePaths?.length ? true : false,
-                cwsprChatHasWorkspaceContext: triggerContext.hasWorkspace ?? false,
                 cwsprChatFolderContextCount: triggerContext.contextInfo.contextCount.folderContextCount,
                 cwsprChatFileContextCount: triggerContext.contextInfo.contextCount.fileContextCount,
                 cwsprChatRuleContextCount: triggerContext.contextInfo.contextCount.activeRuleContextCount,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.test.ts
@@ -326,27 +326,6 @@ describe('AdditionalContextProvider', () => {
             assert.strictEqual(triggerContext.cursorState, undefined)
         })
 
-        it('should set hasWorkspace flag when @workspace is present', async () => {
-            const mockWorkspaceFolder = {
-                uri: URI.file('/workspace').toString(),
-                name: 'test',
-            }
-            sinon.stub(workspaceUtils, 'getWorkspaceFolderPaths').returns(['/workspace'])
-            const triggerContext: TriggerContext = {
-                workspaceFolder: mockWorkspaceFolder,
-            }
-
-            const workspaceContext = [{ id: '@workspace', command: 'Workspace', label: 'folder' }]
-            ;(chatHistoryDb.getPinnedContext as sinon.SinonStub).returns(workspaceContext)
-
-            fsExistsStub.resolves(false)
-            getContextCommandPromptStub.resolves([])
-
-            await provider.getAdditionalContext(triggerContext, 'tab1')
-
-            assert.strictEqual(triggerContext.hasWorkspace, true)
-        })
-
         it('should count context types correctly', async () => {
             const mockWorkspaceFolder = {
                 uri: URI.file('/workspace').toString(),

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/additionalContextProvider.ts
@@ -436,9 +436,6 @@ export class AdditionalContextProvider {
             contextInfo = contextInfo.filter(item => item.id !== ACTIVE_EDITOR_CONTEXT_ID)
         }
 
-        if (contextInfo.some(item => item.id === '@workspace')) {
-            triggerContext.hasWorkspace = true
-        }
         // Handle code symbol ID mismatches between indexing sessions
         // When a workspace is re-indexed, code symbols receive new IDs
         // If a pinned symbol's ID is no longer found in the current index:

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/agenticChatTriggerContext.ts
@@ -14,6 +14,7 @@ import {
     EnvState,
     Origin,
     ImageBlock,
+    RelevantTextDocument,
 } from '@amzn/codewhisperer-streaming'
 import {
     BedrockTools,
@@ -22,18 +23,15 @@ import {
     InlineChatParams,
     FileList,
     TextDocument,
-    OPEN_WORKSPACE_INDEX_SETTINGS_BUTTON_ID,
 } from '@aws/language-server-runtimes/server-interface'
 import { Features } from '../../types'
 import { DocumentContext, DocumentContextExtractor } from '../../chat/contexts/documentContext'
 import { workspaceUtils } from '@aws/lsp-core'
 import { URI } from 'vscode-uri'
-import { LocalProjectContextController } from '../../../shared/localProjectContextController'
 import * as path from 'path'
-import { RelevantTextDocument } from '@amzn/codewhisperer-streaming'
 import { languageByExtension } from '../../../shared/languageDetection'
 import { AgenticChatResultStream } from '../agenticChatResultStream'
-import { ContextInfo, mergeFileLists, mergeRelevantTextDocuments } from './contextUtils'
+import { ContextInfo } from './contextUtils'
 import { WorkspaceFolderManager } from '../../workspaceContext/workspaceFolderManager'
 import { getRelativePathWithWorkspaceFolder } from '../../workspaceContext/util'
 import { ChatCommandInput } from '../../../shared/streamingClientService'
@@ -47,7 +45,6 @@ export interface TriggerContext extends Partial<DocumentContext> {
      * Represents the context transparency list displayed at the top of the assistant response.
      */
     documentReference?: FileList
-    hasWorkspace?: boolean
 }
 export type LineInfo = { startLine: number; endLine: number }
 
@@ -178,7 +175,6 @@ export class AgenticChatTriggerContext {
         const { prompt } = params
         const workspaceFolders = workspaceUtils.getWorkspaceFolderPaths(this.#workspace).slice(0, maxWorkspaceFolders)
         const defaultEditorState = { workspaceFolders }
-        const hasWorkspace = triggerContext.hasWorkspace
 
         // prompt.prompt is what user typed in the input, should be sent to backend
         // prompt.escapedPrompt is HTML serialized string, which should only be used for UI.
@@ -188,10 +184,6 @@ export class AgenticChatTriggerContext {
         // This intereferes with routing logic thus we need to remove it
         if (promptContent && promptContent.includes('@sage')) {
             promptContent = promptContent.replace(/\*\*@sage\*\*/g, '@sage')
-        }
-
-        if (hasWorkspace) {
-            promptContent = promptContent?.replace(/\*\*@workspace\*\*/, '')
         }
 
         // Append remote workspaceId if it exists
@@ -204,15 +196,7 @@ export class AgenticChatTriggerContext {
             undefined
         this.#logging.info(`remote workspaceId: ${workspaceId}`)
 
-        // Get workspace documents if @workspace is used
-        let relevantDocuments = hasWorkspace
-            ? await this.#getRelevantDocuments(promptContent ?? '', chatResultStream)
-            : []
-
-        const workspaceFileList = mergeRelevantTextDocuments(relevantDocuments)
-        triggerContext.documentReference = triggerContext.documentReference
-            ? mergeFileLists(triggerContext.documentReference, workspaceFileList)
-            : workspaceFileList
+        const relevantDocuments: RelevantTextDocumentAddition[] = []
         // Add @context in prompt to relevantDocuments
         if (additionalContent) {
             for (const item of additionalContent.filter(item => !item.pinned)) {
@@ -443,82 +427,5 @@ export class AgenticChatTriggerContext {
         }
 
         return [...uris]
-    }
-
-    async #getRelevantDocuments(
-        prompt: string,
-        chatResultStream?: AgenticChatResultStream
-    ): Promise<RelevantTextDocumentAddition[]> {
-        const localProjectContextController = await LocalProjectContextController.getInstance()
-        if (!localProjectContextController.isIndexingEnabled() && chatResultStream) {
-            await chatResultStream.writeResultBlock({
-                body: `To add your workspace as context, enable local indexing in your IDE settings. After enabling, add @workspace to your question, and I'll generate a response using your workspace as context.`,
-                buttons: [
-                    {
-                        id: OPEN_WORKSPACE_INDEX_SETTINGS_BUTTON_ID,
-                        text: 'Open settings',
-                        icon: 'external',
-                        keepCardAfterClick: false,
-                        status: 'info',
-                    },
-                ],
-            })
-            return []
-        }
-
-        let relevantTextDocuments = await this.#queryRelevantDocuments(prompt, localProjectContextController)
-        relevantTextDocuments = relevantTextDocuments.filter(doc => doc.text && doc.text.length > 0)
-        for (const relevantDocument of relevantTextDocuments) {
-            if (relevantDocument.text && relevantDocument.text.length > workspaceChunkMaxSize) {
-                relevantDocument.text = relevantDocument.text.substring(0, workspaceChunkMaxSize)
-                this.#logging.debug(`Truncating @workspace chunk: ${relevantDocument.relativeFilePath} `)
-            }
-        }
-
-        return relevantTextDocuments
-    }
-
-    async #queryRelevantDocuments(
-        prompt: string,
-        localProjectContextController: LocalProjectContextController
-    ): Promise<RelevantTextDocumentAddition[]> {
-        try {
-            const chunks = await localProjectContextController.queryVectorIndex({ query: prompt })
-            const relevantTextDocuments: RelevantTextDocumentAddition[] = []
-            if (!chunks) {
-                return relevantTextDocuments
-            }
-
-            for (const chunk of chunks) {
-                const text = chunk.context ?? chunk.content
-                const baseDocument = {
-                    text,
-                    path: chunk.filePath,
-                    relativeFilePath: chunk.relativePath ?? path.basename(chunk.filePath),
-                    startLine: chunk.startLine ?? -1,
-                    endLine: chunk.endLine ?? -1,
-                }
-
-                if (chunk.programmingLanguage && chunk.programmingLanguage !== 'unknown') {
-                    relevantTextDocuments.push({
-                        ...baseDocument,
-                        programmingLanguage: {
-                            languageName: chunk.programmingLanguage,
-                        },
-                        type: ContentType.WORKSPACE,
-                    })
-                } else {
-                    relevantTextDocuments.push({
-                        ...baseDocument,
-                        type: ContentType.WORKSPACE,
-                    })
-                }
-            }
-
-            return relevantTextDocuments
-        } catch (e) {
-            this.#logging.error(`Error querying query vector index to get relevant documents: ${e}`)
-            return []
-        }
     }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
@@ -106,31 +106,6 @@ describe('ContextCommandsProvider', () => {
         })
     })
 
-    describe('onIndexingInProgressChanged', () => {
-        it('should update workspacePending and call processContextCommandUpdate when indexing status changes', async () => {
-            let capturedCallback: ((indexingInProgress: boolean) => void) | undefined
-
-            const mockController = {
-                onContextItemsUpdated: sinon.stub(),
-                set onIndexingInProgressChanged(callback: (indexingInProgress: boolean) => void) {
-                    capturedCallback = callback
-                },
-            }
-
-            const processUpdateSpy = sinon.spy(provider, 'processContextCommandUpdate')
-            ;(LocalProjectContextController.getInstance as sinon.SinonStub).resolves(mockController as any)
-
-            // Set initial state to false so condition is met
-            ;(provider as any).workspacePending = false
-
-            await (provider as any).registerContextCommandHandler()
-
-            capturedCallback?.(true)
-
-            sinon.assert.calledWith(processUpdateSpy, [])
-        })
-    })
-
     describe('setFilesAndFoldersFailed', () => {
         it('should set filesAndFoldersFailed to true and filesAndFoldersPending to false', () => {
             provider.setFilesAndFoldersFailed(true)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -16,7 +16,6 @@ export class ContextCommandsProvider implements Disposable {
     private codeSymbolsFailed = false
     private filesAndFoldersPending = true
     private filesAndFoldersFailed = false
-    private workspacePending = true
     private initialStateSent = false
     constructor(
         private readonly logging: Logging,
@@ -44,12 +43,6 @@ export class ContextCommandsProvider implements Disposable {
             const controller = await LocalProjectContextController.getInstance()
             controller.onContextItemsUpdated = async contextItems => {
                 await this.processContextCommandUpdate(contextItems)
-            }
-            controller.onIndexingInProgressChanged = (indexingInProgress: boolean) => {
-                if (this.workspacePending !== indexingInProgress) {
-                    this.workspacePending = indexingInProgress
-                    void this.processContextCommandUpdate(this.cachedContextCommands ?? [])
-                }
             }
         } catch (e) {
             this.logging.warn(`Error processing context command update: ${e}`)
@@ -177,12 +170,6 @@ export class ContextCommandsProvider implements Disposable {
             placeholder: 'Select an image file',
         }
 
-        const workspaceCmd: ContextCommand = {
-            command: '@workspace',
-            id: '@workspace',
-            description: 'Reference all code in workspace',
-            disabledText: this.workspacePending ? 'pending' : undefined,
-        }
         const commands = [folderCmdGroup, fileCmdGroup, codeCmdGroup, promptCmdGroup]
 
         if (imageContextEnabled) {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -183,7 +183,7 @@ export class ContextCommandsProvider implements Disposable {
             description: 'Reference all code in workspace',
             disabledText: this.workspacePending ? 'pending' : undefined,
         }
-        const commands = [workspaceCmd, folderCmdGroup, fileCmdGroup, codeCmdGroup, promptCmdGroup]
+        const commands = [folderCmdGroup, fileCmdGroup, codeCmdGroup, promptCmdGroup]
 
         if (imageContextEnabled) {
             commands.push(imageCmdGroup)


### PR DESCRIPTION
Previous PR which removed the `@workspace` functionality: https://github.com/aws/language-servers/pull/2669

## Problem

After removing `@workspace` from the context commands menu, there is dead code remaining.

## Solution
Clean up dead code