### PR TITLE
fix: reserve folder budget in initial context command cap

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -27,7 +27,7 @@
         "@aws/chat-client-ui-types": "0.1.68",
         "@aws/language-server-runtimes": "^0.3.16",
         "@aws/language-server-runtimes-types": "^0.1.64",
-        "@aws/mynah-ui": "^4.40.0"
+        "@aws/mynah-ui": "^4.40.1"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -1485,30 +1485,18 @@ ${params.message}`,
             commands: toContextCommands(group.commands),
         }))
 
-        const highlightCommands = featureConfig?.get('highlightCommand')
-            ? [
-                  {
-                      groupName: 'Additional commands',
-                      commands: [toMynahContextCommand(featureConfig.get('highlightCommand'))],
-                  },
-              ]
-            : []
-
-        // Update the store so the picker's store listener refreshes with
-        // filtered results (fires synchronously during updateStore).
         mynahUi.updateStore(lastFilterTabId, {
-            contextCommands: [...filtered, ...highlightCommands],
-        })
-
-        // Restore the base contextCommandGroups to the store on the next
-        // microtask. The picker already captured the filtered items above.
-        // This ensures sub-menu navigation (@Folder/@File) reads from the
-        // full base set, not the filtered results.
-        const tabToRestore = lastFilterTabId
-        Promise.resolve().then(() => {
-            mynahUi.updateStore(tabToRestore, {
-                contextCommands: [...(contextCommandGroups || []), ...highlightCommands],
-            })
+            contextCommands: [
+                ...filtered,
+                ...(featureConfig?.get('highlightCommand')
+                    ? [
+                          {
+                              groupName: 'Additional commands',
+                              commands: [toMynahContextCommand(featureConfig.get('highlightCommand'))],
+                          },
+                      ]
+                    : []),
+            ],
         })
     }
 

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -382,7 +382,6 @@ export const createMynahUi = (
             }
         },
         onChatPrompt(tabId, prompt, eventId) {
-            lastFilterTabId = undefined
             handleChatPrompt(mynahUi, tabId, prompt, messager, 'click', eventId, agenticMode, tabFactory)
         },
         onReady: () => {
@@ -432,12 +431,10 @@ export const createMynahUi = (
             messager.onListAvailableModels({ tabId })
         },
         onTabRemove: (tabId: string) => {
-            if (lastFilterTabId === tabId) lastFilterTabId = undefined
             messager.onStopChatResponse(tabId)
             messager.onTabRemove(tabId)
         },
         onTabChange: (tabId: string) => {
-            lastFilterTabId = undefined
             messager.onTabChange(tabId)
         },
         onResetStore: () => {},
@@ -1474,10 +1471,6 @@ ${params.message}`,
         ]
 
         Object.keys(mynahUi.getAllTabs()).forEach(tabId => {
-            // Skip tabs with an active filter session to avoid resetting
-            // the picker while the user is browsing sub-menus or search results.
-            if (tabId === lastFilterTabId) return
-
             mynahUi.updateStore(tabId, {
                 contextCommands: commandsWithHighlight,
             })
@@ -1492,18 +1485,30 @@ ${params.message}`,
             commands: toContextCommands(group.commands),
         }))
 
+        const highlightCommands = featureConfig?.get('highlightCommand')
+            ? [
+                  {
+                      groupName: 'Additional commands',
+                      commands: [toMynahContextCommand(featureConfig.get('highlightCommand'))],
+                  },
+              ]
+            : []
+
+        // Update the store so the picker's store listener refreshes with
+        // filtered results (fires synchronously during updateStore).
         mynahUi.updateStore(lastFilterTabId, {
-            contextCommands: [
-                ...filtered,
-                ...(featureConfig?.get('highlightCommand')
-                    ? [
-                          {
-                              groupName: 'Additional commands',
-                              commands: [toMynahContextCommand(featureConfig.get('highlightCommand'))],
-                          },
-                      ]
-                    : []),
-            ],
+            contextCommands: [...filtered, ...highlightCommands],
+        })
+
+        // Restore the base contextCommandGroups to the store on the next
+        // microtask. The picker already captured the filtered items above.
+        // This ensures sub-menu navigation (@Folder/@File) reads from the
+        // full base set, not the filtered results.
+        const tabToRestore = lastFilterTabId
+        Promise.resolve().then(() => {
+            mynahUi.updateStore(tabToRestore, {
+                contextCommands: [...(contextCommandGroups || []), ...highlightCommands],
+            })
         })
     }
 

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -813,27 +813,12 @@ export const createMynahUi = (
             store: tabFactory.createTab(false),
         },
         onContextCommandFilter: (tabId, searchTerm) => {
+            // Always forward to the server. Server pulls fresh items from
+            // the indexer on every request (no client-side cache), so the
+            // empty-term case (@ press) returns a fresh capped list and
+            // non-empty terms return the scored top matches.
             lastFilterTabId = tabId
-            if (!searchTerm || searchTerm.trim() === '') {
-                // Empty search: restore the base context commands directly
-                // instead of round-tripping to the server, which would
-                // overwrite the store with a potentially different set.
-                mynahUi.updateStore(tabId, {
-                    contextCommands: [
-                        ...(contextCommandGroups || []),
-                        ...(featureConfig?.get('highlightCommand')
-                            ? [
-                                  {
-                                      groupName: 'Additional commands',
-                                      commands: [toMynahContextCommand(featureConfig.get('highlightCommand'))],
-                                  },
-                              ]
-                            : []),
-                    ],
-                })
-                return
-            }
-            messager.onFilterContextCommands({ tabId, searchTerm })
+            messager.onFilterContextCommands({ tabId, searchTerm: searchTerm ?? '' })
         },
         config: {
             maxTabs: 10,

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -814,6 +814,25 @@ export const createMynahUi = (
         },
         onContextCommandFilter: (tabId, searchTerm) => {
             lastFilterTabId = tabId
+            if (!searchTerm || searchTerm.trim() === '') {
+                // Empty search: restore the base context commands directly
+                // instead of round-tripping to the server, which would
+                // overwrite the store with a potentially different set.
+                mynahUi.updateStore(tabId, {
+                    contextCommands: [
+                        ...(contextCommandGroups || []),
+                        ...(featureConfig?.get('highlightCommand')
+                            ? [
+                                  {
+                                      groupName: 'Additional commands',
+                                      commands: [toMynahContextCommand(featureConfig.get('highlightCommand'))],
+                                  },
+                              ]
+                            : []),
+                    ],
+                })
+                return
+            }
             messager.onFilterContextCommands({ tabId, searchTerm })
         },
         config: {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -382,6 +382,7 @@ export const createMynahUi = (
             }
         },
         onChatPrompt(tabId, prompt, eventId) {
+            lastFilterTabId = undefined
             handleChatPrompt(mynahUi, tabId, prompt, messager, 'click', eventId, agenticMode, tabFactory)
         },
         onReady: () => {
@@ -431,10 +432,12 @@ export const createMynahUi = (
             messager.onListAvailableModels({ tabId })
         },
         onTabRemove: (tabId: string) => {
+            if (lastFilterTabId === tabId) lastFilterTabId = undefined
             messager.onStopChatResponse(tabId)
             messager.onTabRemove(tabId)
         },
         onTabChange: (tabId: string) => {
+            lastFilterTabId = undefined
             messager.onTabChange(tabId)
         },
         onResetStore: () => {},
@@ -1458,19 +1461,25 @@ ${params.message}`,
             commands: toContextCommands(group.commands),
         }))
 
+        const commandsWithHighlight = [
+            ...(contextCommandGroups || []),
+            ...(featureConfig?.get('highlightCommand')
+                ? [
+                      {
+                          groupName: 'Additional commands',
+                          commands: [toMynahContextCommand(featureConfig.get('highlightCommand'))],
+                      },
+                  ]
+                : []),
+        ]
+
         Object.keys(mynahUi.getAllTabs()).forEach(tabId => {
+            // Skip tabs with an active filter session to avoid resetting
+            // the picker while the user is browsing sub-menus or search results.
+            if (tabId === lastFilterTabId) return
+
             mynahUi.updateStore(tabId, {
-                contextCommands: [
-                    ...(contextCommandGroups || []),
-                    ...(featureConfig?.get('highlightCommand')
-                        ? [
-                              {
-                                  groupName: 'Additional commands',
-                                  commands: [toMynahContextCommand(featureConfig.get('highlightCommand'))],
-                              },
-                          ]
-                        : []),
-                ],
+                contextCommands: commandsWithHighlight,
             })
         })
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,7 +257,7 @@
                 "@aws/chat-client-ui-types": "0.1.68",
                 "@aws/language-server-runtimes": "^0.3.16",
                 "@aws/language-server-runtimes-types": "^0.1.64",
-                "@aws/mynah-ui": "^4.40.0"
+                "@aws/mynah-ui": "^4.40.1"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -4633,9 +4633,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.40.0",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.40.0.tgz",
-            "integrity": "sha512-KDUcm4P9j734Xxm08yIr2E6pLXZ0Ist1YdYO6ysohO9rJLpdckhDvrYRIE5OnaHRxCUHrBliWCW0AVvegKsIhA==",
+            "version": "4.40.1",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.40.1.tgz",
+            "integrity": "sha512-4Dj1ESywJWlwjGjI/yxjC8Ba4ilrGt5oU4YUjZg+TMj/k6ihNIDyK/3w3BMPyWryhH6N/MkgMKn4IiAknBQv1Q==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.preservation.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.preservation.test.ts
@@ -128,9 +128,16 @@ describe('Preservation: Context Commands Provider Small Payload Behavior', () =>
      * **Validates: Requirements 3.2**
      *
      * Property 2e: For all valid context item selections, processContextCommandUpdate
-     * sends the full payload to the webview via chat.sendContextCommands and caches items.
+     * dispatches exactly one chat.sendContextCommands call with a contextCommandGroups
+     * payload.
+     *
+     * Note: the prior version of this test also asserted that items were cached on
+     * `cachedContextCommands`. That field was removed in `refactor: remove stale
+     * context command cache, always pull fresh from indexer` — the server now pulls
+     * fresh items from the indexer on every request instead of caching, so the
+     * assertion was deleted.
      */
-    it('processContextCommandUpdate sends all items and caches them for small payloads', async () => {
+    it('processContextCommandUpdate dispatches a single sendContextCommands payload for small payloads', async () => {
         await fc.assert(
             fc.asyncProperty(smallContextItemsArb, async items => {
                 sendContextCommandsSpy.resetHistory()
@@ -143,10 +150,6 @@ describe('Preservation: Context Commands Provider Small Payload Behavior', () =>
                 // The sent payload should contain contextCommandGroups
                 const sentPayload = sendContextCommandsSpy.firstCall.args[0]
                 if (!sentPayload.contextCommandGroups) return false
-
-                // Cached items should match the input
-                const cached = (provider as any).cachedContextCommands
-                if (cached !== items) return false
 
                 return true
             }),

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
@@ -279,4 +279,104 @@ describe('ContextCommandsProvider', () => {
             sinon.assert.match(fileChildren.length, 51) // 50 + Active File
         })
     })
+
+    describe('getFreshItems', () => {
+        it('should return empty array and log when LocalProjectContextController.getInstance rejects', async () => {
+            ;(LocalProjectContextController.getInstance as sinon.SinonStub).rejects(new Error('boom'))
+            const errorSpy = testFeatures.logging.error as unknown as sinon.SinonStub
+
+            const result = await (provider as any).getFreshItems()
+
+            sinon.assert.match(result.length, 0)
+            sinon.assert.calledOnce(errorSpy)
+        })
+
+        it('should return empty array and log when getContextCommandItems rejects', async () => {
+            ;(LocalProjectContextController.getInstance as sinon.SinonStub).resolves({
+                getContextCommandItems: sinon.stub().rejects(new Error('indexer down')),
+            } as any)
+            const errorSpy = testFeatures.logging.error as unknown as sinon.SinonStub
+
+            const result = await (provider as any).getFreshItems()
+
+            sinon.assert.match(result.length, 0)
+            sinon.assert.calledOnce(errorSpy)
+        })
+
+        it('should return items from controller on success', async () => {
+            const fakeItems: ContextCommandItem[] = [
+                { workspaceFolder: '/workspace', type: 'file', relativePath: 'a.ts', id: 'a' },
+            ]
+            ;(LocalProjectContextController.getInstance as sinon.SinonStub).resolves({
+                getContextCommandItems: sinon.stub().resolves(fakeItems),
+            } as any)
+
+            const result = await (provider as any).getFreshItems()
+
+            sinon.assert.match(result.length, 1)
+            sinon.assert.match(result[0].id, 'a')
+        })
+    })
+
+    describe('registerFilterHandler empty-search path', () => {
+        let existsSyncStub: sinon.SinonStub
+
+        function makeItem(type: 'file' | 'folder', index: number): ContextCommandItem {
+            return {
+                workspaceFolder: '/workspace',
+                type,
+                relativePath: type === 'folder' ? `dir${index}` : `file${index}.ts`,
+                id: `${type}-${index}`,
+            }
+        }
+
+        beforeEach(() => {
+            existsSyncStub = sinon.stub(fs, 'existsSync').returns(true)
+        })
+
+        it('should apply capItems folder budget when filter handler called with empty searchTerm', async () => {
+            const folders = Array.from({ length: 200 }, (_, i) => makeItem('folder', i))
+            const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
+            ;(LocalProjectContextController.getInstance as sinon.SinonStub).resolves({
+                getContextCommandItems: sinon.stub().resolves([...files, ...folders]),
+            } as any)
+
+            // Register a fresh filter handler so the new stubbed controller is used.
+            ;(provider as any).registerFilterHandler()
+
+            const onFilterStub = testFeatures.chat.onFilterContextCommands as unknown as sinon.SinonStub
+            // The handler is the most recently-registered one (initial registration
+            // happens in the constructor with the placeholder controller stub).
+            const handler = onFilterStub.lastCall.args[0]
+            const result = await handler({ searchTerm: '' })
+
+            const topCommands = result.contextCommandGroups[0].commands
+            const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
+            const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
+
+            // Folder budget = ceil(1000 * 0.1) = 100
+            sinon.assert.match(folderChildren.length, 100)
+            // Files fill the remaining 900 + the "Active File" command
+            sinon.assert.match(fileChildren.length, 901)
+        })
+
+        it('should also apply capItems when searchTerm is whitespace-only', async () => {
+            const folders = Array.from({ length: 200 }, (_, i) => makeItem('folder', i))
+            const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
+            ;(LocalProjectContextController.getInstance as sinon.SinonStub).resolves({
+                getContextCommandItems: sinon.stub().resolves([...files, ...folders]),
+            } as any)
+            ;(provider as any).registerFilterHandler()
+
+            const onFilterStub = testFeatures.chat.onFilterContextCommands as unknown as sinon.SinonStub
+            const handler = onFilterStub.lastCall.args[0]
+            const result = await handler({ searchTerm: '   ' })
+
+            const topCommands = result.contextCommandGroups[0].commands
+            const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
+
+            // Whitespace trims to empty → folder budget enforced
+            sinon.assert.match(folderChildren.length, 100)
+        })
+    })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
@@ -280,6 +280,131 @@ describe('ContextCommandsProvider', () => {
         })
     })
 
+    describe('processContextCommandUpdate code budget', () => {
+        let sendContextCommandsSpy: sinon.SinonStub
+        let existsSyncStub: sinon.SinonStub
+
+        function makeFile(index: number): ContextCommandItem {
+            return {
+                workspaceFolder: '/workspace',
+                type: 'file',
+                relativePath: `file${index}.ts`,
+                id: `file-${index}`,
+            }
+        }
+
+        function makeFolder(index: number): ContextCommandItem {
+            return {
+                workspaceFolder: '/workspace',
+                type: 'folder',
+                relativePath: `dir${index}`,
+                id: `folder-${index}`,
+            }
+        }
+
+        function makeCode(index: number): ContextCommandItem {
+            return {
+                workspaceFolder: '/workspace',
+                type: 'code',
+                relativePath: `file${index}.ts`,
+                id: `code-${index}`,
+                symbol: {
+                    kind: 'Function',
+                    name: `func${index}`,
+                    range: {
+                        start: { line: 0, column: 0 },
+                        end: { line: 10, column: 0 },
+                    },
+                },
+            } as ContextCommandItem
+        }
+
+        beforeEach(() => {
+            sendContextCommandsSpy = testFeatures.chat.sendContextCommands as unknown as sinon.SinonStub
+            existsSyncStub = sinon.stub(fs, 'existsSync').returns(true)
+        })
+
+        it('should include code symbols in capped payload when items exceed cap', async () => {
+            const code = Array.from({ length: 200 }, (_, i) => makeCode(i))
+            const files = Array.from({ length: 2000 }, (_, i) => makeFile(i))
+            // Files first in input order to mirror typical indexer output (files
+            // scanned before AST symbol extraction).
+            const items = [...files, ...code]
+
+            await provider.processContextCommandUpdate(items)
+
+            const sent = sendContextCommandsSpy.firstCall.args[0]
+            const topCommands = sent.contextCommandGroups[0].commands
+            const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
+            const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
+
+            // Code budget = ceil(1000 * 0.1) = 100
+            sinon.assert.match(codeChildren.length, 100)
+            // Files fill the remaining budget (1000 - 100 = 900), plus the "Active File" command
+            sinon.assert.match(fileChildren.length, 901)
+        })
+
+        it('should include all code symbols when fewer than budget', async () => {
+            const code = Array.from({ length: 5 }, (_, i) => makeCode(i))
+            const files = Array.from({ length: 2000 }, (_, i) => makeFile(i))
+            const items = [...files, ...code]
+
+            await provider.processContextCommandUpdate(items)
+
+            const sent = sendContextCommandsSpy.firstCall.args[0]
+            const topCommands = sent.contextCommandGroups[0].commands
+            const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
+            const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
+
+            // All 5 code symbols included
+            sinon.assert.match(codeChildren.length, 5)
+            // File budget grows to absorb the slack: 1000 - 5 = 995, plus Active File
+            sinon.assert.match(fileChildren.length, 996)
+        })
+
+        it('should split 100/100/800 when folders, code, and files all exceed budget', async () => {
+            const folders = Array.from({ length: 200 }, (_, i) => makeFolder(i))
+            const code = Array.from({ length: 200 }, (_, i) => makeCode(i))
+            const files = Array.from({ length: 2000 }, (_, i) => makeFile(i))
+            const items = [...files, ...folders, ...code]
+
+            await provider.processContextCommandUpdate(items)
+
+            const sent = sendContextCommandsSpy.firstCall.args[0]
+            const topCommands = sent.contextCommandGroups[0].commands
+            const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
+            const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
+            const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
+
+            sinon.assert.match(folderChildren.length, 100)
+            sinon.assert.match(codeChildren.length, 100)
+            sinon.assert.match(fileChildren.length, 801) // 800 + Active File
+
+            // Total non-active items must not exceed CONTEXT_COMMAND_PAYLOAD_CAP
+            const totalItems = folderChildren.length + codeChildren.length + (fileChildren.length - 1)
+            sinon.assert.match(totalItems <= CONTEXT_COMMAND_PAYLOAD_CAP, true)
+        })
+
+        it('should not starve code symbols when files come first in input', async () => {
+            // This is the regression case: pre-fix, the flat slice(0, 900) on
+            // nonFolders consumed the entire budget with files (which appear
+            // first in typical indexer output) and dropped all code symbols.
+            const files = Array.from({ length: 5000 }, (_, i) => makeFile(i))
+            const code = Array.from({ length: 50 }, (_, i) => makeCode(i))
+            const items = [...files, ...code]
+
+            await provider.processContextCommandUpdate(items)
+
+            const sent = sendContextCommandsSpy.firstCall.args[0]
+            const topCommands = sent.contextCommandGroups[0].commands
+            const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
+
+            // All 50 code symbols should appear regardless of where they sit
+            // in the input array.
+            sinon.assert.match(codeChildren.length, 50)
+        })
+    })
+
     describe('getFreshItems', () => {
         it('should return empty array and log when LocalProjectContextController.getInstance rejects', async () => {
             ;(LocalProjectContextController.getInstance as sinon.SinonStub).rejects(new Error('boom'))
@@ -377,6 +502,44 @@ describe('ContextCommandsProvider', () => {
 
             // Whitespace trims to empty → folder budget enforced
             sinon.assert.match(folderChildren.length, 100)
+        })
+
+        it('should reserve a code budget on the empty-search path', async () => {
+            const folders = Array.from({ length: 200 }, (_, i) => makeItem('folder', i))
+            const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
+            const code = Array.from({ length: 200 }, (_, i) => ({
+                workspaceFolder: '/workspace',
+                type: 'code' as const,
+                relativePath: `file${i}.ts`,
+                id: `code-${i}`,
+                symbol: {
+                    kind: 'Function',
+                    name: `func${i}`,
+                    range: {
+                        start: { line: 0, column: 0 },
+                        end: { line: 10, column: 0 },
+                    },
+                },
+            })) as ContextCommandItem[]
+            ;(LocalProjectContextController.getInstance as sinon.SinonStub).resolves({
+                // Files first to mirror typical indexer output.
+                getContextCommandItems: sinon.stub().resolves([...files, ...folders, ...code]),
+            } as any)
+            ;(provider as any).registerFilterHandler()
+
+            const onFilterStub = testFeatures.chat.onFilterContextCommands as unknown as sinon.SinonStub
+            const handler = onFilterStub.lastCall.args[0]
+            const result = await handler({ searchTerm: '' })
+
+            const topCommands = result.contextCommandGroups[0].commands
+            const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
+            const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
+            const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
+
+            // 100 / 100 / 800 split (+ 1 Active File pseudo-command in the Files group)
+            sinon.assert.match(folderChildren.length, 100)
+            sinon.assert.match(codeChildren.length, 100)
+            sinon.assert.match(fileChildren.length, 801)
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
@@ -1,5 +1,6 @@
-import { ContextCommandsProvider, INDEXING_THROTTLE_MS } from './contextCommandsProvider'
+import { ContextCommandsProvider, CONTEXT_COMMAND_PAYLOAD_CAP, INDEXING_THROTTLE_MS } from './contextCommandsProvider'
 import * as sinon from 'sinon'
+import * as fs from 'fs'
 import { TestFeatures } from '@aws/language-server-runtimes/testing'
 import * as chokidar from 'chokidar'
 import { ContextCommandItem } from 'local-indexing'
@@ -184,6 +185,98 @@ describe('ContextCommandsProvider', () => {
 
             sinon.assert.match(filesCmd?.disabledText, undefined)
             sinon.assert.match(foldersCmd?.disabledText, undefined)
+        })
+    })
+
+    describe('processContextCommandUpdate folder budget', () => {
+        let sendContextCommandsSpy: sinon.SinonStub
+        let existsSyncStub: sinon.SinonStub
+
+        function makeItem(type: 'file' | 'folder', index: number): ContextCommandItem {
+            return {
+                workspaceFolder: '/workspace',
+                type,
+                relativePath: type === 'folder' ? `dir${index}` : `file${index}.ts`,
+                id: `${type}-${index}`,
+            }
+        }
+
+        beforeEach(() => {
+            sendContextCommandsSpy = testFeatures.chat.sendContextCommands as unknown as sinon.SinonStub
+            existsSyncStub = sinon.stub(fs, 'existsSync').returns(true)
+        })
+
+        it('should include folders in capped payload when items exceed cap', async () => {
+            const folders = Array.from({ length: 200 }, (_, i) => makeItem('folder', i))
+            const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
+            const items = [...files, ...folders]
+
+            await provider.processContextCommandUpdate(items)
+
+            sinon.assert.calledOnce(sendContextCommandsSpy)
+            const sent = sendContextCommandsSpy.firstCall.args[0]
+            const topCommands = sent.contextCommandGroups[0].commands
+            const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
+            const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
+
+            // Folders should be present (budget = ceil(1000 * 0.1) = 100)
+            sinon.assert.match(folderChildren.length, 100)
+            // Files fill the remaining budget (1000 - 100 = 900), plus the "Active File" command
+            sinon.assert.match(fileChildren.length, 901)
+        })
+
+        it('should include all folders when fewer than budget', async () => {
+            const folders = Array.from({ length: 5 }, (_, i) => makeItem('folder', i))
+            const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
+            const items = [...files, ...folders]
+
+            await provider.processContextCommandUpdate(items)
+
+            const sent = sendContextCommandsSpy.firstCall.args[0]
+            const topCommands = sent.contextCommandGroups[0].commands
+            const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
+            const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
+
+            // All 5 folders included
+            sinon.assert.match(folderChildren.length, 5)
+            // Remaining budget: 1000 - 5 = 995, plus "Active File"
+            sinon.assert.match(fileChildren.length, 996)
+        })
+
+        it('should not exceed cap total', async () => {
+            const folders = Array.from({ length: 500 }, (_, i) => makeItem('folder', i))
+            const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
+            const items = [...files, ...folders]
+
+            await provider.processContextCommandUpdate(items)
+
+            const sent = sendContextCommandsSpy.firstCall.args[0]
+            const topCommands = sent.contextCommandGroups[0].commands
+            const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
+            const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
+
+            // Folder budget capped at ceil(1000 * 0.1) = 100
+            sinon.assert.match(folderChildren.length, 100)
+            // Total items (excluding "Active File") should not exceed CONTEXT_COMMAND_PAYLOAD_CAP
+            const totalItems = folderChildren.length + (fileChildren.length - 1) // subtract Active File
+            sinon.assert.match(totalItems <= CONTEXT_COMMAND_PAYLOAD_CAP, true)
+        })
+
+        it('should work normally when items are under cap', async () => {
+            const folders = Array.from({ length: 10 }, (_, i) => makeItem('folder', i))
+            const files = Array.from({ length: 50 }, (_, i) => makeItem('file', i))
+            const items = [...files, ...folders]
+
+            await provider.processContextCommandUpdate(items)
+
+            const sent = sendContextCommandsSpy.firstCall.args[0]
+            const topCommands = sent.contextCommandGroups[0].commands
+            const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
+            const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
+
+            // All items included when under cap
+            sinon.assert.match(folderChildren.length, 10)
+            sinon.assert.match(fileChildren.length, 51) // 50 + Active File
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
@@ -207,7 +207,7 @@ describe('ContextCommandsProvider', () => {
         })
 
         it('should include folders in capped payload when items exceed cap', async () => {
-            const folders = Array.from({ length: 200 }, (_, i) => makeItem('folder', i))
+            const folders = Array.from({ length: 600 }, (_, i) => makeItem('folder', i))
             const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
             const items = [...files, ...folders]
 
@@ -219,10 +219,10 @@ describe('ContextCommandsProvider', () => {
             const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            // Folders should be present (budget = ceil(2000 * 0.1) = 200)
-            sinon.assert.match(folderChildren.length, 200)
-            // Files fill the remaining budget (2000 - 200 = 1800), plus the "Active File" command
-            sinon.assert.match(fileChildren.length, 1801)
+            // Folders should be present (budget = ceil(2000 * 0.25) = 500)
+            sinon.assert.match(folderChildren.length, 500)
+            // Files fill the remaining budget (2000 - 500 = 1500), plus the "Active File" command
+            sinon.assert.match(fileChildren.length, 1501)
         })
 
         it('should include all folders when fewer than budget', async () => {
@@ -244,7 +244,7 @@ describe('ContextCommandsProvider', () => {
         })
 
         it('should not exceed cap total', async () => {
-            const folders = Array.from({ length: 500 }, (_, i) => makeItem('folder', i))
+            const folders = Array.from({ length: 800 }, (_, i) => makeItem('folder', i))
             const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
             const items = [...files, ...folders]
 
@@ -255,8 +255,8 @@ describe('ContextCommandsProvider', () => {
             const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            // Folder budget capped at ceil(2000 * 0.1) = 200
-            sinon.assert.match(folderChildren.length, 200)
+            // Folder budget capped at ceil(2000 * 0.25) = 500
+            sinon.assert.match(folderChildren.length, 500)
             // Total items (excluding "Active File") should not exceed CONTEXT_COMMAND_PAYLOAD_CAP
             const totalItems = folderChildren.length + (fileChildren.length - 1) // subtract Active File
             sinon.assert.match(totalItems <= CONTEXT_COMMAND_PAYLOAD_CAP, true)
@@ -325,7 +325,7 @@ describe('ContextCommandsProvider', () => {
         })
 
         it('should include code symbols in capped payload when items exceed cap', async () => {
-            const code = Array.from({ length: 200 }, (_, i) => makeCode(i))
+            const code = Array.from({ length: 600 }, (_, i) => makeCode(i))
             const files = Array.from({ length: 2000 }, (_, i) => makeFile(i))
             // Files first in input order to mirror typical indexer output (files
             // scanned before AST symbol extraction).
@@ -338,10 +338,10 @@ describe('ContextCommandsProvider', () => {
             const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            // Code budget = ceil(2000 * 0.1) = 200
-            sinon.assert.match(codeChildren.length, 200)
-            // Files fill the remaining budget (2000 - 200 = 1800), plus the "Active File" command
-            sinon.assert.match(fileChildren.length, 1801)
+            // Code budget = ceil(2000 * 0.25) = 500
+            sinon.assert.match(codeChildren.length, 500)
+            // Files fill the remaining budget (2000 - 500 = 1500), plus the "Active File" command
+            sinon.assert.match(fileChildren.length, 1501)
         })
 
         it('should include all code symbols when fewer than budget', async () => {
@@ -362,9 +362,9 @@ describe('ContextCommandsProvider', () => {
             sinon.assert.match(fileChildren.length, 1996)
         })
 
-        it('should split 200/200/1600 when folders, code, and files all exceed budget', async () => {
-            const folders = Array.from({ length: 300 }, (_, i) => makeFolder(i))
-            const code = Array.from({ length: 300 }, (_, i) => makeCode(i))
+        it('should split 500/500/1000 when folders, code, and files all exceed budget', async () => {
+            const folders = Array.from({ length: 800 }, (_, i) => makeFolder(i))
+            const code = Array.from({ length: 800 }, (_, i) => makeCode(i))
             const files = Array.from({ length: 3000 }, (_, i) => makeFile(i))
             const items = [...files, ...folders, ...code]
 
@@ -376,9 +376,9 @@ describe('ContextCommandsProvider', () => {
             const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            sinon.assert.match(folderChildren.length, 200)
-            sinon.assert.match(codeChildren.length, 200)
-            sinon.assert.match(fileChildren.length, 1601) // 1600 + Active File
+            sinon.assert.match(folderChildren.length, 500)
+            sinon.assert.match(codeChildren.length, 500)
+            sinon.assert.match(fileChildren.length, 1001) // 1000 + Active File
 
             // Total non-active items must not exceed CONTEXT_COMMAND_PAYLOAD_CAP
             const totalItems = folderChildren.length + codeChildren.length + (fileChildren.length - 1)
@@ -460,7 +460,7 @@ describe('ContextCommandsProvider', () => {
         })
 
         it('should apply capItems folder budget when filter handler called with empty searchTerm', async () => {
-            const folders = Array.from({ length: 200 }, (_, i) => makeItem('folder', i))
+            const folders = Array.from({ length: 600 }, (_, i) => makeItem('folder', i))
             const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
             ;(LocalProjectContextController.getInstance as sinon.SinonStub).resolves({
                 getContextCommandItems: sinon.stub().resolves([...files, ...folders]),
@@ -479,14 +479,14 @@ describe('ContextCommandsProvider', () => {
             const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            // Folder budget = ceil(2000 * 0.1) = 200
-            sinon.assert.match(folderChildren.length, 200)
-            // Files fill the remaining 1800 + the "Active File" command
-            sinon.assert.match(fileChildren.length, 1801)
+            // Folder budget = ceil(2000 * 0.25) = 500
+            sinon.assert.match(folderChildren.length, 500)
+            // Files fill the remaining 1500 + the "Active File" command
+            sinon.assert.match(fileChildren.length, 1501)
         })
 
         it('should also apply capItems when searchTerm is whitespace-only', async () => {
-            const folders = Array.from({ length: 300 }, (_, i) => makeItem('folder', i))
+            const folders = Array.from({ length: 800 }, (_, i) => makeItem('folder', i))
             const files = Array.from({ length: 3000 }, (_, i) => makeItem('file', i))
             ;(LocalProjectContextController.getInstance as sinon.SinonStub).resolves({
                 getContextCommandItems: sinon.stub().resolves([...files, ...folders]),
@@ -501,13 +501,13 @@ describe('ContextCommandsProvider', () => {
             const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
 
             // Whitespace trims to empty → folder budget enforced
-            sinon.assert.match(folderChildren.length, 200)
+            sinon.assert.match(folderChildren.length, 500)
         })
 
         it('should reserve a code budget on the empty-search path', async () => {
-            const folders = Array.from({ length: 300 }, (_, i) => makeItem('folder', i))
+            const folders = Array.from({ length: 800 }, (_, i) => makeItem('folder', i))
             const files = Array.from({ length: 3000 }, (_, i) => makeItem('file', i))
-            const code = Array.from({ length: 300 }, (_, i) => ({
+            const code = Array.from({ length: 800 }, (_, i) => ({
                 workspaceFolder: '/workspace',
                 type: 'code' as const,
                 relativePath: `file${i}.ts`,
@@ -536,10 +536,10 @@ describe('ContextCommandsProvider', () => {
             const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            // 200 / 200 / 1600 split (+ 1 Active File pseudo-command in the Files group)
-            sinon.assert.match(folderChildren.length, 200)
-            sinon.assert.match(codeChildren.length, 200)
-            sinon.assert.match(fileChildren.length, 1601)
+            // 500 / 500 / 1000 split (+ 1 Active File pseudo-command in the Files group)
+            sinon.assert.match(folderChildren.length, 500)
+            sinon.assert.match(codeChildren.length, 500)
+            sinon.assert.match(fileChildren.length, 1001)
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.test.ts
@@ -219,10 +219,10 @@ describe('ContextCommandsProvider', () => {
             const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            // Folders should be present (budget = ceil(1000 * 0.1) = 100)
-            sinon.assert.match(folderChildren.length, 100)
-            // Files fill the remaining budget (1000 - 100 = 900), plus the "Active File" command
-            sinon.assert.match(fileChildren.length, 901)
+            // Folders should be present (budget = ceil(2000 * 0.1) = 200)
+            sinon.assert.match(folderChildren.length, 200)
+            // Files fill the remaining budget (2000 - 200 = 1800), plus the "Active File" command
+            sinon.assert.match(fileChildren.length, 1801)
         })
 
         it('should include all folders when fewer than budget', async () => {
@@ -239,8 +239,8 @@ describe('ContextCommandsProvider', () => {
 
             // All 5 folders included
             sinon.assert.match(folderChildren.length, 5)
-            // Remaining budget: 1000 - 5 = 995, plus "Active File"
-            sinon.assert.match(fileChildren.length, 996)
+            // Remaining budget: 2000 - 5 = 1995, plus "Active File"
+            sinon.assert.match(fileChildren.length, 1996)
         })
 
         it('should not exceed cap total', async () => {
@@ -255,8 +255,8 @@ describe('ContextCommandsProvider', () => {
             const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            // Folder budget capped at ceil(1000 * 0.1) = 100
-            sinon.assert.match(folderChildren.length, 100)
+            // Folder budget capped at ceil(2000 * 0.1) = 200
+            sinon.assert.match(folderChildren.length, 200)
             // Total items (excluding "Active File") should not exceed CONTEXT_COMMAND_PAYLOAD_CAP
             const totalItems = folderChildren.length + (fileChildren.length - 1) // subtract Active File
             sinon.assert.match(totalItems <= CONTEXT_COMMAND_PAYLOAD_CAP, true)
@@ -338,10 +338,10 @@ describe('ContextCommandsProvider', () => {
             const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            // Code budget = ceil(1000 * 0.1) = 100
-            sinon.assert.match(codeChildren.length, 100)
-            // Files fill the remaining budget (1000 - 100 = 900), plus the "Active File" command
-            sinon.assert.match(fileChildren.length, 901)
+            // Code budget = ceil(2000 * 0.1) = 200
+            sinon.assert.match(codeChildren.length, 200)
+            // Files fill the remaining budget (2000 - 200 = 1800), plus the "Active File" command
+            sinon.assert.match(fileChildren.length, 1801)
         })
 
         it('should include all code symbols when fewer than budget', async () => {
@@ -358,14 +358,14 @@ describe('ContextCommandsProvider', () => {
 
             // All 5 code symbols included
             sinon.assert.match(codeChildren.length, 5)
-            // File budget grows to absorb the slack: 1000 - 5 = 995, plus Active File
-            sinon.assert.match(fileChildren.length, 996)
+            // File budget grows to absorb the slack: 2000 - 5 = 1995, plus Active File
+            sinon.assert.match(fileChildren.length, 1996)
         })
 
-        it('should split 100/100/800 when folders, code, and files all exceed budget', async () => {
-            const folders = Array.from({ length: 200 }, (_, i) => makeFolder(i))
-            const code = Array.from({ length: 200 }, (_, i) => makeCode(i))
-            const files = Array.from({ length: 2000 }, (_, i) => makeFile(i))
+        it('should split 200/200/1600 when folders, code, and files all exceed budget', async () => {
+            const folders = Array.from({ length: 300 }, (_, i) => makeFolder(i))
+            const code = Array.from({ length: 300 }, (_, i) => makeCode(i))
+            const files = Array.from({ length: 3000 }, (_, i) => makeFile(i))
             const items = [...files, ...folders, ...code]
 
             await provider.processContextCommandUpdate(items)
@@ -376,9 +376,9 @@ describe('ContextCommandsProvider', () => {
             const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            sinon.assert.match(folderChildren.length, 100)
-            sinon.assert.match(codeChildren.length, 100)
-            sinon.assert.match(fileChildren.length, 801) // 800 + Active File
+            sinon.assert.match(folderChildren.length, 200)
+            sinon.assert.match(codeChildren.length, 200)
+            sinon.assert.match(fileChildren.length, 1601) // 1600 + Active File
 
             // Total non-active items must not exceed CONTEXT_COMMAND_PAYLOAD_CAP
             const totalItems = folderChildren.length + codeChildren.length + (fileChildren.length - 1)
@@ -386,7 +386,7 @@ describe('ContextCommandsProvider', () => {
         })
 
         it('should not starve code symbols when files come first in input', async () => {
-            // This is the regression case: pre-fix, the flat slice(0, 900) on
+            // This is the regression case: pre-fix, the flat slice(0, 1800) on
             // nonFolders consumed the entire budget with files (which appear
             // first in typical indexer output) and dropped all code symbols.
             const files = Array.from({ length: 5000 }, (_, i) => makeFile(i))
@@ -479,15 +479,15 @@ describe('ContextCommandsProvider', () => {
             const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            // Folder budget = ceil(1000 * 0.1) = 100
-            sinon.assert.match(folderChildren.length, 100)
-            // Files fill the remaining 900 + the "Active File" command
-            sinon.assert.match(fileChildren.length, 901)
+            // Folder budget = ceil(2000 * 0.1) = 200
+            sinon.assert.match(folderChildren.length, 200)
+            // Files fill the remaining 1800 + the "Active File" command
+            sinon.assert.match(fileChildren.length, 1801)
         })
 
         it('should also apply capItems when searchTerm is whitespace-only', async () => {
-            const folders = Array.from({ length: 200 }, (_, i) => makeItem('folder', i))
-            const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
+            const folders = Array.from({ length: 300 }, (_, i) => makeItem('folder', i))
+            const files = Array.from({ length: 3000 }, (_, i) => makeItem('file', i))
             ;(LocalProjectContextController.getInstance as sinon.SinonStub).resolves({
                 getContextCommandItems: sinon.stub().resolves([...files, ...folders]),
             } as any)
@@ -501,13 +501,13 @@ describe('ContextCommandsProvider', () => {
             const folderChildren = topCommands.find((c: any) => c.command === 'Folders')?.children?.[0]?.commands ?? []
 
             // Whitespace trims to empty → folder budget enforced
-            sinon.assert.match(folderChildren.length, 100)
+            sinon.assert.match(folderChildren.length, 200)
         })
 
         it('should reserve a code budget on the empty-search path', async () => {
-            const folders = Array.from({ length: 200 }, (_, i) => makeItem('folder', i))
-            const files = Array.from({ length: 2000 }, (_, i) => makeItem('file', i))
-            const code = Array.from({ length: 200 }, (_, i) => ({
+            const folders = Array.from({ length: 300 }, (_, i) => makeItem('folder', i))
+            const files = Array.from({ length: 3000 }, (_, i) => makeItem('file', i))
+            const code = Array.from({ length: 300 }, (_, i) => ({
                 workspaceFolder: '/workspace',
                 type: 'code' as const,
                 relativePath: `file${i}.ts`,
@@ -536,10 +536,10 @@ describe('ContextCommandsProvider', () => {
             const codeChildren = topCommands.find((c: any) => c.command === 'Code')?.children?.[0]?.commands ?? []
             const fileChildren = topCommands.find((c: any) => c.command === 'Files')?.children?.[0]?.commands ?? []
 
-            // 100 / 100 / 800 split (+ 1 Active File pseudo-command in the Files group)
-            sinon.assert.match(folderChildren.length, 100)
-            sinon.assert.match(codeChildren.length, 100)
-            sinon.assert.match(fileChildren.length, 801)
+            // 200 / 200 / 1600 split (+ 1 Active File pseudo-command in the Files group)
+            sinon.assert.match(folderChildren.length, 200)
+            sinon.assert.match(codeChildren.length, 200)
+            sinon.assert.match(fileChildren.length, 1601)
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -219,7 +219,14 @@ export class ContextCommandsProvider implements Disposable {
         // Cap the push payload — the client's existing code dispatches
         // onFilterContextCommands when the user types, which searches
         // the full cached set server-side (no cap).
-        const capped = items.filter(existsOnDisk).slice(0, CONTEXT_COMMAND_PAYLOAD_CAP)
+        // Partition by type so folders aren't starved by a file-heavy list.
+        const alive = items.filter(existsOnDisk)
+        const folders = alive.filter(i => i.type === 'folder')
+        const nonFolders = alive.filter(i => i.type !== 'folder')
+
+        const folderBudget = Math.min(folders.length, Math.ceil(CONTEXT_COMMAND_PAYLOAD_CAP * 0.1))
+        const remainingBudget = CONTEXT_COMMAND_PAYLOAD_CAP - folderBudget
+        const capped = [...folders.slice(0, folderBudget), ...nonFolders.slice(0, remainingBudget)]
 
         const allItems = await this.mapContextCommandItems(capped)
         this.chat.sendContextCommands({ contextCommandGroups: allItems })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -185,7 +185,15 @@ export class ContextCommandsProvider implements Disposable {
                 const searchTerm = params.searchTerm?.trim() ?? ''
 
                 if (!searchTerm) {
-                    const mapped = await this.mapContextCommandItems(items.filter(existsOnDisk))
+                    // Return the same capped set as the initial push so the
+                    // store stays consistent with contextCommandGroups.
+                    const alive = items.filter(existsOnDisk)
+                    const folders = alive.filter(i => i.type === 'folder')
+                    const nonFolders = alive.filter(i => i.type !== 'folder')
+                    const folderBudget = Math.min(folders.length, Math.ceil(CONTEXT_COMMAND_PAYLOAD_CAP * 0.1))
+                    const remainingBudget = CONTEXT_COMMAND_PAYLOAD_CAP - folderBudget
+                    const capped = [...folders.slice(0, folderBudget), ...nonFolders.slice(0, remainingBudget)]
+                    const mapped = await this.mapContextCommandItems(capped)
                     return { contextCommandGroups: mapped }
                 }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -215,16 +215,21 @@ export class ContextCommandsProvider implements Disposable {
 
     /**
      * Cap items with reserved budgets for folders and code symbols so neither
-     * is starved by file-heavy repos. Default split is 10/10/80 (folders /
+     * is starved by file-heavy repos. Default split is 25/25/50 (folders /
      * code / files); slack from an under-filled folder or code budget flows
      * automatically into the file budget via the subtraction below.
+     *
+     * NOTE: this only affects the **empty-search** picker view (initial open).
+     * The non-empty filter path scores every item in the full indexer set —
+     * a search term will find a code symbol or file regardless of whether it
+     * fit into the cap.
      */
     private capItems(items: ContextCommandItem[]): ContextCommandItem[] {
         const folders = items.filter(i => i.type === 'folder')
         const code = items.filter(i => i.type === 'code')
         const files = items.filter(i => i.type === 'file')
-        const folderBudget = Math.min(folders.length, Math.ceil(CONTEXT_COMMAND_PAYLOAD_CAP * 0.1))
-        const codeBudget = Math.min(code.length, Math.ceil(CONTEXT_COMMAND_PAYLOAD_CAP * 0.1))
+        const folderBudget = Math.min(folders.length, Math.ceil(CONTEXT_COMMAND_PAYLOAD_CAP * 0.25))
+        const codeBudget = Math.min(code.length, Math.ceil(CONTEXT_COMMAND_PAYLOAD_CAP * 0.25))
         const fileBudget = CONTEXT_COMMAND_PAYLOAD_CAP - folderBudget - codeBudget
         return [...folders.slice(0, folderBudget), ...code.slice(0, codeBudget), ...files.slice(0, fileBudget)]
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -28,10 +28,10 @@ export const INDEXING_THROTTLE_MS = 500
  * The client shows these when the user presses `@` before typing.
  * Server-side filtering (onFilterContextCommands) searches the full set.
  */
-export const CONTEXT_COMMAND_PAYLOAD_CAP = 1000
+export const CONTEXT_COMMAND_PAYLOAD_CAP = 2000
 
 /** Maximum number of items returned by a single filter request. */
-export const MAX_FILTER_RESULTS = 1000
+export const MAX_FILTER_RESULTS = 2000
 
 /**
  * Score a candidate string against a search term.

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -214,15 +214,19 @@ export class ContextCommandsProvider implements Disposable {
     }
 
     /**
-     * Cap items with a reserved budget for folders so they aren't starved
-     * by file-heavy repos.
+     * Cap items with reserved budgets for folders and code symbols so neither
+     * is starved by file-heavy repos. Default split is 10/10/80 (folders /
+     * code / files); slack from an under-filled folder or code budget flows
+     * automatically into the file budget via the subtraction below.
      */
     private capItems(items: ContextCommandItem[]): ContextCommandItem[] {
         const folders = items.filter(i => i.type === 'folder')
-        const nonFolders = items.filter(i => i.type !== 'folder')
+        const code = items.filter(i => i.type === 'code')
+        const files = items.filter(i => i.type === 'file')
         const folderBudget = Math.min(folders.length, Math.ceil(CONTEXT_COMMAND_PAYLOAD_CAP * 0.1))
-        const remainingBudget = CONTEXT_COMMAND_PAYLOAD_CAP - folderBudget
-        return [...folders.slice(0, folderBudget), ...nonFolders.slice(0, remainingBudget)]
+        const codeBudget = Math.min(code.length, Math.ceil(CONTEXT_COMMAND_PAYLOAD_CAP * 0.1))
+        const fileBudget = CONTEXT_COMMAND_PAYLOAD_CAP - folderBudget - codeBudget
+        return [...folders.slice(0, folderBudget), ...code.slice(0, codeBudget), ...files.slice(0, fileBudget)]
     }
 
     /**

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/context/contextCommandsProvider.ts
@@ -65,7 +65,6 @@ function existsOnDisk(item: ContextCommandItem): boolean {
 
 export class ContextCommandsProvider implements Disposable {
     private promptFileWatcher?: FSWatcher
-    private cachedContextCommands?: ContextCommandItem[]
     private codeSymbolsPending = true
     private codeSymbolsFailed = false
     private filesAndFoldersPending = true
@@ -119,7 +118,7 @@ export class ContextCommandsProvider implements Disposable {
                             await this.processContextCommandUpdate(items)
                         } catch (e) {
                             this.logging.error(`Error fetching context command items: ${e}`)
-                            void this.processContextCommandUpdate(this.cachedContextCommands ?? [])
+                            void this.processContextCommandUpdate([])
                         }
                     }, INDEXING_THROTTLE_MS)
                 }
@@ -137,11 +136,11 @@ export class ContextCommandsProvider implements Disposable {
         })
 
         this.promptFileWatcher.on('add', async () => {
-            await this.processContextCommandUpdate(this.cachedContextCommands ?? [])
+            await this.processContextCommandUpdate(await this.getFreshItems())
         })
 
         this.promptFileWatcher.on('unlink', async () => {
-            await this.processContextCommandUpdate(this.cachedContextCommands ?? [])
+            await this.processContextCommandUpdate(await this.getFreshItems())
         })
     }
 
@@ -181,18 +180,11 @@ export class ContextCommandsProvider implements Disposable {
     private registerFilterHandler() {
         this.chat.onFilterContextCommands(
             async (params: FilterContextCommandsParams): Promise<FilterContextCommandsResult> => {
-                const items = this.cachedContextCommands ?? []
+                const items = await this.getFreshItems()
                 const searchTerm = params.searchTerm?.trim() ?? ''
 
                 if (!searchTerm) {
-                    // Return the same capped set as the initial push so the
-                    // store stays consistent with contextCommandGroups.
-                    const alive = items.filter(existsOnDisk)
-                    const folders = alive.filter(i => i.type === 'folder')
-                    const nonFolders = alive.filter(i => i.type !== 'folder')
-                    const folderBudget = Math.min(folders.length, Math.ceil(CONTEXT_COMMAND_PAYLOAD_CAP * 0.1))
-                    const remainingBudget = CONTEXT_COMMAND_PAYLOAD_CAP - folderBudget
-                    const capped = [...folders.slice(0, folderBudget), ...nonFolders.slice(0, remainingBudget)]
+                    const capped = this.capItems(items.filter(existsOnDisk))
                     const mapped = await this.mapContextCommandItems(capped)
                     return { contextCommandGroups: mapped }
                 }
@@ -221,21 +213,33 @@ export class ContextCommandsProvider implements Disposable {
         )
     }
 
-    async processContextCommandUpdate(items: ContextCommandItem[]) {
-        this.cachedContextCommands = items
-
-        // Cap the push payload — the client's existing code dispatches
-        // onFilterContextCommands when the user types, which searches
-        // the full cached set server-side (no cap).
-        // Partition by type so folders aren't starved by a file-heavy list.
-        const alive = items.filter(existsOnDisk)
-        const folders = alive.filter(i => i.type === 'folder')
-        const nonFolders = alive.filter(i => i.type !== 'folder')
-
+    /**
+     * Cap items with a reserved budget for folders so they aren't starved
+     * by file-heavy repos.
+     */
+    private capItems(items: ContextCommandItem[]): ContextCommandItem[] {
+        const folders = items.filter(i => i.type === 'folder')
+        const nonFolders = items.filter(i => i.type !== 'folder')
         const folderBudget = Math.min(folders.length, Math.ceil(CONTEXT_COMMAND_PAYLOAD_CAP * 0.1))
         const remainingBudget = CONTEXT_COMMAND_PAYLOAD_CAP - folderBudget
-        const capped = [...folders.slice(0, folderBudget), ...nonFolders.slice(0, remainingBudget)]
+        return [...folders.slice(0, folderBudget), ...nonFolders.slice(0, remainingBudget)]
+    }
 
+    /**
+     * Pull fresh items from the indexer. Returns empty array on failure.
+     */
+    private async getFreshItems(): Promise<ContextCommandItem[]> {
+        try {
+            const controller = await LocalProjectContextController.getInstance()
+            return await controller.getContextCommandItems()
+        } catch (e) {
+            this.logging.error(`Error fetching fresh context command items: ${e}`)
+            return []
+        }
+    }
+
+    async processContextCommandUpdate(items: ContextCommandItem[]) {
+        const capped = this.capItems(items.filter(existsOnDisk))
         const allItems = await this.mapContextCommandItems(capped)
         this.chat.sendContextCommands({ contextCommandGroups: allItems })
     }
@@ -372,7 +376,7 @@ export class ContextCommandsProvider implements Disposable {
         } catch (error) {
             this.codeSymbolsFailed = true
             this.codeSymbolsPending = false
-            await this.processContextCommandUpdate(this.cachedContextCommands ?? [])
+            await this.processContextCommandUpdate([])
             throw error
         }
     }


### PR DESCRIPTION
## Problem

The `@` context picker had three related issues in large repos (e.g. Linux kernel, 212k+ items), all stemming from the initial push cap and how the chat-client cached results:

1. **Folder starvation in the initial push** (the original PR title). The pre-fix `slice(0, 1000)` cap took the first 1000 items in indexer order. In file-heavy repos those 1000 are almost all files, so `@Folder` shows no children until the user types a search term.

2. **Code symbol starvation in the initial push.** Same shape as the folder bug — code symbols (`type: 'code'`) shared the same flat slice with files and got dropped from any repo with more than ~900 indexed files. `@Code` was empty on the initial picker view; typing a function name still found it via the score-based filter, but the empty-search picker couldn't surface anything.

3. **Stale cache after a search.** The chat-client cached filter responses in a local `contextCommandGroups` and the server kept items in `cachedContextCommands`. After typing `@foo`, dismissing the picker, and reopening `@`, the picker rendered from this stale cache instead of refreshing from the indexer. Reproduce: `@foo` → Esc → backspace `@foo` → `@` → click Folder → empty/wrong list. After ~10s the indexer would push a refresh and self-correct, but there was no way to force a refresh.

Pairs with [aws/mynah-ui#480](https://github.com/aws/mynah-ui/pull/480), which delivers the UI-side companion (sub-menu navigation reads from a snapshot, sub-menu in-place re-render, focus preservation across the listener-driven re-render).

## Solution

### Server — `server/aws-lsp-codewhisperer/.../contextCommandsProvider.ts`

- **Removed `cachedContextCommands` field.** The server no longer caches; every request pulls fresh from the indexer.
- **`getFreshItems()` helper** wraps `LocalProjectContextController.getInstance().getContextCommandItems()`. Returns `[]` on failure with logging. Called from `processContextCommandUpdate`, the prompt-file watcher (`add`/`unlink`), and `registerFilterHandler` for both empty-term and non-empty-term paths.
- **`capItems()` with 3-way 25/25/50 budget split.** With the cap at 2000, this is **500 folders / 500 code / 1000 files**. Slack from an under-filled folder or code budget flows automatically into the file budget via the subtraction below. Keeps both folders and code symbols visible in the initial picker view in any repo, even when files dominate. The fix supersedes the original 10% folder reservation by adding a parallel reservation for code symbols and bumping the cap from 1000 → 2000.
- **`CONTEXT_COMMAND_PAYLOAD_CAP` and `MAX_FILTER_RESULTS` bumped from 1000 → 2000.** The bottleneck under load is `fs.existsSync` over the full ~212k indexer item set, not the cap; doubling the cap adds <50KB to the LSP payload and a few ms to mapping/rendering but is otherwise negligible. mynah-ui's `DetailedListWrapper` virtualizes by visible block, so 2x items don't add proportional render cost. **Search semantics unchanged**: the non-empty filter path still iterates and scores every item in the full fresh indexer set — a search term will find a file or code symbol regardless of whether it fit into the empty-search cap.
- **Empty-term filter path now caps.** Previously it returned all items unfiltered (no cap), which combined with `existsOnDisk` over 212k items was slow and produced inconsistent picker structure. Now it applies `capItems` to the filtered set, matching the initial push behavior.

### Chat-client — `chat-client/src/client/mynahUi.ts`

- **Removed empty-search short-circuit in `onContextCommandFilter`.** Previously, when called with an empty search term, the chat-client restored the store from a local `contextCommandGroups` cache instead of round-tripping to the server. This was fragile — the cache could be stale, late filter responses could overwrite the just-restored store, and `lastFilterTabId` retention caused subsequent `sendContextCommands` pushes to be skipped indefinitely. The handler now always forwards to the server, including the empty term — the server's empty-term path returns the fresh capped list directly.
- Minor refactor in `sendContextCommands`: extracted `commandsWithHighlight` into a local const before the per-tab loop (no behavior change).
- **Bumped `@aws/mynah-ui` to `^4.40.1`** (`chat-client/package.json` + `package-lock.json`).

## Tests

Server unit tests in `contextCommandsProvider.test.ts` — **24 total**, organized into:

- **`processContextCommandUpdate folder budget`** (4 tests, original): folders included when items exceed cap, all folders included when fewer than budget, total never exceeds cap, small payloads pass through unchanged.
- **`processContextCommandUpdate code budget`** (4 tests, new): code symbols included when items exceed cap, all code symbols included when fewer than budget, **3-way split test verifying 500/500/1000 when all categories overflow** (input 800 folders + 800 code + 3000 files), and a **regression case** verifying code is not starved when files come first in input order (5000 files + 50 code → all 50 code visible).
- **`getFreshItems`** (3 tests, new): returns `[]` and logs when `LocalProjectContextController.getInstance()` rejects, returns `[]` and logs when `getContextCommandItems()` rejects, returns items from controller on success.
- **`registerFilterHandler empty-search path`** (3 tests, new): applies `capItems` folder budget on empty searchTerm, also applies on whitespace-only searchTerm, **reserves a code budget on the empty-search path**.

Plus **fixed a stale assertion in `contextCommandsProvider.preservation.test.ts`**: the property-based test `processContextCommandUpdate sends all items and caches them for small payloads` had been failing in CI since the cache-removal refactor — it asserted `(provider as any).cachedContextCommands === items`, which always evaluated to `undefined !== []` on the empty-array counterexample. Renamed to `dispatches a single sendContextCommands payload for small payloads` and dropped the cache assertion. The test still validates the meaningful contract: exactly one `sendContextCommands` call with a `contextCommandGroups` payload.

Local repro:
```
cd server/aws-lsp-codewhisperer
npx mocha --require ts-node/register \
  'src/language-server/agenticChat/context/contextCommandsProvider*.test.ts'
# 28 passing
```

Manual verification on Linux kernel (212k+ items) — see [aws/mynah-ui#480](https://github.com/aws/mynah-ui/pull/480) test matrix:

- [x] `@Folder` shows up to 500 folders on first press in the Linux kernel repo
- [x] `@Code` shows up to 500 code symbols on first press
- [x] `@File` shows up to 1000 files on first press
- [x] `@foo` → Esc → backspace → `@` → click Folder → 500 folders (no stale cache)
- [x] Indexer changes mid-search no longer freeze the picker on a stale view
- [x] Typing a function name finds the symbol regardless of where it sits in the indexer (search runs against the full fresh set, not the cap)
- [x] Server-side unit tests pass

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.