### PR TITLE
feat(amazonq): enable two-way workspace sync for customer edits

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -3163,11 +3163,28 @@ export class ATXTransformHandler {
                 return { Success: false, Error: 'ATX FES client not initialized' }
             }
 
-            // Get the cached step HITL task ID, or query for it if not cached
+            // Get the cached step HITL task ID, or query for it if not cached.
+            // The client-supplied stepId is advisory — it may be a stale substep id that
+            // doesn't match the backend's review HITL tag (which uses the top-level project
+            // step id). When the client id misses, fall back to resolving the real pending
+            // step server-side via the plan tree — the same pattern getTransformInfo uses.
             let taskId: string | null = this.cachedStepHitl
             if (!taskId) {
                 this.logging.log('ATX: No cached step HITL, querying for active step HITL')
-                const stepHitl = await this.findStepLevelHitl(workspaceId, jobId, stepId)
+                let stepHitl = await this.findStepLevelHitl(workspaceId, jobId, stepId)
+
+                if (!stepHitl || !stepHitl.taskId) {
+                    this.logging.log(
+                        `ATX: Client stepId ${stepId} did not match a review HITL, resolving pending step from plan`
+                    )
+                    const plan = await this.fetchPlanTree(workspaceId, jobId)
+                    const pendingStep = this.findPendingHumanInputStep(plan.Root)
+                    if (pendingStep?.StepId && pendingStep.StepId !== stepId) {
+                        this.logging.log(`ATX: Resolved pending step ${pendingStep.StepId}, retrying HITL lookup`)
+                        stepHitl = await this.findStepLevelHitl(workspaceId, jobId, pendingStep.StepId)
+                    }
+                }
+
                 if (!stepHitl || !stepHitl.taskId) {
                     return { Success: false, Error: 'No active step HITL found' }
                 }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -3173,6 +3173,7 @@ export class ATXTransformHandler {
                 this.logging.log('ATX: No cached step HITL, querying for active step HITL')
                 let stepHitl = await this.findStepLevelHitl(workspaceId, jobId, stepId)
 
+                // Fallback 1: resolve the real pending step from plan tree
                 if (!stepHitl || !stepHitl.taskId) {
                     this.logging.log(
                         `ATX: Client stepId ${stepId} did not match a review HITL, resolving pending step from plan`
@@ -3182,6 +3183,21 @@ export class ATXTransformHandler {
                     if (pendingStep?.StepId && pendingStep.StepId !== stepId) {
                         this.logging.log(`ATX: Resolved pending step ${pendingStep.StepId}, retrying HITL lookup`)
                         stepHitl = await this.findStepLevelHitl(workspaceId, jobId, pendingStep.StepId)
+                    }
+                }
+
+                // Fallback 2: list all active HITLs and find a -review one directly.
+                // Covers the race where step status already flipped (e.g. to IN_PROGRESS
+                // on retry) but the review HITL is still alive awaiting the workspace sync.
+                if (!stepHitl || !stepHitl.taskId) {
+                    this.logging.log('ATX: Plan-based resolution missed, scanning active HITLs for a review task')
+                    const allHitls = await this.listHitls(workspaceId, jobId)
+                    const reviewHitl = allHitls?.find(h => typeof h.tag === 'string' && h.tag.endsWith('-review'))
+                    if (reviewHitl?.taskId) {
+                        this.logging.log(
+                            `ATX: Found active review HITL via scan: tag=${reviewHitl.tag}, taskId=${reviewHitl.taskId}`
+                        )
+                        stepHitl = reviewHitl
                     }
                 }
 
@@ -3245,6 +3261,11 @@ export class ATXTransformHandler {
 
             // Clear the cached step HITL after successful update
             this.cachedStepHitl = null
+
+            // Reset the watermark so the incoming retry checkpoint isn't treated as a
+            // conflict. The customer's edits have been uploaded — they expect the agent's
+            // retry output to land on disk, not be skipped by edit-protection.
+            this.saveLastAppliedTimestamp(solutionRootPath, jobId, 'updateWorkspace')
 
             this.logging.log(`ATX: updateWorkspace completed successfully`)
             return { Success: true }

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -2045,7 +2045,11 @@ export class ATXTransformHandler {
      * Gets the list of files that have been modified since the last checkpoint was applied.
      * Returns absolute paths of modified files.
      */
-    private getModifiedFilesSinceCheckpoint(solutionRootPath: string, jobId: string): string[] {
+    private getModifiedFilesSinceCheckpoint(
+        solutionRootPath: string,
+        jobId: string,
+        sinceJobStart: boolean = false
+    ): string[] {
         try {
             const checkpointsDir = path.join(solutionRootPath, workspaceFolderName, jobId, 'checkpoints')
             const manifestPath = path.join(checkpointsDir, 'source-files.json')
@@ -2058,9 +2062,19 @@ export class ATXTransformHandler {
             const manifestContent = fs.readFileSync(manifestPath, 'utf-8')
             const manifest = JSON.parse(manifestContent)
 
-            const lastAppliedTimestamp = manifest.lastAppliedTimestamp
-            if (!lastAppliedTimestamp) {
-                this.logging.log('ATX: No last applied timestamp found')
+            // For the uplink (updateWorkspace), use createdAt as the baseline so edits to
+            // files in not-yet-transformed projects are detected — their mtime is before
+            // lastAppliedTimestamp (set when an earlier project's checkpoint applied) but
+            // after the job started.
+            let baseline: number | undefined
+            if (sinceJobStart) {
+                baseline = manifest.createdAt ? new Date(manifest.createdAt).getTime() : undefined
+            } else {
+                baseline = manifest.lastAppliedTimestamp
+            }
+
+            if (!baseline) {
+                this.logging.log('ATX: No baseline timestamp found for modified file detection')
                 return []
             }
 
@@ -2071,7 +2085,7 @@ export class ATXTransformHandler {
                 try {
                     if (fs.existsSync(filePath)) {
                         const stats = fs.statSync(filePath)
-                        if (stats.mtimeMs > lastAppliedTimestamp) {
+                        if (stats.mtimeMs > baseline) {
                             modifiedFiles.push(filePath)
                         }
                     }
@@ -2080,7 +2094,9 @@ export class ATXTransformHandler {
                 }
             }
 
-            this.logging.log(`ATX: Found ${modifiedFiles.length} modified files since last checkpoint`)
+            this.logging.log(
+                `ATX: Found ${modifiedFiles.length} modified files since ${sinceJobStart ? 'job start' : 'last checkpoint'}`
+            )
             return modifiedFiles
         } catch (error) {
             this.logging.error(`ATX: Failed to get modified files: ${String(error)}`)
@@ -3209,8 +3225,11 @@ export class ATXTransformHandler {
 
             const validTaskId = taskId as string
 
-            // Check for user-modified files since last checkpoint
-            const modifiedFiles = this.getModifiedFilesSinceCheckpoint(solutionRootPath, jobId)
+            // Check for user-modified files since job start — not since last checkpoint.
+            // Files in not-yet-transformed projects may have been edited before any checkpoint
+            // applied (mtime < lastAppliedTimestamp) but still need to be uploaded so the agent
+            // sees them when it starts those projects.
+            const modifiedFiles = this.getModifiedFilesSinceCheckpoint(solutionRootPath, jobId, true)
 
             this.logging.log(`ATX: Found ${modifiedFiles.length} user-modified files, creating zip with metadata`)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -838,6 +838,7 @@ describe('ATXTransformHandler - updateWorkspace & applyChanges', () => {
             sinon.stub(handler as any, 'fetchPlanTree').resolves({
                 Root: { StepId: 'root', Children: [], Status: 'SUCCEEDED' },
             })
+            sinon.stub(handler, 'listHitls').resolves([])
 
             const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
 
@@ -913,6 +914,7 @@ describe('ATXTransformHandler - updateWorkspace & applyChanges', () => {
                     Children: [{ StepId: 'step-1', Status: 'PENDING_HUMAN_INPUT', Children: [] }],
                 },
             })
+            sinon.stub(handler, 'listHitls').resolves([])
 
             const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
 
@@ -920,6 +922,35 @@ describe('ATXTransformHandler - updateWorkspace & applyChanges', () => {
             expect(result.Error).to.equal('No active step HITL found')
             // Should only call findStepLevelHitl once (no retry since pending.StepId === stepId)
             expect(findHitlStub.callCount).to.equal(1)
+        })
+
+        it('should find review HITL via scan when plan-based resolution misses (race condition)', async () => {
+            sinon.stub(handler as any, 'findStepLevelHitl').resolves(null)
+            // Plan has no PENDING_HUMAN_INPUT step (already flipped to IN_PROGRESS on retry)
+            sinon.stub(handler as any, 'fetchPlanTree').resolves({
+                Root: {
+                    StepId: 'root',
+                    Status: 'IN_PROGRESS',
+                    Children: [{ StepId: 'project-step', Status: 'IN_PROGRESS', Children: [] }],
+                },
+            })
+            // But the review HITL is still alive
+            sinon.stub(handler, 'listHitls').resolves([{ tag: 'project-step-review', taskId: 'review-task-123' }])
+            sinon.stub(handler as any, 'getModifiedFilesSinceCheckpoint').returns([])
+            sinon.stub(handler as any, 'createUpdateWorkspaceZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'https://s3/upload',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true } as any)
+            sinon.stub(handler, 'updateHitl').resolves({ ok: true })
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'stale-step')
+
+            expect(result.Success).to.be.true
         })
 
         it('should return error when createUpdateWorkspaceZip returns empty path', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -833,13 +833,93 @@ describe('ATXTransformHandler - updateWorkspace & applyChanges', () => {
     })
 
     describe('updateWorkspace', () => {
-        it('should return error when no active step HITL is found', async () => {
+        it('should return error when no active step HITL is found and no pending step in plan', async () => {
             sinon.stub(handler as any, 'findStepLevelHitl').resolves(null)
+            sinon.stub(handler as any, 'fetchPlanTree').resolves({
+                Root: { StepId: 'root', Children: [], Status: 'SUCCEEDED' },
+            })
 
             const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
 
             expect(result.Success).to.be.false
             expect(result.Error).to.equal('No active step HITL found')
+        })
+
+        it('should resolve the real pending step when client stepId misses (C2-a fallback)', async () => {
+            const findHitlStub = sinon.stub(handler as any, 'findStepLevelHitl')
+            // First call with client's stale stepId returns null
+            findHitlStub.withArgs('ws-1', 'job-1', 'stale-substep-id').resolves(null)
+            // Second call with the resolved pending step id succeeds
+            findHitlStub.withArgs('ws-1', 'job-1', 'real-project-step').resolves({ taskId: 'resolved-task' })
+
+            sinon.stub(handler as any, 'fetchPlanTree').resolves({
+                Root: {
+                    StepId: 'root',
+                    Status: 'IN_PROGRESS',
+                    Children: [
+                        {
+                            StepId: 'real-project-step',
+                            Status: 'PENDING_HUMAN_INPUT',
+                            Children: [],
+                        },
+                    ],
+                },
+            })
+            sinon.stub(handler as any, 'getModifiedFilesSinceCheckpoint').returns([])
+            sinon.stub(handler as any, 'createUpdateWorkspaceZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'https://s3/upload',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true } as any)
+            sinon.stub(handler, 'updateHitl').resolves({ ok: true })
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'stale-substep-id')
+
+            expect(result.Success).to.be.true
+            expect(findHitlStub.calledWith('ws-1', 'job-1', 'real-project-step')).to.be.true
+        })
+
+        it('should not fetch plan when cachedStepHitl is set (no extra round-trip)', async () => {
+            ;(handler as any).cachedStepHitl = 'cached-task-id'
+            const fetchPlanStub = sinon.stub(handler as any, 'fetchPlanTree')
+            sinon.stub(handler as any, 'getModifiedFilesSinceCheckpoint').returns([])
+            sinon.stub(handler as any, 'createUpdateWorkspaceZip').resolves('C:/zip.zip')
+            sinon.stub(handler, 'createArtifactUploadUrl').resolves({
+                uploadUrl: 'https://s3/upload',
+                uploadId: 'upload-1',
+                requestHeaders: {},
+            } as any)
+            const utilsModule = require('../utils')
+            sinon.stub(utilsModule.Utils, 'uploadArtifact').resolves(true)
+            sinon.stub(handler, 'completeArtifactUpload').resolves({ success: true } as any)
+            sinon.stub(handler, 'updateHitl').resolves({ ok: true })
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
+
+            expect(result.Success).to.be.true
+            expect(fetchPlanStub.called).to.be.false
+        })
+
+        it('should not retry when pending step id equals client stepId', async () => {
+            const findHitlStub = sinon.stub(handler as any, 'findStepLevelHitl').resolves(null)
+            sinon.stub(handler as any, 'fetchPlanTree').resolves({
+                Root: {
+                    StepId: 'root',
+                    Status: 'IN_PROGRESS',
+                    Children: [{ StepId: 'step-1', Status: 'PENDING_HUMAN_INPUT', Children: [] }],
+                },
+            })
+
+            const result = await handler.updateWorkspace('ws-1', 'job-1', 'C:/sln', 'step-1')
+
+            expect(result.Success).to.be.false
+            expect(result.Error).to.equal('No active step HITL found')
+            // Should only call findStepLevelHitl once (no retry since pending.StepId === stepId)
+            expect(findHitlStub.callCount).to.equal(1)
         })
 
         it('should return error when createUpdateWorkspaceZip returns empty path', async () => {


### PR DESCRIPTION
## Summary

Fixes the customer edit uplink (`updateWorkspace`) which never fired in production — edits made during transform review now reach the agent on retry/continue.

- **Self-resolve review HITL server-side**: when the client sends a stale/wrong stepId, the LSP falls back to plan-tree resolution and active-HITL scan to find the correct review HITL
- **Reset watermark after uplink**: the retry checkpoint applies cleanly (customer expects agent's output on disk, not their own input preserved by edit-protection)
- **Detect edits in not-yet-transformed projects**: uses job-start time as baseline for modified-file detection so edits across all projects in a multi-project solution are captured

## Test plan

### Single project — retry with syntax error
- Start transformation (interactive, review toggle ON)
- Agent transforms → checkpoint applies → review pause
- Add a syntax error to Program.cs
- Type "retry project" in chat
- Verify: uplink fires, agent re-transforms with edits, retry checkpoint applies cleanly

### Multi-project — edits across projects
- Start transformation (2 projects: SharedLib + WebApi, interactive, review toggle ON)
- While SharedLib is transforming, edit WebApi/Program.cs (add syntax error)
- SharedLib finishes → review pause → also edit SharedLib/Class1.cs (add syntax error)
- Type "continue" in chat
- Verify: uplink detects both modified files, agent transforms WebApi with edits (removes syntax errors on both), checkpoint applies cleanly

<img width="2396" height="1389" alt="Screenshot 2026-06-26 at 6 21 43 PM" src="https://github.com/user-attachments/assets/efe7888f-3ae8-4de1-9dc7-96ce05a5ce0d" />
