### PR TITLE
revert(chat-client): remove postMessage origin check causing regressi…

### DIFF
--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -31,7 +31,6 @@ describe('Chat', () => {
     const initialTabId = 'tab-1'
     let mynahUi: MynahUI
     let clientApi: { postMessage: sinon.SinonStub }
-    let messageHandler: ((event: MessageEvent) => void) | undefined
 
     before(() => {
         // Mock global observers for test environment
@@ -52,24 +51,12 @@ describe('Chat', () => {
             postMessage: sandbox.stub(),
         }
 
-        const originalAddEventListener = window.addEventListener.bind(window)
-        sandbox.stub(window, 'addEventListener').callsFake((type: string, handler: any, ...rest: any[]) => {
-            if (type === 'message') {
-                messageHandler = handler
-            }
-            return originalAddEventListener(type, handler, ...rest)
-        })
-
         mynahUi = createChat(clientApi, {
             agenticMode: true,
         })
     })
 
     afterEach(() => {
-        if (messageHandler) {
-            window.removeEventListener('message', messageHandler as EventListener)
-            messageHandler = undefined
-        }
         sandbox.restore()
 
         Object.keys(mynahUi.getAllTabs()).forEach(tabId => {
@@ -140,21 +127,6 @@ describe('Chat', () => {
                 ...eventParams.params,
             },
         })
-    })
-
-    it('rejects inbound messages from a foreign origin (P389799154)', () => {
-        // Simulates a cross-origin postMessage from an attacker page. The
-        // handleInboundMessage same-origin check should drop the event before
-        // any command is dispatched.
-        clientApi.postMessage.resetHistory()
-
-        const foreignEvent = new window.MessageEvent('message', {
-            data: { command: SEND_TO_PROMPT, params: { prompt: 'pwn' } },
-            origin: 'https://attacker.example.com',
-        })
-        window.dispatchEvent(foreignEvent)
-
-        assert.notCalled(clientApi.postMessage)
     })
 
     it('publishes tab added event, when UI tab is added', () => {
@@ -596,15 +568,9 @@ describe('Chat', () => {
     })
 
     function createInboundEvent(params: any) {
-        // Use MessageEvent (not CustomEvent) and set origin to window.location.origin
-        // so that handleInboundMessage's same-origin check accepts it. See
-        // chat.ts handleInboundMessage origin validation (P389799154).
-        // window.MessageEvent is the jsdom event class; using the global Node
-        // MessageEvent fails dispatchEvent's instanceof check.
-        return new window.MessageEvent('message', {
-            data: params,
-            origin: window.location.origin,
-        })
+        const event = new CustomEvent('message') as any
+        event.data = params
+        return event
     }
 
     describe('with client adapter', () => {

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -170,29 +170,9 @@ export const createChat = (
      * 2. Messages without a 'sender' property are processed by the standard
      *    command-based router, which dispatches based on the 'command' field.
      *
-     * Security: rejects messages whose origin does not match the chat iframe's
-     * own origin. The chat iframe is loaded same-origin with its host page in
-     * every supported integration:
-     *   - VS Code / JetBrains / Visual Studio webviews: the host webview iframe
-     *     forwards messages to the inner content iframe with the parent's own
-     *     origin (e.g. `vscode-webview://...`). The inner iframe shares that
-     *     origin via the `allow-same-origin` sandbox flag.
-     *   - SageMaker JupyterLab: the parent calls
-     *     `chatFrame.contentWindow.postMessage(payload, window.location.origin)`
-     *     and loads the iframe `src` from the same SageMaker domain.
-     * Cross-origin postMessage events can only come from an attacker page, so
-     * we drop them. Mitigates DOM XSS via untrusted senders.
-     * See Bug Bounty ticket P389799154.
-     *
      * @param event - The message event containing data from the IDE
      */
     const handleInboundMessage = (event: MessageEvent): void => {
-        if (event.origin !== window.location.origin) {
-            // Log so any unexpected host environment surfaces in logs rather
-            // than silently breaking the chat.
-            console.warn('Chat client rejected message from untrusted origin:', event.origin)
-            return
-        }
         if (event.data === undefined) {
             return
         }


### PR DESCRIPTION
…on (#2732)

This reverts commit 0dabdeab which added a postMessage origin check that is causing a regression in certain environments.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
