### PR TITLE
fix: fixing write lock on worklogs json

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -80,6 +80,7 @@ export class ATXTransformHandler {
     private cachedHitl: string | null = null
     private cachedStepHitl: string | null = null
     private cachedInteractiveMode: InteractiveMode | null = null
+    private _applyingCheckpoints = false
 
     constructor(serviceManager: AtxTokenServiceManager, workspace: Workspace, logging: Logging, runtime: Runtime) {
         this.serviceManager = serviceManager
@@ -2354,6 +2355,13 @@ export class ATXTransformHandler {
         solutionRootPath: string,
         plan: AtxTransformationPlan
     ): Promise<void> {
+        // Prevent concurrent execution
+        if (this._applyingCheckpoints) {
+            this.logging.log('ATX: downloadCompletedStepArtifacts already in progress, skipping')
+            return
+        }
+        this._applyingCheckpoints = true
+
         try {
             const completedSteps = this.findCompletedSteps(plan.Root)
 
@@ -2408,6 +2416,8 @@ export class ATXTransformHandler {
             }
         } catch (error) {
             this.logging.error(`ATX: downloadCompletedStepArtifacts error: ${String(error)}`)
+        } finally {
+            this._applyingCheckpoints = false
         }
     }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/utils.ts
@@ -120,14 +120,21 @@ export class Utils {
                     worklogData[stepId].push(entry)
                 }
 
-                fs.writeFileSync(worklogPath, JSON.stringify(worklogData, null, 2))
+                // Write to temp file and rename for atomic update (avoids file lock conflicts with toolkit reader)
+                const tempPath = worklogPath + '.tmp'
+                fs.writeFileSync(tempPath, JSON.stringify(worklogData, null, 2))
+                fs.renameSync(tempPath, worklogPath)
                 return
             } catch (err: any) {
-                if (err.code === 'EBUSY' && attempt < maxRetries - 1) {
+                if ((err.code === 'EBUSY' || err.code === 'EPERM') && attempt < maxRetries - 1) {
                     await new Promise(resolve => setTimeout(resolve, 100 * (attempt + 1)))
                     continue
                 }
-                throw err
+                // Don't throw - worklogs are non-critical, will retry on next poll
+                console.error(
+                    `ATX: Failed to write worklogs after ${maxRetries} attempts: ${err.code} - ${err.message}`
+                )
+                return
             }
         }
     }


### PR DESCRIPTION
# Fix worklog file lock 

## Problem

1. **Worklogs stuck/empty on reconnect**: The toolkit couldn't read `worklogs.json` because the LSP held an exclusive file lock during `writeFileSync` on every poll cycle. The toolkit's read attempts failed with "The process cannot access the file" for the entire job duration (~12 minutes of continuous failures).

2. **Checkpoint applied 4x redundantly**: `downloadCompletedStepArtifacts` was called on every poll cycle from `getTransformationPlan`. Multiple concurrent calls raced to apply the same checkpoint before `checkpoints-applied.json` was saved.

## Fix

### utils.ts — Atomic worklog write
- Write to `.tmp` file then `renameSync` to target — avoids holding exclusive lock on the file the toolkit reads
- Added `EPERM` to retry conditions (Windows rename can fail with this)
- On final failure: log and return gracefully instead of throwing (worklogs are non-critical, will retry next poll)

### atxTransformHandler.ts — Concurrency guard
- Added `_applyingCheckpoints` flag to prevent concurrent execution of `downloadCompletedStepArtifacts`
- Resets in `finally` block to ensure cleanup on error

## Testing

1. Start job → verify worklogs update in real-time in the Worklogs tab
2. Disconnect → reconnect → verify worklogs load after reconnect
3. Verify checkpoint is applied only once (check logs for "Saved applied checkpoint" appearing once per step, not 4x)
