### PR TITLE
test(chat-client): avoid leaking mynah-ui state from origin-check tests

### DIFF
--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -160,41 +160,41 @@ describe('Chat', () => {
     it('accepts inbound messages with empty origin (Eclipse SWT Browser)', () => {
         // Eclipse SWT Browser loads content via file:// protocol, so
         // postMessage events arrive with an empty string origin.
-        clientApi.postMessage.resetHistory()
+        const warnStub = sandbox.stub(console, 'warn')
 
         const eclipseEvent = new window.MessageEvent('message', {
-            data: { command: SEND_TO_PROMPT, params: { prompt: { prompt: 'hello', escapedPrompt: 'hello' } } },
+            data: { command: 'noop-test-command' },
             origin: '',
         })
         window.dispatchEvent(eclipseEvent)
 
-        assert.called(clientApi.postMessage)
+        assert.notCalled(warnStub)
     })
 
     it('accepts inbound messages with "null" origin (sandboxed iframes)', () => {
         // Sandboxed iframes without allow-same-origin report origin as
         // the string "null".
-        clientApi.postMessage.resetHistory()
+        const warnStub = sandbox.stub(console, 'warn')
 
         const nullOriginEvent = new window.MessageEvent('message', {
-            data: { command: SEND_TO_PROMPT, params: { prompt: { prompt: 'hello', escapedPrompt: 'hello' } } },
+            data: { command: 'noop-test-command' },
             origin: 'null',
         })
         window.dispatchEvent(nullOriginEvent)
 
-        assert.called(clientApi.postMessage)
+        assert.notCalled(warnStub)
     })
 
     it('accepts inbound messages with non-HTTP origin (file:// protocol)', () => {
-        clientApi.postMessage.resetHistory()
+        const warnStub = sandbox.stub(console, 'warn')
 
         const fileEvent = new window.MessageEvent('message', {
-            data: { command: SEND_TO_PROMPT, params: { prompt: { prompt: 'hello', escapedPrompt: 'hello' } } },
+            data: { command: 'noop-test-command' },
             origin: 'file://',
         })
         window.dispatchEvent(fileEvent)
 
-        assert.called(clientApi.postMessage)
+        assert.notCalled(warnStub)
     })
 
     it('publishes tab added event, when UI tab is added', () => {


### PR DESCRIPTION
The new origin-check tests dispatched real SEND_TO_PROMPT messages, which exercised mynah-ui DOM code (addToUserPrompt) on the shared global JSDOM. On slow CI runners this accumulated state pushed an unrelated mynah-ui test ('should create a new tab if current tab is loading') over its 10s timeout.

Switch to an unknown command and assert via the rejection warn() spy so the origin-check logic still runs without touching mynah-ui.

## Problem

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
