### PR TITLE
feat(integ): rewrite ATX integ tests for new chatty-agent handler

### DIFF
--- a/integration-tests/atx-transform-server/src/tests/atxTransformInteg.test.ts
+++ b/integration-tests/atx-transform-server/src/tests/atxTransformInteg.test.ts
@@ -270,10 +270,11 @@ describe('ATX .NET Transform Integration Tests', () => {
             await sleep(10000)
         }
 
-        expect(
-            ['EXECUTING', 'COMPLETED', 'PARTIALLY_COMPLETED'],
-            `Expected job to reach EXECUTING but got: ${jobStatus}`
-        ).to.include(jobStatus)
+        expect(jobStatus, `Expected job to reach EXECUTING but got: ${jobStatus}`).to.be.oneOf([
+            'EXECUTING',
+            'COMPLETED',
+            'PARTIALLY_COMPLETED',
+        ])
     })
 
     // TEST 4: Validates polling through EXECUTING → COMPLETED — exercises GetJob,
@@ -379,10 +380,10 @@ describe('ATX .NET Transform Integration Tests', () => {
         }
 
         console.log('TEST 4: Final status:', jobStatus, 'ArtifactPath:', artifactPath)
-        expect(
-            ['COMPLETED', 'PARTIALLY_COMPLETED'],
-            `Expected COMPLETED or PARTIALLY_COMPLETED but got: ${jobStatus}`
-        ).to.include(jobStatus)
+        expect(jobStatus, `Expected COMPLETED or PARTIALLY_COMPLETED but got: ${jobStatus}`).to.be.oneOf([
+            'COMPLETED',
+            'PARTIALLY_COMPLETED',
+        ])
         // ArtifactPath is only returned when SolutionRootPath is provided (downloads final artifact to disk).
         // We omit SolutionRootPath from polls to avoid fetchWorklogs log flooding, so ArtifactPath is null.
     })

--- a/integration-tests/atx-transform-server/src/tests/atxTransformInteg.test.ts
+++ b/integration-tests/atx-transform-server/src/tests/atxTransformInteg.test.ts
@@ -223,7 +223,7 @@ describe('ATX .NET Transform Integration Tests', () => {
     //         ListJobPlanSteps, ListHitlTasks FES calls. Polls until EXECUTING begins.
     it('TEST 3: should poll transform until EXECUTING', async function (this: Mocha.Context) {
         this.timeout(7200000) // 2 hours — planning phase with Claude Opus can take 60-90 mins
-        const maxPolls = 720  // 720 x 10s = 2 hours
+        const maxPolls = 720 // 720 x 10s = 2 hours
         let jobStatus = ''
 
         for (let i = 0; i < maxPolls; i++) {
@@ -247,7 +247,9 @@ describe('ATX .NET Transform Integration Tests', () => {
             const errorString = result?.ErrorString || null
             const hitlTag = result?.HitlTag || null
             const stepCount = result?.TransformationPlan?.Root?.Children?.length ?? 0
-            console.log(`TEST 3 Poll ${i + 1}: Status=${jobStatus} Steps=${stepCount} HitlTag=${hitlTag} ErrorString=${errorString} (${pollMs}ms)`)
+            console.log(
+                `TEST 3 Poll ${i + 1}: Status=${jobStatus} Steps=${stepCount} HitlTag=${hitlTag} ErrorString=${errorString} (${pollMs}ms)`
+            )
 
             if (jobStatus === 'FAILED') {
                 const reason = job.FailureReason || result?.ErrorString || 'unknown'
@@ -280,7 +282,7 @@ describe('ATX .NET Transform Integration Tests', () => {
     //         ListArtifacts + CreateArtifactDownloadUrl (final artifact) FES calls
     it('TEST 4: should poll transform until COMPLETED', async function (this: Mocha.Context) {
         this.timeout(10800000) // 3 hours — execution phase
-        const maxPolls = 1080  // 1080 x 10s = 3 hours
+        const maxPolls = 1080 // 1080 x 10s = 3 hours
         let jobStatus = ''
         let lastLoggedStatus = ''
         let artifactPath: string | null = null
@@ -323,7 +325,9 @@ describe('ATX .NET Transform Integration Tests', () => {
                 const stepCount = result?.TransformationPlan?.Root?.Children?.length ?? 0
                 artifactPath = result?.ArtifactPath || null
                 if (hitlTag || jobStatus !== lastLoggedStatus || i % 10 === 0) {
-                    console.log(`TEST 4 Poll ${i + 1}: Status=${jobStatus} Steps=${stepCount} HitlTag=${hitlTag} DiffApplyFailed=${diffApplyFailed} ErrorString=${errorString} ArtifactPath=${artifactPath} (${pollMs}ms)`)
+                    console.log(
+                        `TEST 4 Poll ${i + 1}: Status=${jobStatus} Steps=${stepCount} HitlTag=${hitlTag} DiffApplyFailed=${diffApplyFailed} ErrorString=${errorString} ArtifactPath=${artifactPath} (${pollMs}ms)`
+                    )
                     lastLoggedStatus = jobStatus
                 }
 

--- a/integration-tests/atx-transform-server/src/tests/atxTransformInteg.test.ts
+++ b/integration-tests/atx-transform-server/src/tests/atxTransformInteg.test.ts
@@ -43,7 +43,6 @@ describe('ATX .NET Transform Integration Tests', () => {
     let client: LspClient
     let workspaceId: string
     let transformationJobId: string
-    let planPath: string | null = null
     let refreshInterval: NodeJS.Timeout
 
     let testSsoToken = process.env.TEST_SSO_TOKEN || ''
@@ -57,6 +56,7 @@ describe('ATX .NET Transform Integration Tests', () => {
     const domainProjectPath = path.join(testFixturePath, 'app', 'Bookstore.Domain', 'Bookstore.Domain.csproj')
 
     const TOKEN_REFRESH_INTERVAL_MS = 25 * 60 * 1000
+    const TERMINAL_STATUSES = ['COMPLETED', 'PARTIALLY_COMPLETED', 'FAILED', 'STOPPED']
 
     async function refreshToken(): Promise<void> {
         try {
@@ -78,6 +78,7 @@ describe('ATX .NET Transform Integration Tests', () => {
             command: 'aws/atxTransform/startTransform',
             WorkspaceId: workspaceId,
             JobName: jobName,
+            useOrchestratorAgent: true,
             StartTransformRequest: {
                 SolutionRootPath: testFixturePath,
                 SolutionFilePath: solutionFilePath,
@@ -171,114 +172,232 @@ describe('ATX .NET Transform Integration Tests', () => {
         if (client) client.close()
     })
 
+    // TEST 1: Validates listOrCreateWorkspace — exercises ListWorkspaces + CreateWorkspace FES calls
     it('TEST 1: should list or create workspace', async () => {
+        console.log('TEST 1: calling listOrCreateWorkspace')
         const result = await client.sendRequest('workspace/executeCommand', {
             command: 'aws/atxTransform/listOrCreateWorkspace',
             arguments: [],
         })
 
+        console.log('TEST 1: raw result:', JSON.stringify(result))
         workspaceId = result?.CreatedWorkspace?.Id || result?.AvailableWorkspaces?.[0]?.Id
-        expect(workspaceId).to.exist
-        console.log('WorkspaceId:', workspaceId)
+        expect(workspaceId, 'workspaceId should exist in listOrCreateWorkspace response').to.exist
+        console.log('TEST 1: WorkspaceId:', workspaceId)
     })
 
+    // TEST 2: Validates startTransform — exercises CreateJob, CreateArtifactUploadUrl,
+    //         CompleteArtifactUpload, StartJob FES calls
     it('TEST 2: should start transform job', async () => {
         const sourceFiles = getSourceFiles(testFixturePath)
-        console.log(`Found ${sourceFiles.length} source files`)
+        console.log(`TEST 2: Found ${sourceFiles.length} source files`)
+
+        const jobName = 'IntegTest-BobsBookstore-' + Date.now()
+        console.log('TEST 2: Starting transform job:', jobName)
 
         const result = await client.sendRequest(
             'workspace/executeCommand',
-            buildStartTransformRequest('IntegTest-BobsBookstore-' + Date.now(), sourceFiles)
+            buildStartTransformRequest(jobName, sourceFiles)
         )
 
+        console.log('TEST 2: raw result:', JSON.stringify(result))
         transformationJobId = result?.TransformationJobId
-        expect(transformationJobId).to.exist
-        console.log('TransformationJobId:', transformationJobId)
+        expect(transformationJobId, 'TransformationJobId should exist in startTransform response').to.exist
+        console.log('TEST 2: TransformationJobId:', transformationJobId)
+
+        // Send initial message to trigger the backend orchestrator
+        // The backend agent container needs ~30s to fully initialize before it can receive messages
+        await sleep(30000)
+        console.log('TEST 2: Sending init message to trigger orchestrator')
+        const msgResult = await client.sendRequest('workspace/executeCommand', {
+            command: 'aws/atxTransform/sendMessage',
+            workspaceId: workspaceId,
+            jobId: transformationJobId,
+            text: 'I have uploaded the code, please start the assessment',
+            skipPolling: true,
+        })
+        console.log('TEST 2: sendMessage result:', JSON.stringify(msgResult))
     })
 
-    it('TEST 3: should poll transform until AWAITING_HUMAN_INPUT', async function (this: Mocha.Context) {
-        this.timeout(3600000)
-        const maxPolls = 360
+    // TEST 3: Validates polling through PLANNING phase — exercises GetJob, ListWorklogs,
+    //         ListJobPlanSteps, ListHitlTasks FES calls. Polls until EXECUTING begins.
+    it('TEST 3: should poll transform until EXECUTING', async function (this: Mocha.Context) {
+        this.timeout(7200000) // 2 hours — planning phase with Claude Opus can take 60-90 mins
+        const maxPolls = 720  // 720 x 10s = 2 hours
         let jobStatus = ''
 
         for (let i = 0; i < maxPolls; i++) {
+            const pollStart = Date.now()
             const result = await client.sendRequest('workspace/executeCommand', {
                 command: 'aws/atxTransform/getTransformInfo',
                 TransformationJobId: transformationJobId,
                 WorkspaceId: workspaceId,
-                SolutionRootPath: testFixturePath,
+                useOrchestratorAgent: true,
             })
+            const pollMs = Date.now() - pollStart
+
+            if (result === null || result === undefined) {
+                console.error(`TEST 3 Poll ${i + 1}: getTransformInfo returned null/undefined (${pollMs}ms)`)
+                await sleep(10000)
+                continue
+            }
 
             const job = result?.TransformationJob || {}
             jobStatus = job.Status || ''
-            planPath = result?.PlanPath || null
-            console.log(`Poll ${i + 1}: Status = ${jobStatus}`)
+            const errorString = result?.ErrorString || null
+            const hitlTag = result?.HitlTag || null
+            const stepCount = result?.TransformationPlan?.Root?.Children?.length ?? 0
+            console.log(`TEST 3 Poll ${i + 1}: Status=${jobStatus} Steps=${stepCount} HitlTag=${hitlTag} ErrorString=${errorString} (${pollMs}ms)`)
 
             if (jobStatus === 'FAILED') {
                 const reason = job.FailureReason || result?.ErrorString || 'unknown'
-                console.log('FAILED - Reason:', reason)
-                throw new Error(`Job failed: ${reason}`)
+                console.error('TEST 3: Job FAILED - Reason:', reason)
+                throw new Error(`Job failed during planning: ${reason}`)
             }
 
-            if (jobStatus === 'AWAITING_HUMAN_INPUT' && planPath) break
-            if (['COMPLETED', 'FAILED', 'STOPPED'].includes(jobStatus)) break
+            if (jobStatus === 'EXECUTING') {
+                console.log('TEST 3: Reached EXECUTING — planning phase complete')
+                break
+            }
+
+            if (TERMINAL_STATUSES.includes(jobStatus)) {
+                console.log('TEST 3: Reached terminal status:', jobStatus)
+                break
+            }
 
             await sleep(10000)
         }
 
-        expect(jobStatus).to.equal('AWAITING_HUMAN_INPUT')
-        expect(planPath).to.exist
+        expect(
+            ['EXECUTING', 'COMPLETED', 'PARTIALLY_COMPLETED'],
+            `Expected job to reach EXECUTING but got: ${jobStatus}`
+        ).to.include(jobStatus)
     })
 
-    it('TEST 4: should upload plan and complete transform', async function (this: Mocha.Context) {
-        this.timeout(10800000)
-        if (!planPath) {
-            this.skip()
-            return
-        }
+    // TEST 4: Validates polling through EXECUTING → COMPLETED — exercises GetJob,
+    //         ListJobPlanSteps, ListWorklogs, ListHitlTasks (HITL probe),
+    //         CreateArtifactDownloadUrl + S3 download (checkpoint artifacts),
+    //         ListArtifacts + CreateArtifactDownloadUrl (final artifact) FES calls
+    it('TEST 4: should poll transform until COMPLETED', async function (this: Mocha.Context) {
+        this.timeout(10800000) // 3 hours — execution phase
+        const maxPolls = 1080  // 1080 x 10s = 3 hours
+        let jobStatus = ''
+        let lastLoggedStatus = ''
+        let artifactPath: string | null = null
 
-        const uploadResult = await client.sendRequest('workspace/executeCommand', {
-            command: 'aws/atxTransform/uploadPlan',
+        // If TEST 3 already reached COMPLETED/PARTIALLY_COMPLETED, skip polling
+        const checkResult = await client.sendRequest('workspace/executeCommand', {
+            command: 'aws/atxTransform/getTransformInfo',
             TransformationJobId: transformationJobId,
             WorkspaceId: workspaceId,
-            PlanPath: planPath,
+            useOrchestratorAgent: true,
         })
-        console.log('UploadPlan result:', uploadResult?.VerificationStatus)
-
-        const maxPolls = 1080
-        let jobStatus = ''
-
-        for (let i = 0; i < maxPolls; i++) {
-            const result = await client.sendRequest('workspace/executeCommand', {
-                command: 'aws/atxTransform/getTransformInfo',
-                TransformationJobId: transformationJobId,
-                WorkspaceId: workspaceId,
-                SolutionRootPath: testFixturePath,
-            })
-
-            jobStatus = result?.TransformationJob?.Status || ''
-            console.log(`Poll ${i + 1}: Status = ${jobStatus}`)
-
-            if (['COMPLETED', 'FAILED', 'STOPPED', 'PARTIALLY_COMPLETED'].includes(jobStatus)) break
-
-            await sleep(10000)
+        jobStatus = checkResult?.TransformationJob?.Status || ''
+        if (['COMPLETED', 'PARTIALLY_COMPLETED'].includes(jobStatus)) {
+            artifactPath = checkResult?.ArtifactPath || null
+            console.log(`TEST 4: Already at terminal status ${jobStatus}, ArtifactPath: ${artifactPath}`)
         }
 
-        expect(['COMPLETED', 'PARTIALLY_COMPLETED']).to.include(jobStatus)
+        if (!TERMINAL_STATUSES.includes(jobStatus)) {
+            for (let i = 0; i < maxPolls; i++) {
+                const pollStart = Date.now()
+                const result = await client.sendRequest('workspace/executeCommand', {
+                    command: 'aws/atxTransform/getTransformInfo',
+                    TransformationJobId: transformationJobId,
+                    WorkspaceId: workspaceId,
+                    useOrchestratorAgent: true,
+                })
+                const pollMs = Date.now() - pollStart
+
+                if (result === null || result === undefined) {
+                    console.error(`TEST 4 Poll ${i + 1}: getTransformInfo returned null/undefined (${pollMs}ms)`)
+                    await sleep(10000)
+                    continue
+                }
+
+                jobStatus = result?.TransformationJob?.Status || ''
+                const hitlTag = result?.HitlTag || null
+                const hitlTaskId = result?.HitlTaskId || null
+                const errorString = result?.ErrorString || null
+                const diffApplyFailed = result?.DiffApplyFailed || false
+                const stepCount = result?.TransformationPlan?.Root?.Children?.length ?? 0
+                artifactPath = result?.ArtifactPath || null
+                if (hitlTag || jobStatus !== lastLoggedStatus || i % 10 === 0) {
+                    console.log(`TEST 4 Poll ${i + 1}: Status=${jobStatus} Steps=${stepCount} HitlTag=${hitlTag} DiffApplyFailed=${diffApplyFailed} ErrorString=${errorString} ArtifactPath=${artifactPath} (${pollMs}ms)`)
+                    lastLoggedStatus = jobStatus
+                }
+
+                // Handle local-build-verification HITL — respond with fake successful build
+                if (hitlTag === 'local-build-verification' && hitlTaskId) {
+                    console.log(`TEST 4: Responding to local-build-verification HITL taskId=${hitlTaskId}`)
+                    const buildResult = JSON.stringify({
+                        status: 'SUCCESS',
+                        errorCount: 0,
+                        errors: [],
+                        warningCount: 0,
+                        timedOut: false,
+                        startedAt: new Date().toISOString(),
+                        finishedAt: new Date().toISOString(),
+                        durationSeconds: 1,
+                    })
+                    const hitlResult = await client.sendRequest('workspace/executeCommand', {
+                        command: 'aws/atxTransform/completeLocalBuildHitl',
+                        WorkspaceId: workspaceId,
+                        TransformationJobId: transformationJobId,
+                        TaskId: hitlTaskId,
+                        BuildResultJson: buildResult,
+                        SolutionRootPath: testFixturePath,
+                    })
+                    console.log('TEST 4: completeLocalBuildHitl result:', JSON.stringify(hitlResult))
+
+                    // After LBV is done, send "Mark this job as complete" to trigger COMPLETED
+                    await sleep(10000)
+                    console.log('TEST 4: Sending mark-complete message')
+                    await client.sendRequest('workspace/executeCommand', {
+                        command: 'aws/atxTransform/sendMessage',
+                        workspaceId: workspaceId,
+                        jobId: transformationJobId,
+                        text: 'Mark this job as complete',
+                        skipPolling: true,
+                    })
+                    console.log('TEST 4: Mark-complete message sent')
+                }
+
+                if (jobStatus === 'FAILED') {
+                    const reason = result?.TransformationJob?.FailureReason || result?.ErrorString || 'unknown'
+                    console.error('TEST 4: Job FAILED - Reason:', reason)
+                }
+
+                if (TERMINAL_STATUSES.includes(jobStatus)) break
+
+                await sleep(10000)
+            }
+        }
+
+        console.log('TEST 4: Final status:', jobStatus, 'ArtifactPath:', artifactPath)
+        expect(
+            ['COMPLETED', 'PARTIALLY_COMPLETED'],
+            `Expected COMPLETED or PARTIALLY_COMPLETED but got: ${jobStatus}`
+        ).to.include(jobStatus)
+        // ArtifactPath is only returned when SolutionRootPath is provided (downloads final artifact to disk).
+        // We omit SolutionRootPath from polls to avoid fetchWorklogs log flooding, so ArtifactPath is null.
     })
 
+    // TEST 5: Validates stopJob — exercises CreateJob, StartJob, StopJob FES calls
     it('TEST 5: should stop a transform job', async function (this: Mocha.Context) {
-        this.timeout(60000)
+        this.timeout(120000)
         const sourceFiles = getSourceFiles(testFixturePath)
 
+        const jobName = 'IntegTest-ToStop-' + Date.now()
+        console.log('TEST 5: Starting job to stop:', jobName)
         const startResult = await client.sendRequest(
             'workspace/executeCommand',
-            buildStartTransformRequest('IntegTest-ToStop-' + Date.now(), sourceFiles)
+            buildStartTransformRequest(jobName, sourceFiles)
         )
 
         const jobToStop = startResult?.TransformationJobId
-        expect(jobToStop).to.exist
-        console.log('Created job to stop:', jobToStop)
+        expect(jobToStop, 'TransformationJobId should exist for job-to-stop').to.exist
+        console.log('TEST 5: Created job to stop:', jobToStop)
 
         await sleep(5000)
 
@@ -288,7 +407,8 @@ describe('ATX .NET Transform Integration Tests', () => {
             JobId: jobToStop,
         })
 
-        console.log('StopJob result:', stopResult?.Status)
-        expect(stopResult).to.exist
+        console.log('TEST 5: StopJob raw result:', JSON.stringify(stopResult))
+        expect(stopResult, 'stopJob should return a result').to.exist
+        expect(stopResult?.Status, 'StopJob status should be STOPPING or STOPPED').to.be.oneOf(['STOPPING', 'STOPPED'])
     })
 })

--- a/integration-tests/atx-transform-server/src/tests/lspClient.ts
+++ b/integration-tests/atx-transform-server/src/tests/lspClient.ts
@@ -37,13 +37,13 @@ export class LspClient {
 
     private startServerAndConnect(): Promise<void> {
         return new Promise((resolve, reject) => {
-            this.server = net.createServer((socket) => {
+            this.server = net.createServer(socket => {
                 this.socket = socket
                 this.socket.on('data', (data: Buffer) => {
                     this.rawBuffer = Buffer.concat([this.rawBuffer, data])
                     this.processBuffer()
                 })
-                this.socket.on('error', (err) => {
+                this.socket.on('error', err => {
                     console.error('Socket error:', err.message)
                 })
                 resolve()
@@ -53,12 +53,12 @@ export class LspClient {
                 this.process = spawn('node', [this.runtimeFile, `--socket=${this.port}`], {
                     stdio: 'ignore',
                 })
-                this.process.on('error', (err) => {
+                this.process.on('error', err => {
                     reject(new Error(`Failed to spawn LSP: ${err.message}`))
                 })
             })
 
-            this.server.on('error', (err) => {
+            this.server.on('error', err => {
                 reject(new Error(`Failed to start TCP server: ${err.message}`))
             })
 

--- a/integration-tests/atx-transform-server/src/tests/lspClient.ts
+++ b/integration-tests/atx-transform-server/src/tests/lspClient.ts
@@ -1,4 +1,5 @@
-import { ChildProcessWithoutNullStreams, spawn } from 'child_process'
+import { ChildProcess, spawn } from 'child_process'
+import * as net from 'net'
 
 export interface JsonRpcMessage {
     jsonrpc: string
@@ -10,35 +11,74 @@ export interface JsonRpcMessage {
 }
 
 export class LspClient {
-    private process: ChildProcessWithoutNullStreams
+    private process: ChildProcess | null = null
+    private socket: net.Socket | null = null
+    private server: net.Server | null = null
     private requestId = 100
     private pendingRequests: Map<number, { resolve: (value: any) => void; reject: (reason: any) => void }> = new Map()
-    private buffer = ''
+    private rawBuffer: Buffer = Buffer.alloc(0)
+    private port: number
+    private runtimeFile: string
 
     constructor(runtimeFile: string) {
-        this.process = spawn('node', [runtimeFile, '--stdio'], {
-            stdio: ['pipe', 'pipe', 'pipe'],
-        })
+        this.port = 30000 + Math.floor(Math.random() * 10000)
+        this.runtimeFile = runtimeFile
+    }
 
-        this.process.stdout.on('data', (data: Buffer) => {
-            this.buffer += data.toString()
-            this.processBuffer()
+    async initialize(): Promise<any> {
+        await this.startServerAndConnect()
+        return this.sendRequest('initialize', {
+            processId: process.pid,
+            capabilities: {},
+            rootUri: null,
+            initializationOptions: { aws: { awsConfigSectionName: 'aws' } },
         })
+    }
 
-        this.process.stderr.on('data', (data: Buffer) => {
-            console.error(`[LSP stderr] ${data.toString()}`)
+    private startServerAndConnect(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            this.server = net.createServer((socket) => {
+                this.socket = socket
+                this.socket.on('data', (data: Buffer) => {
+                    this.rawBuffer = Buffer.concat([this.rawBuffer, data])
+                    this.processBuffer()
+                })
+                this.socket.on('error', (err) => {
+                    console.error('Socket error:', err.message)
+                })
+                resolve()
+            })
+
+            this.server.listen(this.port, '127.0.0.1', () => {
+                this.process = spawn('node', [this.runtimeFile, `--socket=${this.port}`], {
+                    stdio: 'ignore',
+                })
+                this.process.on('error', (err) => {
+                    reject(new Error(`Failed to spawn LSP: ${err.message}`))
+                })
+            })
+
+            this.server.on('error', (err) => {
+                reject(new Error(`Failed to start TCP server: ${err.message}`))
+            })
+
+            setTimeout(() => {
+                if (!this.socket) {
+                    reject(new Error('LSP did not connect within 10 seconds'))
+                }
+            }, 10000)
         })
     }
 
     private processBuffer(): void {
         while (true) {
-            const headerEnd = this.buffer.indexOf('\r\n\r\n')
+            const headerEnd = this.rawBuffer.indexOf('\r\n\r\n')
             if (headerEnd === -1) break
 
-            const header = this.buffer.substring(0, headerEnd)
+            const header = this.rawBuffer.slice(0, headerEnd).toString('utf8')
             const match = header.match(/Content-Length: (\d+)/)
             if (!match) {
-                this.buffer = this.buffer.substring(headerEnd + 4)
+                this.rawBuffer = this.rawBuffer.slice(headerEnd + 4)
                 continue
             }
 
@@ -46,16 +86,20 @@ export class LspClient {
             const messageStart = headerEnd + 4
             const messageEnd = messageStart + contentLength
 
-            if (this.buffer.length < messageEnd) break
+            if (this.rawBuffer.length < messageEnd) break
 
-            const content = this.buffer.substring(messageStart, messageEnd)
-            this.buffer = this.buffer.substring(messageEnd)
+            const content = this.rawBuffer.slice(messageStart, messageEnd).toString('utf8')
+            this.rawBuffer = this.rawBuffer.slice(messageEnd)
 
             try {
                 const message: JsonRpcMessage = JSON.parse(content)
 
                 if (message.method === 'workspace/configuration' && message.id !== undefined) {
                     this.sendResponse(message.id, [{}])
+                    continue
+                }
+
+                if (message.method === 'window/logMessage') {
                     continue
                 }
 
@@ -75,9 +119,10 @@ export class LspClient {
     }
 
     private send(obj: JsonRpcMessage): void {
+        if (!this.socket) throw new Error('Socket not connected')
         const content = JSON.stringify(obj)
         const header = `Content-Length: ${Buffer.byteLength(content)}\r\n\r\n`
-        this.process.stdin.write(header + content)
+        this.socket.write(header + content)
     }
 
     private sendResponse(id: number, result: any): void {
@@ -96,16 +141,15 @@ export class LspClient {
         this.send({ jsonrpc: '2.0', method, params })
     }
 
-    async initialize(): Promise<any> {
-        return this.sendRequest('initialize', {
-            processId: process.pid,
-            capabilities: {},
-            rootUri: null,
-            initializationOptions: { aws: { awsConfigSectionName: 'aws' } },
-        })
-    }
-
     close(): void {
-        this.process.kill()
+        if (this.socket) {
+            this.socket.destroy()
+        }
+        if (this.server) {
+            this.server.close()
+        }
+        if (this.process) {
+            this.process.kill()
+        }
     }
 }

--- a/integration-tests/atx-transform-server/src/tests/lspClient.ts
+++ b/integration-tests/atx-transform-server/src/tests/lspClient.ts
@@ -64,6 +64,8 @@ export class LspClient {
 
             setTimeout(() => {
                 if (!this.socket) {
+                    if (this.process) this.process.kill()
+                    if (this.server) this.server.close()
                     reject(new Error('LSP did not connect within 10 seconds'))
                 }
             }, 10000)

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -4,6 +4,7 @@ import * as archiver from 'archiver'
 import got from 'got'
 import * as path from 'path'
 import * as crypto from 'crypto'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
 import AdmZip = require('adm-zip')
 import { ArtifactManager } from './artifactManager'
 import {
@@ -128,7 +129,7 @@ export class ATXTransformHandler {
             this.atxClient = new ElasticGumbyFrontendClient({
                 region: region,
                 endpoint: endpoint,
-                requestHandler: new (require('@smithy/node-http-handler').NodeHttpHandler)({
+                requestHandler: new NodeHttpHandler({
                     requestTimeout: 30000,
                     connectionTimeout: 10000,
                 }),

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -124,6 +124,10 @@ export class ATXTransformHandler {
             this.atxClient = new ElasticGumbyFrontendClient({
                 region: region,
                 endpoint: endpoint,
+                requestHandler: new (require('@smithy/node-http-handler').NodeHttpHandler)({
+                    requestTimeout: 30000,
+                    connectionTimeout: 10000,
+                }),
             })
 
             this.logging.log('ATX: Client initialization completed')
@@ -1110,6 +1114,7 @@ export class ATXTransformHandler {
                 const response = await got.get(downloadInfo.s3PresignedUrl, {
                     headers: downloadInfo.requestHeaders || {},
                     responseType: 'buffer',
+                    timeout: { request: 30000 },
                 })
                 const rawPath = path.join(pathToDownload, 'missing-packages.json')
                 fs.writeFileSync(rawPath, response.body)
@@ -1131,6 +1136,7 @@ export class ATXTransformHandler {
                         const response = await got.get(downloadInfo.s3PresignedUrl, {
                             headers: downloadInfo.requestHeaders || {},
                             responseType: 'buffer',
+                            timeout: { request: 30000 },
                         })
                         const rawPath = path.join(pathToDownload, `hitl-artifact-${hitlTag || 'unknown'}`)
                         fs.writeFileSync(rawPath, response.body)
@@ -1653,6 +1659,7 @@ export class ATXTransformHandler {
             const response = await got.get(downloadInfo.s3PresignedUrl, {
                 headers: downloadInfo.requestHeaders || {},
                 responseType: 'text',
+                timeout: { request: 30000 },
             })
 
             const artifactJson = JSON.parse(response.body)
@@ -3525,6 +3532,7 @@ export class ATXTransformHandler {
             const response = await got.get(downloadInfo.s3PresignedUrl, {
                 headers: downloadInfo.requestHeaders || {},
                 responseType: 'buffer',
+                timeout: { request: 30000 },
             })
 
             await Utils.directoryExists(savePath)

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/utils.ts
@@ -152,6 +152,7 @@ export class Utils {
         const response = await got.get(downloadUrl, {
             headers: requestHeaders || {},
             responseType: 'buffer',
+            timeout: { request: 30000 },
         })
 
         const buffer = [Buffer.from(response.body)]


### PR DESCRIPTION
Replaces the legacy DOTNET_IDE integ test flow with the new orchestrator agent (chatty-agent) flow, matching the VS Toolkit IDE behavior.

Test changes:
- Use TCP socket transport with Buffer-based JSON-RPC parsing to correctly handle Content-Length (bytes) vs string length (characters) for UTF-8
- Add sendMessage trigger after startTransform with 30s delay
- Handle local-build-verification HITL with fake build result
- Send "Mark this job as complete" chat message to reach COMPLETED
- Poll without SolutionRootPath to avoid fetchWorklogs log flooding

Handler improvements:
- Add 30s request timeout to FES client via NodeHttpHandler
- Add 30s timeout to all got.get() S3 download calls in handler and utils

Tests validate: ListWorkspaces, CreateWorkspace, CreateJob, CreateArtifactUploadUrl, CompleteArtifactUpload, StartJob, SendMessage, GetJob, ListJobPlanSteps, ListHitlTasks, SubmitCriticalHitlTask, StopJob


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
