### PR TITLE
Karsraja atx handler coverage

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxNetTransformServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxNetTransformServer.test.ts
@@ -1,0 +1,262 @@
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+import { AtxNetTransformServerToken } from '../atxNetTransformServer'
+import { ATXTransformHandler } from '../atxTransformHandler'
+import { AtxTransformHandlerLegacy } from '../atxTransformHandlerLegacy'
+import { AtxTokenServiceManager } from '../../../shared/amazonQServiceManager/AtxTokenServiceManager'
+
+const AtxStartTransformCommand = 'aws/atxTransform/startTransform'
+const AtxGetTransformInfoCommand = 'aws/atxTransform/getTransformInfo'
+const AtxUploadPlanCommand = 'aws/atxTransform/uploadPlan'
+
+describe('AtxNetTransformServer - routing', () => {
+    let executeCommandHandler: any
+    let onInitializedFn: any
+    let logging: any
+
+    let newStartTransform: sinon.SinonStub
+    let legacyStartTransform: sinon.SinonStub
+    let newGetTransformInfo: sinon.SinonStub
+    let legacyGetTransformInfo: sinon.SinonStub
+    let newUploadPlan: sinon.SinonStub
+    let legacyUploadPlan: sinon.SinonStub
+
+    beforeEach(() => {
+        // Stub the singleton getInstance with a minimal fake satisfying handler ctors
+        const fakeServiceManager: any = {
+            registerCacheCallback: sinon.stub(),
+            getActiveApplicationUrl: sinon.stub().returns('https://app.example.com'),
+            getBearerToken: sinon.stub().resolves('token'),
+            hasValidCredentials: sinon.stub().returns(true),
+            isReady: sinon.stub().returns(true),
+        }
+        sinon.stub(AtxTokenServiceManager, 'getInstance').returns(fakeServiceManager)
+
+        // Stub the handler methods we route to. Default the start methods to a
+        // valid response so the server doesn't throw "StartTransform workflow failed".
+        newStartTransform = sinon
+            .stub(ATXTransformHandler.prototype, 'startTransform')
+            .resolves({ TransformationJobId: 'j-new', ArtifactPath: 'p', UploadId: 'u' })
+        legacyStartTransform = sinon
+            .stub(AtxTransformHandlerLegacy.prototype, 'startTransform')
+            .resolves({ TransformationJobId: 'j-legacy', ArtifactPath: 'p', UploadId: 'u' })
+
+        newGetTransformInfo = sinon
+            .stub(ATXTransformHandler.prototype, 'getTransformInfo')
+            .resolves({ TransformationJob: { Status: 'NEW-RESULT' } } as any)
+        legacyGetTransformInfo = sinon
+            .stub(AtxTransformHandlerLegacy.prototype, 'getTransformInfo')
+            .resolves({ TransformationJob: { Status: 'LEGACY-RESULT' } } as any)
+
+        newUploadPlan = sinon
+            .stub(ATXTransformHandler.prototype, 'uploadPlan')
+            .resolves({ VerificationStatus: true, Message: 'NEW' } as any)
+        legacyUploadPlan = sinon
+            .stub(AtxTransformHandlerLegacy.prototype, 'uploadPlan')
+            .resolves({ VerificationStatus: true, Message: 'LEGACY' } as any)
+
+        // Capture the LSP handlers the server registers so we can invoke them in tests.
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() }
+        const lspMock = {
+            addInitializer: sinon.stub(),
+            onInitialized: (fn: any) => {
+                onInitializedFn = fn
+            },
+            onExecuteCommand: (fn: any) => {
+                executeCommandHandler = fn
+            },
+        }
+
+        const features: any = {
+            workspace: {},
+            logging,
+            lsp: lspMock,
+            telemetry: {},
+            runtime: {},
+        }
+
+        // Building the server returns the inner closure that wires the handlers.
+        const serverFactory = AtxNetTransformServerToken()
+        serverFactory(features)
+
+        // Run onInitialized to construct both handlers
+        onInitializedFn()
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('startTransform', () => {
+        it('should route to NEW handler when useOrchestratorAgent=true', async () => {
+            await executeCommandHandler(
+                {
+                    command: AtxStartTransformCommand,
+                    WorkspaceId: 'ws-1',
+                    StartTransformRequest: {},
+                    useOrchestratorAgent: true,
+                } as any,
+                {} as any
+            )
+
+            expect(newStartTransform.calledOnce).to.be.true
+            expect(legacyStartTransform.called).to.be.false
+        })
+
+        it('should route to LEGACY handler when useOrchestratorAgent=false', async () => {
+            await executeCommandHandler(
+                {
+                    command: AtxStartTransformCommand,
+                    WorkspaceId: 'ws-1',
+                    StartTransformRequest: {},
+                    useOrchestratorAgent: false,
+                } as any,
+                {} as any
+            )
+
+            expect(legacyStartTransform.calledOnce).to.be.true
+            expect(newStartTransform.called).to.be.false
+        })
+
+        it('should route to LEGACY handler when useOrchestratorAgent is omitted (prod IDE)', async () => {
+            await executeCommandHandler(
+                {
+                    command: AtxStartTransformCommand,
+                    WorkspaceId: 'ws-1',
+                    StartTransformRequest: {},
+                } as any,
+                {} as any
+            )
+
+            expect(legacyStartTransform.calledOnce).to.be.true
+            expect(newStartTransform.called).to.be.false
+        })
+    })
+
+    describe('getTransformInfo', () => {
+        it('should route to NEW handler when useOrchestratorAgent=true', async () => {
+            await executeCommandHandler(
+                {
+                    command: AtxGetTransformInfoCommand,
+                    TransformationJobId: 'j',
+                    WorkspaceId: 'ws-1',
+                    SolutionRootPath: 'C:/sln',
+                    useOrchestratorAgent: true,
+                } as any,
+                {} as any
+            )
+
+            expect(newGetTransformInfo.calledOnce).to.be.true
+            expect(legacyGetTransformInfo.called).to.be.false
+        })
+
+        it('should route to LEGACY handler when useOrchestratorAgent is omitted', async () => {
+            await executeCommandHandler(
+                {
+                    command: AtxGetTransformInfoCommand,
+                    TransformationJobId: 'j',
+                    WorkspaceId: 'ws-1',
+                    SolutionRootPath: 'C:/sln',
+                } as any,
+                {} as any
+            )
+
+            expect(legacyGetTransformInfo.calledOnce).to.be.true
+            expect(newGetTransformInfo.called).to.be.false
+        })
+
+        it('should route per-request, not based on prior startTransform flag', async () => {
+            // Simulate: prior startTransform set NEW, then a getTransformInfo without flag arrives
+            await executeCommandHandler(
+                {
+                    command: AtxStartTransformCommand,
+                    WorkspaceId: 'ws-1',
+                    StartTransformRequest: {},
+                    useOrchestratorAgent: true,
+                } as any,
+                {} as any
+            )
+
+            await executeCommandHandler(
+                {
+                    command: AtxGetTransformInfoCommand,
+                    TransformationJobId: 'j',
+                    WorkspaceId: 'ws-1',
+                    SolutionRootPath: 'C:/sln',
+                    // no useOrchestratorAgent here
+                } as any,
+                {} as any
+            )
+
+            // The startTransform NEW call doesn't bleed into the next request:
+            // getTransformInfo without flag must route LEGACY.
+            expect(legacyGetTransformInfo.calledOnce).to.be.true
+            expect(newGetTransformInfo.called).to.be.false
+        })
+    })
+
+    describe('uploadPlan', () => {
+        it('should route to NEW handler when useOrchestratorAgent=true', async () => {
+            await executeCommandHandler(
+                {
+                    command: AtxUploadPlanCommand,
+                    TransformationJobId: 'j',
+                    WorkspaceId: 'ws-1',
+                    PlanPath: 'C:/plan.md',
+                    useOrchestratorAgent: true,
+                } as any,
+                {} as any
+            )
+
+            expect(newUploadPlan.calledOnce).to.be.true
+            expect(legacyUploadPlan.called).to.be.false
+        })
+
+        it('should route to LEGACY handler when useOrchestratorAgent is omitted', async () => {
+            await executeCommandHandler(
+                {
+                    command: AtxUploadPlanCommand,
+                    TransformationJobId: 'j',
+                    WorkspaceId: 'ws-1',
+                    PlanPath: 'C:/plan.md',
+                } as any,
+                {} as any
+            )
+
+            expect(legacyUploadPlan.calledOnce).to.be.true
+            expect(newUploadPlan.called).to.be.false
+        })
+    })
+
+    describe('routing log messages', () => {
+        it('should log NEW handler routing decision for startTransform', async () => {
+            await executeCommandHandler(
+                {
+                    command: AtxStartTransformCommand,
+                    WorkspaceId: 'ws-1',
+                    StartTransformRequest: {},
+                    useOrchestratorAgent: true,
+                } as any,
+                {} as any
+            )
+
+            const logCalls = (logging.log as sinon.SinonStub).getCalls().map(c => c.args[0])
+            expect(logCalls.some((m: string) => m.includes('startTransform') && m.includes('NEW'))).to.be.true
+        })
+
+        it('should log LEGACY handler routing decision for getTransformInfo', async () => {
+            await executeCommandHandler(
+                {
+                    command: AtxGetTransformInfoCommand,
+                    TransformationJobId: 'j',
+                    WorkspaceId: 'ws-1',
+                    SolutionRootPath: 'C:/sln',
+                } as any,
+                {} as any
+            )
+
+            const logCalls = (logging.log as sinon.SinonStub).getCalls().map(c => c.args[0])
+            expect(logCalls.some((m: string) => m.includes('getTransformInfo') && m.includes('LEGACY'))).to.be.true
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -1180,3 +1180,341 @@ describe('ATXTransformHandler - setCheckpoints, getHitlAgentArtifact, getJobDash
         })
     })
 })
+
+describe('ATXTransformHandler - lifecycle (startTransform & helpers)', () => {
+    let handler: ATXTransformHandler
+    let serviceManager: AtxTokenServiceManager
+    let workspace: Workspace
+    let logging: Logging
+    let runtime: Runtime
+    let sendStub: sinon.SinonStub
+
+    beforeEach(() => {
+        serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
+        workspace = {} as Workspace
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        runtime = {} as Runtime
+
+        handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+        sendStub = sinon.stub()
+        sinon.stub(handler as any, 'initializeAtxClient').resolves(true)
+        sinon.stub(handler as any, 'addAuthToCommand').resolves()
+        ;(handler as any).atxClient = { send: sendStub }
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('createJob', () => {
+        it('should return jobId/status on success', async () => {
+            sendStub.resolves({ jobId: 'job-123', status: 'CREATED' })
+
+            const result = await handler.createJob({ workspaceId: 'ws-1' })
+
+            expect(result).to.deep.equal({ jobId: 'job-123', status: 'CREATED' })
+        })
+
+        it('should return null when response missing jobId', async () => {
+            sendStub.resolves({ status: 'CREATED' /* no jobId */ })
+
+            const result = await handler.createJob({ workspaceId: 'ws-1' })
+
+            expect(result).to.be.null
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+
+        it('should return null and log error when send rejects', async () => {
+            sendStub.rejects(new Error('AWS down'))
+
+            const result = await handler.createJob({ workspaceId: 'ws-1' })
+
+            expect(result).to.be.null
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+
+        it('should map Interactive interactive_mode to "interactive" in objective', async () => {
+            sendStub.resolves({ jobId: 'j', status: 'CREATED' })
+
+            await handler.createJob({ workspaceId: 'ws-1', interactiveMode: 'Interactive' })
+
+            const command = sendStub.firstCall.args[0]
+            const objective = JSON.parse(command.input.objective)
+            expect(objective.interactive_mode).to.equal('interactive')
+        })
+
+        it('should default interactive_mode to "auto" when mode not specified', async () => {
+            sendStub.resolves({ jobId: 'j', status: 'CREATED' })
+
+            await handler.createJob({ workspaceId: 'ws-1' })
+
+            const command = sendStub.firstCall.args[0]
+            const objective = JSON.parse(command.input.objective)
+            expect(objective.interactive_mode).to.equal('auto')
+        })
+    })
+
+    describe('createArtifactUploadUrl', () => {
+        it('should return uploadId/uploadUrl on success', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'getSha256Async').resolves('abc-sha256')
+            sendStub.resolves({
+                artifactId: 'art-1',
+                s3PreSignedUrl: 'https://s3/upload',
+                requestHeaders: { 'x-foo': 'bar' },
+            })
+
+            const result = await handler.createArtifactUploadUrl(
+                'ws-1',
+                'job-1',
+                'C:/file.zip',
+                'CUSTOMER_INPUT' as any,
+                'ZIP' as any
+            )
+
+            expect(result?.uploadId).to.equal('art-1')
+            expect(result?.uploadUrl).to.equal('https://s3/upload')
+            expect(result?.requestHeaders).to.deep.equal({ 'x-foo': 'bar' })
+        })
+
+        it('should return null when response missing required fields', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'getSha256Async').resolves('sha')
+            sendStub.resolves({ artifactId: 'art-1' /* no s3PreSignedUrl */ })
+
+            const result = await handler.createArtifactUploadUrl(
+                'ws-1',
+                'job-1',
+                'C:/file.zip',
+                'CUSTOMER_INPUT' as any,
+                'ZIP' as any
+            )
+
+            expect(result).to.be.null
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+
+        it('should return null and log on send error', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'getSha256Async').resolves('sha')
+            sendStub.rejects(new Error('boom'))
+
+            const result = await handler.createArtifactUploadUrl(
+                'ws-1',
+                'job-1',
+                'C:/file.zip',
+                'CUSTOMER_INPUT' as any,
+                'ZIP' as any
+            )
+
+            expect(result).to.be.null
+        })
+    })
+
+    describe('completeArtifactUpload', () => {
+        it('should return success=true on resolve', async () => {
+            sendStub.resolves({
+                /* server response */
+            })
+
+            const result = await handler.completeArtifactUpload('ws-1', 'job-1', 'art-1')
+
+            expect(result).to.deep.equal({ success: true })
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+
+            const result = await handler.completeArtifactUpload('ws-1', 'job-1', 'art-1')
+
+            expect(result).to.be.null
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+    })
+
+    describe('startJob', () => {
+        it('should return success=true on resolve', async () => {
+            sendStub.resolves({
+                /* aws ack */
+            })
+
+            const result = await handler.startJob('ws-1', 'job-1')
+
+            expect(result).to.deep.equal({ success: true })
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+
+            const result = await handler.startJob('ws-1', 'job-1')
+
+            expect(result).to.be.null
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+    })
+
+    describe('startTransform', () => {
+        it('should return null when createJob returns null', async () => {
+            sinon.stub(handler, 'createJob').resolves(null)
+
+            const result = await handler.startTransform({
+                workspaceId: 'ws-1',
+                startTransformRequest: { TargetFramework: 'net8.0' },
+            })
+
+            expect(result).to.be.null
+        })
+
+        it('should return null when createZip throws', async () => {
+            sinon.stub(handler, 'createJob').resolves({ jobId: 'job-1', status: 'CREATED' })
+            sinon.stub(handler, 'createZip').rejects(new Error('zip fail'))
+
+            const result = await handler.startTransform({
+                workspaceId: 'ws-1',
+                startTransformRequest: {},
+            })
+
+            expect(result).to.be.null
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+
+        it('should return null when createArtifactUploadUrl returns null', async () => {
+            sinon.stub(handler, 'createJob').resolves({ jobId: 'job-1', status: 'CREATED' })
+            sinon.stub(handler, 'createZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves(null)
+
+            const result = await handler.startTransform({
+                workspaceId: 'ws-1',
+                startTransformRequest: {},
+            })
+
+            expect(result).to.be.null
+        })
+
+        it('should return null when uploadArtifact returns false', async () => {
+            sinon.stub(handler, 'createJob').resolves({ jobId: 'job-1', status: 'CREATED' })
+            sinon.stub(handler, 'createZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadId: 'u',
+                uploadUrl: 'https://s3',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(false)
+
+            const result = await handler.startTransform({
+                workspaceId: 'ws-1',
+                startTransformRequest: {},
+            })
+
+            expect(result).to.be.null
+        })
+
+        it('should return null when completeArtifactUpload returns null', async () => {
+            sinon.stub(handler, 'createJob').resolves({ jobId: 'job-1', status: 'CREATED' })
+            sinon.stub(handler, 'createZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadId: 'u',
+                uploadUrl: 'https://s3',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves(null)
+
+            const result = await handler.startTransform({
+                workspaceId: 'ws-1',
+                startTransformRequest: {},
+            })
+
+            expect(result).to.be.null
+        })
+
+        it('should return null when startJob returns null', async () => {
+            sinon.stub(handler, 'createJob').resolves({ jobId: 'job-1', status: 'CREATED' })
+            sinon.stub(handler, 'createZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadId: 'u',
+                uploadUrl: 'https://s3',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+            sinon.stub(handler, 'startJob').resolves(null)
+
+            const result = await handler.startTransform({
+                workspaceId: 'ws-1',
+                startTransformRequest: {},
+            })
+
+            expect(result).to.be.null
+        })
+
+        it('should return TransformationJobId on full happy path', async () => {
+            sinon.stub(handler, 'createJob').resolves({ jobId: 'job-1', status: 'CREATED' })
+            sinon.stub(handler, 'createZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadId: 'upload-1',
+                uploadUrl: 'https://s3',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+            sinon.stub(handler, 'startJob').resolves({ success: true })
+
+            const result = await handler.startTransform({
+                workspaceId: 'ws-1',
+                startTransformRequest: {},
+            })
+
+            expect(result?.TransformationJobId).to.equal('job-1')
+            expect(result?.ArtifactPath).to.equal('C:/zip.zip')
+            expect(result?.UploadId).to.equal('upload-1')
+        })
+
+        it('should cache interactive mode from request', async () => {
+            sinon.stub(handler, 'createJob').resolves({ jobId: 'job-1', status: 'CREATED' })
+            sinon.stub(handler, 'createZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadId: 'u',
+                uploadUrl: 'https://s3',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+            sinon.stub(handler, 'startJob').resolves({ success: true })
+
+            await handler.startTransform({
+                workspaceId: 'ws-1',
+                interactiveMode: 'Interactive',
+                startTransformRequest: {},
+            })
+
+            expect((handler as any).cachedInteractiveMode).to.equal('Interactive')
+        })
+
+        it('should default cached interactive mode to Autonomous when not specified', async () => {
+            sinon.stub(handler, 'createJob').resolves({ jobId: 'job-1', status: 'CREATED' })
+            sinon.stub(handler, 'createZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadId: 'u',
+                uploadUrl: 'https://s3',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+            sinon.stub(handler, 'startJob').resolves({ success: true })
+
+            await handler.startTransform({
+                workspaceId: 'ws-1',
+                startTransformRequest: {},
+            })
+
+            expect((handler as any).cachedInteractiveMode).to.equal('Autonomous')
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -1991,3 +1991,384 @@ describe('ATXTransformHandler - workspace, job, artifact, HITL helpers', () => {
         })
     })
 })
+
+describe('ATXTransformHandler - upload flows, polling, and small wrappers', () => {
+    let handler: ATXTransformHandler
+    let serviceManager: any
+    let workspace: Workspace
+    let logging: Logging
+    let runtime: Runtime
+    let sendStub: sinon.SinonStub
+
+    beforeEach(() => {
+        serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
+        serviceManager.getActiveApplicationUrl = sinon.stub().returns('https://app.example.com')
+        workspace = {} as Workspace
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        runtime = {} as Runtime
+
+        handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+        sendStub = sinon.stub()
+        sinon.stub(handler as any, 'initializeAtxClient').resolves(true)
+        sinon.stub(handler as any, 'addAuthToCommand').resolves()
+        ;(handler as any).atxClient = { send: sendStub }
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('uploadCustomPlan', () => {
+        it('should return Success=false when send returns missing fields', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'getSha256Async').resolves('sha')
+            sendStub.resolves({
+                /* no artifactId / s3PreSignedUrl */
+            })
+
+            const result = await handler.uploadCustomPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                FilePath: 'C:/plan.json',
+                Description: 'desc',
+            } as any)
+
+            expect(result.Success).to.be.false
+        })
+
+        it('should return Success=false when uploadArtifact fails', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'getSha256Async').resolves('sha')
+            sendStub.resolves({ artifactId: 'a', s3PreSignedUrl: 'u', requestHeaders: {} })
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(false)
+
+            const result = await handler.uploadCustomPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                FilePath: 'C:/plan.json',
+            } as any)
+
+            expect(result.Success).to.be.false
+        })
+
+        it('should return Success=true with ArtifactId on full happy path', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'getSha256Async').resolves('sha')
+            sendStub.resolves({ artifactId: 'art-1', s3PreSignedUrl: 'u', requestHeaders: {} })
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+
+            const result = await handler.uploadCustomPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                FilePath: 'C:/plan.json',
+            } as any)
+
+            expect(result.Success).to.be.true
+            expect(result.ArtifactId).to.equal('art-1')
+        })
+
+        it('should map common file extensions to FileType', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'getSha256Async').resolves('sha')
+            sendStub.resolves({ artifactId: 'a', s3PreSignedUrl: 'u', requestHeaders: {} })
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+
+            await handler.uploadCustomPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                FilePath: 'C:/plan.csv',
+            } as any)
+
+            const command = sendStub.firstCall.args[0]
+            expect(command.input.artifactReference.artifactType.fileType).to.equal('CSV')
+        })
+    })
+
+    describe('uploadPlan', () => {
+        it('should return null when no cachedHitl', async () => {
+            ;(handler as any).cachedHitl = null
+
+            const result = await handler.uploadPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                PlanPath: 'C:/sln/plan.md',
+            } as any)
+
+            expect(result).to.be.null
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+
+        it('should return null when createArtifactUploadUrl fails', async () => {
+            ;(handler as any).cachedHitl = 'task-1'
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'zipFile').resolves(undefined)
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves(null)
+
+            const result = await handler.uploadPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                PlanPath: 'C:/sln/plan.md',
+            } as any)
+
+            expect(result).to.be.null
+        })
+
+        it('should return VerificationStatus=true on validation success', async () => {
+            ;(handler as any).cachedHitl = 'task-1'
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'zipFile').resolves(undefined)
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'up-1',
+                requestHeaders: {},
+            } as any)
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+            sinon.stub(handler, 'submitHitl').resolves({ status: 'SUBMITTED' } as any)
+            sinon.stub(handler, 'pollHitlTask').resolves('Validation Success!')
+
+            const result = await handler.uploadPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                PlanPath: 'C:/sln/plan.md',
+            } as any)
+
+            expect(result?.VerificationStatus).to.equal(true)
+            expect(result?.Message).to.equal('Validation Success!')
+        })
+
+        it('should return VerificationStatus=false with retry artifact paths on validation failure', async () => {
+            ;(handler as any).cachedHitl = 'task-1'
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'zipFile').resolves(undefined)
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'up-1',
+                requestHeaders: {},
+            } as any)
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+            sinon.stub(handler, 'submitHitl').resolves({ status: 'SUBMITTED' } as any)
+            sinon
+                .stub(handler, 'pollHitlTask')
+                .resolves('Submitted plan did not pass validation, please check the plan for details....')
+            sinon.stub(handler, 'getHitlAgentArtifact').resolves({
+                PlanPath: '/p',
+                ReportPath: '/r',
+            } as any)
+
+            const result = await handler.uploadPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                PlanPath: 'C:/sln/plan.md',
+            } as any)
+
+            expect(result?.VerificationStatus).to.equal(false)
+            expect(result?.PlanPath).to.equal('/p')
+            expect(result?.ReportPath).to.equal('/r')
+        })
+
+        it('should return null when submitHitl fails', async () => {
+            ;(handler as any).cachedHitl = 'task-1'
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'zipFile').resolves(undefined)
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'up-1',
+                requestHeaders: {},
+            } as any)
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+            sinon.stub(handler, 'submitHitl').resolves(null)
+
+            const result = await handler.uploadPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                PlanPath: 'C:/sln/plan.md',
+            } as any)
+
+            expect(result).to.be.null
+        })
+    })
+
+    describe('uploadPackages', () => {
+        it('should return Success=false when no cachedHitl', async () => {
+            ;(handler as any).cachedHitl = null
+
+            const result = await handler.uploadPackages({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                PackagesZipPath: 'C:/pkg.zip',
+            } as any)
+
+            expect(result?.Success).to.be.false
+            expect(result?.Message).to.equal('No cached HITL task')
+        })
+
+        it('should return Success=false when no PackagesZipPath provided', async () => {
+            ;(handler as any).cachedHitl = 'task-1'
+
+            const result = await handler.uploadPackages({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+            } as any)
+
+            expect(result?.Success).to.be.false
+            expect(result?.Message).to.match(/No Package/i)
+        })
+
+        it('should return Success=true on full happy path', async () => {
+            ;(handler as any).cachedHitl = 'task-1'
+            sinon.stub(handler as any, 'uploadArtifactAndComplete').resolves('artifact-1')
+            sinon.stub(handler, 'submitHitl').resolves({ status: 'SUBMITTED' } as any)
+
+            const result = await handler.uploadPackages({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                PackagesZipPath: 'C:/pkg.zip',
+            } as any)
+
+            expect(result?.Success).to.be.true
+        })
+
+        it('should return Success=false when uploadArtifactAndComplete fails', async () => {
+            ;(handler as any).cachedHitl = 'task-1'
+            sinon.stub(handler as any, 'uploadArtifactAndComplete').resolves(null)
+
+            const result = await handler.uploadPackages({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                PackagesZipPath: 'C:/pkg.zip',
+            } as any)
+
+            expect(result?.Success).to.be.false
+            expect(result?.Message).to.equal('Failed to upload packages')
+        })
+
+        it('should return Success=false when submitHitl fails after upload', async () => {
+            ;(handler as any).cachedHitl = 'task-1'
+            sinon.stub(handler as any, 'uploadArtifactAndComplete').resolves('artifact-1')
+            sinon.stub(handler, 'submitHitl').resolves(null)
+
+            const result = await handler.uploadPackages({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                PackagesZipPath: 'C:/pkg.zip',
+            } as any)
+
+            expect(result?.Success).to.be.false
+        })
+    })
+
+    describe('pollHitlTask', () => {
+        it('should return success message when task transitions to CLOSED', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'sleep').resolves(undefined)
+            sinon.stub(handler, 'getHitl').resolves({ status: 'CLOSED' })
+
+            const result = await handler.pollHitlTask('ws-1', 'job-1', 't1')
+
+            expect(result).to.equal('Validation Success!')
+        })
+
+        it('should return validation-failed message on CLOSED_PENDING_NEXT_TASK', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'sleep').resolves(undefined)
+            sinon.stub(handler, 'getHitl').resolves({ status: 'CLOSED_PENDING_NEXT_TASK' })
+
+            const result = await handler.pollHitlTask('ws-1', 'job-1', 't1')
+
+            expect(result).to.equal('Submitted plan did not pass validation, please check the plan for details....')
+        })
+
+        it('should return timeout message on CANCELLED', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'sleep').resolves(undefined)
+            sinon.stub(handler, 'getHitl').resolves({ status: 'CANCELLED' })
+
+            const result = await handler.pollHitlTask('ws-1', 'job-1', 't1')
+
+            expect(result).to.equal('Timeout occured during planning, proceeding with default plan....')
+        })
+
+        it('should poll multiple times before transitioning to CLOSED', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'sleep').resolves(undefined)
+            const getHitlStub = sinon.stub(handler, 'getHitl')
+            getHitlStub.onFirstCall().resolves({ status: 'AWAITING_HUMAN_INPUT' })
+            getHitlStub.onSecondCall().resolves({ status: 'IN_PROGRESS' })
+            getHitlStub.onThirdCall().resolves({ status: 'CLOSED' })
+
+            const result = await handler.pollHitlTask('ws-1', 'job-1', 't1')
+
+            expect(result).to.equal('Validation Success!')
+            expect(getHitlStub.callCount).to.equal(3)
+        })
+    })
+
+    describe('listArtifactsForDownload', () => {
+        it('should map artifacts with fileMetadata.path to download shape', async () => {
+            sinon.stub(handler as any, 'listArtifacts').resolves([
+                {
+                    artifactId: 'a1',
+                    fileMetadata: { path: 'reports/r1.xlsx', description: 'Report' },
+                    sizeInBytes: 1024,
+                    artifactCreatedTimestamp: 12345,
+                },
+                {
+                    artifactId: 'a2',
+                    /* no fileMetadata - should be filtered out */
+                },
+            ])
+
+            const result = await handler.listArtifactsForDownload('ws-1', 'job-1')
+
+            expect(result.Artifacts).to.have.lengthOf(1)
+            expect(result.Artifacts[0]).to.deep.include({
+                ArtifactId: 'a1',
+                Name: 'reports/r1.xlsx',
+                Description: 'Report',
+                SizeInBytes: 1024,
+                CreatedTimestamp: 12345,
+            })
+        })
+
+        it('should return error when listArtifacts returns null', async () => {
+            sinon.stub(handler as any, 'listArtifacts').resolves(null)
+
+            const result = await handler.listArtifactsForDownload('ws-1', 'job-1')
+
+            expect(result.Artifacts).to.deep.equal([])
+            expect(result.Error).to.equal('Failed to list artifacts')
+        })
+    })
+
+    describe('downloadArtifactToPath', () => {
+        it('should return Success=false when createArtifactDownloadUrl fails', async () => {
+            sinon.stub(handler, 'createArtifactDownloadUrl').resolves(null)
+
+            const result = await handler.downloadArtifactToPath('ws-1', 'job-1', 'art-1', 'C:/save')
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to get download URL')
+        })
+    })
+
+    describe('getJobReport', () => {
+        it('should return null when no artifactId provided', async () => {
+            const result = await handler.getJobReport('ws-1', 'job-1', '')
+
+            expect(result).to.be.null
+        })
+
+        it('should return null when createArtifactDownloadUrl fails', async () => {
+            sinon.stub(handler, 'createArtifactDownloadUrl').resolves(null)
+
+            const result = await handler.getJobReport('ws-1', 'job-1', 'art-1')
+
+            expect(result).to.be.null
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -1,5 +1,8 @@
 import { expect } from 'chai'
 import * as sinon from 'sinon'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
 import { ATXTransformHandler } from '../atxTransformHandler'
 import { AtxTokenServiceManager } from '../../../shared/amazonQServiceManager/AtxTokenServiceManager'
 import { Logging, Runtime, Workspace } from '@aws/language-server-runtimes/server-interface'
@@ -652,6 +655,270 @@ describe('ATXTransformHandler - getTransformationPlan & helpers', () => {
 
         it('should default to NOT_STARTED when status missing', () => {
             expect((handler as any).mapApiStatus(undefined)).to.equal('NOT_STARTED')
+        })
+    })
+})
+
+describe('ATXTransformHandler - updateWorkspace & applyChanges', () => {
+    let handler: ATXTransformHandler
+    let serviceManager: AtxTokenServiceManager
+    let workspace: Workspace
+    let logging: Logging
+    let runtime: Runtime
+
+    beforeEach(() => {
+        serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
+        workspace = {} as Workspace
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        runtime = {} as Runtime
+
+        handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+        sinon.stub(handler as any, 'initializeAtxClient').resolves(true)
+        ;(handler as any).atxClient = { send: sinon.stub() }
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('updateWorkspace', () => {
+        it('should return error when no active step HITL is found', async () => {
+            sinon.stub(handler as any, 'findStepLevelHitl').resolves(null)
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('No active step HITL found')
+        })
+
+        it('should return error when createUpdateWorkspaceZip returns empty path', async () => {
+            sinon.stub(handler as any, 'findStepLevelHitl').resolves({ taskId: 't1' })
+            sinon.stub(handler as any, 'getModifiedFilesSinceCheckpoint').returns([])
+            sinon.stub(handler as any, 'createUpdateWorkspaceZip').resolves('')
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to create update workspace zip')
+        })
+
+        it('should return error when createArtifactUploadUrl fails', async () => {
+            sinon.stub(handler as any, 'findStepLevelHitl').resolves({ taskId: 't1' })
+            sinon.stub(handler as any, 'getModifiedFilesSinceCheckpoint').returns([])
+            sinon.stub(handler as any, 'createUpdateWorkspaceZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves(null)
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to create artifact upload URL')
+        })
+
+        it('should return success and clear cachedStepHitl on full happy path', async () => {
+            ;(handler as any).cachedStepHitl = 'cached-task-id'
+            sinon.stub(handler as any, 'getModifiedFilesSinceCheckpoint').returns([])
+            sinon.stub(handler as any, 'createUpdateWorkspaceZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'https://s3/upload',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true } as any)
+            sinon.stub(handler, 'updateHitl').resolves({ ok: true })
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
+
+            expect(result.Success).to.be.true
+            expect((handler as any).cachedStepHitl).to.be.null
+        })
+
+        it('should return error when uploadArtifact fails', async () => {
+            sinon.stub(handler as any, 'findStepLevelHitl').resolves({ taskId: 't1' })
+            sinon.stub(handler as any, 'getModifiedFilesSinceCheckpoint').returns([])
+            sinon.stub(handler as any, 'createUpdateWorkspaceZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'https://s3/upload',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(false)
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to upload update workspace zip to S3')
+        })
+
+        it('should return error when completeArtifactUpload fails', async () => {
+            sinon.stub(handler as any, 'findStepLevelHitl').resolves({ taskId: 't1' })
+            sinon.stub(handler as any, 'getModifiedFilesSinceCheckpoint').returns([])
+            sinon.stub(handler as any, 'createUpdateWorkspaceZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: false } as any)
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to complete artifact upload')
+        })
+
+        it('should return error when updateHitl returns null', async () => {
+            sinon.stub(handler as any, 'findStepLevelHitl').resolves({ taskId: 't1' })
+            sinon.stub(handler as any, 'getModifiedFilesSinceCheckpoint').returns([])
+            sinon.stub(handler as any, 'createUpdateWorkspaceZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true } as any)
+            sinon.stub(handler, 'updateHitl').resolves(null)
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to update workspace HITL')
+        })
+
+        it('should return error when client cannot be initialized', async () => {
+            sinon.restore()
+            logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+            handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+            sinon.stub(handler as any, 'initializeAtxClient').resolves(false)
+            ;(handler as any).atxClient = null
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('ATX FES client not initialized')
+        })
+    })
+
+    describe('applyChanges', () => {
+        let tmpRoot: string
+        let checkpointFolder: string
+        let solutionRoot: string
+
+        beforeEach(() => {
+            // Create a fresh temp working tree for each test
+            tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'atx-applychanges-'))
+            checkpointFolder = path.join(tmpRoot, 'checkpoint')
+            solutionRoot = path.join(tmpRoot, 'sln')
+            fs.mkdirSync(path.join(checkpointFolder, 'after'), { recursive: true })
+            fs.mkdirSync(solutionRoot, { recursive: true })
+        })
+
+        afterEach(() => {
+            try {
+                fs.rmSync(tmpRoot, { recursive: true, force: true })
+            } catch {
+                // best effort
+            }
+        })
+
+        const writeMetadata = (data: any) => {
+            fs.writeFileSync(path.join(checkpointFolder, 'metadata.json'), JSON.stringify(data))
+        }
+
+        it('should fail when metadata.json is missing', async () => {
+            const result = await (handler as any).applyChanges(checkpointFolder, solutionRoot)
+
+            expect(result.success).to.be.false
+            expect(result.error).to.include('metadata.json not found')
+        })
+
+        it('should add files from after/ directory', async () => {
+            const relPath = 'src/Added.cs'
+            fs.mkdirSync(path.join(checkpointFolder, 'after', 'src'), { recursive: true })
+            fs.writeFileSync(path.join(checkpointFolder, 'after', relPath), '// added')
+            writeMetadata({ filesAdded: [relPath] })
+
+            const result = await (handler as any).applyChanges(checkpointFolder, solutionRoot)
+
+            expect(result.success).to.be.true
+            expect(result.filesAdded).to.equal(1)
+            expect(result.addedFiles).to.deep.equal([relPath])
+            expect(fs.existsSync(path.join(solutionRoot, relPath))).to.be.true
+        })
+
+        it('should remove files listed in filesRemoved', async () => {
+            const relPath = 'OldFile.cs'
+            fs.writeFileSync(path.join(solutionRoot, relPath), '// old')
+            writeMetadata({ filesRemoved: [relPath] })
+
+            const result = await (handler as any).applyChanges(checkpointFolder, solutionRoot)
+
+            expect(result.success).to.be.true
+            expect(result.filesRemoved).to.equal(1)
+            expect(fs.existsSync(path.join(solutionRoot, relPath))).to.be.false
+        })
+
+        it('should update files from after/ directory', async () => {
+            const relPath = 'Existing.cs'
+            fs.writeFileSync(path.join(solutionRoot, relPath), '// old content')
+            fs.writeFileSync(path.join(checkpointFolder, 'after', relPath), '// new content')
+            writeMetadata({ filesUpdated: [relPath] })
+
+            const result = await (handler as any).applyChanges(checkpointFolder, solutionRoot)
+
+            expect(result.success).to.be.true
+            expect(result.filesUpdated).to.equal(1)
+            expect(fs.readFileSync(path.join(solutionRoot, relPath), 'utf-8')).to.equal('// new content')
+        })
+
+        it('should move files according to movedFilesMap', async () => {
+            fs.writeFileSync(path.join(solutionRoot, 'before.cs'), '// content')
+            writeMetadata({
+                movedFilesMap: [{ before: 'before.cs', after: 'newdir/after.cs' }],
+            })
+
+            const result = await (handler as any).applyChanges(checkpointFolder, solutionRoot)
+
+            expect(result.success).to.be.true
+            expect(result.filesMoved).to.equal(1)
+            expect(fs.existsSync(path.join(solutionRoot, 'before.cs'))).to.be.false
+            expect(fs.existsSync(path.join(solutionRoot, 'newdir/after.cs'))).to.be.true
+        })
+
+        it('should succeed with zero counts when metadata is empty', async () => {
+            writeMetadata({})
+
+            const result = await (handler as any).applyChanges(checkpointFolder, solutionRoot)
+
+            expect(result.success).to.be.true
+            expect(result.filesAdded).to.equal(0)
+            expect(result.filesRemoved).to.equal(0)
+            expect(result.filesUpdated).to.equal(0)
+            expect(result.filesMoved).to.equal(0)
+        })
+
+        it('should skip removal when target file does not exist', async () => {
+            writeMetadata({ filesRemoved: ['NotThere.cs'] })
+
+            const result = await (handler as any).applyChanges(checkpointFolder, solutionRoot)
+
+            expect(result.success).to.be.true
+            expect(result.filesRemoved).to.equal(0)
+        })
+
+        it('should fail gracefully when metadata.json is invalid JSON', async () => {
+            fs.writeFileSync(path.join(checkpointFolder, 'metadata.json'), '{not json')
+
+            const result = await (handler as any).applyChanges(checkpointFolder, solutionRoot)
+
+            expect(result.success).to.be.false
+            expect(result.error).to.be.a('string')
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -245,3 +245,199 @@ describe('ATXTransformHandler - Chat APIs', () => {
         })
     })
 })
+
+describe('ATXTransformHandler - getTransformInfo', () => {
+    let handler: ATXTransformHandler
+    let serviceManager: AtxTokenServiceManager
+    let workspace: Workspace
+    let logging: Logging
+    let runtime: Runtime
+    let getJobStub: sinon.SinonStub
+    let getTransformationPlanStub: sinon.SinonStub
+    let listHitlsStub: sinon.SinonStub
+    let listWorklogsStub: sinon.SinonStub
+    let downloadFinalArtifactStub: sinon.SinonStub
+    let getHitlAgentArtifactStub: sinon.SinonStub
+
+    const baseRequest = {
+        TransformationJobId: 'job-123',
+        WorkspaceId: 'ws-123',
+        SolutionRootPath: 'C:/sln',
+    }
+
+    beforeEach(() => {
+        serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
+        workspace = {} as Workspace
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        runtime = {} as Runtime
+
+        handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+        sinon.stub(handler as any, 'initializeAtxClient').resolves(true)
+        ;(handler as any).atxClient = { send: sinon.stub() }
+
+        getJobStub = sinon.stub(handler, 'getJob')
+        getTransformationPlanStub = sinon.stub(handler, 'getTransformationPlan')
+        listHitlsStub = sinon.stub(handler, 'listHitls')
+        listWorklogsStub = sinon.stub(handler as any, 'listWorklogs').resolves(undefined)
+        downloadFinalArtifactStub = sinon.stub(handler, 'downloadFinalArtifact')
+        getHitlAgentArtifactStub = sinon.stub(handler, 'getHitlAgentArtifact')
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    it('should return JOB_NOT_FOUND when getJob returns null', async () => {
+        getJobStub.resolves(null)
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.ErrorString).to.equal('JOB_NOT_FOUND')
+        expect((logging.error as sinon.SinonStub).called).to.be.true
+    })
+
+    it('should return COMPLETED with artifact path and plan', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'COMPLETED' } })
+        downloadFinalArtifactStub.resolves('C:/sln/artifact.zip')
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.TransformationJob.Status).to.equal('COMPLETED')
+        expect(result?.ArtifactPath).to.equal('C:/sln/artifact.zip')
+        expect(result?.TransformationPlan).to.deep.equal({ Root: { Children: [] } })
+    })
+
+    it('should return FAILED with failureReason', async () => {
+        getJobStub.resolves({
+            statusDetails: { status: 'FAILED', failureReason: 'compile error' },
+        })
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.TransformationJob.Status).to.equal('FAILED')
+        expect((result?.TransformationJob as any).FailureReason).to.equal('compile error')
+        expect(result?.ErrorString).to.equal('Transformation job failed')
+    })
+
+    it('should return STOPPED with error string', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'STOPPED' } })
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.TransformationJob.Status).to.equal('STOPPED')
+        expect(result?.ErrorString).to.equal('Transformation job stopped')
+    })
+
+    it('should return EXECUTING with plan when no HITLs pending', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'EXECUTING' } })
+        getTransformationPlanStub.resolves({ Root: { Children: [{ StepId: 's1', Children: [] }] } })
+        listHitlsStub.resolves([])
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.TransformationJob.Status).to.equal('EXECUTING')
+        expect(result?.TransformationPlan?.Root.Children).to.have.lengthOf(1)
+    })
+
+    it('should surface AWAITING_HUMAN_INPUT when EXECUTING with pending HITL', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'EXECUTING' } })
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+        listHitlsStub.resolves([{ tag: 'local-build-verification', taskId: 'task-1' }])
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.TransformationJob.Status).to.equal('AWAITING_HUMAN_INPUT')
+        expect(result?.HitlTag).to.equal('local-build-verification')
+        expect(result?.HitlTaskId).to.equal('task-1')
+    })
+
+    it('should prefer local-build-verification over other HITL tags', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'EXECUTING' } })
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+        listHitlsStub.resolves([
+            { tag: 'missing-packages', taskId: 'task-mp' },
+            { tag: 'local-build-verification', taskId: 'task-lbv' },
+            { tag: 'other', taskId: 'task-other' },
+        ])
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.HitlTag).to.equal('local-build-verification')
+        expect(result?.HitlTaskId).to.equal('task-lbv')
+    })
+
+    it('should default to PLANNING-like fallthrough for unknown statuses', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'PLANNING' } })
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+        listHitlsStub.resolves([])
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.TransformationJob.Status).to.equal('PLANNING')
+        expect(listWorklogsStub.calledOnce).to.be.true
+    })
+
+    it('should set DiffApplyFailed flag when diff context records failures', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'EXECUTING' } })
+        getTransformationPlanStub.callsFake(async () => {
+            const ctx = (handler as any)._currentDiffContext
+            if (ctx) {
+                ctx.failed = true
+                ctx.failedStepIds.push('step-x')
+            }
+            return { Root: { Children: [] } }
+        })
+        listHitlsStub.resolves([])
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.DiffApplyFailed).to.equal(true)
+        expect(result?.DiffApplyFailedStepIds).to.deep.equal(['step-x'])
+    })
+
+    it('should clear diff context after the call (no leak across calls)', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'COMPLETED' } })
+        downloadFinalArtifactStub.resolves('path')
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+
+        await handler.getTransformInfo(baseRequest)
+
+        expect((handler as any)._currentDiffContext).to.be.null
+    })
+
+    it('should parse interactive_mode from job objective on first call', async () => {
+        getJobStub.resolves({
+            statusDetails: { status: 'EXECUTING' },
+            objective: '{"interactive_mode":"interactive"}',
+        })
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+        listHitlsStub.resolves([])
+
+        await handler.getTransformInfo(baseRequest)
+
+        expect((handler as any).cachedInteractiveMode).to.equal('Interactive')
+    })
+
+    it('should default cachedInteractiveMode to Autonomous when objective is unparseable', async () => {
+        getJobStub.resolves({
+            statusDetails: { status: 'EXECUTING' },
+            objective: 'not-json',
+        })
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+        listHitlsStub.resolves([])
+
+        await handler.getTransformInfo(baseRequest)
+
+        expect((handler as any).cachedInteractiveMode).to.equal('Autonomous')
+    })
+
+    it('should return null when getJob throws', async () => {
+        getJobStub.rejects(new Error('network'))
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result).to.be.null
+        expect((logging.error as sinon.SinonStub).called).to.be.true
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import { ATXTransformHandler } from '../atxTransformHandler'
+import { workspaceFolderName } from '../utils'
 import { AtxTokenServiceManager } from '../../../shared/amazonQServiceManager/AtxTokenServiceManager'
 import { Logging, Runtime, Workspace } from '@aws/language-server-runtimes/server-interface'
 
@@ -919,6 +920,263 @@ describe('ATXTransformHandler - updateWorkspace & applyChanges', () => {
 
             expect(result.success).to.be.false
             expect(result.error).to.be.a('string')
+        })
+    })
+})
+
+describe('ATXTransformHandler - setCheckpoints, getHitlAgentArtifact, getJobDashboard', () => {
+    let handler: ATXTransformHandler
+    let serviceManager: AtxTokenServiceManager
+    let workspace: Workspace
+    let logging: Logging
+    let runtime: Runtime
+    let tmpRoot: string
+
+    beforeEach(() => {
+        serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
+        workspace = {} as Workspace
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        runtime = {} as Runtime
+
+        handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+        sinon.stub(handler as any, 'initializeAtxClient').resolves(true)
+        ;(handler as any).atxClient = { send: sinon.stub() }
+
+        tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'atx-batch-'))
+    })
+
+    afterEach(() => {
+        sinon.restore()
+        try {
+            fs.rmSync(tmpRoot, { recursive: true, force: true })
+        } catch {
+            // best effort
+        }
+    })
+
+    describe('setCheckpoints', () => {
+        it('should return error when no checkpoint-settings HITL is found', async () => {
+            sinon.stub(handler as any, 'findCheckpointSettingsHitl').resolves(null)
+
+            const result = await handler.setCheckpoints('ws-1', 'job-1', tmpRoot, {})
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('No HITL task found with checkpoint-settings tag')
+        })
+
+        it('should return error when client cannot be initialized', async () => {
+            sinon.restore()
+            logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+            handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+            sinon.stub(handler as any, 'initializeAtxClient').resolves(false)
+            ;(handler as any).atxClient = null
+
+            const result = await handler.setCheckpoints('ws-1', 'job-1', tmpRoot, {})
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('ATX FES client not initialized')
+        })
+
+        it('should write checkpoint-settings.json with mapped interactive_mode and succeed', async () => {
+            sinon.stub(handler as any, 'findCheckpointSettingsHitl').resolves({ taskId: 't1' })
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true } as any)
+            sinon.stub(handler, 'updateHitl').resolves({ ok: true })
+
+            const result = await handler.setCheckpoints(
+                'ws-1',
+                'job-1',
+                tmpRoot,
+                { 'step-a': true, 'step-b': false },
+                'Interactive'
+            )
+
+            expect(result.Success).to.be.true
+            const settingsPath = path.join(
+                tmpRoot,
+                workspaceFolderName,
+                'job-1',
+                'checkpoints',
+                'checkpoint-settings.json'
+            )
+            expect(fs.existsSync(settingsPath)).to.be.true
+            const written = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'))
+            expect(written['step-a']).to.equal(true)
+            expect(written.interactive_mode).to.equal('interactive')
+        })
+
+        it('should map Autonomous mode to "auto"', async () => {
+            sinon.stub(handler as any, 'findCheckpointSettingsHitl').resolves({ taskId: 't1' })
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true } as any)
+            sinon.stub(handler, 'updateHitl').resolves({ ok: true })
+
+            await handler.setCheckpoints('ws-1', 'job-1', tmpRoot, {}, 'Autonomous')
+
+            const settingsPath = path.join(
+                tmpRoot,
+                workspaceFolderName,
+                'job-1',
+                'checkpoints',
+                'checkpoint-settings.json'
+            )
+            const written = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'))
+            expect(written.interactive_mode).to.equal('auto')
+        })
+
+        it('should return error when uploadArtifact fails', async () => {
+            sinon.stub(handler as any, 'findCheckpointSettingsHitl').resolves({ taskId: 't1' })
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(false)
+
+            const result = await handler.setCheckpoints('ws-1', 'job-1', tmpRoot, {})
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to upload checkpoints artifact to S3')
+        })
+
+        it('should return error when updateHitl fails', async () => {
+            sinon.stub(handler as any, 'findCheckpointSettingsHitl').resolves({ taskId: 't1' })
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true } as any)
+            sinon.stub(handler, 'updateHitl').resolves(null)
+
+            const result = await handler.setCheckpoints('ws-1', 'job-1', tmpRoot, {})
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to update HITL task with checkpoints artifact')
+        })
+    })
+
+    describe('getHitlAgentArtifact', () => {
+        it('should return null when listHitls returns empty', async () => {
+            sinon.stub(handler, 'listHitls').resolves([])
+
+            const result = await handler.getHitlAgentArtifact('ws-1', 'job-1', tmpRoot)
+
+            expect(result).to.be.null
+        })
+
+        it('should return null when listHitls returns null', async () => {
+            sinon.stub(handler, 'listHitls').resolves(null)
+
+            const result = await handler.getHitlAgentArtifact('ws-1', 'job-1', tmpRoot)
+
+            expect(result).to.be.null
+        })
+
+        it('should return tag and taskId early for local-build-verification HITL (no download)', async () => {
+            sinon.stub(handler, 'listHitls').resolves([{ tag: 'local-build-verification', taskId: 'task-lbv' }])
+            const downloadStub = sinon.stub(handler, 'createArtifactDownloadUrl')
+
+            const result = await handler.getHitlAgentArtifact('ws-1', 'job-1', tmpRoot)
+
+            expect(result).to.deep.equal({ HitlTag: 'local-build-verification', TaskId: 'task-lbv' })
+            expect(downloadStub.called).to.be.false
+            expect((handler as any).cachedHitl).to.equal('task-lbv')
+        })
+
+        it('should return tag and taskId when HITL has no agentArtifact', async () => {
+            sinon.stub(handler, 'listHitls').resolves([{ tag: 'some-tag', taskId: 'task-1' /* no agentArtifact */ }])
+
+            const result = await handler.getHitlAgentArtifact('ws-1', 'job-1', tmpRoot)
+
+            expect(result?.HitlTag).to.equal('some-tag')
+            expect(result?.TaskId).to.equal('task-1')
+        })
+
+        it('should pick local-build-verification over other HITL tags when both present', async () => {
+            sinon.stub(handler, 'listHitls').resolves([
+                { tag: 'missing-packages', taskId: 'task-mp' },
+                { tag: 'local-build-verification', taskId: 'task-lbv' },
+            ])
+
+            const result = await handler.getHitlAgentArtifact('ws-1', 'job-1', tmpRoot)
+
+            expect(result?.HitlTag).to.equal('local-build-verification')
+            expect(result?.TaskId).to.equal('task-lbv')
+        })
+
+        it('should return guardrail tag/taskId when download URL fails', async () => {
+            sinon.stub(handler, 'listHitls').resolves([
+                {
+                    tag: 'plan-review',
+                    taskId: 'task-1',
+                    agentArtifact: { artifactId: 'art-1' },
+                },
+            ])
+            sinon.stub(handler, 'createArtifactDownloadUrl').resolves(null)
+
+            const result = await handler.getHitlAgentArtifact('ws-1', 'job-1', tmpRoot)
+
+            expect(result?.HitlTag).to.equal('plan-review')
+            expect(result?.TaskId).to.equal('task-1')
+        })
+    })
+
+    describe('getJobDashboard', () => {
+        it('should throw and return null when client cannot initialize', async () => {
+            sinon.restore()
+            logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+            handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+            sinon.stub(handler as any, 'initializeAtxClient').resolves(false)
+            ;(handler as any).atxClient = null
+
+            const result = await handler.getJobDashboard('ws-1', 'job-1')
+
+            expect(result).to.be.null
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+
+        it('should return null when no DASHBOARD HITL task exists', async () => {
+            const sendStub = (handler as any).atxClient.send as sinon.SinonStub
+            sendStub.resolves({ hitlTasks: [] })
+
+            const result = await handler.getJobDashboard('ws-1', 'job-1')
+
+            expect(result).to.be.null
+        })
+
+        it('should return null when DASHBOARD task has no agent artifact', async () => {
+            const sendStub = (handler as any).atxClient.send as sinon.SinonStub
+            sendStub.resolves({ hitlTasks: [{ taskId: 't1' /* no agentArtifact */ }] })
+
+            const result = await handler.getJobDashboard('ws-1', 'job-1')
+
+            expect(result).to.be.null
+        })
+
+        it('should return null on send error (caught and logged)', async () => {
+            const sendStub = (handler as any).atxClient.send as sinon.SinonStub
+            sendStub.rejects(new Error('AWS SDK failure'))
+
+            const result = await handler.getJobDashboard('ws-1', 'job-1')
+
+            expect(result).to.be.null
+            expect((logging.error as sinon.SinonStub).called).to.be.true
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -441,3 +441,217 @@ describe('ATXTransformHandler - getTransformInfo', () => {
         expect((logging.error as sinon.SinonStub).called).to.be.true
     })
 })
+
+describe('ATXTransformHandler - getTransformationPlan & helpers', () => {
+    let handler: ATXTransformHandler
+    let serviceManager: AtxTokenServiceManager
+    let workspace: Workspace
+    let logging: Logging
+    let runtime: Runtime
+
+    beforeEach(() => {
+        serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
+        workspace = {} as Workspace
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        runtime = {} as Runtime
+
+        handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+        sinon.stub(handler as any, 'initializeAtxClient').resolves(true)
+        ;(handler as any).atxClient = { send: sinon.stub() }
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('getTransformationPlan', () => {
+        it('should return plan from fetchPlanTree on happy path', async () => {
+            const plan = { Root: { StepId: 'root', Children: [{ StepId: 's1', Children: [] }] } } as any
+            sinon.stub(handler as any, 'fetchPlanTree').resolves(plan)
+            sinon.stub(handler as any, 'fetchWorklogs').resolves(undefined)
+            sinon.stub(handler as any, 'downloadCompletedStepArtifacts').resolves(false)
+
+            const result = await handler.getTransformationPlan('ws-1', 'job-1', 'C:/sln')
+
+            expect(result.Root.Children).to.have.lengthOf(1)
+            expect(result.Root.Children[0].StepId).to.equal('s1')
+        })
+
+        it('should return empty root when fetchPlanTree throws', async () => {
+            sinon.stub(handler as any, 'fetchPlanTree').rejects(new Error('boom'))
+            sinon.stub(handler as any, 'fetchWorklogs').resolves(undefined)
+
+            const result = await handler.getTransformationPlan('ws-1', 'job-1', 'C:/sln')
+
+            expect(result.Root.StepId).to.equal('root')
+            expect(result.Root.Children).to.have.lengthOf(0)
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+
+        it('should mark diff context as failed when downloadCompletedStepArtifacts reports failure', async () => {
+            const plan = { Root: { StepId: 'root', Children: [] } } as any
+            sinon.stub(handler as any, 'fetchPlanTree').resolves(plan)
+            sinon.stub(handler as any, 'fetchWorklogs').resolves(undefined)
+            sinon.stub(handler as any, 'downloadCompletedStepArtifacts').resolves(true)
+            ;(handler as any)._currentDiffContext = { failed: false, failedStepIds: [] }
+
+            await handler.getTransformationPlan('ws-1', 'job-1', 'C:/sln')
+
+            expect((handler as any)._currentDiffContext.failed).to.equal(true)
+        })
+
+        it('should not throw when fetchWorklogs rejects (fire-and-forget)', async () => {
+            const plan = { Root: { StepId: 'root', Children: [] } } as any
+            sinon.stub(handler as any, 'fetchPlanTree').resolves(plan)
+            sinon.stub(handler as any, 'fetchWorklogs').rejects(new Error('worklog network'))
+            sinon.stub(handler as any, 'downloadCompletedStepArtifacts').resolves(false)
+
+            const result = await handler.getTransformationPlan('ws-1', 'job-1', 'C:/sln')
+
+            expect(result.Root).to.exist
+        })
+    })
+
+    describe('buildTreeFromFlatList', () => {
+        it('should build a parent-child tree from flat list', () => {
+            const flat = [
+                { stepId: 'a', parentStepId: 'root', stepName: 'A', score: 1 },
+                { stepId: 'b', parentStepId: 'a', stepName: 'B', score: 2 },
+                { stepId: 'c', parentStepId: 'a', stepName: 'C', score: 3 },
+            ]
+
+            const tree = (handler as any).buildTreeFromFlatList(flat)
+
+            expect(tree).to.have.lengthOf(1)
+            expect(tree[0].StepId).to.equal('a')
+            expect(tree[0].Children).to.have.lengthOf(2)
+            expect(tree[0].Children.map((c: any) => c.StepId)).to.deep.equal(['b', 'c'])
+        })
+
+        it('should treat orphan steps (parent not in list) as root-level', () => {
+            const flat = [
+                { stepId: 'a', parentStepId: 'missing-parent', stepName: 'A' },
+                { stepId: 'b', parentStepId: 'root', stepName: 'B' },
+            ]
+
+            const tree = (handler as any).buildTreeFromFlatList(flat)
+
+            expect(tree).to.have.lengthOf(2)
+            const ids = tree.map((s: any) => s.StepId).sort()
+            expect(ids).to.deep.equal(['a', 'b'])
+        })
+
+        it('should sort children by score ascending', () => {
+            const flat = [
+                { stepId: 'p', parentStepId: 'root', stepName: 'P', score: 0 },
+                { stepId: 'b', parentStepId: 'p', stepName: 'B', score: 30 },
+                { stepId: 'a', parentStepId: 'p', stepName: 'A', score: 10 },
+                { stepId: 'c', parentStepId: 'p', stepName: 'C', score: 20 },
+            ]
+
+            const tree = (handler as any).buildTreeFromFlatList(flat)
+
+            expect(tree[0].Children.map((c: any) => c.StepId)).to.deep.equal(['a', 'c', 'b'])
+        })
+
+        it('should return empty array for empty input', () => {
+            const tree = (handler as any).buildTreeFromFlatList([])
+            expect(tree).to.deep.equal([])
+        })
+    })
+
+    describe('mapApiStepToNode', () => {
+        it('should map camelCase API fields to PascalCase node fields', () => {
+            const node = (handler as any).mapApiStepToNode({
+                stepId: 's1',
+                parentStepId: 'p1',
+                stepName: 'Name',
+                description: 'Desc',
+                status: 'SUCCEEDED',
+                score: 5,
+            })
+
+            expect(node).to.deep.include({
+                StepId: 's1',
+                ParentStepId: 'p1',
+                StepName: 'Name',
+                Description: 'Desc',
+                Status: 'SUCCEEDED',
+                score: 5,
+            })
+            expect(node.Children).to.deep.equal([])
+        })
+
+        it('should convert parentStepId="root" to null', () => {
+            const node = (handler as any).mapApiStepToNode({
+                stepId: 's1',
+                parentStepId: 'root',
+                status: 'NOT_STARTED',
+            })
+
+            expect(node.ParentStepId).to.be.null
+        })
+
+        it('should default missing fields to safe values', () => {
+            const node = (handler as any).mapApiStepToNode({})
+
+            expect(node.StepId).to.equal('')
+            expect(node.ParentStepId).to.be.null
+            expect(node.Status).to.equal('NOT_STARTED')
+            expect(node.score).to.equal(0)
+        })
+    })
+
+    describe('findCompletedSteps', () => {
+        it('should return only SUCCEEDED steps at depth 2', () => {
+            // depth 0 = root, depth 1 = root's children, depth 2 = grandchildren
+            const root = {
+                StepId: 'root',
+                Status: 'SUCCEEDED', // depth 0, must be ignored
+                Children: [
+                    {
+                        StepId: 'lvl1',
+                        Status: 'SUCCEEDED', // depth 1, must be ignored
+                        Children: [
+                            { StepId: 'g1', Status: 'SUCCEEDED', Children: [] },
+                            { StepId: 'g2', Status: 'IN_PROGRESS', Children: [] },
+                            { StepId: 'g3', Status: 'SUCCEEDED', Children: [] },
+                        ],
+                    },
+                ],
+            } as any
+
+            const completed = (handler as any).findCompletedSteps(root)
+
+            expect(completed.map((s: any) => s.StepId)).to.deep.equal(['g1', 'g3'])
+        })
+
+        it('should return empty when no SUCCEEDED at depth 2', () => {
+            const root = {
+                StepId: 'root',
+                Status: 'NOT_STARTED',
+                Children: [
+                    {
+                        StepId: 'lvl1',
+                        Status: 'IN_PROGRESS',
+                        Children: [{ StepId: 'g1', Status: 'IN_PROGRESS', Children: [] }],
+                    },
+                ],
+            } as any
+
+            const completed = (handler as any).findCompletedSteps(root)
+            expect(completed).to.deep.equal([])
+        })
+    })
+
+    describe('mapApiStatus', () => {
+        it('should pass through valid statuses', () => {
+            expect((handler as any).mapApiStatus('SUCCEEDED')).to.equal('SUCCEEDED')
+            expect((handler as any).mapApiStatus('IN_PROGRESS')).to.equal('IN_PROGRESS')
+        })
+
+        it('should default to NOT_STARTED when status missing', () => {
+            expect((handler as any).mapApiStatus(undefined)).to.equal('NOT_STARTED')
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -2372,3 +2372,402 @@ describe('ATXTransformHandler - upload flows, polling, and small wrappers', () =
         })
     })
 })
+
+describe('ATXTransformHandler - HITL state branches and fs helpers', () => {
+    let handler: ATXTransformHandler
+    let serviceManager: any
+    let workspace: Workspace
+    let logging: Logging
+    let runtime: Runtime
+    let sendStub: sinon.SinonStub
+    let tmpRoot: string
+
+    beforeEach(() => {
+        serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
+        serviceManager.getActiveApplicationUrl = sinon.stub().returns('https://app.example.com')
+        serviceManager.getBearerToken = sinon.stub().resolves('token')
+        workspace = {} as Workspace
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        runtime = {} as Runtime
+
+        handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+        sendStub = sinon.stub()
+        sinon.stub(handler as any, 'initializeAtxClient').resolves(true)
+        sinon.stub(handler as any, 'addAuthToCommand').resolves()
+        ;(handler as any).atxClient = { send: sendStub }
+
+        tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'atx-statebranch-'))
+    })
+
+    afterEach(() => {
+        sinon.restore()
+        try {
+            fs.rmSync(tmpRoot, { recursive: true, force: true })
+        } catch {
+            // best effort
+        }
+    })
+
+    describe('handleAwaitingHumanInput (via getTransformInfo)', () => {
+        const baseRequest = {
+            TransformationJobId: 'job-1',
+            WorkspaceId: 'ws-1',
+            SolutionRootPath: 'C:/sln',
+        }
+
+        it('should route AWAITING_HUMAN_INPUT + local-build-verification HITL straight back', async () => {
+            sinon.stub(handler, 'getJob').resolves({
+                statusDetails: { status: 'AWAITING_HUMAN_INPUT' },
+            } as any)
+            sinon.stub(handler, 'getHitlAgentArtifact').resolves({
+                HitlTag: 'local-build-verification',
+                TaskId: 'lbv-task',
+            } as any)
+            sinon.stub(handler, 'getTransformationPlan').resolves({
+                Root: { Children: [] },
+            } as any)
+
+            const result = await handler.getTransformInfo(baseRequest as any)
+
+            expect(result?.HitlTag).to.equal('local-build-verification')
+            expect(result?.HitlTaskId).to.equal('lbv-task')
+            expect(result?.TransformationJob.Status).to.equal('AWAITING_HUMAN_INPUT')
+        })
+
+        it('should route to handlePlanningPhaseHitl when no plan yet', async () => {
+            sinon.stub(handler, 'getJob').resolves({
+                statusDetails: { status: 'AWAITING_HUMAN_INPUT' },
+            } as any)
+            const getHitlStub = sinon.stub(handler, 'getHitlAgentArtifact')
+            getHitlStub.onFirstCall().resolves(null) // no local-build-verification
+            getHitlStub.onSecondCall().resolves({
+                PlanPath: '/p',
+                ReportPath: '/r',
+                HitlTag: 'plan-review',
+                TaskId: 'task-1',
+            } as any)
+            sinon.stub(handler, 'getTransformationPlan').resolves({
+                Root: { Children: [] }, // empty plan -> planning phase
+            } as any)
+
+            const result = await handler.getTransformInfo(baseRequest as any)
+
+            expect(result?.PlanPath).to.equal('/p')
+            expect(result?.ReportPath).to.equal('/r')
+            expect(result?.HitlTag).to.equal('plan-review')
+        })
+
+        it('should route to handleExecutionPhaseHitl when plan exists', async () => {
+            sinon.stub(handler, 'getJob').resolves({
+                statusDetails: { status: 'AWAITING_HUMAN_INPUT' },
+            } as any)
+            sinon.stub(handler, 'getHitlAgentArtifact').resolves(null)
+            sinon.stub(handler, 'getTransformationPlan').resolves({
+                Root: {
+                    StepId: 'root',
+                    Children: [
+                        {
+                            StepId: 'lvl1',
+                            Status: 'IN_PROGRESS',
+                            Children: [{ StepId: 'g1', Status: 'PENDING_HUMAN_INPUT', Children: [] }],
+                        },
+                    ],
+                },
+            } as any)
+            sinon.stub(handler as any, 'findStepLevelHitl').resolves({
+                taskId: 'step-task',
+                agentArtifact: { artifactId: 'art-1' },
+            })
+            sinon
+                .stub(handler as any, 'downloadAndParseStepHitlArtifact')
+                .resolves({ StepId: 'g1', DiffArtifactPath: '/d' })
+
+            const result = await handler.getTransformInfo(baseRequest as any)
+
+            expect(result?.TransformationJob.Status).to.equal('AWAITING_HUMAN_INPUT')
+            expect(result?.StepInformation?.StepId).to.equal('g1')
+        })
+
+        it('should return plan only when no pending step found in execution phase', async () => {
+            sinon.stub(handler, 'getJob').resolves({
+                statusDetails: { status: 'AWAITING_HUMAN_INPUT' },
+            } as any)
+            sinon.stub(handler, 'getHitlAgentArtifact').resolves(null)
+            sinon.stub(handler, 'getTransformationPlan').resolves({
+                Root: {
+                    StepId: 'root',
+                    Children: [
+                        {
+                            StepId: 'lvl1',
+                            Status: 'SUCCEEDED',
+                            Children: [{ StepId: 'g1', Status: 'SUCCEEDED', Children: [] }],
+                        },
+                    ],
+                },
+            } as any)
+
+            const result = await handler.getTransformInfo(baseRequest as any)
+
+            expect(result?.TransformationJob.Status).to.equal('AWAITING_HUMAN_INPUT')
+            expect(result?.StepInformation).to.be.undefined
+        })
+    })
+
+    describe('findPendingHumanInputStep', () => {
+        it('should find a deeply nested PENDING_HUMAN_INPUT step', () => {
+            const root = {
+                StepId: 'root',
+                Status: 'NOT_STARTED',
+                Children: [
+                    {
+                        StepId: 'a',
+                        Status: 'NOT_STARTED',
+                        Children: [
+                            {
+                                StepId: 'a-b',
+                                Status: 'PENDING_HUMAN_INPUT',
+                                Children: [],
+                            },
+                        ],
+                    },
+                ],
+            } as any
+
+            const found = (handler as any).findPendingHumanInputStep(root)
+            expect(found?.StepId).to.equal('a-b')
+        })
+
+        it('should return null when no pending step exists', () => {
+            const root = {
+                StepId: 'root',
+                Status: 'NOT_STARTED',
+                Children: [{ StepId: 'a', Status: 'SUCCEEDED', Children: [] }],
+            } as any
+
+            expect((handler as any).findPendingHumanInputStep(root)).to.be.null
+        })
+    })
+
+    describe('findStepLevelHitl', () => {
+        it('should return first task and cache its taskId', async () => {
+            sendStub.resolves({ hitlTasks: [{ taskId: 'step-task-1' }] })
+
+            const result = await (handler as any).findStepLevelHitl('ws-1', 'job-1', 'step-1')
+
+            expect(result?.taskId).to.equal('step-task-1')
+            expect((handler as any).cachedStepHitl).to.equal('step-task-1')
+        })
+
+        it('should return null when no tasks present', async () => {
+            sendStub.resolves({ hitlTasks: [] })
+            expect(await (handler as any).findStepLevelHitl('ws-1', 'job-1', 'step-1')).to.be.null
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+            expect(await (handler as any).findStepLevelHitl('ws-1', 'job-1', 'step-1')).to.be.null
+        })
+    })
+
+    describe('findCheckpointSettingsHitl', () => {
+        it('should return first task on success', async () => {
+            sendStub.resolves({ hitlTasks: [{ taskId: 'cs-1' }] })
+
+            const result = await (handler as any).findCheckpointSettingsHitl('ws-1', 'job-1')
+            expect(result?.taskId).to.equal('cs-1')
+        })
+
+        it('should return null when no tasks', async () => {
+            sendStub.resolves({ hitlTasks: [] })
+            expect(await (handler as any).findCheckpointSettingsHitl('ws-1', 'job-1')).to.be.null
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+            expect(await (handler as any).findCheckpointSettingsHitl('ws-1', 'job-1')).to.be.null
+        })
+    })
+
+    describe('loadAppliedCheckpoints', () => {
+        it('should return empty array when checkpoints-applied.json missing', () => {
+            const result = (handler as any).loadAppliedCheckpoints(tmpRoot, 'job-1')
+            expect(result).to.deep.equal([])
+        })
+
+        it('should return appliedSteps from disk', () => {
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            fs.writeFileSync(path.join(dir, 'checkpoints-applied.json'), JSON.stringify({ appliedSteps: ['s1', 's2'] }))
+
+            const result = (handler as any).loadAppliedCheckpoints(tmpRoot, 'job-1')
+
+            expect(result).to.deep.equal(['s1', 's2'])
+        })
+
+        it('should return empty array on parse error', () => {
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            fs.writeFileSync(path.join(dir, 'checkpoints-applied.json'), '{not json')
+
+            const result = (handler as any).loadAppliedCheckpoints(tmpRoot, 'job-1')
+
+            expect(result).to.deep.equal([])
+        })
+    })
+
+    describe('saveAppliedCheckpoint', () => {
+        it('should create checkpoints-applied.json with the step and ensure dir exists', () => {
+            ;(handler as any).saveAppliedCheckpoint(tmpRoot, 'job-1', 's1')
+
+            const filePath = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints', 'checkpoints-applied.json')
+            expect(fs.existsSync(filePath)).to.be.true
+            const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+            expect(data.appliedSteps).to.deep.equal(['s1'])
+        })
+
+        it('should append step when file already exists', () => {
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            fs.writeFileSync(path.join(dir, 'checkpoints-applied.json'), JSON.stringify({ appliedSteps: ['s1'] }))
+            ;(handler as any).saveAppliedCheckpoint(tmpRoot, 'job-1', 's2')
+
+            const data = JSON.parse(fs.readFileSync(path.join(dir, 'checkpoints-applied.json'), 'utf-8'))
+            expect(data.appliedSteps).to.deep.equal(['s1', 's2'])
+        })
+
+        it('should not duplicate already-recorded steps', () => {
+            ;(handler as any).saveAppliedCheckpoint(tmpRoot, 'job-1', 's1')
+            ;(handler as any).saveAppliedCheckpoint(tmpRoot, 'job-1', 's1')
+
+            const filePath = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints', 'checkpoints-applied.json')
+            const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+            expect(data.appliedSteps).to.deep.equal(['s1'])
+        })
+    })
+
+    describe('populateCheckpointsOnPlan', () => {
+        it('should default HasCheckpoint=true for every step when no settings file', () => {
+            const plan = {
+                Root: {
+                    StepId: 'root',
+                    Children: [
+                        {
+                            StepId: 's1',
+                            Status: 'NOT_STARTED',
+                            Children: [{ StepId: 's2', Status: 'NOT_STARTED', Children: [] }],
+                        },
+                    ],
+                },
+            } as any
+
+            ;(handler as any).populateCheckpointsOnPlan(plan, 'job-1', tmpRoot)
+
+            expect(plan.Root.HasCheckpoint).to.be.undefined // root skipped
+            expect(plan.Root.Children[0].HasCheckpoint).to.equal(true)
+            expect(plan.Root.Children[0].Children[0].HasCheckpoint).to.equal(true)
+        })
+
+        it('should apply settings from checkpoint-settings.json', () => {
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            fs.writeFileSync(path.join(dir, 'checkpoint-settings.json'), JSON.stringify({ s1: false, s2: true }))
+
+            const plan = {
+                Root: {
+                    StepId: 'root',
+                    Children: [
+                        { StepId: 's1', Status: 'NOT_STARTED', Children: [] },
+                        { StepId: 's2', Status: 'NOT_STARTED', Children: [] },
+                        { StepId: 's3', Status: 'NOT_STARTED', Children: [] }, // not in settings -> default true
+                    ],
+                },
+            } as any
+
+            ;(handler as any).populateCheckpointsOnPlan(plan, 'job-1', tmpRoot)
+
+            expect(plan.Root.Children[0].HasCheckpoint).to.equal(false)
+            expect(plan.Root.Children[1].HasCheckpoint).to.equal(true)
+            expect(plan.Root.Children[2].HasCheckpoint).to.equal(true)
+        })
+
+        it('should handle malformed checkpoint-settings.json gracefully', () => {
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            fs.writeFileSync(path.join(dir, 'checkpoint-settings.json'), '{not json')
+
+            const plan = {
+                Root: {
+                    StepId: 'root',
+                    Children: [{ StepId: 's1', Status: 'NOT_STARTED', Children: [] }],
+                },
+            } as any
+
+            expect(() => (handler as any).populateCheckpointsOnPlan(plan, 'job-1', tmpRoot)).to.not.throw()
+            expect(plan.Root.Children[0].HasCheckpoint).to.equal(true)
+        })
+    })
+
+    describe('writeSourceFilesManifest & updateSourceFilesManifest', () => {
+        it('should write source-files.json with project paths', () => {
+            ;(handler as any).writeSourceFilesManifest(tmpRoot, 'job-1', {
+                ProjectMetadata: [
+                    {
+                        SourceCodeFilePaths: ['C:/sln/A.cs', 'C:/sln/B.cs'],
+                        ProjectPath: 'C:/sln/Proj.csproj',
+                    },
+                ],
+                SolutionFilePath: 'C:/sln/Proj.sln',
+                SolutionConfigPaths: ['C:/sln/Directory.Build.props'],
+            })
+
+            const filePath = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints', 'source-files.json')
+            expect(fs.existsSync(filePath)).to.be.true
+            const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+            expect(data.sourceFiles).to.include.members([
+                'C:/sln/A.cs',
+                'C:/sln/B.cs',
+                'C:/sln/Proj.csproj',
+                'C:/sln/Proj.sln',
+                'C:/sln/Directory.Build.props',
+            ])
+        })
+
+        it('should append new files to existing manifest', () => {
+            ;(handler as any).writeSourceFilesManifest(tmpRoot, 'job-1', {
+                ProjectMetadata: [{ SourceCodeFilePaths: ['C:/sln/A.cs'] }],
+            })
+            ;(handler as any).updateSourceFilesManifest(tmpRoot, 'job-1', ['NewFile.cs'])
+
+            const filePath = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints', 'source-files.json')
+            const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+            expect(data.sourceFiles).to.have.lengthOf(2)
+            expect(data.lastUpdated).to.be.a('string')
+        })
+
+        it('should be a no-op when manifest does not exist (updateSourceFilesManifest)', () => {
+            expect(() => (handler as any).updateSourceFilesManifest(tmpRoot, 'job-1', ['NewFile.cs'])).to.not.throw()
+        })
+
+        it('should be a no-op when newFiles is empty', () => {
+            expect(() => (handler as any).updateSourceFilesManifest(tmpRoot, 'job-1', [])).to.not.throw()
+        })
+    })
+
+    describe('verifySession', () => {
+        it('should return true when init + bearer token + applicationUrl all succeed', async () => {
+            const result = await (handler as any).verifySession()
+            expect(result).to.be.true
+        })
+
+        it('should return false when initializeAtxClient returns false', async () => {
+            sinon.restore()
+            logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+            handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+            sinon.stub(handler as any, 'initializeAtxClient').resolves(false)
+
+            const result = await (handler as any).verifySession()
+
+            expect(result).to.be.false
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -263,7 +263,7 @@ describe('ATXTransformHandler - getTransformInfo', () => {
     let downloadFinalArtifactStub: sinon.SinonStub
     let getHitlAgentArtifactStub: sinon.SinonStub
 
-    const baseRequest = {
+    const baseRequest: any = {
         TransformationJobId: 'job-123',
         WorkspaceId: 'ws-123',
         SolutionRootPath: 'C:/sln',
@@ -2409,7 +2409,7 @@ describe('ATXTransformHandler - HITL state branches and fs helpers', () => {
     })
 
     describe('handleAwaitingHumanInput (via getTransformInfo)', () => {
-        const baseRequest = {
+        const baseRequest: any = {
             TransformationJobId: 'job-1',
             WorkspaceId: 'ws-1',
             SolutionRootPath: 'C:/sln',
@@ -3123,7 +3123,7 @@ describe('ATXTransformHandler - final coverage push', () => {
     })
 
     describe('getTransformInfo - PLANNING + missing-packages HITL', () => {
-        const baseRequest = {
+        const baseRequest: any = {
             TransformationJobId: 'job-1',
             WorkspaceId: 'ws-1',
             SolutionRootPath: 'C:/sln',

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -1518,3 +1518,476 @@ describe('ATXTransformHandler - lifecycle (startTransform & helpers)', () => {
         })
     })
 })
+
+describe('ATXTransformHandler - workspace, job, artifact, HITL helpers', () => {
+    let handler: ATXTransformHandler
+    let serviceManager: any
+    let workspace: Workspace
+    let logging: Logging
+    let runtime: Runtime
+    let sendStub: sinon.SinonStub
+
+    beforeEach(() => {
+        serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
+        // Stub the methods getActiveTransformProfileApplicationUrl etc. depend on
+        serviceManager.getActiveApplicationUrl = sinon.stub().returns('https://app.example.com')
+        serviceManager.getBearerToken = sinon.stub().resolves('token')
+        workspace = {} as Workspace
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        runtime = {} as Runtime
+
+        handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+        sendStub = sinon.stub()
+        sinon.stub(handler as any, 'initializeAtxClient').resolves(true)
+        sinon.stub(handler as any, 'addAuthToCommand').resolves()
+        ;(handler as any).atxClient = { send: sendStub }
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    describe('getActiveTransformProfileApplicationUrl', () => {
+        it('should return the cached application URL', async () => {
+            const result = await handler.getActiveTransformProfileApplicationUrl()
+            expect(result).to.equal('https://app.example.com')
+        })
+
+        it('should return null and log error when no URL cached', async () => {
+            serviceManager.getActiveApplicationUrl = sinon.stub().returns(null)
+
+            const result = await handler.getActiveTransformProfileApplicationUrl()
+
+            expect(result).to.be.null
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+    })
+
+    describe('onProfileUpdate', () => {
+        it('should null-out the cached atxClient', () => {
+            ;(handler as any).atxClient = { send: () => null }
+            handler.onProfileUpdate()
+            expect((handler as any).atxClient).to.be.null
+        })
+    })
+
+    describe('listWorkspaces', () => {
+        it('should map workspace items to PascalCase response shape', async () => {
+            sendStub.resolves({
+                items: [
+                    { id: 'ws-1', name: 'One', description: 'first' },
+                    { id: 'ws-2', name: 'Two', description: 'second' },
+                ],
+            })
+
+            const result = await handler.listWorkspaces()
+
+            expect(result.workspaces).to.have.lengthOf(2)
+            expect(result.workspaces[0]).to.include({ Id: 'ws-1', Name: 'One', Description: 'first' })
+            expect(result.applicationUrl).to.equal('https://app.example.com')
+        })
+
+        it('should return empty workspaces and null URL on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+
+            const result = await handler.listWorkspaces()
+
+            expect(result.workspaces).to.deep.equal([])
+            expect(result.applicationUrl).to.be.null
+        })
+
+        it('should handle missing items array gracefully', async () => {
+            sendStub.resolves({
+                /* no items */
+            })
+
+            const result = await handler.listWorkspaces()
+
+            expect(result.workspaces).to.deep.equal([])
+        })
+    })
+
+    describe('createWorkspace', () => {
+        it('should return workspace info on success', async () => {
+            sendStub.resolves({ workspace: { id: 'ws-9', name: 'New' } })
+
+            const result = await handler.createWorkspace('New', 'desc')
+
+            expect(result).to.deep.equal({ workspaceId: 'ws-9', workspaceName: 'New' })
+        })
+
+        it('should return null when response missing workspace fields', async () => {
+            sendStub.resolves({ workspace: { id: 'ws-9' /* no name */ } })
+
+            const result = await handler.createWorkspace('New')
+
+            expect(result).to.be.null
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+
+            const result = await handler.createWorkspace(null)
+
+            expect(result).to.be.null
+        })
+
+        it('should auto-generate description when name is provided without description', async () => {
+            sendStub.resolves({ workspace: { id: 'ws-9', name: 'New' } })
+
+            await handler.createWorkspace('MyWorkspace')
+
+            const command = sendStub.firstCall.args[0]
+            expect(command.input.description).to.include('MyWorkspace')
+        })
+    })
+
+    describe('listJobs', () => {
+        it('should paginate and aggregate jobs from multiple pages', async () => {
+            sendStub.onFirstCall().resolves({
+                jobList: [{ jobInfo: { jobId: 'j1', statusDetails: { status: 'COMPLETED' } } }],
+                nextToken: 'page-2',
+            })
+            sendStub.onSecondCall().resolves({
+                jobList: [{ jobInfo: { jobId: 'j2', statusDetails: { status: 'EXECUTING' } } }],
+                nextToken: undefined,
+            })
+
+            const result = await handler.listJobs('ws-1')
+
+            expect(result?.Jobs).to.have.lengthOf(2)
+            expect(result?.Jobs[0].JobId).to.equal('j1')
+            expect(result?.Jobs[1].Status).to.equal('EXECUTING')
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+
+            const result = await handler.listJobs('ws-1')
+
+            expect(result).to.be.null
+        })
+
+        it('should default Status to UNKNOWN when missing in response', async () => {
+            sendStub.resolves({
+                jobList: [{ jobInfo: { jobId: 'j1' /* no statusDetails */ } }],
+            })
+
+            const result = await handler.listJobs('ws-1')
+
+            expect(result?.Jobs[0].Status).to.equal('UNKNOWN')
+        })
+    })
+
+    describe('listOrCreateWorkspace', () => {
+        it('should return AvailableWorkspaces when CreateWorkspaceName not provided', async () => {
+            sinon.stub(handler, 'listWorkspaces').resolves({
+                workspaces: [{ Id: 'ws-1', Name: 'One' }],
+                applicationUrl: 'u',
+            })
+            const createStub = sinon.stub(handler, 'createWorkspace')
+
+            const result = await handler.listOrCreateWorkspace({} as any)
+
+            expect(result?.AvailableWorkspaces).to.have.lengthOf(1)
+            expect(result?.CreatedWorkspace).to.be.undefined
+            expect(createStub.called).to.be.false
+        })
+
+        it('should create workspace and append it to AvailableWorkspaces when name is provided', async () => {
+            sinon.stub(handler, 'listWorkspaces').resolves({
+                workspaces: [],
+                applicationUrl: 'u',
+            })
+            sinon.stub(handler, 'createWorkspace').resolves({
+                workspaceId: 'ws-new',
+                workspaceName: 'Brand New',
+            })
+
+            const result = await handler.listOrCreateWorkspace({
+                CreateWorkspaceName: 'Brand New',
+                CreateWorkspaceDescription: 'desc',
+            } as any)
+
+            expect(result?.CreatedWorkspace).to.deep.equal({
+                WorkspaceId: 'ws-new',
+                WorkspaceName: 'Brand New',
+            })
+            expect(result?.AvailableWorkspaces).to.have.lengthOf(1)
+            expect(result?.AvailableWorkspaces[0].Id).to.equal('ws-new')
+        })
+
+        it('should return null when verifySession fails', async () => {
+            sinon.stub(handler as any, 'verifySession').resolves(false)
+
+            const result = await handler.listOrCreateWorkspace({} as any)
+
+            expect(result).to.be.null
+        })
+    })
+
+    describe('getJob', () => {
+        it('should return the job from response on success', async () => {
+            sendStub.resolves({ job: { statusDetails: { status: 'COMPLETED' } } })
+
+            const result = await handler.getJob('ws-1', 'job-1')
+
+            expect(result?.statusDetails?.status).to.equal('COMPLETED')
+        })
+
+        it('should return null when response has no job', async () => {
+            sendStub.resolves({})
+
+            const result = await handler.getJob('ws-1', 'job-1')
+
+            expect(result).to.be.null
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+
+            const result = await handler.getJob('ws-1', 'job-1')
+
+            expect(result).to.be.null
+        })
+    })
+
+    describe('createArtifactDownloadUrl', () => {
+        it('should return s3PresignedUrl and normalized headers on success', async () => {
+            sendStub.resolves({
+                s3PreSignedUrl: 'https://s3/dl',
+                requestHeaders: { 'x-foo': ['bar'], 'x-baz': 'qux' },
+            })
+
+            const result = await handler.createArtifactDownloadUrl('ws-1', 'job-1', 'art-1')
+
+            expect(result?.s3PresignedUrl).to.equal('https://s3/dl')
+            expect(result?.requestHeaders).to.deep.equal({ 'x-foo': 'bar', 'x-baz': 'qux' })
+        })
+
+        it('should return null when s3PreSignedUrl missing', async () => {
+            sendStub.resolves({
+                /* no s3PreSignedUrl */
+            })
+
+            const result = await handler.createArtifactDownloadUrl('ws-1', 'job-1', 'art-1')
+
+            expect(result).to.be.null
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+
+            const result = await handler.createArtifactDownloadUrl('ws-1', 'job-1', 'art-1')
+
+            expect(result).to.be.null
+        })
+    })
+
+    describe('listHitls', () => {
+        it('should return hitlTasks array on success', async () => {
+            sendStub.resolves({ hitlTasks: [{ taskId: 't1' }] })
+
+            const result = await handler.listHitls('ws-1', 'job-1')
+
+            expect(result).to.have.lengthOf(1)
+            expect(result?.[0].taskId).to.equal('t1')
+        })
+
+        it('should return empty array when hitlTasks is missing', async () => {
+            sendStub.resolves({})
+
+            const result = await handler.listHitls('ws-1', 'job-1')
+
+            expect(result).to.deep.equal([])
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+
+            const result = await handler.listHitls('ws-1', 'job-1')
+
+            expect(result).to.be.null
+        })
+    })
+
+    describe('submitHitl & updateHitl & getHitl', () => {
+        it('submitHitl should return result on success', async () => {
+            sendStub.resolves({ status: 'SUBMITTED' })
+            const result = await handler.submitHitl('ws-1', 'job-1', 't1', 'art-1')
+            expect(result?.status).to.equal('SUBMITTED')
+        })
+
+        it('submitHitl should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+            expect(await handler.submitHitl('ws-1', 'job-1', 't1', 'art-1')).to.be.null
+        })
+
+        it('updateHitl should return result on success', async () => {
+            sendStub.resolves({ status: 'UPDATED' })
+            const result = await handler.updateHitl('ws-1', 'job-1', 't1', 'art-1')
+            expect(result?.status).to.equal('UPDATED')
+        })
+
+        it('updateHitl should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+            expect(await handler.updateHitl('ws-1', 'job-1', 't1', 'art-1')).to.be.null
+        })
+
+        it('getHitl should return task object on success', async () => {
+            sendStub.resolves({ task: { status: 'CLOSED' } })
+            const result = await handler.getHitl('ws-1', 'job-1', 't1')
+            expect(result?.status).to.equal('CLOSED')
+        })
+
+        it('getHitl should return null when no task in response', async () => {
+            sendStub.resolves({})
+            expect(await handler.getHitl('ws-1', 'job-1', 't1')).to.be.null
+        })
+    })
+
+    describe('stopJob', () => {
+        it('should return status on success and clear job cache', async () => {
+            sendStub.resolves({ status: 'STOPPING' })
+            ;(handler as any).cachedHitl = 'h1'
+
+            const result = await handler.stopJob('ws-1', 'job-1')
+
+            expect(result).to.equal('STOPPING')
+            expect((handler as any).cachedHitl).to.be.null
+        })
+
+        it('should return "FAILED" on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+
+            const result = await handler.stopJob('ws-1', 'job-1')
+
+            expect(result).to.equal('FAILED')
+        })
+
+        it('should default to "STOPPED" when response status is missing', async () => {
+            sendStub.resolves({
+                /* no status */
+            })
+
+            const result = await handler.stopJob('ws-1', 'job-1')
+
+            expect(result).to.equal('STOPPED')
+        })
+    })
+
+    describe('downloadFinalArtifact', () => {
+        it('should return null when no artifacts available', async () => {
+            sinon.stub(handler as any, 'listArtifacts').resolves([])
+
+            const result = await handler.downloadFinalArtifact('ws-1', 'job-1', 'C:/sln')
+
+            expect(result).to.be.null
+        })
+
+        it('should return null when listArtifacts returns null', async () => {
+            sinon.stub(handler as any, 'listArtifacts').resolves(null)
+
+            const result = await handler.downloadFinalArtifact('ws-1', 'job-1', 'C:/sln')
+
+            expect(result).to.be.null
+        })
+
+        it('should return null when createArtifactDownloadUrl fails', async () => {
+            sinon.stub(handler as any, 'listArtifacts').resolves([{ artifactId: 'art-1' }])
+            sinon.stub(handler, 'createArtifactDownloadUrl').resolves(null)
+
+            const result = await handler.downloadFinalArtifact('ws-1', 'job-1', 'C:/sln')
+
+            expect(result).to.be.null
+        })
+
+        it('should return download path on full happy flow', async () => {
+            sinon.stub(handler as any, 'listArtifacts').resolves([{ artifactId: 'art-1' }])
+            sinon.stub(handler, 'createArtifactDownloadUrl').resolves({
+                s3PresignedUrl: 'https://s3/dl',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'downloadAndExtractArchive').resolves(undefined)
+
+            const result = await handler.downloadFinalArtifact('ws-1', 'job-1', 'C:/sln')
+
+            expect(result).to.be.a('string')
+            expect(result).to.include('job-1')
+        })
+    })
+
+    describe('completeHitlWithBuildResults', () => {
+        let tmpRoot: string
+
+        beforeEach(() => {
+            tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'atx-hitlbuild-'))
+        })
+
+        afterEach(() => {
+            try {
+                fs.rmSync(tmpRoot, { recursive: true, force: true })
+            } catch {
+                // best effort
+            }
+        })
+
+        it('should return error when createArtifactUploadUrl fails', async () => {
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves(null)
+
+            const result = await handler.completeHitlWithBuildResults('ws-1', 'job-1', 't1', 'BUILD OK', tmpRoot)
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to create artifact upload URL')
+        })
+
+        it('should return error when uploadArtifact fails', async () => {
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(false)
+
+            const result = await handler.completeHitlWithBuildResults('ws-1', 'job-1', 't1', 'BUILD OK', tmpRoot)
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to upload build results')
+        })
+
+        it('should return success on full happy path', async () => {
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+            sinon.stub(handler, 'submitHitl').resolves({ status: 'SUBMITTED' } as any)
+
+            const result = await handler.completeHitlWithBuildResults('ws-1', 'job-1', 't1', 'BUILD OK', tmpRoot)
+
+            expect(result.Success).to.be.true
+        })
+
+        it('should return error when submitHitl returns null', async () => {
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+            sinon.stub(handler, 'submitHitl').resolves(null)
+
+            const result = await handler.completeHitlWithBuildResults('ws-1', 'job-1', 't1', 'BUILD OK', tmpRoot)
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('Failed to submit HITL task')
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -3121,4 +3121,255 @@ describe('ATXTransformHandler - final coverage push', () => {
             expect((handler as any).cachedInteractiveMode).to.be.null
         })
     })
+
+    describe('getTransformInfo - PLANNING + missing-packages HITL', () => {
+        const baseRequest = {
+            TransformationJobId: 'job-1',
+            WorkspaceId: 'ws-1',
+            SolutionRootPath: 'C:/sln',
+        }
+
+        it('should surface AWAITING_HUMAN_INPUT for missing-packages HITL with no artifact', async () => {
+            sinon.stub(handler, 'getJob').resolves({
+                statusDetails: { status: 'PLANNING' },
+            } as any)
+            sinon.stub(handler as any, 'listWorklogs').resolves(undefined)
+            sinon.stub(handler, 'getTransformationPlan').resolves({
+                Root: { Children: [] },
+            } as any)
+            sinon.stub(handler, 'listHitls').resolves([{ tag: 'missing-packages', taskId: 'mp-task' }])
+
+            const result = await handler.getTransformInfo(baseRequest as any)
+
+            expect(result?.TransformationJob.Status).to.equal('AWAITING_HUMAN_INPUT')
+            expect(result?.HitlTag).to.equal('missing-packages')
+            expect(result?.HitlTaskId).to.equal('mp-task')
+            expect((handler as any).cachedHitl).to.equal('mp-task')
+        })
+
+        it('should surface MissingPackageJsonPath when artifact is present', async () => {
+            sinon.stub(handler, 'getJob').resolves({
+                statusDetails: { status: 'PLANNING' },
+            } as any)
+            sinon.stub(handler as any, 'listWorklogs').resolves(undefined)
+            sinon.stub(handler, 'getTransformationPlan').resolves({
+                Root: { Children: [] },
+            } as any)
+            sinon.stub(handler, 'listHitls').resolves([
+                {
+                    tag: 'handle_missing_packages_hitl',
+                    taskId: 'mp-task',
+                    agentArtifact: { artifactId: 'art-1' },
+                },
+            ])
+            sinon.stub(handler as any, 'handlePlanningPhaseHitl').resolves({
+                MissingPackageJsonPath: 'C:/missing.json',
+            })
+
+            const result = await handler.getTransformInfo(baseRequest as any)
+
+            expect(result?.MissingPackageJsonPath).to.equal('C:/missing.json')
+            expect(result?.HitlTag).to.equal('handle_missing_packages_hitl')
+        })
+
+        it('should ignore missing-packages download failures and still surface HITL', async () => {
+            sinon.stub(handler, 'getJob').resolves({
+                statusDetails: { status: 'PLANNING' },
+            } as any)
+            sinon.stub(handler as any, 'listWorklogs').resolves(undefined)
+            sinon.stub(handler, 'getTransformationPlan').resolves({
+                Root: { Children: [] },
+            } as any)
+            sinon.stub(handler, 'listHitls').resolves([
+                {
+                    tag: 'missing-packages',
+                    taskId: 'mp-task',
+                    agentArtifact: { artifactId: 'art-1' },
+                },
+            ])
+            sinon.stub(handler as any, 'handlePlanningPhaseHitl').rejects(new Error('download failed'))
+
+            const result = await handler.getTransformInfo(baseRequest as any)
+
+            expect(result?.TransformationJob.Status).to.equal('AWAITING_HUMAN_INPUT')
+            expect(result?.MissingPackageJsonPath).to.be.undefined
+        })
+
+        it('should swallow getTransformationPlan errors in fallthrough branch', async () => {
+            sinon.stub(handler, 'getJob').resolves({
+                statusDetails: { status: 'PLANNING' },
+            } as any)
+            sinon.stub(handler as any, 'listWorklogs').resolves(undefined)
+            sinon.stub(handler, 'getTransformationPlan').rejects(new Error('plan not ready'))
+            sinon.stub(handler, 'listHitls').resolves([])
+
+            const result = await handler.getTransformInfo(baseRequest as any)
+
+            expect(result?.TransformationJob.Status).to.equal('PLANNING')
+            expect(result?.TransformationPlan).to.be.undefined
+        })
+    })
+
+    describe('createModifiedFilesZip (private)', () => {
+        it('should return empty string when modifiedFiles is empty', async () => {
+            const result = await (handler as any).createModifiedFilesZip(tmpRoot, 'job-1', [])
+            expect(result).to.equal('')
+        })
+
+        it('should create zip when files are provided', async function () {
+            this.timeout(15000)
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            const file1 = path.join(tmpRoot, 'a.cs')
+            fs.writeFileSync(file1, 'content')
+
+            const result = await (handler as any).createModifiedFilesZip(tmpRoot, 'job-1', [file1])
+
+            expect(result).to.include('user-modifications.zip')
+            expect(fs.existsSync(result)).to.be.true
+        })
+    })
+
+    describe('writeSourceFilesManifest edge cases', () => {
+        it('should produce empty sourceFiles when request has no metadata', () => {
+            ;(handler as any).writeSourceFilesManifest(tmpRoot, 'job-1', {})
+
+            const filePath = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints', 'source-files.json')
+            expect(fs.existsSync(filePath)).to.be.true
+            const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+            expect(data.sourceFiles).to.deep.equal([])
+        })
+
+        it('should skip falsy file paths in SourceCodeFilePaths', () => {
+            ;(handler as any).writeSourceFilesManifest(tmpRoot, 'job-1', {
+                ProjectMetadata: [{ SourceCodeFilePaths: ['', null, 'C:/real.cs'] }],
+            })
+
+            const filePath = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints', 'source-files.json')
+            const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+            expect(data.sourceFiles).to.deep.equal(['C:/real.cs'])
+        })
+    })
+
+    describe('listOrCreateWorkspace - createWorkspace returns null', () => {
+        it('should still return AvailableWorkspaces even when createWorkspace fails', async () => {
+            sinon.stub(handler as any, 'verifySession').resolves(true)
+            sinon.stub(handler, 'listWorkspaces').resolves({
+                workspaces: [{ Id: 'ws-1', Name: 'Existing' }],
+                applicationUrl: 'u',
+            })
+            sinon.stub(handler, 'createWorkspace').resolves(null)
+
+            const result = await handler.listOrCreateWorkspace({
+                CreateWorkspaceName: 'fail-me',
+            } as any)
+
+            expect(result?.AvailableWorkspaces).to.have.lengthOf(1)
+            expect(result?.CreatedWorkspace).to.be.undefined
+        })
+    })
+
+    describe('listJobs - empty page handling', () => {
+        it('should return empty Jobs array when first page has no jobList', async () => {
+            sendStub.resolves({})
+
+            const result = await handler.listJobs('ws-1')
+
+            expect(result?.Jobs).to.deep.equal([])
+        })
+    })
+
+    describe('createWorkspace - bare-name input', () => {
+        it('should call API with auto-generated description for null name', async () => {
+            sendStub.resolves({ workspace: { id: 'ws-9', name: 'Auto' } })
+
+            await handler.createWorkspace(null)
+
+            const command = sendStub.firstCall.args[0]
+            expect(command.input.description).to.equal('Auto-generated workspace')
+        })
+    })
+
+    describe('uploadCustomPlan - more file extension and path branches', () => {
+        it('should default to OTHER for unknown extension', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'getSha256Async').resolves('sha')
+            sendStub.resolves({ artifactId: 'a', s3PreSignedUrl: 'u', requestHeaders: {} })
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+
+            await handler.uploadCustomPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                FilePath: 'C:/random.xyz',
+            } as any)
+
+            const command = sendStub.firstCall.args[0]
+            expect(command.input.artifactReference.artifactType.fileType).to.equal('OTHER')
+        })
+
+        it('should respect ArtifactStorePath prefix', async () => {
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'getSha256Async').resolves('sha')
+            sendStub.resolves({ artifactId: 'a', s3PreSignedUrl: 'u', requestHeaders: {} })
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+
+            await handler.uploadCustomPlan({
+                WorkspaceId: 'ws-1',
+                TransformationJobId: 'job-1',
+                FilePath: 'C:/plan.json',
+                ArtifactStorePath: 'subdir/',
+            } as any)
+
+            const command = sendStub.firstCall.args[0]
+            expect(command.input.fileMetadata.path).to.equal('subdir/plan.json')
+        })
+    })
+
+    describe('client init failure paths', () => {
+        it('startJob should return null when client cannot init', async () => {
+            sinon.restore()
+            logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+            handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+            sinon.stub(handler as any, 'initializeAtxClient').resolves(false)
+
+            const result = await handler.startJob('ws-1', 'job-1')
+
+            expect(result).to.be.null
+        })
+
+        it('createArtifactDownloadUrl should return null when client cannot init', async () => {
+            sinon.restore()
+            logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+            handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+            sinon.stub(handler as any, 'initializeAtxClient').resolves(false)
+
+            const result = await handler.createArtifactDownloadUrl('ws-1', 'job-1', 'art-1')
+
+            expect(result).to.be.null
+        })
+
+        it('createJob should return null when client cannot init', async () => {
+            sinon.restore()
+            logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+            handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+            sinon.stub(handler as any, 'initializeAtxClient').resolves(false)
+
+            const result = await handler.createJob({ workspaceId: 'ws-1' })
+
+            expect(result).to.be.null
+        })
+
+        it('completeArtifactUpload should return null when client cannot init', async () => {
+            sinon.restore()
+            logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+            handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+            sinon.stub(handler as any, 'initializeAtxClient').resolves(false)
+
+            const result = await handler.completeArtifactUpload('ws-1', 'job-1', 'art-1')
+
+            expect(result).to.be.null
+        })
+    })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -2771,3 +2771,354 @@ describe('ATXTransformHandler - HITL state branches and fs helpers', () => {
         })
     })
 })
+
+describe('ATXTransformHandler - final coverage push', () => {
+    let handler: ATXTransformHandler
+    let serviceManager: any
+    let workspace: Workspace
+    let logging: Logging
+    let runtime: Runtime
+    let sendStub: sinon.SinonStub
+    let tmpRoot: string
+
+    beforeEach(() => {
+        serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
+        serviceManager.getActiveApplicationUrl = sinon.stub().returns('https://app.example.com')
+        serviceManager.getBearerToken = sinon.stub().resolves('token')
+        workspace = {} as Workspace
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        runtime = {} as Runtime
+
+        handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+        sendStub = sinon.stub()
+        sinon.stub(handler as any, 'initializeAtxClient').resolves(true)
+        sinon.stub(handler as any, 'addAuthToCommand').resolves()
+        ;(handler as any).atxClient = { send: sendStub }
+
+        tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'atx-final-'))
+    })
+
+    afterEach(() => {
+        sinon.restore()
+        try {
+            fs.rmSync(tmpRoot, { recursive: true, force: true })
+        } catch {
+            // best effort
+        }
+    })
+
+    describe('listArtifacts (private)', () => {
+        it('should return artifacts array on success', async () => {
+            sendStub.resolves({ artifacts: [{ artifactId: 'a1' }, { artifactId: 'a2' }] })
+            const result = await (handler as any).listArtifacts('ws-1', 'job-1')
+            expect(result).to.have.lengthOf(2)
+        })
+
+        it('should return empty array when artifacts missing', async () => {
+            sendStub.resolves({})
+            const result = await (handler as any).listArtifacts('ws-1', 'job-1')
+            expect(result).to.deep.equal([])
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+            const result = await (handler as any).listArtifacts('ws-1', 'job-1')
+            expect(result).to.be.null
+        })
+    })
+
+    describe('listArtifactsForStep (private)', () => {
+        it('should return artifacts array on success', async () => {
+            sendStub.resolves({ artifacts: [{ artifactId: 'step-art-1' }] })
+            const result = await (handler as any).listArtifactsForStep('ws-1', 'job-1', 'step-1')
+            expect(result).to.have.lengthOf(1)
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+            const result = await (handler as any).listArtifactsForStep('ws-1', 'job-1', 'step-1')
+            expect(result).to.be.null
+        })
+    })
+
+    describe('fetchAllSteps (private)', () => {
+        it('should paginate when nextToken is returned', async () => {
+            sendStub.onFirstCall().resolves({ steps: [{ stepId: 's1' }], nextToken: 'page-2' })
+            sendStub.onSecondCall().resolves({ steps: [{ stepId: 's2' }] })
+
+            const result = await (handler as any).fetchAllSteps('ws-1', 'job-1')
+
+            expect(result).to.have.lengthOf(2)
+            expect(sendStub.callCount).to.equal(2)
+        })
+
+        it('should return empty array on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+            const result = await (handler as any).fetchAllSteps('ws-1', 'job-1')
+            expect(result).to.deep.equal([])
+        })
+    })
+
+    describe('fetchPlanTree (private)', () => {
+        it('should return empty plan when fetchAllSteps returns empty', async () => {
+            sinon.stub(handler as any, 'fetchAllSteps').resolves([])
+            const result = await (handler as any).fetchPlanTree('ws-1', 'job-1')
+            expect(result.Root.Children).to.deep.equal([])
+        })
+
+        it('should build tree from fetched steps', async () => {
+            sinon.stub(handler as any, 'fetchAllSteps').resolves([
+                { stepId: 'a', parentStepId: 'root', stepName: 'A' },
+                { stepId: 'b', parentStepId: 'a', stepName: 'B' },
+            ])
+
+            const result = await (handler as any).fetchPlanTree('ws-1', 'job-1')
+
+            expect(result.Root.Children).to.have.lengthOf(1)
+            expect(result.Root.Children[0].StepId).to.equal('a')
+            expect(result.Root.Children[0].Children[0].StepId).to.equal('b')
+        })
+    })
+
+    describe('downloadCompletedStepArtifacts (private)', () => {
+        const buildPlan = (g1Status = 'SUCCEEDED'): any => ({
+            Root: {
+                StepId: 'root',
+                Status: 'NOT_STARTED',
+                Children: [
+                    {
+                        StepId: 'lvl1',
+                        Status: 'NOT_STARTED',
+                        Children: [{ StepId: 'g1', Status: g1Status, Children: [], score: 1 }],
+                    },
+                ],
+            },
+        })
+
+        it('should skip when _applyingCheckpoints is already true', async () => {
+            ;(handler as any)._applyingCheckpoints = true
+            const result = await (handler as any).downloadCompletedStepArtifacts('ws-1', 'job-1', tmpRoot, buildPlan())
+            expect(result).to.be.false
+        })
+
+        it('should return false when no completed steps at depth 2', async () => {
+            const result = await (handler as any).downloadCompletedStepArtifacts(
+                'ws-1',
+                'job-1',
+                tmpRoot,
+                buildPlan('IN_PROGRESS')
+            )
+            expect(result).to.be.false
+            expect((handler as any)._applyingCheckpoints).to.be.false
+        })
+
+        it('should report failure when checkpoint folder is missing after download attempt', async () => {
+            sinon.stub(handler as any, 'downloadCompletedStepArtifact').resolves(undefined)
+
+            const result = await (handler as any).downloadCompletedStepArtifacts('ws-1', 'job-1', tmpRoot, buildPlan())
+
+            expect(result).to.be.true
+        })
+
+        it('should skip already-applied steps', async () => {
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            fs.writeFileSync(path.join(dir, 'checkpoints-applied.json'), JSON.stringify({ appliedSteps: ['g1'] }))
+
+            const result = await (handler as any).downloadCompletedStepArtifacts('ws-1', 'job-1', tmpRoot, buildPlan())
+
+            expect(result).to.be.false
+        })
+
+        it('should record failure into diff context', async () => {
+            ;(handler as any)._currentDiffContext = { failed: false, failedStepIds: [] }
+            sinon.stub(handler as any, 'downloadCompletedStepArtifact').resolves(undefined)
+
+            await (handler as any).downloadCompletedStepArtifacts('ws-1', 'job-1', tmpRoot, buildPlan())
+
+            expect((handler as any)._currentDiffContext.failedStepIds).to.deep.equal(['g1'])
+        })
+    })
+
+    describe('createUpdateWorkspaceZip (private)', () => {
+        it('should create zip at expected path with empty modifiedFiles list', async function () {
+            this.timeout(15000)
+            const zipPath = await (handler as any).createUpdateWorkspaceZip(tmpRoot, 'job-1', [])
+
+            expect(zipPath).to.include('update-workspace.zip')
+            expect(fs.existsSync(zipPath)).to.be.true
+        })
+    })
+
+    describe('getModifiedFilesSinceCheckpoint (private)', () => {
+        it('should return empty when manifest is missing', () => {
+            const result = (handler as any).getModifiedFilesSinceCheckpoint(tmpRoot, 'job-1')
+            expect(result).to.deep.equal([])
+        })
+
+        it('should return empty when no lastAppliedTimestamp', () => {
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            fs.writeFileSync(path.join(dir, 'source-files.json'), JSON.stringify({ sourceFiles: ['/a.cs'] }))
+
+            const result = (handler as any).getModifiedFilesSinceCheckpoint(tmpRoot, 'job-1')
+            expect(result).to.deep.equal([])
+        })
+
+        it('should return files modified after lastAppliedTimestamp', () => {
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            const trackedFile = path.join(tmpRoot, 'tracked.cs')
+            fs.writeFileSync(trackedFile, 'content')
+
+            const oldTimestamp = Date.now() - 60_000
+            fs.writeFileSync(
+                path.join(dir, 'source-files.json'),
+                JSON.stringify({ sourceFiles: [trackedFile], lastAppliedTimestamp: oldTimestamp })
+            )
+
+            const result = (handler as any).getModifiedFilesSinceCheckpoint(tmpRoot, 'job-1')
+            expect(result).to.include(trackedFile)
+        })
+
+        it('should skip files that no longer exist on disk', () => {
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            fs.writeFileSync(
+                path.join(dir, 'source-files.json'),
+                JSON.stringify({
+                    sourceFiles: ['C:/totally-missing-file.cs'],
+                    lastAppliedTimestamp: 1,
+                })
+            )
+
+            const result = (handler as any).getModifiedFilesSinceCheckpoint(tmpRoot, 'job-1')
+            expect(result).to.deep.equal([])
+        })
+    })
+
+    describe('saveLastAppliedTimestamp (private)', () => {
+        it('should be no-op when manifest does not exist', () => {
+            expect(() => (handler as any).saveLastAppliedTimestamp(tmpRoot, 'job-1', 's1')).to.not.throw()
+        })
+
+        it('should set lastAppliedTimestamp and lastAppliedStepId on existing manifest', () => {
+            const dir = path.join(tmpRoot, workspaceFolderName, 'job-1', 'checkpoints')
+            fs.mkdirSync(dir, { recursive: true })
+            const manifestPath = path.join(dir, 'source-files.json')
+            fs.writeFileSync(manifestPath, JSON.stringify({ sourceFiles: [] }))
+            ;(handler as any).saveLastAppliedTimestamp(tmpRoot, 'job-1', 'step-x')
+
+            const data = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
+            expect(data.lastAppliedTimestamp).to.be.a('number')
+            expect(data.lastAppliedStepId).to.equal('step-x')
+        })
+    })
+
+    describe('submitStandardHitl (private)', () => {
+        it('should return result on success', async () => {
+            sendStub.resolves({ status: 'SUBMITTED' })
+            const result = await (handler as any).submitStandardHitl('ws-1', 'job-1', 't1', 'art-1')
+            expect(result?.status).to.equal('SUBMITTED')
+        })
+
+        it('should return null on send error', async () => {
+            sendStub.rejects(new Error('boom'))
+            const result = await (handler as any).submitStandardHitl('ws-1', 'job-1', 't1', 'art-1')
+            expect(result).to.be.null
+        })
+    })
+
+    describe('uploadArtifactAndComplete (private)', () => {
+        it('should return uploadId on full happy path', async () => {
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'art-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true })
+
+            const result = await (handler as any).uploadArtifactAndComplete('ws-1', 'job-1', 'C:/file.zip')
+
+            expect(result).to.equal('art-1')
+        })
+
+        it('should return null when createArtifactUploadUrl returns null', async () => {
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves(null)
+            const result = await (handler as any).uploadArtifactAndComplete('ws-1', 'job-1', 'C:/file.zip')
+            expect(result).to.be.null
+        })
+
+        it('should return null when uploadArtifact fails', async () => {
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'art-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(false)
+
+            const result = await (handler as any).uploadArtifactAndComplete('ws-1', 'job-1', 'C:/file.zip')
+
+            expect(result).to.be.null
+        })
+
+        it('should return null when completeArtifactUpload fails', async () => {
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'u',
+                uploadId: 'art-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves(null)
+
+            const result = await (handler as any).uploadArtifactAndComplete('ws-1', 'job-1', 'C:/file.zip')
+
+            expect(result).to.be.null
+        })
+    })
+
+    describe('downloadCompletedStepArtifact (private)', () => {
+        it('should return early when no artifacts found for step', async () => {
+            sinon.stub(handler as any, 'listArtifactsForStep').resolves([])
+            const dlSpy = sinon.stub(handler as any, 'downloadDiffArtifact').resolves('')
+
+            await (handler as any).downloadCompletedStepArtifact('ws-1', 'job-1', 's1', tmpRoot)
+
+            expect(dlSpy.called).to.be.false
+        })
+
+        it('should call downloadDiffArtifact when artifact is found', async () => {
+            sinon.stub(handler as any, 'listArtifactsForStep').resolves([{ artifactId: 'art-1' }])
+            const dlSpy = sinon.stub(handler as any, 'downloadDiffArtifact').resolves('')
+
+            await (handler as any).downloadCompletedStepArtifact('ws-1', 'job-1', 's1', tmpRoot)
+
+            expect(dlSpy.calledOnce).to.be.true
+        })
+
+        it('should swallow errors and not throw', async () => {
+            sinon.stub(handler as any, 'listArtifactsForStep').rejects(new Error('boom'))
+
+            await (handler as any).downloadCompletedStepArtifact('ws-1', 'job-1', 's1', tmpRoot)
+
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+    })
+
+    describe('clearJobCache (private)', () => {
+        it('should null-out all cached HITL state', () => {
+            ;(handler as any).cachedHitl = 'h'
+            ;(handler as any).cachedStepHitl = 's'
+            ;(handler as any).cachedInteractiveMode = 'Interactive'
+            ;(handler as any).clearJobCache()
+
+            expect((handler as any).cachedHitl).to.be.null
+            expect((handler as any).cachedStepHitl).to.be.null
+            expect((handler as any).cachedInteractiveMode).to.be.null
+        })
+    })
+})


### PR DESCRIPTION
 ## Summary

  Adds unit test coverage for `atxTransformHandler.ts` and routing tests for `atxNetTransformServer.ts`. The handler had no meaningful coverage before this PR; the routing logic introduced in #2722 had none.

  No source code modified — only test files added.

  ## Coverage delta

  ### `atxTransformHandler.ts`

  | Metric     | Before | After  |
  |------------|--------|--------|
  | Lines      | 11.53% | 82.26% |
  | Branches   | 0%     | 76.97% |
  | Functions  | 0%     | 90.12% |

  ### `atxNetTransformServer.ts` (routing only)

  | Metric     | Before | After  |
  |------------|--------|--------|
  | Lines      | 0%     | 47.88% |
  | Functions  | 0%     | 80%    |

  All thresholds (lines/statements 80, branches 50, functions 80) met for `atxTransformHandler.ts`.

  ## What's covered

  `atxTransformHandler.test.ts` — 232 tests covering the full transform lifecycle (`getTransformInfo`, `getTransformationPlan`, `startTransform`, `updateWorkspace`, `setCheckpoints`, `uploadPlan`, `uploadPackages`, HITL flows, plan-tree building, fs helpers,
  workspace/job/artifact wrappers, and error paths).

  `atxNetTransformServer.test.ts` — 10 routing tests covering `startTransform`, `getTransformInfo`, and `uploadPlan` dispatch to NEW vs LEGACY handler based on the `useOrchestratorAgent` flag. Includes a regression guard asserting routing is per-request (defends against the
  LSP-restart-mid-job bug fixed in #2722).


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
