### PR TITLE
fix: strip vector search from indexing library + update indexing library to `75a7294a`

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-darwin-arm64.zip
+++ b/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-darwin-arm64.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09b75b788854e2c2f08b9fa73c671e476f7e20b8284521f544ea7f2e2c82d3fa
-size 96549602
+oid sha256:f59a63572dbadb648fe60741b41d929cbd2735a72312fedd07dc37bf9b9a78e8
+size 3080924

--- a/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-darwin-x64.zip
+++ b/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-darwin-x64.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f13048f6989d01f8a5b8d9743ca2efa023cc4ae0c05efcd4fc0cb22f4b2dd5c3
-size 98233434
+oid sha256:f59a63572dbadb648fe60741b41d929cbd2735a72312fedd07dc37bf9b9a78e8
+size 3080924

--- a/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-linux-arm64.zip
+++ b/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-linux-arm64.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e119ae06538b7bfe7ce0050d88909c64989b10c481477e24bdd6ab9f6152846
-size 102483123
+oid sha256:f59a63572dbadb648fe60741b41d929cbd2735a72312fedd07dc37bf9b9a78e8
+size 3080924

--- a/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-linux-x64.zip
+++ b/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-linux-x64.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8aea05af87c620a7be4cb58b4b9b1a579e5726b1eb3682e55c42302ff19d853d
-size 114470426
+oid sha256:f59a63572dbadb648fe60741b41d929cbd2735a72312fedd07dc37bf9b9a78e8
+size 3080924

--- a/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-win32-x64.zip
+++ b/app/aws-lsp-codewhisperer-runtimes/_bundle-assets/qserver-win32-x64.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aafb3ef97fca6ba0369f7bfc48b5846e2b4f4fdec0014aae58be70f49cc42116
-size 113755807
+oid sha256:f59a63572dbadb648fe60741b41d929cbd2735a72312fedd07dc37bf9b9a78e8
+size 3080924


### PR DESCRIPTION
## Problem

The @workspace vector/semantic search feature (ONNX + faiss + CodeSage model) is being removed.The qserver bundle zips still contain ~160MB of native binaries and ML models per platform that are no longer needed.

## Solution
Updated the qserver-*.zip bundle assets with a rebuilt indexing library (`75a7294a`) that has all vector search code removed from AWSVectorConsolasLocalWorkspaceIndexing

- Removed: ONNX runtime native binaries (dist/bin/), faiss native binaries (dist/build/), CodeSage model (models/)
- Kept: extension.js (BM25 + context commands), tree-sitter.wasm, tree-sitter-wasms/ (21 language grammars), lspServer.js







## Impact

- Each qserver zip: ~100MB → 2.9MB (97% reduction)
- All 5 platform zips are now identical (no platform-specific native binaries)
- @file, @folder, @code continue to work
- BM25 cross-file context for inline completions continues to work
- @workspace / queryVectorIndex no longer functional (being removed)

## Note
All 5 platform zips are now identical (no platform-specific native binaries). **They could technically be combined into a single zip, but that would require changes across multiple build scripts (package.sh, lspArtifact.ts, build.gradle.kts, manifest generation, etc.), so keeping 5 individual zips for now.**

## Testing
- E2E verified locally: @file, @folder, @code all work with stripped indexing bundle
- No "Vector library failed" errors in logs