### PR TITLE
feat: render welcome splash via tabHeaderDetails

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -27,7 +27,7 @@
         "@aws/chat-client-ui-types": "0.1.68",
         "@aws/language-server-runtimes": "^0.3.17",
         "@aws/language-server-runtimes-types": "^0.1.64",
-        "@aws/mynah-ui": "^4.40.2"
+        "@aws/mynah-ui": "^4.40.3"
     },
     "devDependencies": {
         "@types/jsdom": "^21.1.6",

--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -265,7 +265,12 @@ describe('MynahUI', () => {
             inboundChatApi.sendGenericCommand({ genericCommand, selection, tabId, triggerType })
 
             sinon.assert.calledOnceWithExactly(createTabStub, false)
-            sinon.assert.calledThrice(updateStoreSpy)
+            // updateStore is called four times for a brand new tab:
+            //   1. onTabAdd seeds the tab (chatItems + welcome tabHeaderDetails)
+            //   2. handleChatPrompt clears the welcome splash before the first prompt
+            //   3. handleChatPrompt sets loadingChat / cancelButton state
+            //   4. handleChatPrompt resets disabled state once streaming begins
+            sinon.assert.callCount(updateStoreSpy, 4)
             setTimeoutStub.restore()
         })
 
@@ -288,7 +293,8 @@ describe('MynahUI', () => {
             inboundChatApi.sendGenericCommand({ genericCommand, selection, tabId, triggerType })
 
             sinon.assert.calledOnceWithExactly(createTabStub, false)
-            sinon.assert.calledThrice(updateStoreSpy)
+            // See note above on the four updateStore calls.
+            sinon.assert.callCount(updateStoreSpy, 4)
             setTimeoutStub.restore()
         })
 

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -72,6 +72,7 @@ import { ChatHistory, ChatHistoryList } from './features/history'
 import { pairProgrammingModeOff, pairProgrammingModeOn, programmerModeCard } from './texts/pairProgramming'
 import { ContextRule, RulesList } from './features/rules'
 import { getModelSelectionChatItem, modelUnavailableBanner, modelThrottledBanner } from './texts/modelSelection'
+import { getWelcomeTabHeader } from './texts/welcome'
 import {
     freeTierLimitSticky,
     upgradeSuccessSticky,
@@ -175,6 +176,14 @@ export const handleChatPrompt = (
     tabFactory?: TabFactory
 ) => {
     let userPrompt = prompt.escapedPrompt
+
+    // Hide the welcome splash (tabHeaderDetails) once the user starts a
+    // conversation so it does not sit above their messages. mynah-ui treats
+    // a null tabHeaderDetails as "no header"; setting it more than once is a
+    // no-op so we do not need to guard for the first prompt explicitly.
+    if (mynahUi.getTabData(tabId)?.getStore()?.tabHeaderDetails != null) {
+        mynahUi.updateStore(tabId, { tabHeaderDetails: null })
+    }
 
     // Check if there's an ongoing request
     const isLoading = mynahUi.getTabData(tabId)?.getStore()?.loadingChat
@@ -425,6 +434,14 @@ export const createMynahUi = (
             // since this indicates we're loading a previous chat session rather than starting a new one.
             if (!tabStore?.tabMetadata || !tabStore.tabMetadata.openTabKey) {
                 defaultTabConfig.chatItems = tabFactory.getChatItems(true, programmingModeCardActive, [])
+                // Roll a fresh "Did you know?" tip for every new tab. The
+                // mynah-ui defaults.store is built once at startup, so without
+                // this override every new tab would inherit the same cached tip.
+                defaultTabConfig.tabHeaderDetails = getWelcomeTabHeader()
+            } else {
+                // Restoring a previous chat session: hide the welcome splash so
+                // it does not appear above historical messages.
+                defaultTabConfig.tabHeaderDetails = null
             }
             mynahUi.updateStore(tabId, defaultTabConfig)
             messager.onTabAdd(tabId, undefined, tabStore?.tabMetadata?.openTabKey === true)
@@ -1387,6 +1404,9 @@ ${params.message}`,
             if (tabId) {
                 mynahUi.updateStore(tabId, {
                     chatItems: tabFactory.getChatItems(messages ? false : true, programmingModeCardActive, messages),
+                    // When restoring a tab with prior messages, suppress the
+                    // welcome splash so it does not sit above the conversation.
+                    ...(messages ? { tabHeaderDetails: null } : {}),
                 })
                 messager.onOpenTab(requestId, { tabId })
             } else {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -178,9 +178,10 @@ export const handleChatPrompt = (
     let userPrompt = prompt.escapedPrompt
 
     // Hide the welcome splash (tabHeaderDetails) once the user starts a
-    // conversation so it does not sit above their messages. mynah-ui treats
-    // a null tabHeaderDetails as "no header"; setting it more than once is a
-    // no-op so we do not need to guard for the first prompt explicitly.
+    // conversation so it does not sit above their messages. The guard is
+    // important: mynah-ui's chat-wrapper re-runs a 750ms tab-mode-switch
+    // animation on every tabHeaderDetails write, so writing null again on
+    // every prompt would re-trigger that animation.
     if (mynahUi.getTabData(tabId)?.getStore()?.tabHeaderDetails != null) {
         mynahUi.updateStore(tabId, { tabHeaderDetails: null })
     }
@@ -1404,9 +1405,13 @@ ${params.message}`,
             if (tabId) {
                 mynahUi.updateStore(tabId, {
                     chatItems: tabFactory.getChatItems(messages ? false : true, programmingModeCardActive, messages),
-                    // When restoring a tab with prior messages, suppress the
-                    // welcome splash so it does not sit above the conversation.
-                    ...(messages ? { tabHeaderDetails: null } : {}),
+                    // onTabAdd suppresses the welcome splash whenever
+                    // openTabKey is true (which createTabId(true) sets), so
+                    // re-establish it here for the no-messages case so a
+                    // server-initiated "open a fresh tab" still shows the
+                    // splash. When messages are provided we keep the splash
+                    // hidden so it does not sit above the conversation.
+                    tabHeaderDetails: messages ? null : getWelcomeTabHeader(),
                 })
                 messager.onOpenTab(requestId, { tabId })
             } else {

--- a/chat-client/src/client/tabs/tabFactory.ts
+++ b/chat-client/src/client/tabs/tabFactory.ts
@@ -11,6 +11,7 @@ import { ChatMessage } from '@aws/language-server-runtimes-types'
 import { ChatHistory } from '../features/history'
 import { pairProgrammingPromptInput, programmerModeCard } from '../texts/pairProgramming'
 import { modelSelection } from '../texts/modelSelection'
+import { getWelcomeTabHeader } from '../texts/welcome'
 import { chatMessageToChatItem } from '../utils'
 
 export type DefaultTabData = MynahUIDataModel
@@ -55,6 +56,7 @@ export class TabFactory {
                 ? [pairProgrammingPromptInput, ...(this.modelSelectionEnabled ? [modelSelection] : [])]
                 : [],
             cancelButtonWhenLoading: this.agenticMode, // supported for agentic chat only
+            tabHeaderDetails: getWelcomeTabHeader(),
         }
         return tabData
     }
@@ -67,24 +69,9 @@ export class TabFactory {
         return [
             ...(this.bannerMessage ? [this.getBannerMessage() as ChatItem] : []),
             ...(needWelcomeMessages
-                ? [
-                      ...(this.agenticMode && pairProgrammingCardActive ? [programmerModeCard] : []),
-                      {
-                          type: ChatItemType.ANSWER,
-                          body: `<div style="display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 200px 0 20px 0;">
-
-<div style="font-size: 24px; margin-bottom: 12px;"><strong>Amazon Q</strong></div>
-<div style="background: rgba(128, 128, 128, 0.15); border: 1px solid rgba(128, 128, 128, 0.25); border-radius: 8px; padding: 8px; margin: 4px 0; text-align: center;">
-<div style="font-size: 14px; margin-bottom: 4px;"><strong>Did you know?</strong></div>
-<div>${this.getRandomTip()}</div>
-</div>
-
-Select code & ask me to explain, debug or optimize it, or type \`/\` for quick actions
-
-</div>`,
-                          canBeVoted: false,
-                      },
-                  ]
+                ? this.agenticMode && pairProgrammingCardActive
+                    ? [programmerModeCard]
+                    : []
                 : chatMessages
                   ? chatMessages.map(msg => chatMessageToChatItem(msg, this.agenticMode))
                   : []),
@@ -165,20 +152,6 @@ Select code & ask me to explain, debug or optimize it, or type \`/\` for quick a
             } as ChatItem
         }
         return undefined
-    }
-
-    private getRandomTip(): string {
-        const hints = [
-            'You can now see logs with 1-Click!',
-            'MCP is available in Amazon Q!',
-            'Pinned context is always included in future chat messages',
-            'Create and add Saved Prompts using the @ context menu',
-            'Compact your conversation with /compact',
-            'Ask Q to review your code and see results in the code issues panel!',
-        ]
-
-        const randomIndex = Math.floor(Math.random() * hints.length)
-        return hints[randomIndex]
     }
 
     private getTabBarButtons(): TabBarMainAction[] | undefined {

--- a/chat-client/src/client/texts/welcome.test.ts
+++ b/chat-client/src/client/texts/welcome.test.ts
@@ -1,15 +1,7 @@
 import * as assert from 'assert'
-import { getRandomTip, getWelcomeTabHeader } from './welcome'
+import { getWelcomeTabHeader } from './welcome'
 
 describe('welcome', () => {
-    describe('getRandomTip', () => {
-        it('returns a non-empty string from the tip pool', () => {
-            const tip = getRandomTip()
-            assert.strictEqual(typeof tip, 'string')
-            assert.ok(tip.length > 0)
-        })
-    })
-
     describe('getWelcomeTabHeader', () => {
         it('renders the centered Amazon Q splash through tabHeaderDetails fields', () => {
             const header = getWelcomeTabHeader()
@@ -27,20 +19,50 @@ describe('welcome', () => {
             assert.notStrictEqual(a.tip, b.tip)
         })
 
-        it('does not include raw inline HTML in any tab-header field (escaped by mynah-ui >= 4.40.2)', () => {
+        it('exposes the tip body as one of the curated tips (no leakage of unrelated content)', () => {
+            // Sample multiple times to give the random selector a fair chance to vary.
+            const expectedTips = new Set([
+                'You can now see logs with 1-Click!',
+                'MCP is available in Amazon Q!',
+                'Pinned context is always included in future chat messages',
+                'Create and add Saved Prompts using the @ context menu',
+                'Compact your conversation with /compact',
+                'Ask Q to review your code and see results in the code issues panel!',
+            ])
+            for (let i = 0; i < 20; i++) {
+                const body = getWelcomeTabHeader().tip?.body ?? ''
+                assert.ok(
+                    expectedTips.has(body),
+                    `tip body "${body}" is not from the curated tip pool`
+                )
+            }
+        })
+
+        it('does not include any HTML markup or entities in tab-header fields (escaped by mynah-ui >= 4.40.2)', () => {
             // Regression guard: PR #2724 bumped @aws/mynah-ui to ^4.40.2 which
             // escapes inline HTML in markdown bodies (mynah-ui PR #484). The
             // welcome surface MUST stay HTML-free or it will render as visible
             // tags instead of styled UI.
+            //
+            // Catch both tag-like sequences (e.g. "<br>", "<br/>", "</div>")
+            // and HTML entities (e.g. "&lt;", "&amp;"). A bare ampersand on
+            // its own is fine because mynah-ui appends string fields via
+            // insertAdjacentText (raw text, not HTML).
             const header = getWelcomeTabHeader()
-            const fields = [
-                header.title ?? '',
-                header.description ?? '',
-                header.tip?.title ?? '',
-                header.tip?.body ?? '',
+            const fields: Array<[string, string]> = [
+                ['title', header.title ?? ''],
+                ['description', header.description ?? ''],
+                ['tip.title', header.tip?.title ?? ''],
+                ['tip.body', header.tip?.body ?? ''],
             ]
-            for (const field of fields) {
-                assert.ok(!/<\w+/.test(field), `unexpected HTML tag in welcome field: "${field}"`)
+            const tagLike = /<\/?[a-zA-Z][^>]*>?/
+            const entityLike = /&[a-zA-Z]+;|&#\d+;|&#x[0-9a-fA-F]+;/
+            for (const [name, value] of fields) {
+                assert.ok(!tagLike.test(value), `welcome field "${name}" contains an HTML tag: "${value}"`)
+                assert.ok(
+                    !entityLike.test(value),
+                    `welcome field "${name}" contains an HTML entity: "${value}"`
+                )
             }
         })
     })

--- a/chat-client/src/client/texts/welcome.test.ts
+++ b/chat-client/src/client/texts/welcome.test.ts
@@ -31,10 +31,7 @@ describe('welcome', () => {
             ])
             for (let i = 0; i < 20; i++) {
                 const body = getWelcomeTabHeader().tip?.body ?? ''
-                assert.ok(
-                    expectedTips.has(body),
-                    `tip body "${body}" is not from the curated tip pool`
-                )
+                assert.ok(expectedTips.has(body), `tip body "${body}" is not from the curated tip pool`)
             }
         })
 
@@ -59,10 +56,7 @@ describe('welcome', () => {
             const entityLike = /&[a-zA-Z]+;|&#\d+;|&#x[0-9a-fA-F]+;/
             for (const [name, value] of fields) {
                 assert.ok(!tagLike.test(value), `welcome field "${name}" contains an HTML tag: "${value}"`)
-                assert.ok(
-                    !entityLike.test(value),
-                    `welcome field "${name}" contains an HTML entity: "${value}"`
-                )
+                assert.ok(!entityLike.test(value), `welcome field "${name}" contains an HTML entity: "${value}"`)
             }
         })
     })

--- a/chat-client/src/client/texts/welcome.test.ts
+++ b/chat-client/src/client/texts/welcome.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert'
+import { getRandomTip, getWelcomeTabHeader } from './welcome'
+
+describe('welcome', () => {
+    describe('getRandomTip', () => {
+        it('returns a non-empty string from the tip pool', () => {
+            const tip = getRandomTip()
+            assert.strictEqual(typeof tip, 'string')
+            assert.ok(tip.length > 0)
+        })
+    })
+
+    describe('getWelcomeTabHeader', () => {
+        it('renders the centered Amazon Q splash through tabHeaderDetails fields', () => {
+            const header = getWelcomeTabHeader()
+            assert.strictEqual(header.title, 'Amazon Q')
+            assert.strictEqual(header.centered, true)
+            assert.strictEqual(header.tip?.title, 'Did you know?')
+            assert.ok(header.tip?.body && header.tip.body.length > 0)
+            assert.ok(header.description && header.description.length > 0)
+        })
+
+        it('returns a fresh object each call so the random tip can rotate', () => {
+            const a = getWelcomeTabHeader()
+            const b = getWelcomeTabHeader()
+            assert.notStrictEqual(a, b)
+            assert.notStrictEqual(a.tip, b.tip)
+        })
+
+        it('does not include raw inline HTML in any tab-header field (escaped by mynah-ui >= 4.40.2)', () => {
+            // Regression guard: PR #2724 bumped @aws/mynah-ui to ^4.40.2 which
+            // escapes inline HTML in markdown bodies (mynah-ui PR #484). The
+            // welcome surface MUST stay HTML-free or it will render as visible
+            // tags instead of styled UI.
+            const header = getWelcomeTabHeader()
+            const fields = [
+                header.title ?? '',
+                header.description ?? '',
+                header.tip?.title ?? '',
+                header.tip?.body ?? '',
+            ]
+            for (const field of fields) {
+                assert.ok(!/<\w+/.test(field), `unexpected HTML tag in welcome field: "${field}"`)
+            }
+        })
+    })
+})

--- a/chat-client/src/client/texts/welcome.ts
+++ b/chat-client/src/client/texts/welcome.ts
@@ -1,7 +1,4 @@
-import {
-    // MynahIcons,
-    TabHeaderDetails,
-} from '@aws/mynah-ui'
+import { TabHeaderDetails } from '@aws/mynah-ui'
 
 const tips: string[] = [
     'You can now see logs with 1-Click!',
@@ -12,7 +9,7 @@ const tips: string[] = [
     'Ask Q to review your code and see results in the code issues panel!',
 ]
 
-export const getRandomTip = (): string => {
+const getRandomTip = (): string => {
     return tips[Math.floor(Math.random() * tips.length)]
 }
 
@@ -21,20 +18,19 @@ export const getRandomTip = (): string => {
  *
  * mynah-ui's `tabHeaderDetails` (>= the version that ships `centered` and
  * `tip` on `TitleDescriptionWithIcon`) renders the entire splash from this
- * data object: theme-aware Q logo, centered "Amazon Q" title, "Did you
- * know?" tip card, and helper description. The chat-client only passes
- * data; mynah-ui owns the styling.
+ * data object: centered "Amazon Q" title, "Did you know?" tip card, and
+ * helper description. The chat-client only passes data; mynah-ui owns the
+ * styling.
  *
  * Returns a fresh object on each call so a new random tip is shown each
  * time a new tab is created.
  */
 export const getWelcomeTabHeader = (): TabHeaderDetails => ({
-    // icon: MynahIcons.Q,
     title: 'Amazon Q',
     tip: {
         title: 'Did you know?',
         body: getRandomTip(),
     },
-    description: 'Select code & ask me to explain, debug or optimize it, or type `/` for quick actions.',
+    description: 'Select code & ask me to explain, debug or optimize it, or type / for quick actions.',
     centered: true,
 })

--- a/chat-client/src/client/texts/welcome.ts
+++ b/chat-client/src/client/texts/welcome.ts
@@ -1,0 +1,40 @@
+import {
+    // MynahIcons,
+    TabHeaderDetails,
+} from '@aws/mynah-ui'
+
+const tips: string[] = [
+    'You can now see logs with 1-Click!',
+    'MCP is available in Amazon Q!',
+    'Pinned context is always included in future chat messages',
+    'Create and add Saved Prompts using the @ context menu',
+    'Compact your conversation with /compact',
+    'Ask Q to review your code and see results in the code issues panel!',
+]
+
+export const getRandomTip = (): string => {
+    return tips[Math.floor(Math.random() * tips.length)]
+}
+
+/**
+ * Tab-level welcome splash for new chat tabs.
+ *
+ * mynah-ui's `tabHeaderDetails` (>= the version that ships `centered` and
+ * `tip` on `TitleDescriptionWithIcon`) renders the entire splash from this
+ * data object: theme-aware Q logo, centered "Amazon Q" title, "Did you
+ * know?" tip card, and helper description. The chat-client only passes
+ * data; mynah-ui owns the styling.
+ *
+ * Returns a fresh object on each call so a new random tip is shown each
+ * time a new tab is created.
+ */
+export const getWelcomeTabHeader = (): TabHeaderDetails => ({
+    // icon: MynahIcons.Q,
+    title: 'Amazon Q',
+    tip: {
+        title: 'Did you know?',
+        body: getRandomTip(),
+    },
+    description: 'Select code & ask me to explain, debug or optimize it, or type `/` for quick actions.',
+    centered: true,
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,7 +257,7 @@
                 "@aws/chat-client-ui-types": "0.1.68",
                 "@aws/language-server-runtimes": "^0.3.17",
                 "@aws/language-server-runtimes-types": "^0.1.64",
-                "@aws/mynah-ui": "^4.40.2"
+                "@aws/mynah-ui": "^4.40.3"
             },
             "devDependencies": {
                 "@types/jsdom": "^21.1.6",
@@ -3872,9 +3872,9 @@
             "link": true
         },
         "node_modules/@aws/mynah-ui": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.40.2.tgz",
-            "integrity": "sha512-LtGrbMPQTzWBEc8u4386G5FUZaQtp3nUfO1GZ7FPXykwnBAkasL9Lk9aTTSoxi0BgSIKWmZxv7bwy8QGE4Pzvg==",
+            "version": "4.40.3",
+            "resolved": "https://registry.npmjs.org/@aws/mynah-ui/-/mynah-ui-4.40.3.tgz",
+            "integrity": "sha512-n3tNoziywys5PNQOVoEUo7Rh2LdYHiEU3HVFbnaa3zswmHTg2gmXwwbPG3qWwrAIowy/uQM2glpcO0xfQvX3tg==",
             "hasInstallScript": true,
             "license": "Apache License 2.0",
             "dependencies": {


### PR DESCRIPTION
## Problem
- Welcome UX is broken if user open a new chat tab
<img width="3018" height="1812" alt="image" src="https://github.com/user-attachments/assets/4be84fc5-6039-4674-8a4c-cec6d6bd684d" />


## Solution
- Fixed this by using mynah-ui component.

<img width="775" height="1375" alt="image" src="https://github.com/user-attachments/assets/e250fe37-ad51-42d9-9ede-4a5a754c78e3" />


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
