### PR TITLE
ci: declare permissions on four workflows

### DIFF
--- a/.github/workflows/create-agent-standalone.yml
+++ b/.github/workflows/create-agent-standalone.yml
@@ -5,6 +5,9 @@ on:
         branches: [main, feature/*, release/agentic/*]
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -5,6 +5,9 @@ on:
     pull_request:
         branches: [main, dev, feature/*, release/agentic/*]
 
+permissions:
+    contents: read
+
 jobs:
     test:
         name: Test

--- a/.github/workflows/new_pr.yml
+++ b/.github/workflows/new_pr.yml
@@ -3,6 +3,8 @@ on:
     pull_request:
         branches: [main]
         types: [opened, reopened, ready_for_review, synchronize]
+permissions: {}
+
 jobs:
     notify:
         name: Slack notification

--- a/.github/workflows/npm-packaging.yaml
+++ b/.github/workflows/npm-packaging.yaml
@@ -5,6 +5,9 @@ on:
     pull_request:
         branches: [main, dev, feature/*, release/agentic/*]
 
+permissions:
+    contents: read
+
 jobs:
     build:
         name: Test public NPM packages


### PR DESCRIPTION
Four workflows ran without explicit `permissions:` blocks:

- `create-agent-standalone.yml`, `lsp-ci.yaml`, `npm-packaging.yaml` — pure CI (`contents: read` for checkout; upload-artifact works at this scope).
- `new_pr.yml` — only posts a Slack notification using `github.event.pull_request` fields, never touches GitHub APIs, so `permissions: {}` is correct.