### PR TITLE
ci(lsp-ci): cap GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/lsp-ci.yaml
+++ b/.github/workflows/lsp-ci.yaml
@@ -5,6 +5,9 @@ on:
     pull_request:
         branches: [main, dev, feature/*, release/agentic/*]
 
+permissions:
+  contents: read
+
 jobs:
     test:
         name: Test


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.