### PR TITLE
fix(amazonq): route inline chat through getChatResponse for correct API selection

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -2159,8 +2159,8 @@ describe('AgenticChatController', () => {
             assert.deepStrictEqual(chatResult, expectedCompleteInlineChatResult)
         })
 
-        it('returns a ResponseError if sendMessage returns an error', async () => {
-            sendMessageStub.callsFake(() => {
+        it('returns a ResponseError if generateAssistantResponse returns an error', async () => {
+            generateAssistantResponseStub.callsFake(() => {
                 throw new Error('Error')
             })
 
@@ -2172,8 +2172,8 @@ describe('AgenticChatController', () => {
             assert.ok(chatResult instanceof ResponseError)
         })
 
-        it('returns a Response error if sendMessage returns an auth error', async () => {
-            sendMessageStub.callsFake(() => {
+        it('returns a Response error if generateAssistantResponse returns an auth error', async () => {
+            generateAssistantResponseStub.callsFake(() => {
                 throw new Error('Error')
             })
 
@@ -2189,12 +2189,12 @@ describe('AgenticChatController', () => {
         })
 
         it('returns a ResponseError if response streams return an error event', async () => {
-            sendMessageStub.callsFake(() => {
+            generateAssistantResponseStub.callsFake(() => {
                 return Promise.resolve({
                     $metadata: {
                         requestId: mockMessageId,
                     },
-                    sendMessageResponse: createIterableResponse([
+                    generateAssistantResponseResponse: createIterableResponse([
                         // ["Hello ", "World"]
                         ...mockChatResponseList.slice(1, 3),
                         { error: { message: 'some error' } },
@@ -2213,12 +2213,12 @@ describe('AgenticChatController', () => {
         })
 
         it('returns a ResponseError if response streams return an invalid state event', async () => {
-            sendMessageStub.callsFake(() => {
+            generateAssistantResponseStub.callsFake(() => {
                 return Promise.resolve({
                     $metadata: {
                         requestId: mockMessageId,
                     },
-                    sendMessageResponse: createIterableResponse([
+                    generateAssistantResponseResponse: createIterableResponse([
                         // ["Hello ", "World"]
                         ...mockChatResponseList.slice(1, 3),
                         { invalidStateEvent: { message: 'invalid state' } },
@@ -2279,7 +2279,8 @@ describe('AgenticChatController', () => {
                     mockCancellationToken
                 )
 
-                const calledRequestInput: SendMessageCommandInput = sendMessageStub.firstCall.firstArg
+                const calledRequestInput: GenerateAssistantResponseCommandInput =
+                    generateAssistantResponseStub.firstCall.firstArg
 
                 assert.strictEqual(
                     calledRequestInput.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
@@ -2304,7 +2305,8 @@ describe('AgenticChatController', () => {
                     mockCancellationToken
                 )
 
-                const calledRequestInput: SendMessageCommandInput = sendMessageStub.firstCall.firstArg
+                const calledRequestInput: GenerateAssistantResponseCommandInput =
+                    generateAssistantResponseStub.firstCall.firstArg
 
                 assert.strictEqual(
                     calledRequestInput.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
@@ -2330,7 +2332,8 @@ describe('AgenticChatController', () => {
                     mockCancellationToken
                 )
 
-                const calledRequestInput: SendMessageCommandInput = sendMessageStub.firstCall.firstArg
+                const calledRequestInput: GenerateAssistantResponseCommandInput =
+                    generateAssistantResponseStub.firstCall.firstArg
 
                 assert.deepStrictEqual(
                     calledRequestInput.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -37,12 +37,7 @@ import {
     SUFFIX_UNDOALL,
     SUFFIX_EXPLANATION,
 } from './constants/toolConstants'
-import {
-    SendMessageCommandInput,
-    SendMessageCommandOutput,
-    ChatCommandInput,
-    ChatCommandOutput,
-} from '../../shared/streamingClientService'
+import { SendMessageCommandInput, ChatCommandInput, ChatCommandOutput } from '../../shared/streamingClientService'
 import {
     Button,
     Status,
@@ -3776,8 +3771,8 @@ export class AgenticChatController implements ChatHandlers {
                 throw new Error('amazonQServiceManager is not initialized')
             }
 
-            const client = this.#serviceManager.getStreamingClient()
-            response = await client.sendMessage(requestInput as SendMessageCommandInput)
+            const session = new ChatSessionService(this.#serviceManager, this.#features.lsp, this.#features.logging)
+            response = await session.getChatResponse(requestInput)
             this.#log('Response for inline chat', JSON.stringify(response.$metadata), JSON.stringify(response))
         } catch (err) {
             if (err instanceof AmazonQServicePendingSigninError || err instanceof AmazonQServicePendingProfileError) {
@@ -4697,14 +4692,21 @@ export class AgenticChatController implements ChatHandlers {
     }
 
     async #processSendMessageResponseForInlineChat(
-        response: SendMessageCommandOutput,
+        response: ChatCommandOutput,
         metric: Metric<AddMessageEvent>,
         partialResultToken?: string | number
     ): Promise<Result<ChatResultWithMetadata, string>> {
         const requestId = response.$metadata.requestId!
         const chatEventParser = new ChatEventParser(requestId, metric)
 
-        for await (const chatEvent of response.sendMessageResponse!) {
+        let chatEventStream = undefined
+        if ('generateAssistantResponseResponse' in response) {
+            chatEventStream = response.generateAssistantResponseResponse
+        } else if ('sendMessageResponse' in response) {
+            chatEventStream = response.sendMessageResponse
+        }
+
+        for await (const chatEvent of chatEventStream!) {
             const result = chatEventParser.processPartialEvent(chatEvent)
 
             // terminate early when there is an error


### PR DESCRIPTION
## Notes:
- Feature branch PR: https://github.com/aws/language-servers/pull/2713

Tested in Eclipse inline chat:

https://github.com/user-attachments/assets/0606fa53-468b-4974-a951-d1624ff171a6



<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
