### PR TITLE
feat(amazonq): add client-side chat delivery metrics

### DIFF
--- a/chat-client/src/client/chat.test.ts
+++ b/chat-client/src/client/chat.test.ts
@@ -18,6 +18,8 @@ import { createChat } from './chat'
 import * as sinon from 'sinon'
 import { TELEMETRY } from '../contracts/serverContracts'
 import {
+    CHAT_MESSAGE_RENDERED_TELEMETRY_EVENT,
+    CHAT_POST_MESSAGE_REJECTED_TELEMETRY_EVENT,
     ERROR_MESSAGE_TELEMETRY_EVENT,
     SEND_TO_PROMPT_TELEMETRY_EVENT,
     TAB_ADD_TELEMETRY_EVENT,
@@ -145,7 +147,7 @@ describe('Chat', () => {
     it('rejects inbound messages from a foreign origin (P389799154)', () => {
         // Simulates a cross-origin postMessage from an attacker page. The
         // handleInboundMessage same-origin check should drop the event before
-        // any command is dispatched.
+        // any command is dispatched to mynah.
         clientApi.postMessage.resetHistory()
 
         const foreignEvent = new window.MessageEvent('message', {
@@ -154,7 +156,89 @@ describe('Chat', () => {
         })
         window.dispatchEvent(foreignEvent)
 
-        assert.notCalled(clientApi.postMessage)
+        // The attacker command is NOT dispatched to mynah, but the rejection
+        // IS now recorded as telemetry. So postMessage is called exactly once — with the reject
+        // telemetry event, never with a chat-command dispatch. (Outbound telemetry travels a
+        // different direction than the inbound origin check, so the signal escapes even here.)
+        assert.calledOnceWithExactly(clientApi.postMessage, {
+            command: TELEMETRY,
+            params: {
+                name: CHAT_POST_MESSAGE_REJECTED_TELEMETRY_EVENT,
+                reason: 'untrustedOrigin',
+                command: undefined,
+                tabId: undefined,
+            },
+        })
+    })
+
+    it('publishes chatMessageRendered telemetry on a terminal (non-partial) chat response', () => {
+        clientApi.postMessage.resetHistory()
+        const event = createInboundEvent({
+            command: CHAT_REQUEST_METHOD,
+            params: { body: 'hello' },
+            tabId: initialTabId,
+            isPartialResult: false,
+        })
+        window.dispatchEvent(event)
+
+        assert.calledWithExactly(clientApi.postMessage, {
+            command: TELEMETRY,
+            params: { name: CHAT_MESSAGE_RENDERED_TELEMETRY_EVENT, tabId: initialTabId },
+        })
+    })
+
+    it('does NOT publish chatMessageRendered telemetry on a partial chat response chunk', () => {
+        clientApi.postMessage.resetHistory()
+        const event = createInboundEvent({
+            command: CHAT_REQUEST_METHOD,
+            params: { body: 'partial…' },
+            tabId: initialTabId,
+            isPartialResult: true,
+        })
+        window.dispatchEvent(event)
+
+        assert.neverCalledWithMatch(clientApi.postMessage, {
+            command: TELEMETRY,
+            params: { name: CHAT_MESSAGE_RENDERED_TELEMETRY_EVENT },
+        })
+    })
+
+    it('publishes chatPostMessageRejected telemetry for an unknown command', () => {
+        clientApi.postMessage.resetHistory()
+        const event = createInboundEvent({ command: 'totally-bogus-command' })
+        window.dispatchEvent(event)
+
+        assert.calledWithExactly(clientApi.postMessage, {
+            command: TELEMETRY,
+            params: {
+                name: CHAT_POST_MESSAGE_REJECTED_TELEMETRY_EVENT,
+                reason: 'unknownCommand',
+                command: 'totally-bogus-command',
+                tabId: undefined,
+            },
+        })
+    })
+
+    it('publishes chatPostMessageRejected telemetry when inbound data is undefined', () => {
+        clientApi.postMessage.resetHistory()
+        // NOTE: a dispatched jsdom/browser MessageEvent always coerces `data` to null (never
+        // undefined), so this branch can't be reached via window.dispatchEvent. We invoke the
+        // captured handler directly with a synthetic event to exercise the event.data===undefined
+        // drop branch deterministically.
+        if (!messageHandler) {
+            throw new Error('message handler was not registered')
+        }
+        messageHandler({ origin: window.location.origin, data: undefined } as MessageEvent)
+
+        assert.calledOnceWithExactly(clientApi.postMessage, {
+            command: TELEMETRY,
+            params: {
+                name: CHAT_POST_MESSAGE_REJECTED_TELEMETRY_EVENT,
+                reason: 'undefinedData',
+                command: undefined,
+                tabId: undefined,
+            },
+        })
     })
 
     it('accepts inbound messages with empty origin (Eclipse SWT Browser)', () => {

--- a/chat-client/src/client/chat.ts
+++ b/chat-client/src/client/chat.ts
@@ -202,9 +202,15 @@ export const createChat = (
             // Log so any unexpected host environment surfaces in logs rather
             // than silently breaking the chat.
             console.warn('Chat client rejected message from untrusted origin:', origin)
+            // Record the drop so a silent client-side delivery failure is observable (the backend
+            // can report success while the response never reaches the UI).
+            messager.onInboundMessageRejected('untrustedOrigin')
             return
         }
         if (event.data === undefined) {
+            // Record the drop so a silent client-side delivery failure is observable (the backend
+            // can report success while the response never reaches the UI).
+            messager.onInboundMessageRejected('undefinedData')
             return
         }
         const message = event.data
@@ -223,6 +229,12 @@ export const createChat = (
                 break
             case CHAT_REQUEST_METHOD:
                 mynahApi.addChatResponse(message.params, message.tabId, message.isPartialResult)
+                // Positive delivery signal. Gate on the terminal (non-partial)
+                // chunk only — addChatResponse fires once per streamed chunk, so emitting on every
+                // call would massively inflate volume.
+                if (!message.isPartialResult) {
+                    messager.onInboundMessageRendered(message.tabId)
+                }
                 break
             case CHAT_UPDATE_NOTIFICATION_METHOD: {
                 const messageParams = message.params as ChatUpdateParams
@@ -383,7 +395,9 @@ export const createChat = (
                 break
             }
             default:
-                // TODO: Report error?
+                // An inbound message with an unrecognized command is dropped
+                // here. Record it (with the command) so this silent gap is observable.
+                messager.onInboundMessageRejected('unknownCommand', message?.command)
                 break
         }
     }

--- a/chat-client/src/client/messager.ts
+++ b/chat-client/src/client/messager.ts
@@ -55,6 +55,8 @@ import { TelemetryParams } from '../contracts/serverContracts'
 import {
     ADD_MESSAGE_TELEMETRY_EVENT,
     AUTH_FOLLOW_UP_CLICKED_TELEMETRY_EVENT,
+    CHAT_MESSAGE_RENDERED_TELEMETRY_EVENT,
+    CHAT_POST_MESSAGE_REJECTED_TELEMETRY_EVENT,
     COPY_TO_CLIPBOARD_TELEMETRY_EVENT,
     ENTER_FOCUS,
     ERROR_MESSAGE_TELEMETRY_EVENT,
@@ -150,6 +152,18 @@ export class Messager {
 
     onFocusStateChanged = (focusState: boolean): void => {
         this.chatApi.telemetry({ name: focusState ? ENTER_FOCUS : EXIT_FOCUS })
+    }
+
+    // Positive delivery signal — an inbound message was handed to mynah-ui.
+    onInboundMessageRendered = (tabId?: string): void => {
+        this.chatApi.telemetry({ name: CHAT_MESSAGE_RENDERED_TELEMETRY_EVENT, tabId })
+    }
+
+    // Negative signal — an inbound message was rejected/dropped in
+    // handleInboundMessage. `reason` distinguishes the drop branch; `command` is included
+    // for the unknown-command case.
+    onInboundMessageRejected = (reason: string, command?: string, tabId?: string): void => {
+        this.chatApi.telemetry({ name: CHAT_POST_MESSAGE_REJECTED_TELEMETRY_EVENT, reason, command, tabId })
     }
 
     onSendToPrompt = (params: SendToPromptParams, tabId: string): void => {

--- a/chat-client/src/contracts/telemetry.ts
+++ b/chat-client/src/contracts/telemetry.ts
@@ -14,6 +14,12 @@ export const SOURCE_LINK_CLICK_TELEMETRY_EVENT = 'sourceLinkClick'
 export const AUTH_FOLLOW_UP_CLICKED_TELEMETRY_EVENT = 'authFollowupClicked'
 export const HISTORY_BUTTON_CLICK_TELEMETRY_EVENT = 'historyButtonClick'
 
+// Client-side chat delivery telemetry. Values MUST match the
+// ChatUIEventName enum in language-servers/server/.../chat/telemetry/clientTelemetry.ts,
+// or the server's isClientTelemetryEvent allowlist will silently drop them.
+export const CHAT_MESSAGE_RENDERED_TELEMETRY_EVENT = 'chatMessageRendered'
+export const CHAT_POST_MESSAGE_REJECTED_TELEMETRY_EVENT = 'chatPostMessageRejected'
+
 export enum RelevancyVoteType {
     UP = 'upvote',
     DOWN = 'downvote',

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.test.ts
@@ -71,6 +71,60 @@ describe('TelemetryController', () => {
         })
     })
 
+    // Positive delivery signal.
+    it('handles chatMessageRendered client telemetry', () => {
+        testFeatures.runtime.serverInfo = { version: '1.70.0', name: 'AmazonQ' }
+        const telemetryHandler = testFeatures.telemetry.onClientTelemetry.firstCall.firstArg
+
+        telemetryHandler({
+            name: ChatUIEventName.ChatMessageRendered,
+        })
+
+        sinon.assert.calledOnceWithExactly(testFeatures.telemetry.emitMetric, {
+            name: ChatTelemetryEventName.ChatMessageRendered,
+            data: { credentialStartUrl: undefined, result: 'Succeeded', languageServerVersion: '1.70.0' },
+        })
+    })
+
+    // Negative signal, with reason. Note result stays 'Succeeded' (codebase convention).
+    it('handles chatPostMessageRejected client telemetry', () => {
+        testFeatures.runtime.serverInfo = { version: '1.70.0', name: 'AmazonQ' }
+        const telemetryHandler = testFeatures.telemetry.onClientTelemetry.firstCall.firstArg
+
+        telemetryHandler({
+            name: ChatUIEventName.ChatPostMessageRejected,
+            reason: 'unknownCommand',
+            command: 'bogusCommand',
+        })
+
+        sinon.assert.calledOnceWithExactly(testFeatures.telemetry.emitMetric, {
+            name: ChatTelemetryEventName.ChatPostMessageRejected,
+            data: {
+                credentialStartUrl: undefined,
+                result: 'Succeeded',
+                reason: 'unknownCommand',
+                command: 'bogusCommand',
+                languageServerVersion: '1.70.0',
+            },
+        })
+    })
+
+    // Double-emit guard: vscode-jsonrpc registers notification handlers in a Map keyed by
+    // method (last registration wins), so a single telemetry/event must produce exactly ONE emit
+    // even when multiple ChatTelemetryControllers exist. This locks in that behavior.
+    it('emits a metric only once when multiple controllers are constructed', () => {
+        const telemetryServiceStub = <TelemetryService>{}
+        // Construct a second controller against the SAME features (each calls onClientTelemetry).
+        new ChatTelemetryController(testFeatures, telemetryServiceStub)
+        testFeatures.runtime.serverInfo = { version: '1.70.0', name: 'AmazonQ' }
+
+        // Fire via the LAST-registered handler (what the jsonrpc Map.get would dispatch to).
+        const telemetryHandler = testFeatures.telemetry.onClientTelemetry.lastCall.firstArg
+        telemetryHandler({ name: ChatUIEventName.ChatMessageRendered })
+
+        sinon.assert.calledOnce(testFeatures.telemetry.emitMetric)
+    })
+
     it('does not handle unknown client telemetry', () => {
         const telemetryHandler = testFeatures.telemetry.onClientTelemetry.firstCall.firstArg
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -66,6 +66,7 @@ export class ChatTelemetryController {
     #credentialsProvider: CredentialsProvider
     #telemetry: Telemetry
     #logging: Logging
+    #runtime: Features['runtime']
     #codeDiffTracker: CodeDiffTracker<AcceptedSuggestionChatEntry>
     #telemetryService: TelemetryService
 
@@ -76,6 +77,7 @@ export class ChatTelemetryController {
         this.#telemetry = features.telemetry
         this.#logging = features.logging
         this.#credentialsProvider = features.credentialsProvider
+        this.#runtime = features.runtime
         this.#telemetry.onClientTelemetry(async params => await this.#handleClientTelemetry(params))
         this.#codeDiffTracker = new CodeDiffTracker(features.workspace, features.logging, (entry, percentage) =>
             this.emitModifyCodeMetric(entry, percentage)
@@ -547,6 +549,29 @@ export class ChatTelemetryController {
                         this.emitChatMetric({
                             name: ChatTelemetryEventName.ExitFocusChat,
                             data: {},
+                        })
+                        break
+                    // Positive delivery signal — the chat client handed an
+                    // inbound message to mynah-ui. A drop in this rate per product/os surfaces a
+                    // silent delivery failure. Stateless (does not read controller/tab state).
+                    case ChatUIEventName.ChatMessageRendered:
+                        this.emitChatMetric({
+                            name: ChatTelemetryEventName.ChatMessageRendered,
+                            data: {
+                                languageServerVersion: this.#runtime.serverInfo.version ?? 'unknown',
+                            },
+                        })
+                        break
+                    // Negative signal — the chat client rejected/dropped an
+                    // inbound message in handleInboundMessage. `reason` distinguishes the branch.
+                    case ChatUIEventName.ChatPostMessageRejected:
+                        this.emitChatMetric({
+                            name: ChatTelemetryEventName.ChatPostMessageRejected,
+                            data: {
+                                reason: params.reason,
+                                command: params.command,
+                                languageServerVersion: this.#runtime.serverInfo.version ?? 'unknown',
+                            },
                         })
                         break
                     case ChatUIEventName.Vote:

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/clientTelemetry.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/clientTelemetry.ts
@@ -15,6 +15,10 @@ export enum ChatUIEventName {
     InfoLinkClick = 'infoLinkClick',
     SourceLinkClick = 'sourceLinkClick',
     HistoryButtonClick = 'historyButtonClick',
+    // Client-side chat delivery telemetry. Values MUST match the
+    // CHAT_*_TELEMETRY_EVENT constants in chat-client/src/contracts/telemetry.ts.
+    ChatMessageRendered = 'chatMessageRendered',
+    ChatPostMessageRejected = 'chatPostMessageRejected',
 }
 
 /* Chat client only telemetry - we should import these in the future */
@@ -80,6 +84,23 @@ export type InsertToCursorPositionParams = ServerInterface.InsertToCursorPositio
 
 export type HistoryButtonClickParams = { name: ChatUIEventName.HistoryButtonClick }
 
+// Client-side delivery telemetry. tabId is OPTIONAL (not extending BaseClientTelemetryParams) because
+// the reject branches in handleInboundMessage may fire before a message/tabId is parsed —
+// following the tabId-less HistoryButtonClickParams precedent.
+export type ChatMessageRenderedParams = {
+    name: ChatUIEventName.ChatMessageRendered
+    tabId?: string
+    languageServerVersion?: string
+}
+
+export type ChatPostMessageRejectedParams = {
+    name: ChatUIEventName.ChatPostMessageRejected
+    reason: string
+    command?: string
+    tabId?: string
+    languageServerVersion?: string
+}
+
 export type ClientTelemetryEvent =
     | BaseClientTelemetryParams<ChatUIEventName.EnterFocusChat>
     | BaseClientTelemetryParams<ChatUIEventName.ExitFocusChat>
@@ -93,6 +114,8 @@ export type ClientTelemetryEvent =
     | SourceLinkClickParams
     | InsertToCursorPositionParams
     | HistoryButtonClickParams
+    | ChatMessageRenderedParams
+    | ChatPostMessageRejectedParams
 
 const chatUIEventNameSet = new Set<string>(Object.values(ChatUIEventName))
 

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -212,6 +212,8 @@ export enum ChatTelemetryEventName {
     UiClick = 'ui_click',
     ActiveUser = 'amazonq_activeUser',
     BashCommand = 'amazonq_bashCommand',
+    ChatMessageRendered = 'amazonq_chatMessageRendered',
+    ChatPostMessageRejected = 'amazonq_chatPostMessageRejected',
 }
 
 export interface ChatTelemetryEventMap {
@@ -238,6 +240,8 @@ export interface ChatTelemetryEventMap {
     [ChatTelemetryEventName.UiClick]: UiClickEvent
     [ChatTelemetryEventName.ActiveUser]: ActiveUserEvent
     [ChatTelemetryEventName.BashCommand]: BashCommandEvent
+    [ChatTelemetryEventName.ChatMessageRendered]: ChatMessageRenderedEvent
+    [ChatTelemetryEventName.ChatPostMessageRejected]: ChatPostMessageRejectedEvent
 }
 
 export type AgencticLoop_InvokeLLMEvent = {
@@ -273,6 +277,27 @@ export type InteractWithAgenticChatEvent = {
 export type ActiveUserEvent = {
     credentialStartUrl?: string
     result: string
+}
+
+// Emitted when the chat client successfully delivers an inbound message to the chat UI (mynah-ui).
+// Used as the positive signal for client-side delivery health: a drop in this rate (per product/os)
+// surfaces a silent delivery failure even when the backend reports success. A strict postMessage
+// origin check can drop inbound messages on some IDE webview hosts while the backend still returns
+// HTTP 200, making the failure invisible server-side. See aws/amazon-q-eclipse#555.
+export type ChatMessageRenderedEvent = {
+    credentialStartUrl?: string
+    languageServerVersion?: string
+}
+
+// Emitted when the chat client rejects/drops an inbound message in handleInboundMessage
+// (e.g. untrusted origin, undefined payload, unrecognized command). `reason` distinguishes the
+// drop branch. Note: result stays 'Succeeded' per the codebase convention (failures are conveyed
+// via a distinct metric name + reason, not result:'Failed').
+export type ChatPostMessageRejectedEvent = {
+    credentialStartUrl?: string
+    reason: string
+    command?: string
+    languageServerVersion?: string
 }
 
 export type BashCommandEvent = {


### PR DESCRIPTION
## Problem

  The chat UI runs in a webview and receives inbound messages from the IDE host via postMessage. If handleInboundMessage drops an inbound message — for example a strict origin check
  rejecting it on a host whose webview reports an opaque/empty origin — the chat response never renders, yet the backend still returns HTTP 200. There is currently no client-side signal
  distinguishing "response received by the language server" from "response rendered in the UI," so this class of failure is invisible to server-side metrics. See aws/amazon-q-eclipse#555.

  ## Solution

  Adds two client-side telemetry metrics, emitted from chat-client and re-emitted by Flare's ChatTelemetryController (so they flow to every IDE host through the existing shared telemetry
  path — no per-client definitions needed):

  - amazonq_chatMessageRendered — positive signal, emitted when a chat response is delivered to mynah-ui (gated to the terminal, non-partial chunk to avoid per-chunk volume).
  - amazonq_chatPostMessageRejected — emitted when handleInboundMessage drops an inbound message (reason: untrustedOrigin | undefinedData | unknownCommand).

  product and os are stamped automatically by each host's telemetry envelope; languageServerVersion is included in the metric data.

  ## Testing

  - Unit tests added on both sides (Flare chatTelemetryController.test.ts, including a guard that a single inbound event emits exactly once; chat-client/chat.test.ts). Full suites pass.
  - Verified end-to-end to telemetry on VS Code and Eclipse — both metrics, with correct product / os / languageServerVersion.
  - Not yet validated on JetBrains or Visual Studio. The chat-client emit code is shared across hosts, but per CONTRIBUTING's cross-host requirement I'm flagging that the per-host
  telemetry forwarding/envelope hasn't been confirmed on those two.

  ## License

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.