### PR TITLE
fix(amazonq): honor agentic toggle off as plan mode (no silent edits)

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -36,6 +36,8 @@ import {
     SUFFIX_PERMISSION,
     SUFFIX_UNDOALL,
     SUFFIX_EXPLANATION,
+    shouldRequireAcceptanceForBuiltinTool,
+    shouldRequireAcceptanceForMcpTool,
 } from './constants/toolConstants'
 import { SendMessageCommandInput, ChatCommandInput, ChatCommandOutput } from '../../shared/streamingClientService'
 import {
@@ -2013,9 +2015,16 @@ export class AgenticChatController implements ChatHandlers {
                         const approvedPaths = session.approvedPaths
 
                         // Pass the approved paths to the tool's requiresAcceptance method
-                        const { requiresAcceptance, warning, commandCategory } = await tool.requiresAcceptance(
-                            toolUse.input as any,
-                            approvedPaths
+                        const toolValidation = await tool.requiresAcceptance(toolUse.input as any, approvedPaths)
+                        const { warning, commandCategory } = toolValidation
+                        // Plan mode (pairProgrammingMode === false) forces user approval for every
+                        // mutating built-in tool, even for in-workspace or session-approved paths.
+                        // Read-only tools (fsRead, listDirectory, grepSearch, fileSearch) keep their
+                        // normal behavior so chat can still investigate code.
+                        const requiresAcceptance = shouldRequireAcceptanceForBuiltinTool(
+                            toolUse.name,
+                            session.pairProgrammingMode,
+                            toolValidation.requiresAcceptance
                         )
 
                         // Honor built-in permission if available, otherwise use tool's requiresAcceptance
@@ -2110,10 +2119,17 @@ export class AgenticChatController implements ChatHandlers {
                             }
                             if (def) {
                                 const mcpTool = new McpTool(this.#features, def)
-                                const { requiresAcceptance, warning } = await mcpTool.requiresAcceptance(
-                                    serverName,
-                                    toolName
+                                const mcpValidation = await mcpTool.requiresAcceptance(serverName, toolName)
+                                const { warning } = mcpValidation
+                                // Plan mode: every MCP tool requires explicit approval — MCP tools can
+                                // perform arbitrary side effects, and the user toggling agentic mode off
+                                // is an explicit "review everything" intent that overrides per-tool
+                                // alwaysAllow settings until the toggle is turned back on.
+                                const requiresAcceptance = shouldRequireAcceptanceForMcpTool(
+                                    session.pairProgrammingMode,
+                                    mcpValidation.requiresAcceptance
                                 )
+
                                 if (requiresAcceptance) {
                                     const confirmation = this.#processToolConfirmation(
                                         toolUse,

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/toolConstants.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/toolConstants.test.ts
@@ -1,0 +1,116 @@
+import * as assert from 'assert'
+import {
+    EXECUTE_BASH,
+    FILE_SEARCH,
+    FS_READ,
+    FS_REPLACE,
+    FS_WRITE,
+    GREP_SEARCH,
+    LIST_DIRECTORY,
+    isMutatingBuiltinTool,
+    shouldRequireAcceptanceForBuiltinTool,
+    shouldRequireAcceptanceForMcpTool,
+} from './toolConstants'
+
+describe('toolConstants.isMutatingBuiltinTool', () => {
+    it('returns true for fsWrite (creates/overwrites files)', () => {
+        assert.strictEqual(isMutatingBuiltinTool(FS_WRITE), true)
+    })
+
+    it('returns true for fsReplace (edits files)', () => {
+        assert.strictEqual(isMutatingBuiltinTool(FS_REPLACE), true)
+    })
+
+    it('returns true for executeBash (runs shell commands)', () => {
+        assert.strictEqual(isMutatingBuiltinTool(EXECUTE_BASH), true)
+    })
+
+    it('returns false for fsRead', () => {
+        assert.strictEqual(isMutatingBuiltinTool(FS_READ), false)
+    })
+
+    it('returns false for listDirectory', () => {
+        assert.strictEqual(isMutatingBuiltinTool(LIST_DIRECTORY), false)
+    })
+
+    it('returns false for grepSearch', () => {
+        assert.strictEqual(isMutatingBuiltinTool(GREP_SEARCH), false)
+    })
+
+    it('returns false for fileSearch', () => {
+        assert.strictEqual(isMutatingBuiltinTool(FILE_SEARCH), false)
+    })
+
+    it('returns false for unknown tool names', () => {
+        assert.strictEqual(isMutatingBuiltinTool('codeReview'), false)
+        assert.strictEqual(isMutatingBuiltinTool('semanticSearch'), false)
+        assert.strictEqual(isMutatingBuiltinTool(''), false)
+        assert.strictEqual(isMutatingBuiltinTool('mystery_tool'), false)
+    })
+})
+
+describe('toolConstants.shouldRequireAcceptanceForBuiltinTool (plan-mode gate)', () => {
+    describe('agentic mode ON (pairProgrammingMode === true)', () => {
+        it('preserves the tool-supplied flag for fsWrite when path is approved', () => {
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(FS_WRITE, true, false), false)
+        })
+
+        it('preserves the tool-supplied flag for fsWrite when path is outside workspace', () => {
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(FS_WRITE, true, true), true)
+        })
+
+        it('preserves the tool-supplied flag for fsRead', () => {
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(FS_READ, true, false), false)
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(FS_READ, true, true), true)
+        })
+    })
+
+    describe('plan mode (pairProgrammingMode === false)', () => {
+        it('forces approval for fsWrite even when in-workspace', () => {
+            // In plan mode, in-workspace fsWrite must prompt — otherwise the user's
+            // explicit "review everything" intent is silently ignored.
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(FS_WRITE, false, false), true)
+        })
+
+        it('forces approval for fsReplace even when in-workspace', () => {
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(FS_REPLACE, false, false), true)
+        })
+
+        it('keeps requiring approval for fsWrite when also outside workspace', () => {
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(FS_WRITE, false, true), true)
+        })
+
+        it('forces approval for executeBash regardless of tool-supplied flag', () => {
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(EXECUTE_BASH, false, false), true)
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(EXECUTE_BASH, false, true), true)
+        })
+
+        it('does NOT force approval for read-only tools — chat must still investigate code in plan mode', () => {
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(FS_READ, false, false), false)
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(LIST_DIRECTORY, false, false), false)
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(GREP_SEARCH, false, false), false)
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(FILE_SEARCH, false, false), false)
+        })
+
+        it('still respects the tool-supplied flag for read-only tools', () => {
+            // e.g. fsRead returns true when reading a path outside the workspace
+            assert.strictEqual(shouldRequireAcceptanceForBuiltinTool(FS_READ, false, true), true)
+        })
+    })
+})
+
+describe('toolConstants.shouldRequireAcceptanceForMcpTool (plan-mode gate)', () => {
+    it('preserves the MCP-supplied flag when agentic mode is on', () => {
+        // alwaysAllow MCP tool: validator returned false → still false
+        assert.strictEqual(shouldRequireAcceptanceForMcpTool(true, false), false)
+        // ask MCP tool: validator returned true → still true
+        assert.strictEqual(shouldRequireAcceptanceForMcpTool(true, true), true)
+    })
+
+    it('forces approval for every MCP tool in plan mode, including alwaysAllow', () => {
+        // This is the strict plan-mode policy: user toggled off agentic mode
+        // means review everything, even MCP tools the user previously marked alwaysAllow.
+        assert.strictEqual(shouldRequireAcceptanceForMcpTool(false, false), true)
+        assert.strictEqual(shouldRequireAcceptanceForMcpTool(false, true), true)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/toolConstants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/toolConstants.ts
@@ -21,6 +21,51 @@ export const EXECUTE_BASH = 'executeBash'
 // Code analysis tools
 export const CODE_REVIEW = 'codeReview'
 
+// Built-in tools that mutate filesystem or process state. When the user disables
+// pair-programming/agentic mode (plan mode), these always require explicit approval
+// regardless of workspace location, sensitive-path checks, or session-approved paths.
+export const MUTATING_BUILTIN_TOOLS: ReadonlySet<string> = new Set([FS_WRITE, FS_REPLACE, EXECUTE_BASH])
+
+export function isMutatingBuiltinTool(toolName: string): boolean {
+    return MUTATING_BUILTIN_TOOLS.has(toolName)
+}
+
+/**
+ * Returns the effective `requiresAcceptance` flag after applying plan-mode rules.
+ *
+ * Plan mode is triggered by `pairProgrammingMode === false` (the user toggled
+ * agentic coding off). In plan mode every mutating built-in tool must prompt for
+ * approval — even for in-workspace paths or session-approved paths — so the
+ * model cannot silently change code. Read-only tools are unaffected.
+ */
+export function shouldRequireAcceptanceForBuiltinTool(
+    toolName: string,
+    pairProgrammingMode: boolean,
+    toolRequiresAcceptance: boolean
+): boolean {
+    if (!pairProgrammingMode && isMutatingBuiltinTool(toolName)) {
+        return true
+    }
+    return toolRequiresAcceptance
+}
+
+/**
+ * Returns the effective `requiresAcceptance` flag for an MCP tool after applying
+ * plan-mode rules. In plan mode every MCP tool requires approval — MCP servers
+ * can do anything, and the user toggling agentic mode off is an explicit
+ * "review everything" intent that overrides per-tool alwaysAllow until the
+ * toggle is turned back on.
+ */
+export function shouldRequireAcceptanceForMcpTool(
+    pairProgrammingMode: boolean,
+    mcpRequiresAcceptance: boolean
+): boolean {
+    if (!pairProgrammingMode) {
+        return true
+    }
+    return mcpRequiresAcceptance
+}
+
 // Tool use button IDs
 export const BUTTON_RUN_SHELL_COMMAND = 'run-shell-command'
 export const BUTTON_REJECT_SHELL_COMMAND = 'reject-shell-command'


### PR DESCRIPTION
## Problem

When a user disables the **agentic coding toggle** in chat, they expect the assistant to ask permission before modifying any file or running any command — that is the toggle's whole purpose. Today the toggle is wired only into telemetry, so disabling it has no observable effect: the next `fsWrite` / `fsReplace` to an in-workspace path runs without a prompt, and any MCP tool the user previously marked `alwaysAllow` also runs silently.

### Root cause

`pairProgrammingMode` flows through `agenticChatController.ts` only as a telemetry dimension. Each tool's `requiresAcceptance` validator decides whether to prompt, and those validators don't know about the toggle. `requiresPathAcceptance` returns `false` for in-workspace paths and MCP `alwaysAllow` returns `false` regardless of toggle state — so write/exec tools execute silently when the user expected plan-mode behavior.

## Solution

Treat **agentic mode off ⇢ plan mode**: a strict "review everything" intent that overrides per-tool/per-path approvals until the toggle is turned back on.

Two pure helpers in `constants/toolConstants.ts`:

| Helper | Behavior in plan mode (`pairProgrammingMode === false`) |
|---|---|
| `shouldRequireAcceptanceForBuiltinTool` | Forces approval for `fsWrite`, `fsReplace`, `executeBash`. Read-only tools (`fsRead`, `listDirectory`, `grepSearch`, `fileSearch`) keep their normal validator output so chat can still investigate code in plan mode. |
| `shouldRequireAcceptanceForMcpTool` | Forces approval for **every** MCP tool, including those marked `alwaysAllow`. MCP servers can have arbitrary side effects; `alwaysAllow` resumes when the toggle is turned back on. |

`agenticChatController.ts` calls these helpers at the two existing acceptance gates (built-in tool branch and MCP tool branch). When agentic mode is **on**, the helpers are pass-throughs — existing behavior is preserved exactly.

The mutating-tool list lives in a single named `ReadonlySet` (`MUTATING_BUILTIN_TOOLS`) to keep the rule discoverable for future tool additions.

### Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Toggle ON, fsWrite to workspace file | runs silently ✅ | runs silently ✅ |
| Toggle ON, MCP `alwaysAllow` tool | runs silently ✅ | runs silently ✅ |
| Toggle ON, fsWrite to outside workspace | prompts ✅ | prompts ✅ |
| **Toggle OFF, fsWrite to workspace file** | **runs silently (bug)** | **prompts ✅** |
| **Toggle OFF, fsReplace to workspace file** | **runs silently (bug)** | **prompts ✅** |
| **Toggle OFF, MCP `alwaysAllow` tool** | **runs silently** | **prompts ✅** |
| Toggle OFF, fsRead/grepSearch/listDirectory in workspace | runs silently | runs silently (chat can still plan) |

## Testing

- 19 new unit tests in `constants/toolConstants.test.ts` covering:
  - `isMutatingBuiltinTool` — every built-in tool name, plus unknowns
  - `shouldRequireAcceptanceForBuiltinTool` — preserves behavior when toggle on; forces approval for `fsWrite` / `fsReplace` / `executeBash` when toggle off; leaves read-only tools alone
  - `shouldRequireAcceptanceForMcpTool` — preserves `alwaysAllow` when toggle on; forces approval (including `alwaysAllow`) when toggle off
- All 95 existing tests in `agenticChatController.test.ts` still pass — refactoring the inline gate into named helpers did not change observable behavior in either path
- `tsc --noEmit` clean; `prettier --check` clean

```
$ npx ts-mocha "./src/language-server/agenticChat/constants/toolConstants.test.ts"
  19 passing (5ms)

$ npx ts-mocha "./src/language-server/agenticChat/agenticChatController.test.ts"
  95 passing (1s)
```

### Out of scope

- Re-routing the `pairProgrammingMode` value from telemetry to UX — it stays as both a telemetry dimension and (now) a behavioral gate
- Adding a "plan mode" badge in the UI — separate change for the chat UI layer if desired
- Eclipse / Visual Studio behavior is identical to JetBrains and VS Code because they share this language server; the fix lands in all four IDE plugins simultaneously when they pick up the next manifest

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
