### PR TITLE
fix: allow empty/null origin in postMessage check for Eclipse SWT browser

### DIFF
--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -157,6 +157,46 @@ describe('Chat', () => {
         assert.notCalled(clientApi.postMessage)
     })
 
+    it('accepts inbound messages with empty origin (Eclipse SWT Browser)', () => {
+        // Eclipse SWT Browser loads content via file:// protocol, so
+        // postMessage events arrive with an empty string origin.
+        clientApi.postMessage.resetHistory()
+
+        const eclipseEvent = new window.MessageEvent('message', {
+            data: { command: SEND_TO_PROMPT, params: { prompt: { prompt: 'hello', escapedPrompt: 'hello' } } },
+            origin: '',
+        })
+        window.dispatchEvent(eclipseEvent)
+
+        assert.called(clientApi.postMessage)
+    })
+
+    it('accepts inbound messages with "null" origin (sandboxed iframes)', () => {
+        // Sandboxed iframes without allow-same-origin report origin as
+        // the string "null".
+        clientApi.postMessage.resetHistory()
+
+        const nullOriginEvent = new window.MessageEvent('message', {
+            data: { command: SEND_TO_PROMPT, params: { prompt: { prompt: 'hello', escapedPrompt: 'hello' } } },
+            origin: 'null',
+        })
+        window.dispatchEvent(nullOriginEvent)
+
+        assert.called(clientApi.postMessage)
+    })
+
+    it('accepts inbound messages with non-HTTP origin (file:// protocol)', () => {
+        clientApi.postMessage.resetHistory()
+
+        const fileEvent = new window.MessageEvent('message', {
+            data: { command: SEND_TO_PROMPT, params: { prompt: { prompt: 'hello', escapedPrompt: 'hello' } } },
+            origin: 'file://',
+        })
+        window.dispatchEvent(fileEvent)
+
+        assert.called(clientApi.postMessage)
+    })
+
     it('publishes tab added event, when UI tab is added', () => {
         const tabId = mynahUi.updateStore('', {})
 

--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -160,41 +160,41 @@ describe('Chat', () => {
     it('accepts inbound messages with empty origin (Eclipse SWT Browser)', () => {
         // Eclipse SWT Browser loads content via file:// protocol, so
         // postMessage events arrive with an empty string origin.
-        clientApi.postMessage.resetHistory()
+        const warnStub = sandbox.stub(console, 'warn')
 
         const eclipseEvent = new window.MessageEvent('message', {
-            data: { command: SEND_TO_PROMPT, params: { prompt: { prompt: 'hello', escapedPrompt: 'hello' } } },
+            data: { command: 'noop-test-command' },
             origin: '',
         })
         window.dispatchEvent(eclipseEvent)
 
-        assert.called(clientApi.postMessage)
+        assert.notCalled(warnStub)
     })
 
     it('accepts inbound messages with "null" origin (sandboxed iframes)', () => {
         // Sandboxed iframes without allow-same-origin report origin as
         // the string "null".
-        clientApi.postMessage.resetHistory()
+        const warnStub = sandbox.stub(console, 'warn')
 
         const nullOriginEvent = new window.MessageEvent('message', {
-            data: { command: SEND_TO_PROMPT, params: { prompt: { prompt: 'hello', escapedPrompt: 'hello' } } },
+            data: { command: 'noop-test-command' },
             origin: 'null',
         })
         window.dispatchEvent(nullOriginEvent)
 
-        assert.called(clientApi.postMessage)
+        assert.notCalled(warnStub)
     })
 
     it('accepts inbound messages with non-HTTP origin (file:// protocol)', () => {
-        clientApi.postMessage.resetHistory()
+        const warnStub = sandbox.stub(console, 'warn')
 
         const fileEvent = new window.MessageEvent('message', {
-            data: { command: SEND_TO_PROMPT, params: { prompt: { prompt: 'hello', escapedPrompt: 'hello' } } },
+            data: { command: 'noop-test-command' },
             origin: 'file://',
         })
         window.dispatchEvent(fileEvent)
 
-        assert.called(clientApi.postMessage)
+        assert.notCalled(warnStub)
     })
 
     it('publishes tab added event, when UI tab is added', () => {

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -170,27 +170,27 @@ export const createChat = (
      * 2. Messages without a 'sender' property are processed by the standard
      *    command-based router, which dispatches based on the 'command' field.
      *
-     * Security: rejects messages whose origin does not match the chat iframe's
-     * own origin. The chat iframe is loaded same-origin with its host page in
-     * every supported integration:
-     *   - VS Code / JetBrains / Visual Studio webviews: the host webview iframe
-     *     forwards messages to the inner content iframe with the parent's own
-     *     origin (e.g. `vscode-webview://...`). The inner iframe shares that
-     *     origin via the `allow-same-origin` sandbox flag.
-     *   - SageMaker JupyterLab: the parent calls
-     *     `chatFrame.contentWindow.postMessage(payload, window.location.origin)`
-     *     and loads the iframe `src` from the same SageMaker domain.
-     * Cross-origin postMessage events can only come from an attacker page, so
-     * we drop them. Mitigates DOM XSS via untrusted senders.
+     * Security: rejects messages from cross-origin HTTP(S) pages to prevent
+     * DOM XSS via untrusted postMessage senders.
+     *
+     * Legitimate host environments deliver messages in different ways:
+     *   - VS Code / JetBrains / Visual Studio webviews: same-origin via
+     *     `allow-same-origin` sandbox flag.
+     *   - SageMaker JupyterLab: same-origin (iframe loaded from same domain).
+     *   - Eclipse SWT Browser: non-HTTP origin (file:// protocol or similar).
+     *
+     * Only a real HTTP(S) cross-origin postMessage can come from an attacker
+     * page, so we reject those and allow everything else through.
      * See Bug Bounty ticket P389799154.
      *
      * @param event - The message event containing data from the IDE
      */
     const handleInboundMessage = (event: MessageEvent): void => {
-        if (event.origin !== window.location.origin) {
+        const origin = event.origin
+        if (origin && origin !== 'null' && origin.startsWith('http') && origin !== window.location.origin) {
             // Log so any unexpected host environment surfaces in logs rather
             // than silently breaking the chat.
-            console.warn('Chat client rejected message from untrusted origin:', event.origin)
+            console.warn('Chat client rejected message from untrusted origin:', origin)
             return
         }
         if (event.data === undefined) {


### PR DESCRIPTION
* fix: allow empty/null origin in postMessage check for Eclipse SWT Browser

Eclipse's SWT Browser widget loads the chat UI via file:// protocol, causing postMessage events to arrive with an empty string or "null" origin. The strict same-origin check added in 0dabdeab rejected these messages, silently breaking chat in Eclipse — the backend returns a valid response but it never reaches the UI.

Allow empty-string and "null" origins (which are what file:// and sandboxed opaque-origin contexts report) while still blocking real cross-origin attacks from HTTP(S) pages.

Fixes aws/amazon-q-eclipse#555
Ref: P437110601

* fix: flip origin check to block-known-bad (only reject HTTP(S) cross-origin)

Instead of allowlisting specific origins, only reject messages from real HTTP(S) cross-origin pages. This handles Eclipse (and any future non-HTTP host) without needing to know their exact origin value.

The check now passes through messages with empty, "null", file://, or any non-HTTP origin — only blocking actual cross-origin HTTP(S) attacks.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
