### PR TITLE
fix(chat-client): increase timeout for flaky sendGenericCommand test

### DIFF
--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -270,7 +270,7 @@ describe('MynahUI', () => {
         })
 
         it('should create a new tab if current tab is loading', function () {
-            this.timeout(10000)
+            this.timeout(30000)
             // clear create tab stub since set up process calls it twice
             createTabStub.resetHistory()
             // Stub setTimeout to execute immediately


### PR DESCRIPTION
## Problem

The `should create a new tab if current tab is loading` test in `mynahUi.test.ts` intermittently exceeds its 10s timeout on CI runners, causing flaky failures on release-please and other PRs.

The sibling test (`should create a new tab if none exits`) already takes ~8.5s to complete, leaving almost no margin for the 10s timeout.

## Solution

Increase the test timeout from 10s to 30s to prevent intermittent failures on slower CI runners.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.