### PR TITLE
fix: reset pinned context when creating new tabs 

### DIFF
--- a/chat-client/src/client/mynahUi.test.ts
+++ b/chat-client/src/client/mynahUi.test.ts
@@ -745,6 +745,106 @@ describe('MynahUI', () => {
         })
     })
 
+    describe('onTabAdd pinned context reset', () => {
+        it('should ensure new tabs start with empty pinned context via sendPinnedContext', () => {
+            const tabId = 'tab-1'
+
+            // Simulate a tab that has pinned context items
+            inboundChatApi.sendPinnedContext({
+                tabId,
+                contextCommandGroups: [
+                    {
+                        commands: [
+                            {
+                                id: 'pinned-folder-1',
+                                command: 'src',
+                                label: 'folder',
+                                route: ['/workspace', 'src'],
+                                icon: 'folder',
+                            },
+                            {
+                                id: 'pinned-file-1',
+                                command: 'file1.ts',
+                                label: 'file',
+                                route: ['/workspace', 'src/file1.ts'],
+                                icon: 'file',
+                            },
+                        ],
+                    },
+                ],
+                showRules: true,
+            })
+
+            // Verify pinned items were set
+            sinon.assert.calledWith(updateStoreSpy, tabId, sinon.match({ promptTopBarTitle: '@' }))
+
+            updateStoreSpy.resetHistory()
+
+            // Simulate what the server sends for a new tab (empty pinned context)
+            // This is what happens after onTabAdd triggers sendPinnedContext on the server
+            inboundChatApi.sendPinnedContext({
+                tabId: 'tab-2',
+                contextCommandGroups: [{ commands: [] }],
+                showRules: true,
+            })
+
+            // Verify the new tab gets empty pinned context, not items from tab-1
+            sinon.assert.calledWith(updateStoreSpy, 'tab-2', {
+                promptTopBarContextItems: [],
+                promptTopBarTitle: '@Pin Context',
+                promptTopBarButton: { id: 'Rules', status: 'clear', text: 'Rules', icon: 'check-list' },
+            })
+        })
+
+        it('should not leak pinned context between tabs when server sends per-tab state', () => {
+            // Pin items on tab-1
+            inboundChatApi.sendPinnedContext({
+                tabId: 'tab-1',
+                contextCommandGroups: [
+                    {
+                        commands: [
+                            {
+                                id: 'pinned-folder-1',
+                                command: 'src',
+                                label: 'folder',
+                                route: ['/workspace', 'src'],
+                                icon: 'folder',
+                            },
+                        ],
+                    },
+                ],
+                showRules: true,
+            })
+
+            updateStoreSpy.resetHistory()
+
+            // Server sends pinned context for tab-2 with only active editor (default for new tabs)
+            inboundChatApi.sendPinnedContext({
+                tabId: 'tab-2',
+                contextCommandGroups: [
+                    {
+                        commands: [
+                            {
+                                id: 'active-editor',
+                                command: 'Active file',
+                                icon: 'file',
+                                description: 'Reference active text file',
+                            },
+                        ],
+                    },
+                ],
+                showRules: true,
+                textDocument: { uri: 'file:///workspace/index.ts' },
+            })
+
+            // Verify tab-2 only has the active editor item, not the folder from tab-1
+            const tab2Call = updateStoreSpy.getCalls().find(call => call.args[0] === 'tab-2')
+            const pinnedItems = tab2Call?.args[1]?.promptTopBarContextItems
+            sinon.assert.match(pinnedItems?.length, 1)
+            sinon.assert.match(pinnedItems?.[0]?.id, 'active-editor')
+        })
+    })
+
     describe('stringOverrides', () => {
         it('should apply string overrides to config texts', () => {
             const stringOverrides = {

--- a/chat-client/src/client/mynahUi.ts
+++ b/chat-client/src/client/mynahUi.ts
@@ -408,6 +408,9 @@ export const createMynahUi = (
                           ]
                         : []),
                 ],
+                // Reset pinned context for new tabs - server will send the correct state via sendPinnedContext
+                promptTopBarContextItems: [],
+                promptTopBarTitle: '@Pin Context',
                 ...(disclaimerCardActive ? { promptInputStickyCard: disclaimerCard } : {}),
             }
 


### PR DESCRIPTION
## Problem

Pinned context items (e.g. folders, files) selected in one chat tab were persisting into newly created tabs. When a user pins a folder in tab A and then opens a new tab B, the pinned folder incorrectly appears in tab B as well.

https://github.com/user-attachments/assets/f8c3fc7d-4aa8-42df-ba1a-81a2b25292ac




## Root Cause

The \`onTabAdd\` handler in \`mynahUi.ts\` did not explicitly reset \`promptTopBarContextItems\` when creating a new tab. As a result, new tabs inherited the pinned context from mynah-ui's tab defaults/store.

The server-side logic is correct — \`chatDb.getPinnedContext(newTabId)\` returns only \`DEFAULT_PINNED_CONTEXT\` (the \"Active file\" pill) for a brand new tab. However, there's a race condition: the UI renders the inherited (stale) pinned items before the server's \`sendPinnedContext\` response arrives with the correct empty state.

## Solution

Explicitly set \`promptTopBarContextItems: []\` and \`promptTopBarTitle: '@Pin Context'\` in the \`onTabAdd\` handler's \`defaultTabConfig\`. This ensures new tabs start with a clean pinned context bar, and the server's \`sendPinnedContext\` call then sets the correct default state (active file pill) when it arrives.

## Testing

- Open a chat tab and pin a folder/file to context
- Create a new tab
- Verify the new tab does NOT show the previously pinned items
- Verify the new tab correctly shows the default \"Active file\" pill after server responds"

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
