### PR TITLE
fix: surface lbv and checkpoint hitls regardless of job status

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -1399,6 +1399,64 @@ export class ATXTransformHandler {
                             TransformationPlan: plan,
                         } as AtxGetTransformInfoResponse
                     }
+                    if (hitl.tag === 'local-build-verification') {
+                        if (!this.jobsPastLocalBuild.has(request.TransformationJobId)) {
+                            this.jobsPastLocalBuild.add(request.TransformationJobId)
+                        }
+                        this.logging.log(
+                            `ATX: ${jobStatus} job has pending LBV HITL — taskId=${hitl.taskId}; surfacing AWAITING_HUMAN_INPUT to IDE`
+                        )
+                        return {
+                            TransformationJob: {
+                                WorkspaceId: request.WorkspaceId,
+                                JobId: request.TransformationJobId,
+                                Status: 'AWAITING_HUMAN_INPUT',
+                            } as AtxTransformationJob,
+                            HitlTag: hitl.tag,
+                            HitlTaskId: hitl.taskId,
+                            TransformationPlan: plan,
+                        } as AtxGetTransformInfoResponse
+                    }
+                    // -checkpoint surfaces only post-LBV; pre-job mode-selection stays filtered.
+                    if (
+                        String(hitl.tag).endsWith('-checkpoint') &&
+                        this.jobsPastLocalBuild.has(request.TransformationJobId)
+                    ) {
+                        this.logging.log(
+                            `ATX: ${jobStatus} job has pending post-build checkpoint HITL — taskId=${hitl.taskId}; surfacing AWAITING_HUMAN_INPUT to IDE`
+                        )
+                        return {
+                            TransformationJob: {
+                                WorkspaceId: request.WorkspaceId,
+                                JobId: request.TransformationJobId,
+                                Status: 'AWAITING_HUMAN_INPUT',
+                            } as AtxTransformationJob,
+                            HitlTag: hitl.tag,
+                            HitlTaskId: hitl.taskId,
+                            TransformationPlan: plan,
+                        } as AtxGetTransformInfoResponse
+                    }
+                    // surface any other pending HITL so the IDE never silently misses one.
+                    if (
+                        !(
+                            String(hitl.tag).endsWith('-checkpoint') &&
+                            !this.jobsPastLocalBuild.has(request.TransformationJobId)
+                        )
+                    ) {
+                        this.logging.warn(
+                            `ATX: ${jobStatus} job has unhandled HITL tag '${hitl.tag}' taskId=${hitl.taskId}; surfacing as AWAITING_HUMAN_INPUT (defensive)`
+                        )
+                        return {
+                            TransformationJob: {
+                                WorkspaceId: request.WorkspaceId,
+                                JobId: request.TransformationJobId,
+                                Status: 'AWAITING_HUMAN_INPUT',
+                            } as AtxTransformationJob,
+                            HitlTag: hitl.tag,
+                            HitlTaskId: hitl.taskId,
+                            TransformationPlan: plan,
+                        } as AtxGetTransformInfoResponse
+                    }
                 }
 
                 return {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -1438,13 +1438,13 @@ export class ATXTransformHandler {
                             TransformationPlan: plan,
                         } as AtxGetTransformInfoResponse
                     }
-                    // surface any other pending HITL so the IDE never silently misses one.
-                    if (
-                        !(
-                            String(hitl.tag).endsWith('-checkpoint') &&
-                            !this.jobsPastLocalBuild.has(request.TransformationJobId)
-                        )
-                    ) {
+                    // Surface any other pending HITL so the IDE never silently misses one.
+                    // The only tag we still filter here is a pre-LBV -checkpoint (the always-present
+                    // mode-selection checkpoint that should not be surfaced before LBV has run).
+                    const isPreLbvCheckpoint =
+                        String(hitl.tag).endsWith('-checkpoint') &&
+                        !this.jobsPastLocalBuild.has(request.TransformationJobId)
+                    if (!isPreLbvCheckpoint) {
                         this.logging.warn(
                             `ATX: ${jobStatus} job has unhandled HITL tag '${hitl.tag}' taskId=${hitl.taskId}; surfacing as AWAITING_HUMAN_INPUT (defensive)`
                         )

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -1404,9 +1404,7 @@ export class ATXTransformHandler {
                         } as AtxGetTransformInfoResponse
                     }
                     if (hitl.tag === 'local-build-verification') {
-                        if (!this.jobsPastLocalBuild.has(request.TransformationJobId)) {
-                            this.jobsPastLocalBuild.add(request.TransformationJobId)
-                        }
+                        this.jobsPastLocalBuild.add(request.TransformationJobId)
                         this.logging.log(
                             `ATX: ${jobStatus} job has pending LBV HITL — taskId=${hitl.taskId}; surfacing AWAITING_HUMAN_INPUT to IDE`
                         )

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -363,7 +363,7 @@ describe('ATXTransformHandler - getTransformInfo', () => {
     beforeEach(() => {
         serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
         workspace = {} as Workspace
-        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub(), warn: sinon.stub() } as any
         runtime = {} as Runtime
 
         handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
@@ -471,6 +471,54 @@ describe('ATXTransformHandler - getTransformInfo', () => {
 
         expect(result?.TransformationJob.Status).to.equal('PLANNING')
         expect(listWorklogsStub.calledOnce).to.be.true
+    })
+
+    it('should surface AWAITING_HUMAN_INPUT for LBV HITL when status is PLANNING', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'PLANNING' } })
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+        listHitlsStub.resolves([{ tag: 'local-build-verification', taskId: 'task-lbv' }])
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.TransformationJob.Status).to.equal('AWAITING_HUMAN_INPUT')
+        expect(result?.HitlTag).to.equal('local-build-verification')
+        expect(result?.HitlTaskId).to.equal('task-lbv')
+        expect((handler as any).jobsPastLocalBuild.has('job-123')).to.be.true
+    })
+
+    it('should filter pre-job mode-selection -checkpoint HITL before LBV has run', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'PLANNING' } })
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+        listHitlsStub.resolves([{ tag: 'job-123-checkpoint', taskId: 'task-cp' }])
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.TransformationJob.Status).to.equal('PLANNING')
+        expect(result?.HitlTag).to.be.undefined
+    })
+
+    it('should surface post-build -checkpoint HITL once LBV has been seen', async () => {
+        ;(handler as any).jobsPastLocalBuild.add('job-123')
+        getJobStub.resolves({ statusDetails: { status: 'PLANNING' } })
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+        listHitlsStub.resolves([{ tag: 'job-123-checkpoint', taskId: 'task-postcp' }])
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.TransformationJob.Status).to.equal('AWAITING_HUMAN_INPUT')
+        expect(result?.HitlTaskId).to.equal('task-postcp')
+    })
+
+    it('should defensively surface unhandled HITL tags when status is PLANNING', async () => {
+        getJobStub.resolves({ statusDetails: { status: 'PLANNING' } })
+        getTransformationPlanStub.resolves({ Root: { Children: [] } })
+        listHitlsStub.resolves([{ tag: 'some-future-tag', taskId: 'task-x' }])
+
+        const result = await handler.getTransformInfo(baseRequest)
+
+        expect(result?.TransformationJob.Status).to.equal('AWAITING_HUMAN_INPUT')
+        expect(result?.HitlTag).to.equal('some-future-tag')
+        expect(result?.HitlTaskId).to.equal('task-x')
     })
 
     it('should set DiffApplyFailed flag when diff context records failures', async () => {


### PR DESCRIPTION
mirrors the executing-branch behavior in the non-executing branch so the ide picks up pending hitls when the job reports planning or other non-executing statuses. pre-job mode-selection checkpoint stays filtered.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
