### PR TITLE
docs(chat-client): document per-host postMessage origin behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,12 @@ To send us a pull request, please:
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
+## Chat Client Host Environments
+
+The chat client (`./chat-client`) is rendered inside a webview that is embedded differently by each IDE host (VS Code, JetBrains, Visual Studio, Eclipse, and SageMaker JupyterLab). These hosts use different browser engines, and for Eclipse the engine differs by operating system (Edge WebView2 on Windows, WebKit / WebKitGTK on macOS/Linux). As a result, browser-level behavior — most notably the `event.origin` seen on inbound `window.postMessage` events — is **not** uniform across hosts. For example, Eclipse on Windows injects the chat HTML via `browser.setText()`, which Edge WebView2 treats as an opaque origin (the empty string `""` or the literal `"null"`).
+
+Because of this, any change that affects inbound message handling, origin validation, or the webview message bridge in `chat-client` (for example `chat-client/src/client/chat.ts`) **must be reviewed and validated against every supported host environment — not only the same-origin hosts.** Pay particular attention to Eclipse on Windows, which is the only host that delivers an opaque/empty origin, since a same-origin assumption there can silently drop all inbound messages while the backend still returns HTTP 200. See the JSDoc on `handleInboundMessage` in `chat-client/src/client/chat.ts` for the per-host origin behavior.
+
 ## Finding contributions to work on
 
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.

--- a/chat-client/README.md
+++ b/chat-client/README.md
@@ -9,6 +9,21 @@ The chat client communicates with the host application (e.g., an IDE extension) 
 - When the host application sends a request, the client processes the message and sends it to the UI
 - When an event is triggered in the UI, the client sends a message through `postMessage` to the host application that rendered the chat client
 
+### Host environments
+
+The webview is embedded by different IDE hosts, which use different browser engines and load the chat assets differently. As a result, the `event.origin` observed on inbound `postMessage` events is **not** uniform across hosts:
+
+| Host | Rendering engine | Asset scheme | `window.location.origin` / inbound `event.origin` | Message-delivery bridge |
+|---|---|---|---|---|
+| VS Code | Chromium webview | `vscode-webview://` | `vscode-webview://<id>` (non-HTTP) | `acquireVsCodeApi().postMessage` |
+| JetBrains | JCEF | `https://toolkitasset` | `https://toolkitasset` (same-origin) | JCEF JS query bridge + `postMessage` |
+| Visual Studio | Edge WebView2 | host-served | host-dependent | `window.chrome.webview.postMessage` |
+| Eclipse (Windows) | Edge WebView2 | HTML injected via `Browser.setText()` | empty `""` or `"null"` (opaque origin) | host-injected `window.postMessage` |
+| Eclipse (macOS / Linux) | WebKit / WebKitGTK | local asset server | HTTP(S) same-origin | host-injected `window.postMessage` |
+| SageMaker JupyterLab | Browser (Chromium / Firefox / Safari) | same-domain iframe | same-origin | `window.postMessage` |
+
+Because the origin is not uniform, the inbound message handler validates it defensively: it rejects only a real HTTP(S) cross-origin message and allows empty, `"null"`, and `file://` origins, which are produced by legitimate hosts (for example Eclipse on Windows, where `Browser.setText()`-injected HTML has an opaque origin). Any change to inbound message handling or origin validation **must be validated against every host environment above** — see the `handleInboundMessage` JSDoc in [`src/client/chat.ts`](./src/client/chat.ts).
+
 ## Usage
 
 To use the chat client, embed it in a webview within your application and handle the `postMessage` communication as needed. Chat client is based on inbound (from a destination to the chat client) and outbound events (from the chat client to a destination). Events consist of `command` and `params`:

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -173,15 +173,26 @@ export const createChat = (
      * Security: rejects messages from cross-origin HTTP(S) pages to prevent
      * DOM XSS via untrusted postMessage senders.
      *
-     * Legitimate host environments deliver messages in different ways:
-     *   - VS Code / JetBrains / Visual Studio webviews: same-origin via
-     *     `allow-same-origin` sandbox flag.
+     * IMPORTANT: `event.origin` is NOT uniform across the IDE host environments
+     * that embed this chat client. The host browser engine -- and, for Eclipse,
+     * the engine differs by operating system -- determines the origin value:
+     *   - VS Code / JetBrains / Visual Studio webviews: same-origin
+     *     (`event.origin` matches `window.location.origin`).
      *   - SageMaker JupyterLab: same-origin (iframe loaded from same domain).
-     *   - Eclipse SWT Browser: non-HTTP origin (file:// protocol or similar).
+     *   - Eclipse SWT Browser on macOS/Linux (WebKit / WebKitGTK): a normal
+     *     HTTP(S) origin derived from the local asset server.
+     *   - Eclipse SWT Browser on Windows (Edge WebView2): the chat HTML is
+     *     injected via `browser.setText()`, which WebView2 treats as an opaque
+     *     origin, so `event.origin` is the empty string "" or the literal
+     *     "null". A strict same-origin check (origin !== window.location.origin)
+     *     would silently drop EVERY message on this host while the backend still
+     *     returns HTTP 200 and the chat appears to hang.
      *
-     * Only a real HTTP(S) cross-origin postMessage can come from an attacker
-     * page, so we reject those and allow everything else through.
-     * See Bug Bounty ticket P389799154.
+     * Therefore we reject only a real HTTP(S) cross-origin postMessage (the only
+     * case reachable by an attacker page) and allow empty, "null", and file://
+     * origins through. Any change to this check MUST be validated against every
+     * host environment listed above -- especially Eclipse on Windows -- not just
+     * the same-origin hosts. See Bug Bounty ticket P389799154.
      *
      * @param event - The message event containing data from the IDE
      */


### PR DESCRIPTION
## Problem

The chat client (`./chat-client`) is rendered inside a webview that each IDE host embeds differently. These hosts use different browser engines, and for Eclipse the engine differs by operating system (Edge WebView2 on Windows vs. WebKit / WebKitGTK on macOS/Linux). As a result the `event.origin` seen on inbound `window.postMessage` events is **not** uniform across hosts. In particular, Eclipse on Windows injects the chat HTML via `browser.setText()`, which Edge WebView2 treats as an opaque origin (empty `""` or `"null"`). A strict same-origin assumption silently drops every message on that host while the backend still returns HTTP 200.

This per-host behavior was not documented, making it easy to reintroduce a host-specific regression when changing message handling or origin validation.

## Changes

- **`chat-client/src/client/chat.ts`** — Expand the `handleInboundMessage` JSDoc to document, per host and per OS, how `event.origin` is produced (Chromium webviews, JCEF, Edge WebView2, WebKit/WebKitGTK), and add an explicit instruction that any change to this check must be validated against every host environment.
- **`CONTRIBUTING.md`** — Add a "Chat Client Host Environments" section requiring that changes to inbound message handling, origin validation, or the webview message bridge be reviewed against every supported host environment, with particular attention to Eclipse on Windows.

Documentation only — no functional/behavioral change.

## Testing

- No code paths changed; comment- and docs-only.
- Pre-commit (`pretty-quick`, `git-secrets`) and `commitlint` passed locally.
