### PR TITLE
chore: bump @aws/language-server-runtimes to 0.3.18

### DIFF
--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "@aws/chat-client-ui-types": "0.1.68",
-        "@aws/language-server-runtimes": "^0.3.17",
+        "@aws/language-server-runtimes": "^0.3.18",
         "@aws/language-server-runtimes-types": "^0.1.64",
         "@aws/mynah-ui": "^4.40.3"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -255,7 +255,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/chat-client-ui-types": "0.1.68",
-                "@aws/language-server-runtimes": "^0.3.17",
+                "@aws/language-server-runtimes": "^0.3.18",
                 "@aws/language-server-runtimes-types": "^0.1.64",
                 "@aws/mynah-ui": "^4.40.3"
             },
@@ -3745,9 +3745,9 @@
             }
         },
         "node_modules/@aws/language-server-runtimes": {
-            "version": "0.3.17",
-            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.3.17.tgz",
-            "integrity": "sha512-yA7A7o5YChUlOT0zip9vGQu2Q5+UnHW/39cn7LKsTH0VD8ZiB8I8/4SXUggV3as2Vy7nD447xJGVkqjYqlngRA==",
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/@aws/language-server-runtimes/-/language-server-runtimes-0.3.18.tgz",
+            "integrity": "sha512-U3mPXH1PGr0fAfyUELLL1duSGdbo0GBf26o5LfCui7D+uYckTNc/AcJs4aqoY2wv3PCtp/VlrzsXgOrSgtuReg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws/language-server-runtimes-types": "^0.1.64",
@@ -30361,7 +30361,7 @@
                 "@aws-sdk/util-arn-parser": "^3.723.0",
                 "@aws-sdk/util-retry": "^3.374.0",
                 "@aws/chat-client-ui-types": "0.1.68",
-                "@aws/language-server-runtimes": "^0.3.17",
+                "@aws/language-server-runtimes": "^0.3.18",
                 "@aws/lsp-core": "^0.0.21",
                 "@modelcontextprotocol/sdk": "^1.23.0",
                 "@mozilla/readability": "^0.6.0",

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -38,7 +38,7 @@
         "@aws-sdk/util-arn-parser": "^3.723.0",
         "@aws-sdk/util-retry": "^3.374.0",
         "@aws/chat-client-ui-types": "0.1.68",
-        "@aws/language-server-runtimes": "^0.3.17",
+        "@aws/language-server-runtimes": "^0.3.18",
         "@aws/lsp-core": "^0.0.21",
         "@modelcontextprotocol/sdk": "^1.23.0",
         "@mozilla/readability": "^0.6.0",


### PR DESCRIPTION
## Notes:
- Bumping up `@aws/language-server-runtimes` version to `0.3.18` in `chat-client` and `server/aws-lsp-codewhisperer`.
- Regenerated the corresponding `package-lock.json` entries (version, resolved URL, integrity hash). `0.3.18` has an identical dependency set to `0.3.17`, so no other lockfile changes are required.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
