### PR TITLE
feat: renaming toolkit title

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
@@ -78,7 +78,7 @@ export const AtxNetTransformServerToken =
 
                         if (!useNew) {
                             const msg =
-                                'This version of the AWS Toolkit extension is no longer supported for transformations. Please update to the latest version of the AWS Toolkit extension to continue using AWS Transform.'
+                                'This version of AWS Toolkit with Amazon Q is no longer supported for transformations. Please update to the latest version of AWS Toolkit with Amazon Q to continue using AWS Transform.'
                             try {
                                 await lsp.window.showMessage({ type: MessageType.Error, message: msg })
                             } catch {


### PR DESCRIPTION
# fix: update extension name in V1 rejection message to marketplace name

## Summary

Changed "AWS Toolkit extension" to "AWS Toolkit with Amazon Q" in the V1 rejection error message to match the official marketplace listing name.

## Change

```
- "This version of the AWS Toolkit extension is no longer supported..."
+ "This version of AWS Toolkit with Amazon Q is no longer supported..."
```
