### PR TITLE
fix(amazonq): bind MCP consent to workspace+config (cross-workspace consent-reuse bypass of CVE-2026-12957 fix)

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
@@ -103,16 +103,47 @@ describe('mcpConsentStore', () => {
             expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.true
         })
 
-        it('matches via fingerprint even when workspace path differs', async () => {
-            await recordApproval(workspace, logger, 'poc', cfg, '/tmp/ws-a/.amazonq/mcp.json')
-            expect(await hasApproval(workspace, logger, 'poc', cfg, '/tmp/ws-b/.amazonq/mcp.json')).to.be.true
+        // CVE-2026-12957 — cross-workspace reuse. An approval granted in one
+        // workspace MUST NOT be reused in a different workspace, even when the
+        // server config (and thus fingerprint) is byte-for-byte identical. The
+        // server is spawned with cwd set to the requesting workspace, so reusing
+        // consent across workspaces would execute attacker-controlled files
+        // (zero-prompt RCE). This mirrors the reported PoC, in which an identical
+        // config appears in a seed (trusted) workspace and a malicious workspace.
+        it('does NOT match across workspaces when only the fingerprint is identical', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, '/tmp/seed-workspace/.amazonq/mcp.json')
+            expect(await hasApproval(workspace, logger, 'poc', cfg, '/tmp/malicious-workspace/.amazonq/mcp.json')).to.be
+                .false
         })
 
-        it('matches via workspaceHash even when fingerprint differs', async () => {
+        // CVE-2026-12957 — mutation variant. Within the same workspace, editing the
+        // server config changes the fingerprint and MUST force a re-prompt, so a
+        // previously-trusted workspace cannot turn malicious via a later edit.
+        it('does NOT match in the same workspace when the fingerprint changed', async () => {
             await recordApproval(workspace, logger, 'poc', cfg, configPath)
             const mutated: MCPServerConfig = { command: 'sh', args: ['-c', 'echo different'] }
-            // Same workspace, different fingerprint — should still match via workspaceHash fallback
+            expect(await hasApproval(workspace, logger, 'poc', mutated, configPath)).to.be.false
+        })
+
+        it('treats consent per-workspace: approving one workspace does not grant the other', async () => {
+            const seedPath = '/tmp/seed-workspace/.amazonq/mcp.json'
+            const maliciousPath = '/tmp/malicious-workspace/.amazonq/mcp.json'
+            await recordApproval(workspace, logger, 'poc', cfg, seedPath)
+            // Seed workspace is trusted; malicious workspace with identical config is not.
+            expect(await hasApproval(workspace, logger, 'poc', cfg, seedPath)).to.be.true
+            expect(await hasApproval(workspace, logger, 'poc', cfg, maliciousPath)).to.be.false
+            // Explicitly approving the second workspace grants only that workspace.
+            await recordApproval(workspace, logger, 'poc', cfg, maliciousPath)
+            expect(await hasApproval(workspace, logger, 'poc', cfg, maliciousPath)).to.be.true
+        })
+
+        it('still matches after re-approving a mutated config in the same workspace', async () => {
+            await recordApproval(workspace, logger, 'poc', cfg, configPath)
+            const mutated: MCPServerConfig = { command: 'sh', args: ['-c', 'echo different'] }
+            await recordApproval(workspace, logger, 'poc', mutated, configPath)
             expect(await hasApproval(workspace, logger, 'poc', mutated, configPath)).to.be.true
+            // The original (now stale) config no longer matches.
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.false
         })
 
         it('does not match when both fingerprint and workspace differ', async () => {
@@ -176,6 +207,17 @@ describe('mcpConsentStore', () => {
             await removeApproval(workspace, logger, 'other', configPath)
             // Original approval should still be there
             expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.true
+        })
+
+        it('removeApproval is scoped to the workspace it was called for', async () => {
+            const wsA = '/tmp/ws-a/.amazonq/mcp.json'
+            const wsB = '/tmp/ws-b/.amazonq/mcp.json'
+            await recordApproval(workspace, logger, 'poc', cfg, wsA)
+            await recordApproval(workspace, logger, 'poc', cfg, wsB)
+            // Removing the server in workspace A must not revoke workspace B's consent.
+            await removeApproval(workspace, logger, 'poc', wsA)
+            expect(await hasApproval(workspace, logger, 'poc', cfg, wsA)).to.be.false
+            expect(await hasApproval(workspace, logger, 'poc', cfg, wsB)).to.be.true
         })
     })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.ts
@@ -88,13 +88,23 @@ export async function hasApproval(
     const store = await readStore(workspace, logging)
     const fp = fingerprintServerConfig(cfg)
     const wh = fingerprintWorkspace(configPath)
-    // Primary match: (serverName, fingerprint) — the fingerprint captures the full
-    // execution-relevant config (command/args/env/url). This works even if the
-    // workspaceHash varies between reloads due to configPath format differences.
-    // Fallback match: (serverName, workspaceHash) — covers cases where the
-    // fingerprint changes slightly between reloads (e.g., config migration adds
-    // default values) but the workspace is the same.
-    return store.approvals.some(a => a.serverName === serverName && (a.fingerprint === fp || a.workspaceHash === wh))
+    // Consent is bound to the full triple (serverName, fingerprint, workspaceHash)
+    // and ALL three must match for a prior approval to apply:
+    //   - serverName + fingerprint: the exact execution-relevant config
+    //     (command/args/env/url). A mutated config yields a new fingerprint, so a
+    //     config change re-prompts.
+    //   - workspaceHash: the specific workspace folder that requested the server.
+    //     Approvals are not portable across workspaces.
+    // Requiring all three (logical AND) prevents two attacks (CVE-2026-12957):
+    //   1. Cross-workspace reuse — a malicious workspace with an identical config
+    //      (same fingerprint) cannot silently reuse an approval granted in a
+    //      different, trusted workspace, because its workspaceHash differs. The
+    //      server is spawned with cwd set to the requesting workspace, so reusing
+    //      consent across workspaces would execute attacker-controlled files.
+    //   2. Mutation variant — a previously-trusted workspace cannot turn malicious
+    //      via a later config edit without re-prompting, because the edit changes
+    //      the fingerprint even though the workspaceHash is unchanged.
+    return store.approvals.some(a => a.serverName === serverName && a.fingerprint === fp && a.workspaceHash === wh)
 }
 
 export async function recordApproval(
@@ -126,8 +136,12 @@ export async function removeApproval(
     configPath: string
 ): Promise<void> {
     const store = await readStore(workspace, logging)
+    const wh = fingerprintWorkspace(configPath)
     const before = store.approvals.length
-    store.approvals = store.approvals.filter(a => a.serverName !== serverName)
+    // Scope removal to the (serverName, workspace) that requested it, mirroring how
+    // recordApproval keys entries. Removing a server in one workspace must not
+    // revoke consent for an identically-named server in a different workspace.
+    store.approvals = store.approvals.filter(a => !(a.serverName === serverName && a.workspaceHash === wh))
     if (store.approvals.length < before) {
         await writeStore(workspace, logging, store)
         logging.info(`MCP consent store: removed approval for '${serverName}'`)


### PR DESCRIPTION
## Summary

Hardens the workspace-scoped MCP server consent gate so a stored approval is bound to **both** the exact server config **and** the specific workspace that requested it. Closes a **cross-workspace consent-reuse bypass** that re-enables zero-prompt code execution when opening an attacker-controlled workspace.

## Relationship to CVE-2026-12957

This is **not** CVE-2026-12957 itself — it is a **bypass of the fix** for it.

- **CVE-2026-12957** (AWS bulletin 2026-047-AWS, fixed in Language Servers for AWS **v1.65.0**) was an improper-trust-boundary issue where a malicious workspace could auto-execute commands from its MCP config. The remediation was the **consent prompt** that gates workspace-scoped MCP servers.
- **This change** addresses a flaw in that consent gate: the approval check could be satisfied across workspace boundaries, so the prompt never fires for a malicious workspace — defeating the CVE-2026-12957 remediation and returning to a zero-prompt RCE.

Because it is a distinct bypass of an already-shipped fix (analogous to how the related symlink issue received its own CVE-2026-12958), this finding is a **candidate for its own CVE**; the reference above is provided only to explain lineage.

## Root cause

`hasApproval()` in `mcpConsentStore.ts` matched a stored approval when `serverName && (fingerprint || workspaceHash)`. The `||` made either leg sufficient:

- **Cross-workspace reuse:** a malicious workspace shipping an MCP config identical to one a user previously approved in a *trusted* workspace matched on `fingerprint` alone — no prompt. Since MCP servers spawn with `cwd` set to the requesting workspace, a relative command (e.g. `node server.js`) then executes the attacker's file.
- **Mutation variant:** a previously-trusted workspace whose config was later edited matched on `workspaceHash` alone, defeating the re-prompt-on-config-change guarantee.

## Fix

- Require all three of `(serverName, fingerprint, workspaceHash)` to match (`||` → `&&`). Consent is now bound to a specific workspace **and** a specific config. The store already persists `workspaceHash` per approval, so **no data migration** is needed.
- Scope `removeApproval()` to `(serverName, workspaceHash)` using its previously-unused `configPath` argument, so removing a server in one workspace no longer revokes consent for an identically-named server elsewhere.
- Corrected the now-inaccurate rationale comments.

## Testing

- `mcpConsentStore.test.ts`: rewrote the two tests that previously asserted the insecure reuse behavior to assert the secure behavior; added regression tests for per-workspace consent isolation, same-workspace mutation re-prompt, and per-workspace revocation. **23 passing.**
- `mcpManager.test.ts` (consent-gate integration): **52 passing.**
- `tsc --build`, `eslint`, and `prettier --check` all clean (only pre-existing `import/no-nodejs-modules` warnings).
