### PR TITLE
chore: bump agentic version: 1.69.1

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/src/version.json
+++ b/app/aws-lsp-codewhisperer-runtimes/src/version.json
@@ -1,3 +1,3 @@
 {
-    "agenticChat": "1.69.0"
+    "agenticChat": "1.69.1"
 }


### PR DESCRIPTION
This merges the released changes for 1.69.1 into main.