### PR TITLE
chore: bumpup language server runtime version

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@aws/chat-client-ui-types": "0.1.68",
-        "@aws/language-server-runtimes": "^0.3.16",
+        "@aws/language-server-runtimes": "^0.3.17",
         "@aws/language-server-runtimes-types": "^0.1.64",
         "@aws/mynah-ui": "^4.40.1"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -255,7 +255,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/chat-client-ui-types": "0.1.68",
-                "@aws/language-server-runtimes": "^0.3.16",
+                "@aws/language-server-runtimes": "^0.3.17",
                 "@aws/language-server-runtimes-types": "^0.1.64",
                 "@aws/mynah-ui": "^4.40.1"
             },
@@ -4506,9 +4506,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.3.16",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.3.16.tgz",
-            "integrity": "sha512-i5Rlnq1VUWpihGyd65o5gRqA8rxnkWZkx0WLsBCpuD9Lpztscwq2Si6f1dhhKK59905nG/xNE1xvRVAlXxc0IA==",
+            "version": "0.3.17",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.3.17.tgz",
+            "integrity": "sha512-yA7A7o5YChUlOT0zip9vGQu2Q5+UnHW/39cn7LKsTH0VD8ZiB8I8/4SXUggV3as2Vy7nD447xJGVkqjYqlngRA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.1.64",
@@ -31122,7 +31122,7 @@
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "0.1.68",
-                "@aws/language-server-runtimes": "^0.3.16",
+                "@aws/language-server-runtimes": "^0.3.17",
                 "@aws/lsp-core": "^0.0.21",
                 "@modelcontextprotocol/sdk": "^1.23.0",
                 "@mozilla/readability": "^0.6.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -38,7 +38,7 @@
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "0.1.68",
-        "@aws/language-server-runtimes": "^0.3.16",
+        "@aws/language-server-runtimes": "^0.3.17",
         "@aws/lsp-core": "^0.0.21",
         "@modelcontextprotocol/sdk": "^1.23.0",
         "@mozilla/readability": "^0.6.0",


### PR DESCRIPTION
## Notes:
- Bumping up language-server-runtimes version to `0.3.17`
- Related PR: https://github.com/aws/language-server-runtimes/pull/751

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
