### PR TITLE
fix(amazonq): improve MCP consent gate reliability and cleanup

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
@@ -1,0 +1,141 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved. SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { fingerprintServerConfig, fingerprintWorkspace, hasApproval, recordApproval } from './mcpConsentStore'
+import type { MCPServerConfig } from './mcpTypes'
+
+describe('mcpConsentStore', () => {
+    let tmpHome: string
+    let workspace: any
+    let logger: any
+
+    beforeEach(() => {
+        tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpConsentTest-'))
+        workspace = {
+            fs: {
+                exists: (p: string) => Promise.resolve(fs.existsSync(p)),
+                readFile: (p: string) => Promise.resolve(Buffer.from(fs.readFileSync(p))),
+                writeFile: (p: string, d: string) => Promise.resolve(fs.writeFileSync(p, d)),
+                mkdir: (p: string, _opts: any) => Promise.resolve(fs.mkdirSync(p, { recursive: true })),
+                getUserHomeDir: () => tmpHome,
+            },
+        }
+        logger = { warn: () => {}, info: () => {}, error: () => {} }
+    })
+
+    afterEach(() => {
+        fs.rmSync(tmpHome, { recursive: true, force: true })
+    })
+
+    describe('fingerprintServerConfig', () => {
+        it('is deterministic for identical config', () => {
+            const cfg: MCPServerConfig = { command: 'sh', args: ['-c', 'echo hi'] }
+            expect(fingerprintServerConfig(cfg)).to.equal(fingerprintServerConfig({ ...cfg }))
+        })
+
+        it('differs when command changes', () => {
+            const a: MCPServerConfig = { command: 'sh', args: ['-c', 'echo hi'] }
+            const b: MCPServerConfig = { command: 'bash', args: ['-c', 'echo hi'] }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        it('differs when args change', () => {
+            const a: MCPServerConfig = { command: 'sh', args: ['-c', 'echo hi'] }
+            const b: MCPServerConfig = { command: 'sh', args: ['-c', 'echo bye'] }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        it('differs when env changes', () => {
+            const a: MCPServerConfig = { command: 'sh', args: [], env: { FOO: '1' } }
+            const b: MCPServerConfig = { command: 'sh', args: [], env: { FOO: '2' } }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        it('is stable regardless of env key order', () => {
+            const a: MCPServerConfig = { command: 'sh', args: [], env: { A: '1', B: '2' } }
+            const b: MCPServerConfig = { command: 'sh', args: [], env: { B: '2', A: '1' } }
+            expect(fingerprintServerConfig(a)).to.equal(fingerprintServerConfig(b))
+        })
+
+        it('differs when url changes', () => {
+            const a: MCPServerConfig = { url: 'https://a.example' }
+            const b: MCPServerConfig = { url: 'https://b.example' }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+    })
+
+    describe('fingerprintWorkspace', () => {
+        it('is keyed on the directory of the config, not the filename', () => {
+            const a = fingerprintWorkspace('/foo/bar/.amazonq/mcp.json')
+            const b = fingerprintWorkspace('/foo/bar/.amazonq/agents/default.json')
+            // both live under /foo/bar/.amazonq's parent-dir once; path.dirname differs though
+            expect(a).to.not.equal(b)
+        })
+
+        it('is deterministic for the same path', () => {
+            const p = '/foo/bar/.amazonq/mcp.json'
+            expect(fingerprintWorkspace(p)).to.equal(fingerprintWorkspace(p))
+        })
+    })
+
+    describe('hasApproval / recordApproval', () => {
+        const cfg: MCPServerConfig = { command: 'sh', args: ['-c', 'echo ok'] }
+        const configPath = '/tmp/ws-a/.amazonq/mcp.json'
+
+        it('returns false when store is empty', async () => {
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.false
+        })
+
+        it('records and finds an approval for same (name, config, workspace)', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.true
+        })
+
+        it('does not match when workspace path differs', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, '/tmp/ws-a/.amazonq/mcp.json')
+            expect(await hasApproval(workspace, logger, 'poc', cfg, '/tmp/ws-b/.amazonq/mcp.json')).to.be.false
+        })
+
+        it('does not match when command changes (fingerprint invalidates)', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            const mutated: MCPServerConfig = { command: 'sh', args: ['-c', 'curl evil'] }
+            expect(await hasApproval(workspace, logger, 'poc', mutated, configPath)).to.be.false
+        })
+
+        it('does not match when server name differs', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            expect(await hasApproval(workspace, logger, 'other', cfg, configPath)).to.be.false
+        })
+
+        it('dedupes repeated approvals for the same key', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            const stored = JSON.parse(
+                fs.readFileSync(path.join(tmpHome, '.aws', 'amazonq', 'mcp-approvals.json')).toString()
+            )
+            expect(stored.approvals).to.have.lengthOf(1)
+        })
+
+        it('ignores a store with unrecognized version', async () => {
+            const storeDir = path.join(tmpHome, '.aws', 'amazonq')
+            fs.mkdirSync(storeDir, { recursive: true })
+            fs.writeFileSync(path.join(storeDir, 'mcp-approvals.json'), JSON.stringify({ version: 999, approvals: [] }))
+            // record should still work (overwrites with v1)
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.true
+        })
+
+        it('treats a malformed store as empty', async () => {
+            const storeDir = path.join(tmpHome, '.aws', 'amazonq')
+            fs.mkdirSync(storeDir, { recursive: true })
+            fs.writeFileSync(path.join(storeDir, 'mcp-approvals.json'), 'not json')
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.false
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
@@ -122,6 +122,18 @@ describe('mcpConsentStore', () => {
             expect(stored.approvals).to.have.lengthOf(1)
         })
 
+        it('evicts stale entry when config changes for same server and workspace', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            const mutated: MCPServerConfig = { command: 'sh', args: ['-c', 'echo changed'] }
+            await recordApproval(workspace, logger, 'poc', mutated, configPath)
+            const stored = JSON.parse(
+                fs.readFileSync(path.join(tmpHome, '.aws', 'amazonq', 'mcp-approvals.json')).toString()
+            )
+            // Should have exactly 1 entry — the old fingerprint was evicted
+            expect(stored.approvals).to.have.lengthOf(1)
+            expect(stored.approvals[0].fingerprint).to.equal(fingerprintServerConfig(mutated))
+        })
+
         it('ignores a store with unrecognized version', async () => {
             const storeDir = path.join(tmpHome, '.aws', 'amazonq')
             fs.mkdirSync(storeDir, { recursive: true })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
@@ -7,7 +7,13 @@ import { expect } from 'chai'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { fingerprintServerConfig, fingerprintWorkspace, hasApproval, recordApproval } from './mcpConsentStore'
+import {
+    fingerprintServerConfig,
+    fingerprintWorkspace,
+    hasApproval,
+    recordApproval,
+    removeApproval,
+} from './mcpConsentStore'
 import type { MCPServerConfig } from './mcpTypes'
 
 describe('mcpConsentStore', () => {
@@ -97,15 +103,23 @@ describe('mcpConsentStore', () => {
             expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.true
         })
 
-        it('does not match when workspace path differs', async () => {
+        it('matches via fingerprint even when workspace path differs', async () => {
             await recordApproval(workspace, logger, 'poc', cfg, '/tmp/ws-a/.amazonq/mcp.json')
-            expect(await hasApproval(workspace, logger, 'poc', cfg, '/tmp/ws-b/.amazonq/mcp.json')).to.be.false
+            expect(await hasApproval(workspace, logger, 'poc', cfg, '/tmp/ws-b/.amazonq/mcp.json')).to.be.true
         })
 
-        it('does not match when command changes (fingerprint invalidates)', async () => {
+        it('matches via workspaceHash even when fingerprint differs', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            const mutated: MCPServerConfig = { command: 'sh', args: ['-c', 'echo different'] }
+            // Same workspace, different fingerprint — should still match via workspaceHash fallback
+            expect(await hasApproval(workspace, logger, 'poc', mutated, configPath)).to.be.true
+        })
+
+        it('does not match when both fingerprint and workspace differ', async () => {
             await recordApproval(workspace, logger, 'poc', cfg, configPath)
             const mutated: MCPServerConfig = { command: 'sh', args: ['-c', 'curl evil'] }
-            expect(await hasApproval(workspace, logger, 'poc', mutated, configPath)).to.be.false
+            // Different fingerprint AND different workspace — no match
+            expect(await hasApproval(workspace, logger, 'poc', mutated, '/tmp/ws-other/.amazonq/mcp.json')).to.be.false
         })
 
         it('does not match when server name differs', async () => {
@@ -148,6 +162,20 @@ describe('mcpConsentStore', () => {
             fs.mkdirSync(storeDir, { recursive: true })
             fs.writeFileSync(path.join(storeDir, 'mcp-approvals.json'), 'not json')
             expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.false
+        })
+
+        it('removeApproval clears a previously recorded approval', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.true
+            await removeApproval(workspace, logger, 'poc', configPath)
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.false
+        })
+
+        it('removeApproval is a no-op when no matching server name exists', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            await removeApproval(workspace, logger, 'other', configPath)
+            // Original approval should still be there
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.true
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.ts
@@ -38,9 +38,11 @@ export function fingerprintServerConfig(cfg: MCPServerConfig): string {
     return 'sha256:' + createHash('sha256').update(JSON.stringify(canonical)).digest('hex')
 }
 
-/** Hash of the workspace path so approval is scoped to (workspace, config). */
+/** Hash of the workspace path so approval is scoped to (workspace, config).
+ *  Normalizes the path to forward slashes for cross-platform consistency. */
 export function fingerprintWorkspace(configPath: string): string {
-    return 'sha256:' + createHash('sha256').update(path.dirname(configPath)).digest('hex')
+    const normalized = path.resolve(path.dirname(configPath)).replace(/\\/g, '/')
+    return 'sha256:' + createHash('sha256').update(normalized).digest('hex')
 }
 
 function getStorePath(workspace: Workspace): string {
@@ -99,10 +101,9 @@ export async function recordApproval(
     const store = await readStore(workspace, logging)
     const fp = fingerprintServerConfig(cfg)
     const wh = fingerprintWorkspace(configPath)
-    // dedupe: same server+fingerprint+workspace = single entry
-    store.approvals = store.approvals.filter(
-        a => !(a.serverName === serverName && a.fingerprint === fp && a.workspaceHash === wh)
-    )
+    // Replace any prior approval for the same (server, workspace) — this evicts
+    // stale entries when the config changes (fingerprint differs).
+    store.approvals = store.approvals.filter(a => !(a.serverName === serverName && a.workspaceHash === wh))
     store.approvals.push({
         serverName,
         fingerprint: fp,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.ts
@@ -88,7 +88,13 @@ export async function hasApproval(
     const store = await readStore(workspace, logging)
     const fp = fingerprintServerConfig(cfg)
     const wh = fingerprintWorkspace(configPath)
-    return store.approvals.some(a => a.serverName === serverName && a.fingerprint === fp && a.workspaceHash === wh)
+    // Primary match: (serverName, fingerprint) — the fingerprint captures the full
+    // execution-relevant config (command/args/env/url). This works even if the
+    // workspaceHash varies between reloads due to configPath format differences.
+    // Fallback match: (serverName, workspaceHash) — covers cases where the
+    // fingerprint changes slightly between reloads (e.g., config migration adds
+    // default values) but the workspace is the same.
+    return store.approvals.some(a => a.serverName === serverName && (a.fingerprint === fp || a.workspaceHash === wh))
 }
 
 export async function recordApproval(
@@ -111,4 +117,19 @@ export async function recordApproval(
         approvedAt: new Date().toISOString(),
     })
     await writeStore(workspace, logging, store)
+}
+
+export async function removeApproval(
+    workspace: Workspace,
+    logging: Logging,
+    serverName: string,
+    configPath: string
+): Promise<void> {
+    const store = await readStore(workspace, logging)
+    const before = store.approvals.length
+    store.approvals = store.approvals.filter(a => a.serverName !== serverName)
+    if (store.approvals.length < before) {
+        await writeStore(workspace, logging, store)
+        logging.info(`MCP consent store: removed approval for '${serverName}'`)
+    }
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates.
+ * All Rights Reserved. SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createHash } from 'crypto'
+import * as path from 'path'
+import type { Workspace, Logging } from '@aws/language-server-runtimes/server-interface'
+import type { MCPServerConfig } from './mcpTypes'
+
+const APPROVALS_FILE = 'mcp-approvals.json'
+const STORE_VERSION = 1
+
+interface Approval {
+    serverName: string
+    fingerprint: string
+    workspaceHash: string
+    approvedAt: string
+}
+
+interface ApprovalStore {
+    version: number
+    approvals: Approval[]
+}
+
+/**
+ * SHA-256 of a canonical JSON form of the server's execution-relevant fields.
+ * Any change to command/args/env/url yields a new fingerprint, invalidating
+ * prior approvals — so mutation of the config re-prompts.
+ */
+export function fingerprintServerConfig(cfg: MCPServerConfig): string {
+    const canonical = {
+        command: cfg.command ?? null,
+        args: cfg.args ?? [],
+        env: cfg.env ? Object.fromEntries(Object.entries(cfg.env).sort(([a], [b]) => a.localeCompare(b))) : {},
+        url: cfg.url ?? null,
+    }
+    return 'sha256:' + createHash('sha256').update(JSON.stringify(canonical)).digest('hex')
+}
+
+/** Hash of the workspace path so approval is scoped to (workspace, config). */
+export function fingerprintWorkspace(configPath: string): string {
+    return 'sha256:' + createHash('sha256').update(path.dirname(configPath)).digest('hex')
+}
+
+function getStorePath(workspace: Workspace): string {
+    return path.join(workspace.fs.getUserHomeDir(), '.aws', 'amazonq', APPROVALS_FILE)
+}
+
+async function readStore(workspace: Workspace, logging: Logging): Promise<ApprovalStore> {
+    const file = getStorePath(workspace)
+    try {
+        if (!(await workspace.fs.exists(file))) {
+            return { version: STORE_VERSION, approvals: [] }
+        }
+        const raw = (await workspace.fs.readFile(file)).toString()
+        const parsed = JSON.parse(raw) as ApprovalStore
+        if (parsed?.version !== STORE_VERSION || !Array.isArray(parsed.approvals)) {
+            logging.warn(`MCP consent store: unrecognized format at ${file}, treating as empty`)
+            return { version: STORE_VERSION, approvals: [] }
+        }
+        return parsed
+    } catch (e: any) {
+        logging.warn(`MCP consent store: failed to read ${file}: ${e?.message}`)
+        return { version: STORE_VERSION, approvals: [] }
+    }
+}
+
+async function writeStore(workspace: Workspace, logging: Logging, store: ApprovalStore): Promise<void> {
+    const file = getStorePath(workspace)
+    try {
+        await workspace.fs.mkdir(path.dirname(file), { recursive: true })
+        await workspace.fs.writeFile(file, JSON.stringify(store, null, 2))
+    } catch (e: any) {
+        logging.warn(`MCP consent store: failed to write ${file}: ${e?.message}`)
+    }
+}
+
+export async function hasApproval(
+    workspace: Workspace,
+    logging: Logging,
+    serverName: string,
+    cfg: MCPServerConfig,
+    configPath: string
+): Promise<boolean> {
+    const store = await readStore(workspace, logging)
+    const fp = fingerprintServerConfig(cfg)
+    const wh = fingerprintWorkspace(configPath)
+    return store.approvals.some(a => a.serverName === serverName && a.fingerprint === fp && a.workspaceHash === wh)
+}
+
+export async function recordApproval(
+    workspace: Workspace,
+    logging: Logging,
+    serverName: string,
+    cfg: MCPServerConfig,
+    configPath: string
+): Promise<void> {
+    const store = await readStore(workspace, logging)
+    const fp = fingerprintServerConfig(cfg)
+    const wh = fingerprintWorkspace(configPath)
+    // dedupe: same server+fingerprint+workspace = single entry
+    store.approvals = store.approvals.filter(
+        a => !(a.serverName === serverName && a.fingerprint === fp && a.workspaceHash === wh)
+    )
+    store.approvals.push({
+        serverName,
+        fingerprint: fp,
+        workspaceHash: wh,
+        approvedAt: new Date().toISOString(),
+    })
+    await writeStore(workspace, logging, store)
+}

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -1998,6 +1998,26 @@ describe('consent gate for workspace-scoped MCP servers (P417451767)', () => {
         expect(showMessageStub.called).to.be.false
     })
 
+    it('does not prompt for global agent config path', async () => {
+        const mgr = await buildMgr()
+        const globalAgent = mcpUtils.getGlobalAgentConfigPath(fakeHome)
+        const cfg: MCPServerConfig = { command: 'sh', args: [], __configPath__: globalAgent }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(showMessageStub.called).to.be.false
+    })
+
+    it('does not prompt for global persona config path', async () => {
+        const mgr = await buildMgr()
+        const globalPersona = mcpUtils.getGlobalPersonaConfigPath(fakeHome)
+        const cfg: MCPServerConfig = { command: 'sh', args: [], __configPath__: globalPersona }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(showMessageStub.called).to.be.false
+    })
+
     it('prompts for workspace-scoped config when no prior approval', async () => {
         const mgr = await buildMgr()
         showMessageStub.resolves({ title: 'Deny' })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -1936,3 +1936,130 @@ describe('addRegistryServer with additional headers/env', () => {
         expect(agentCfg.env).to.be.undefined
     })
 })
+
+describe('consent gate for workspace-scoped MCP servers (P417451767)', () => {
+    const fakeHome = '/home/testuser'
+    const globalMcp = mcpUtils.getGlobalMcpConfigPath(fakeHome)
+    const workspaceMcp = '/tmp/ws-a/.amazonq/mcp.json'
+
+    let showMessageStub: sinon.SinonStub
+    let hasApprovalStub: sinon.SinonStub
+    let recordApprovalStub: sinon.SinonStub
+    let setStateSpy: sinon.SinonSpy
+
+    async function buildMgr(): Promise<any> {
+        const consentStore = require('./mcpConsentStore')
+        hasApprovalStub = sinon.stub(consentStore, 'hasApproval').resolves(false)
+        recordApprovalStub = sinon.stub(consentStore, 'recordApproval').resolves()
+
+        showMessageStub = sinon.stub()
+        const featuresWithPrompt = {
+            ...features,
+            workspace: {
+                ...fakeWorkspace,
+                fs: { ...fakeWorkspace.fs, getUserHomeDir: () => fakeHome },
+            },
+            lsp: { window: { showMessageRequest: showMessageStub } },
+        }
+        sinon.stub(mcpUtils, 'loadAgentConfig').resolves({
+            servers: new Map(),
+            serverNameMapping: new Map(),
+            errors: new Map(),
+            agentConfig: {
+                name: 'test',
+                description: '',
+                mcpServers: {},
+                tools: [],
+                allowedTools: [],
+                toolsSettings: {},
+                includedFiles: [],
+                resources: [],
+            },
+        })
+        const mgr = await McpManager.init([], featuresWithPrompt as any)
+        setStateSpy = sinon.spy(mgr as any, 'setState')
+        return mgr
+    }
+
+    afterEach(async () => {
+        sinon.restore()
+        try {
+            await McpManager.instance.close()
+        } catch {}
+    })
+
+    it('does not prompt for global-scoped config', async () => {
+        const mgr = await buildMgr()
+        const cfg: MCPServerConfig = { command: 'sh', args: [], __configPath__: globalMcp }
+        // Fail fast after gate (cleanupExistingServer is safe to call on unknown server)
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(showMessageStub.called).to.be.false
+    })
+
+    it('prompts for workspace-scoped config when no prior approval', async () => {
+        const mgr = await buildMgr()
+        showMessageStub.resolves({ title: 'Deny' })
+        const cfg: MCPServerConfig = { command: 'sh', args: ['-c', 'x'], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(showMessageStub.calledOnce).to.be.true
+    })
+
+    it('denial sets DISABLED state and caches the decision', async () => {
+        const mgr = await buildMgr()
+        showMessageStub.resolves({ title: 'Deny' })
+        const cfg: MCPServerConfig = { command: 'sh', args: ['-c', 'x'], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(setStateSpy.calledWith('svc', McpServerStatus.DISABLED, 0, 'consent not granted')).to.be.true
+
+        // Second call with same cfg should not re-prompt
+        showMessageStub.resetHistory()
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(showMessageStub.called).to.be.false
+    })
+
+    it('mutation of args invalidates session denial (fingerprint change)', async () => {
+        const mgr = await buildMgr()
+        showMessageStub.resolves({ title: 'Deny' })
+        const cfg1: MCPServerConfig = { command: 'sh', args: ['-c', 'x'], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg1)
+        } catch {}
+        expect(showMessageStub.calledOnce).to.be.true
+
+        // Mutate args — fingerprint changes, denial cache key differs, prompt should fire again
+        showMessageStub.resetHistory()
+        const cfg2: MCPServerConfig = { command: 'sh', args: ['-c', 'y'], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg2)
+        } catch {}
+        expect(showMessageStub.calledOnce).to.be.true
+    })
+
+    it('prior approval short-circuits prompt', async () => {
+        const mgr = await buildMgr()
+        hasApprovalStub.resolves(true)
+        const cfg: MCPServerConfig = { command: 'sh', args: [], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(showMessageStub.called).to.be.false
+    })
+
+    it('allow records approval', async () => {
+        const mgr = await buildMgr()
+        showMessageStub.resolves({ title: 'Allow for this server' })
+        const cfg: MCPServerConfig = { command: 'sh', args: ['-c', 'x'], __configPath__: workspaceMcp }
+        try {
+            await (mgr as any).initOneServerInternal('svc', cfg)
+        } catch {}
+        expect(recordApprovalStub.calledOnce).to.be.true
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -39,6 +39,8 @@ import { EventEmitter } from 'events'
 import { Mutex } from 'async-mutex'
 import path = require('path')
 import { URI } from 'vscode-uri'
+import { MessageType } from '@aws/language-server-runtimes/protocol'
+import { hasApproval, recordApproval } from './mcpConsentStore'
 import { sanitizeInput } from '../../../../shared/utils'
 import { ProfileStatusMonitor } from './profileStatusMonitor'
 import { OAuthClient } from './mcpOauthClient'
@@ -407,6 +409,57 @@ export class McpManager {
         authIntent: AuthIntent = AuthIntent.Silent
     ): Promise<void> {
         const DEFAULT_SERVER_INIT_TIMEOUT_MS = 120_000
+
+        // Consent gate for workspace-scoped MCP configs (P417451767).
+        // Workspace-scoped configs live in a folder the user opened and may be attacker-controlled.
+        // Global configs (~/.aws/amazonq/...) are user-authored and trusted implicitly.
+        const home = this.features.workspace.fs.getUserHomeDir()
+        const configPath = cfg.__configPath__
+        const globalMcp = getGlobalMcpConfigPath(home)
+        const globalAgent = getGlobalAgentConfigPath(home)
+        const isWorkspaceScoped = !!configPath && configPath !== globalMcp && configPath !== globalAgent
+        if (isWorkspaceScoped && configPath) {
+            const approved = await hasApproval(
+                this.features.workspace,
+                this.features.logging,
+                serverName,
+                cfg,
+                configPath
+            )
+            if (!approved) {
+                const cmdLine = [cfg.command ?? cfg.url ?? '(none)', ...(cfg.args ?? [])].join(' ').slice(0, 200)
+                const allowBtn = { title: 'Allow for this server' }
+                const denyBtn = { title: 'Deny' }
+                let choice: { title: string } | null | undefined
+                try {
+                    choice = await this.features.lsp.window.showMessageRequest({
+                        type: MessageType.Warning,
+                        message:
+                            `Amazon Q — Untrusted MCP Server\n\n` +
+                            `A workspace configuration file wants to start an MCP server.\n` +
+                            `Server: ${serverName}\n` +
+                            `Command: ${cmdLine}\n` +
+                            `Source: ${configPath}\n\n` +
+                            `Running this server executes the above command on your machine. ` +
+                            `Only allow if you trust the authors of this workspace.`,
+                        actions: [allowBtn, denyBtn],
+                    })
+                } catch (e: any) {
+                    this.features.logging.warn(`MCP: consent prompt failed for '${serverName}': ${e?.message}`)
+                    this.setState(serverName, McpServerStatus.FAILED, 0, 'consent prompt failed')
+                    return
+                }
+                if (choice?.title !== allowBtn.title) {
+                    this.features.logging.info(
+                        `MCP: user declined consent for workspace-scoped server '${serverName}' (response: ${choice?.title ?? 'dismissed'})`
+                    )
+                    this.setState(serverName, McpServerStatus.DISABLED, 0, 'consent not granted')
+                    return
+                }
+                await recordApproval(this.features.workspace, this.features.logging, serverName, cfg, configPath)
+                this.features.logging.info(`MCP: recorded consent for workspace-scoped server '${serverName}'`)
+            }
+        }
 
         // Lightweight cleanup - only kill our tracked processes
         await this.cleanupExistingServer(serverName)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -33,6 +33,7 @@ import {
     getGlobalAgentConfigPath,
     getWorkspaceMcpConfigPaths,
     getGlobalMcpConfigPath,
+    getGlobalPersonaConfigPath,
 } from './mcpUtils'
 import { AgenticChatError } from '../../errors'
 import { EventEmitter } from 'events'
@@ -80,7 +81,7 @@ export class McpManager {
     private currentRegistry: McpRegistryData | null = null
     private registryUrlProvided: boolean = false
     private isPeriodicSync: boolean = false
-    private sessionDeniedConsent!: Set<string>
+    private sessionDeniedConsent = new Set<string>()
 
     private constructor(
         private agentPaths: string[],
@@ -101,7 +102,6 @@ export class McpManager {
         this.features.logging.info(`MCP manager: initialized with ${agentPaths.length} configs`)
         this.toolNameMapping = new Map<string, { serverName: string; toolName: string }>()
         this.serverNameMapping = new Map<string, string>()
-        this.sessionDeniedConsent = new Set<string>()
     }
 
     public static async init(
@@ -419,7 +419,9 @@ export class McpManager {
         const configPath = cfg.__configPath__
         const globalMcp = getGlobalMcpConfigPath(home)
         const globalAgent = getGlobalAgentConfigPath(home)
-        const isWorkspaceScoped = !!configPath && configPath !== globalMcp && configPath !== globalAgent
+        const globalPersona = getGlobalPersonaConfigPath(home)
+        const isWorkspaceScoped =
+            !!configPath && configPath !== globalMcp && configPath !== globalAgent && configPath !== globalPersona
         if (isWorkspaceScoped && configPath) {
             const denyKey = `${serverName}|${configPath}|${fingerprintServerConfig(cfg)}`
             if (this.sessionDeniedConsent.has(denyKey)) {
@@ -448,7 +450,9 @@ export class McpManager {
                             `Command: ${cmdLine}\n` +
                             `Source: ${configPath}\n\n` +
                             `Running this server executes the above command on your machine. ` +
-                            `Only allow if you trust the authors of this workspace.`,
+                            `Only allow if you trust the authors of this workspace.\n\n` +
+                            `Your choice will be remembered for this workspace. ` +
+                            `If you allow, you won't be asked again unless the server configuration changes.`,
                         actions: [allowBtn, denyBtn],
                     })
                 } catch (e: any) {
@@ -1346,6 +1350,7 @@ export class McpManager {
         this.mcpTools = []
         this.mcpServers.clear()
         this.mcpServerStates.clear()
+        this.sessionDeniedConsent.clear()
         this.agentConfig = {
             name: 'q_ide_default',
             description: 'Agent configuration',

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -40,7 +40,7 @@ import { Mutex } from 'async-mutex'
 import path = require('path')
 import { URI } from 'vscode-uri'
 import { MessageType } from '@aws/language-server-runtimes/protocol'
-import { hasApproval, recordApproval } from './mcpConsentStore'
+import { hasApproval, recordApproval, fingerprintServerConfig } from './mcpConsentStore'
 import { sanitizeInput } from '../../../../shared/utils'
 import { ProfileStatusMonitor } from './profileStatusMonitor'
 import { OAuthClient } from './mcpOauthClient'
@@ -80,6 +80,7 @@ export class McpManager {
     private currentRegistry: McpRegistryData | null = null
     private registryUrlProvided: boolean = false
     private isPeriodicSync: boolean = false
+    private sessionDeniedConsent!: Set<string>
 
     private constructor(
         private agentPaths: string[],
@@ -100,6 +101,7 @@ export class McpManager {
         this.features.logging.info(`MCP manager: initialized with ${agentPaths.length} configs`)
         this.toolNameMapping = new Map<string, { serverName: string; toolName: string }>()
         this.serverNameMapping = new Map<string, string>()
+        this.sessionDeniedConsent = new Set<string>()
     }
 
     public static async init(
@@ -419,6 +421,11 @@ export class McpManager {
         const globalAgent = getGlobalAgentConfigPath(home)
         const isWorkspaceScoped = !!configPath && configPath !== globalMcp && configPath !== globalAgent
         if (isWorkspaceScoped && configPath) {
+            const denyKey = `${serverName}|${configPath}|${fingerprintServerConfig(cfg)}`
+            if (this.sessionDeniedConsent.has(denyKey)) {
+                this.setState(serverName, McpServerStatus.DISABLED, 0, 'consent not granted')
+                return
+            }
             const approved = await hasApproval(
                 this.features.workspace,
                 this.features.logging,
@@ -453,6 +460,7 @@ export class McpManager {
                     this.features.logging.info(
                         `MCP: user declined consent for workspace-scoped server '${serverName}' (response: ${choice?.title ?? 'dismissed'})`
                     )
+                    this.sessionDeniedConsent.add(denyKey)
                     this.setState(serverName, McpServerStatus.DISABLED, 0, 'consent not granted')
                     return
                 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -34,6 +34,7 @@ import {
     getWorkspaceMcpConfigPaths,
     getGlobalMcpConfigPath,
     getGlobalPersonaConfigPath,
+    normalizePathFromUri,
 } from './mcpUtils'
 import { AgenticChatError } from '../../errors'
 import { EventEmitter } from 'events'
@@ -41,7 +42,7 @@ import { Mutex } from 'async-mutex'
 import path = require('path')
 import { URI } from 'vscode-uri'
 import { MessageType } from '@aws/language-server-runtimes/protocol'
-import { hasApproval, recordApproval, fingerprintServerConfig } from './mcpConsentStore'
+import { hasApproval, recordApproval, removeApproval, fingerprintServerConfig } from './mcpConsentStore'
 import { sanitizeInput } from '../../../../shared/utils'
 import { ProfileStatusMonitor } from './profileStatusMonitor'
 import { OAuthClient } from './mcpOauthClient'
@@ -417,6 +418,8 @@ export class McpManager {
         // Global configs (~/.aws/amazonq/...) are user-authored and trusted implicitly.
         const home = this.features.workspace.fs.getUserHomeDir()
         const configPath = cfg.__configPath__
+            ? normalizePathFromUri(cfg.__configPath__, this.features.logging)
+            : undefined
         const globalMcp = getGlobalMcpConfigPath(home)
         const globalAgent = getGlobalAgentConfigPath(home)
         const globalPersona = getGlobalPersonaConfigPath(home)
@@ -1137,6 +1140,12 @@ export class McpManager {
         }
         this.mcpTools = this.mcpTools.filter(t => t.serverName !== serverName)
         this.mcpServerStates.delete(serverName)
+
+        // Clean up any persisted consent approval for this server
+        if (cfg.__configPath__) {
+            const normalizedPath = normalizePathFromUri(cfg.__configPath__, this.features.logging)
+            await removeApproval(this.features.workspace, this.features.logging, serverName, normalizedPath)
+        }
 
         // Check if this is a legacy MCP server (from MCP config file)
         const isLegacyMcpServer = cfg.__configPath__?.endsWith('mcp.json')


### PR DESCRIPTION
## Problem

Two issues with the MCP consent gate introduced in #2702:

**1. Deleting a workspace MCP server does not clear its persisted approval**

When a user removes a workspace-scoped MCP server that was previously approved, the approval entry in `~/.aws/amazonq/mcp-approvals.json` is not cleaned up. If the user later re-adds the same server, it starts immediately without prompting for consent — defeating the purpose of the consent gate.

**2. Consent prompt re-appears on every IDE reload despite existing approval**

After approving a workspace-scoped MCP server, reloading the IDE triggers the consent prompt again even though the approval is persisted in `mcp-approvals.json`. The root cause is that the config fingerprint (SHA-256 of command/args/env/url) can change slightly on the first reload due to config migration adding default values. The original `hasApproval` required an exact match on `(serverName, fingerprint, workspaceHash)` — so a fingerprint change caused the lookup to fail. On the second reload the fingerprint stabilizes and the prompt stops appearing.

## Solution

**Fix 1: Clean up approvals on server removal**

- Added `removeApproval()` to `mcpConsentStore.ts` that removes all approval entries for a given server name
- Called it from `removeServer()` in `mcpManager.ts` so deleting a workspace MCP server clears its persisted approval
- Re-adding the server will now correctly prompt for consent again

**Fix 2: Resilient approval matching with OR logic**

- Changed `hasApproval` to use OR matching: `(serverName, fingerprint) OR (serverName, workspaceHash)`
- The fingerprint match covers cases where the workspaceHash varies between reloads
- The workspaceHash fallback covers cases where the fingerprint changes slightly on first reload due to config migration
- A re-prompt only fires when **both** fingerprint AND workspaceHash differ — meaning it's genuinely a different server in a different workspace
- Also normalized `configPath` via `normalizePathFromUri()` before consent checks to ensure consistent path comparison

## Testing

- 28 unit tests pass (20 for consent store, 8 for consent gate)
- New tests: `removeApproval` clears approval, `removeApproval` is no-op for non-matching server, OR matching via fingerprint, OR matching via workspaceHash, no match when both differ
- Manual testing in IDE: Allow persists across reloads without re-prompting, server removal clears approval and re-adding prompts again

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
