### PR TITLE
feat: rejecting atx .ent v1 agent jobs

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
@@ -79,7 +79,7 @@ export const AtxNetTransformServerToken =
                         if (!useNew) {
                             const msg =
                                 'This version of the AWS Toolkit extension is no longer supported for transformations. Please update to the latest version of the AWS Toolkit extension to continue using AWS Transform.'
-                            void lsp.window.showMessage({ type: MessageType.Error, message: msg })
+                            await lsp.window.showMessage({ type: MessageType.Error, message: msg })
                             throw new Error(msg)
                         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
@@ -75,12 +75,18 @@ export const AtxNetTransformServerToken =
                             params as AtxStartTransformRequest
                         const useNew = useOrchestratorAgent === true
 
+                        if (!useNew) {
+                            throw new Error(
+                                'This version of the AWS Toolkit extension is no longer supported for transformations. Please update to the latest version of the AWS Toolkit extension to continue using AWS Transform.'
+                            )
+                        }
+
                         if (!WorkspaceId) {
                             throw new Error('WorkspaceId is required for startTransform')
                         }
 
-                        logging.log(`ATX Server: Routing startTransform -> ${useNew ? 'NEW' : 'LEGACY'} handler`)
-                        const handler = useNew ? atxTransformHandler : atxTransformHandlerLegacy
+                        logging.log(`ATX Server: Routing startTransform -> v2 handler`)
+                        const handler = atxTransformHandler
                         const result = await handler.startTransform({
                             workspaceId: WorkspaceId,
                             jobName: JobName,

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
@@ -85,7 +85,7 @@ export const AtxNetTransformServerToken =
                             throw new Error('WorkspaceId is required for startTransform')
                         }
 
-                        logging.log(`ATX Server: Routing startTransform -> v2 handler`)
+                        logging.log(`ATX Server: Routing startTransform -> NEW handler`)
                         const handler = atxTransformHandler
                         const result = await handler.startTransform({
                             workspaceId: WorkspaceId,
@@ -269,6 +269,7 @@ export const AtxNetTransformServerToken =
                 }
             } catch (e: any) {
                 logging.error(`ATXTransformServer: Error executing command: ${String(e)}`)
+                return { error: true, message: e.message }
             }
         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
@@ -79,7 +79,11 @@ export const AtxNetTransformServerToken =
                         if (!useNew) {
                             const msg =
                                 'This version of the AWS Toolkit extension is no longer supported for transformations. Please update to the latest version of the AWS Toolkit extension to continue using AWS Transform.'
-                            await lsp.window.showMessage({ type: MessageType.Error, message: msg })
+                            try {
+                                await lsp.window.showMessage({ type: MessageType.Error, message: msg })
+                            } catch {
+                                // Best-effort notification — proceed with rejection regardless
+                            }
                             throw new Error(msg)
                         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
@@ -2,6 +2,7 @@ import {
     CancellationToken,
     ExecuteCommandParams,
     InitializeParams,
+    MessageType,
     Server,
 } from '@aws/language-server-runtimes/server-interface'
 import { AtxTokenServiceManager } from '../../shared/amazonQServiceManager/AtxTokenServiceManager'
@@ -76,9 +77,10 @@ export const AtxNetTransformServerToken =
                         const useNew = useOrchestratorAgent === true
 
                         if (!useNew) {
-                            throw new Error(
+                            const msg =
                                 'This version of the AWS Toolkit extension is no longer supported for transformations. Please update to the latest version of the AWS Toolkit extension to continue using AWS Transform.'
-                            )
+                            lsp.window.showMessage({ type: MessageType.Error, message: msg })
+                            throw new Error(msg)
                         }
 
                         if (!WorkspaceId) {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
@@ -79,7 +79,7 @@ export const AtxNetTransformServerToken =
                         if (!useNew) {
                             const msg =
                                 'This version of the AWS Toolkit extension is no longer supported for transformations. Please update to the latest version of the AWS Toolkit extension to continue using AWS Transform.'
-                            lsp.window.showMessage({ type: MessageType.Error, message: msg })
+                            void lsp.window.showMessage({ type: MessageType.Error, message: msg })
                             throw new Error(msg)
                         }
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxNetTransformServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxNetTransformServer.test.ts
@@ -65,6 +65,9 @@ describe('AtxNetTransformServer - routing', () => {
             onExecuteCommand: (fn: any) => {
                 executeCommandHandler = fn
             },
+            window: {
+                showMessage: sinon.stub(),
+            },
         }
 
         const features: any = {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxNetTransformServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxNetTransformServer.test.ts
@@ -103,8 +103,8 @@ describe('AtxNetTransformServer - routing', () => {
             expect(legacyStartTransform.called).to.be.false
         })
 
-        it('should route to LEGACY handler when useOrchestratorAgent=false', async () => {
-            await executeCommandHandler(
+        it('should reject with upgrade message when useOrchestratorAgent=false', async () => {
+            const result = await executeCommandHandler(
                 {
                     command: AtxStartTransformCommand,
                     WorkspaceId: 'ws-1',
@@ -114,12 +114,15 @@ describe('AtxNetTransformServer - routing', () => {
                 {} as any
             )
 
-            expect(legacyStartTransform.calledOnce).to.be.true
+            expect(result.error).to.be.true
+            expect(result.message).to.include('no longer supported')
+            expect(result.message).to.include('update')
             expect(newStartTransform.called).to.be.false
+            expect(legacyStartTransform.called).to.be.false
         })
 
-        it('should route to LEGACY handler when useOrchestratorAgent is omitted (prod IDE)', async () => {
-            await executeCommandHandler(
+        it('should reject with upgrade message when useOrchestratorAgent is omitted (old IDE)', async () => {
+            const result = await executeCommandHandler(
                 {
                     command: AtxStartTransformCommand,
                     WorkspaceId: 'ws-1',
@@ -128,8 +131,11 @@ describe('AtxNetTransformServer - routing', () => {
                 {} as any
             )
 
-            expect(legacyStartTransform.calledOnce).to.be.true
+            expect(result.error).to.be.true
+            expect(result.message).to.include('no longer supported')
+            expect(result.message).to.include('update')
             expect(newStartTransform.called).to.be.false
+            expect(legacyStartTransform.called).to.be.false
         })
     })
 


### PR DESCRIPTION
# fix: reject V1 legacy agent startTransform requests with upgrade message

## Summary

Block V1 (legacy) IDE extensions from starting new transformation jobs via the LSP. When an old IDE (< 1.91) sends a `startTransform` request without the `useOrchestratorAgent` flag, the LSP now returns an error message telling the customer to update their extension.

## Problem

V1 agent is being deprecated. Old IDE extensions that don't send `useOrchestratorAgent: true` should no longer be allowed to start transformations. We need to inform customers to update their IDE extension.

## Change

**File:** `server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts`

In the `AtxStartTransformCommand` handler, added a check before job creation:

```typescript
if (!useNew) {
    throw new Error(
        'This version of the AWS Toolkit extension is no longer supported for transformations. ' +
        'Please update to the latest version of the AWS Toolkit extension to continue using AWS Transform.'
    )
}
```

## Behavior

| IDE Version | `useOrchestratorAgent` | Result |
|---|---|---|
| Old (< 1.91) | `undefined` / `false` | Error thrown → shows in output pane |
| New (>= 1.91) | `true` | Routes to V2 handler (no change) |

## What the user sees (old IDE)

1. User clicks "Start Transform"
2. Job fails immediately
3. Generic InfoBar: "Your transformation failed; please review transformation logs for details."
4. Output pane shows: "This version of the AWS Toolkit extension is no longer supported for transformations. Please update to the latest version of the AWS Toolkit extension to continue using AWS Transform."

## Scope

- Only `startTransform` is blocked (new job creation)
- `getTransformInfo` and `uploadPlan` still route to legacy handler for in-progress jobs that were started before the update
- No IDE-side changes required
- No impact to V2 flow

## Test Plan

- Start transform from latest IDE (useOrchestratorAgent=true) → works normally
- Simulate V1 request (useOrchestratorAgent=false/missing) → error with upgrade message
- Verify error appears in output pane
- Verify existing in-progress jobs (getTransformInfo polling) still work on old IDE
