### PR TITLE
test: add consent gate tests for workspace-scoped MCP servers

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
@@ -1,0 +1,141 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved. SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { fingerprintServerConfig, fingerprintWorkspace, hasApproval, recordApproval } from './mcpConsentStore'
+import type { MCPServerConfig } from './mcpTypes'
+
+describe('mcpConsentStore', () => {
+    let tmpHome: string
+    let workspace: any
+    let logger: any
+
+    beforeEach(() => {
+        tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpConsentTest-'))
+        workspace = {
+            fs: {
+                exists: (p: string) => Promise.resolve(fs.existsSync(p)),
+                readFile: (p: string) => Promise.resolve(Buffer.from(fs.readFileSync(p))),
+                writeFile: (p: string, d: string) => Promise.resolve(fs.writeFileSync(p, d)),
+                mkdir: (p: string, _opts: any) => Promise.resolve(fs.mkdirSync(p, { recursive: true })),
+                getUserHomeDir: () => tmpHome,
+            },
+        }
+        logger = { warn: () => {}, info: () => {}, error: () => {} }
+    })
+
+    afterEach(() => {
+        fs.rmSync(tmpHome, { recursive: true, force: true })
+    })
+
+    describe('fingerprintServerConfig', () => {
+        it('is deterministic for identical config', () => {
+            const cfg: MCPServerConfig = { command: 'sh', args: ['-c', 'echo hi'] }
+            expect(fingerprintServerConfig(cfg)).to.equal(fingerprintServerConfig({ ...cfg }))
+        })
+
+        it('differs when command changes', () => {
+            const a: MCPServerConfig = { command: 'sh', args: ['-c', 'echo hi'] }
+            const b: MCPServerConfig = { command: 'bash', args: ['-c', 'echo hi'] }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        it('differs when args change', () => {
+            const a: MCPServerConfig = { command: 'sh', args: ['-c', 'echo hi'] }
+            const b: MCPServerConfig = { command: 'sh', args: ['-c', 'echo bye'] }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        it('differs when env changes', () => {
+            const a: MCPServerConfig = { command: 'sh', args: [], env: { FOO: '1' } }
+            const b: MCPServerConfig = { command: 'sh', args: [], env: { FOO: '2' } }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        it('is stable regardless of env key order', () => {
+            const a: MCPServerConfig = { command: 'sh', args: [], env: { A: '1', B: '2' } }
+            const b: MCPServerConfig = { command: 'sh', args: [], env: { B: '2', A: '1' } }
+            expect(fingerprintServerConfig(a)).to.equal(fingerprintServerConfig(b))
+        })
+
+        it('differs when url changes', () => {
+            const a: MCPServerConfig = { url: 'https://a.example' }
+            const b: MCPServerConfig = { url: 'https://b.example' }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+    })
+
+    describe('fingerprintWorkspace', () => {
+        it('is keyed on the directory of the config, not the filename', () => {
+            const a = fingerprintWorkspace('/foo/bar/.amazonq/mcp.json')
+            const b = fingerprintWorkspace('/foo/bar/.amazonq/agents/default.json')
+            // both live under /foo/bar/.amazonq's parent-dir once; path.dirname differs though
+            expect(a).to.not.equal(b)
+        })
+
+        it('is deterministic for the same path', () => {
+            const p = '/foo/bar/.amazonq/mcp.json'
+            expect(fingerprintWorkspace(p)).to.equal(fingerprintWorkspace(p))
+        })
+    })
+
+    describe('hasApproval / recordApproval', () => {
+        const cfg: MCPServerConfig = { command: 'sh', args: ['-c', 'echo ok'] }
+        const configPath = '/tmp/ws-a/.amazonq/mcp.json'
+
+        it('returns false when store is empty', async () => {
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.false
+        })
+
+        it('records and finds an approval for same (name, config, workspace)', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.true
+        })
+
+        it('does not match when workspace path differs', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, '/tmp/ws-a/.amazonq/mcp.json')
+            expect(await hasApproval(workspace, logger, 'poc', cfg, '/tmp/ws-b/.amazonq/mcp.json')).to.be.false
+        })
+
+        it('does not match when command changes (fingerprint invalidates)', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            const mutated: MCPServerConfig = { command: 'sh', args: ['-c', 'curl evil'] }
+            expect(await hasApproval(workspace, logger, 'poc', mutated, configPath)).to.be.false
+        })
+
+        it('does not match when server name differs', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            expect(await hasApproval(workspace, logger, 'other', cfg, configPath)).to.be.false
+        })
+
+        it('dedupes repeated approvals for the same key', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            const stored = JSON.parse(
+                fs.readFileSync(path.join(tmpHome, '.aws', 'amazonq', 'mcp-approvals.json')).toString()
+            )
+            expect(stored.approvals).to.have.lengthOf(1)
+        })
+
+        it('ignores a store with unrecognized version', async () => {
+            const storeDir = path.join(tmpHome, '.aws', 'amazonq')
+            fs.mkdirSync(storeDir, { recursive: true })
+            fs.writeFileSync(path.join(storeDir, 'mcp-approvals.json'), JSON.stringify({ version: 999, approvals: [] }))
+            // record should still work (overwrites with v1)
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.true
+        })
+
+        it('treats a malformed store as empty', async () => {
+            const storeDir = path.join(tmpHome, '.aws', 'amazonq')
+            fs.mkdirSync(storeDir, { recursive: true })
+            fs.writeFileSync(path.join(storeDir, 'mcp-approvals.json'), 'not json')
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.false
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -1939,7 +1939,7 @@ describe('addRegistryServer with additional headers/env', () => {
 
 describe('consent gate for workspace-scoped MCP servers (P417451767)', () => {
     const fakeHome = '/home/testuser'
-    const globalMcp = '/home/testuser/.aws/amazonq/mcp.json'
+    const globalMcp = mcpUtils.getGlobalMcpConfigPath(fakeHome)
     const workspaceMcp = '/tmp/ws-a/.amazonq/mcp.json'
 
     let showMessageStub: sinon.SinonStub

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -1936,3 +1936,130 @@ describe('addRegistryServer with additional headers/env', () => {
         expect(agentCfg.env).to.be.undefined
     })
 })
+
+describe('consent gate for workspace-scoped MCP servers (P417451767)', () => {
+    const fakeHome = '/home/testuser'
+    const globalMcp = '/home/testuser/.aws/amazonq/mcp.json'
+    const workspaceMcp = '/tmp/ws-a/.amazonq/mcp.json'
+
+    let showMessageStub: sinon.SinonStub
+    let hasApprovalStub: sinon.SinonStub
+    let recordApprovalStub: sinon.SinonStub
+    let setStateSpy: sinon.SinonSpy
+
+    async function buildMgr(): Promise<any> {
+        const consentStore = require('./mcpConsentStore')
+        hasApprovalStub = sinon.stub(consentStore, 'hasApproval').resolves(false)
+        recordApprovalStub = sinon.stub(consentStore, 'recordApproval').resolves()
+
+        showMessageStub = sinon.stub()
+        const featuresWithPrompt = {
+            ...features,
+            workspace: {
+                ...fakeWorkspace,
+                fs: { ...fakeWorkspace.fs, getUserHomeDir: () => fakeHome },
+            },
+            lsp: { window: { showMessageRequest: showMessageStub } },
+        }
+        sinon.stub(mcpUtils, 'loadAgentConfig').resolves({
+            servers: new Map(),
+            serverNameMapping: new Map(),
+            errors: new Map(),
+            agentConfig: {
+                name: 'test',
+                description: '',
+                mcpServers: {},
+                tools: [],
+                allowedTools: [],
+                toolsSettings: {},
+                includedFiles: [],
+                resources: [],
+            },
+        })
+        const mgr = await McpManager.init([], featuresWithPrompt as any)
+        setStateSpy = sinon.spy(mgr as any, 'setState')
+        return mgr
+    }
+
+    afterEach(async () => {
+        sinon.restore()
+        try {
+            await McpManager.instance.close()
+        } catch {}
+    })
+
+    it('does not prompt for global-scoped config', async () => {
+        const mgr = await buildMgr()
+        const cfg: MCPServerConfig = { command: 'sh', args: [], __configPath__: globalMcp }
+        // Fail fast after gate (cleanupExistingServer is safe to call on unknown server)
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(showMessageStub.called).to.be.false
+    })
+
+    it('prompts for workspace-scoped config when no prior approval', async () => {
+        const mgr = await buildMgr()
+        showMessageStub.resolves({ title: 'Deny' })
+        const cfg: MCPServerConfig = { command: 'sh', args: ['-c', 'x'], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(showMessageStub.calledOnce).to.be.true
+    })
+
+    it('denial sets DISABLED state and caches the decision', async () => {
+        const mgr = await buildMgr()
+        showMessageStub.resolves({ title: 'Deny' })
+        const cfg: MCPServerConfig = { command: 'sh', args: ['-c', 'x'], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(setStateSpy.calledWith('svc', McpServerStatus.DISABLED, 0, 'consent not granted')).to.be.true
+
+        // Second call with same cfg should not re-prompt
+        showMessageStub.resetHistory()
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(showMessageStub.called).to.be.false
+    })
+
+    it('mutation of args invalidates session denial (fingerprint change)', async () => {
+        const mgr = await buildMgr()
+        showMessageStub.resolves({ title: 'Deny' })
+        const cfg1: MCPServerConfig = { command: 'sh', args: ['-c', 'x'], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg1)
+        } catch {}
+        expect(showMessageStub.calledOnce).to.be.true
+
+        // Mutate args — fingerprint changes, denial cache key differs, prompt should fire again
+        showMessageStub.resetHistory()
+        const cfg2: MCPServerConfig = { command: 'sh', args: ['-c', 'y'], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg2)
+        } catch {}
+        expect(showMessageStub.calledOnce).to.be.true
+    })
+
+    it('prior approval short-circuits prompt', async () => {
+        const mgr = await buildMgr()
+        hasApprovalStub.resolves(true)
+        const cfg: MCPServerConfig = { command: 'sh', args: [], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(showMessageStub.called).to.be.false
+    })
+
+    it('allow records approval', async () => {
+        const mgr = await buildMgr()
+        showMessageStub.resolves({ title: 'Allow for this server' })
+        const cfg: MCPServerConfig = { command: 'sh', args: ['-c', 'x'], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(recordApprovalStub.calledOnce).to.be.true
+    })
+})


### PR DESCRIPTION
Adds tests for the workspace-scoped MCP server consent gate feature:
- mcpConsentStore.test.ts: unit tests for the consent store
- mcpManager.test.ts: consent gate integration tests + fix missing closing brace in describe block