### PR TITLE
fix(amazonq): prevent file link click from crashing language server

### DIFF
--- a/chat-client/src/client/utils.ts
+++ b/chat-client/src/client/utils.ts
@@ -50,7 +50,7 @@ export function toMynahFileList(fileList: ChatMessage['fileList']): ChatItemCont
                         filePath.split('/').filter(Boolean).pop() || filePath.split('/').slice(-2, -1)[0] || filePath,
                     clickable: true,
                     data: {
-                        fullPath: fileDetails.fullPath || '',
+                        fullPath: fileDetails.fullPath || fileDetails.description || '',
                     },
                 },
             ])
@@ -111,7 +111,7 @@ export function contextListToHeader(contextList?: ChatResult['contextList']): Ch
                         description: fileDetails.description,
                         clickable: true,
                         data: {
-                            fullPath: fileDetails.fullPath || '',
+                            fullPath: fileDetails.fullPath || fileDetails.description || '',
                         },
                     },
                 ])

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -3919,21 +3919,25 @@ export class AgenticChatController implements ChatHandlers {
         const toolUseId = params.messageId
         const toolUse = toolUseId ? session.data?.toolUseLookup.get(toolUseId) : undefined
 
-        if (toolUse?.name === FS_WRITE || toolUse?.name === FS_REPLACE) {
-            const input = toolUse.input as unknown as FsWriteParams | FsReplaceParams
-            this.#features.lsp.workspace.openFileDiff({
-                originalFileUri: input.path,
-                originalFileContent: toolUse.fileChange?.before,
-                isDeleted: false,
-                fileContent: toolUse.fileChange?.after,
-            })
-        } else if (toolUse?.name === FS_READ) {
-            await this.#features.lsp.window.showDocument({ uri: URI.file(params.filePath).toString() })
-        } else {
-            const absolutePath = params.fullPath ?? (await this.#resolveAbsolutePath(params.filePath))
-            if (absolutePath) {
-                await this.#features.lsp.window.showDocument({ uri: URI.file(absolutePath).toString() })
+        try {
+            if (toolUse?.name === FS_WRITE || toolUse?.name === FS_REPLACE) {
+                const input = toolUse.input as unknown as FsWriteParams | FsReplaceParams
+                this.#features.lsp.workspace.openFileDiff({
+                    originalFileUri: input.path,
+                    originalFileContent: toolUse.fileChange?.before,
+                    isDeleted: false,
+                    fileContent: toolUse.fileChange?.after,
+                })
+            } else if (toolUse?.name === FS_READ) {
+                await this.#features.lsp.window.showDocument({ uri: URI.file(params.filePath).toString() })
+            } else {
+                const absolutePath = params.fullPath ?? (await this.#resolveAbsolutePath(params.filePath))
+                if (absolutePath) {
+                    await this.#features.lsp.window.showDocument({ uri: URI.file(absolutePath).toString() })
+                }
             }
+        } catch (e: any) {
+            this.#features.logging.error(`Error opening file: ${e.message}`)
         }
     }
 
@@ -4118,7 +4122,10 @@ export class AgenticChatController implements ChatHandlers {
 
             // handle prompt file outside of workspace
             if (relativePath.endsWith(promptFileExtension)) {
-                return path.join(getUserPromptsDirectory(), relativePath)
+                const promptPath = path.join(getUserPromptsDirectory(), relativePath)
+                if (await this.#features.workspace.fs.exists(promptPath)) {
+                    return promptPath
+                }
             }
 
             this.#features.logging.error(`File not found: ${relativePath}`)


### PR DESCRIPTION
## Problem

Clicking a file link in agentic chat for a file created by `fsWrite` crashes the language server
and loses all chat context. Two bugs combine to cause this:

1. `#resolveAbsolutePath` assumes any `.md` file not found in workspace folders is a user prompt
   file and returns `~/.aws/amazonq/prompts/<filename>` without checking if it exists there.
2. `onFileClicked` has no error handling — when `showDocument` rejects because the file doesn't
   exist, the unhandled promise rejection crashes the language server process.

The fsWrite file link also never passes `fullPath` through the click handler data, so even when
the toolUseLookup fails to match, the fallback path resolution receives only the basename.

## Solution

- Wrap `onFileClicked` in try/catch so a failed `showDocument` logs an error instead of crashing
  the server
- Add `fs.exists` check in `#resolveAbsolutePath` before returning the prompts directory path
- Fall back to `description` (which already contains the full absolute path) as `fullPath` in
  the chat-client file list mapping, reusing existing data instead of adding a redundant field

## Testing

- `tsc --noEmit` passes for both `aws-lsp-codewhisperer` and `chat-client` packages
- Existing `contextUtils` tests pass
- Manual: create a `.md` file via fsWrite in agentic chat, click the link — should open
  correctly or log an error gracefully without crashing


## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
