### PR TITLE
fix: pass customUserAgent to CodeWhispererServiceToken in QCodeAnalysisServer

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/toolServer.ts
@@ -25,6 +25,7 @@ import {
 import { FsReplace, FsReplaceParams } from './fsReplace'
 import { CodeReviewUtils } from './qCodeAnalysis/codeReviewUtils'
 import { DEFAULT_AWS_Q_ENDPOINT_URL, DEFAULT_AWS_Q_REGION } from '../../../shared/constants'
+import { getUserAgent, makeUserContextObject } from '../../../shared/telemetryUtils'
 import { DisplayFindings } from './qCodeAnalysis/displayFindings'
 import { ProfileStatusMonitor } from './mcp/profileStatusMonitor'
 import { AmazonQTokenServiceManager } from '../../../shared/amazonQServiceManager/AmazonQTokenServiceManager'
@@ -97,6 +98,7 @@ export const QCodeAnalysisServer: Server = ({
     credentialsProvider,
     logging,
     lsp,
+    runtime,
     sdkInitializator,
     telemetry,
     workspace,
@@ -129,6 +131,12 @@ export const QCodeAnalysisServer: Server = ({
         }
 
         // Create the CodeWhisperer client for review tool based on iam auth check
+        const initializeParams = lsp.getClientInitializeParams()
+        const customUserAgent = initializeParams ? getUserAgent(initializeParams, runtime.serverInfo) : undefined
+        const userContext = initializeParams
+            ? makeUserContextObject(initializeParams, runtime.platform, 'token', runtime.serverInfo)
+            : undefined
+
         const codeWhispererClient = isUsingIAMAuth()
             ? new CodeWhispererServiceIAM(
                   credentialsProvider,
@@ -145,7 +153,8 @@ export const QCodeAnalysisServer: Server = ({
                   process.env.CODEWHISPERER_REGION || DEFAULT_AWS_Q_REGION,
                   process.env.CODEWHISPERER_ENDPOINT || DEFAULT_AWS_Q_ENDPOINT_URL,
                   sdkInitializator,
-                  undefined
+                  userContext,
+                  customUserAgent
               )
 
         agent.addTool(


### PR DESCRIPTION
## Problem

The agentic code review tool (`CreateUploadUrl`, `StartCodeAnalysis`, `GetCodeAnalysis`, `ListCodeAnalysisFindings`) fails for users with a **Kiro Enterprise subscription** across all IDE plugins (VSCode, JetBrains, Eclipse, Visual Studio) with:

> `AccessDeniedException: Your subscription does not support this application. Please contact your administrator.`

The server-side `SubscriptionAuthZHandler` validates the `User-Agent` HTTP header against an allowlist of known IDE clients (`kiro`, `visual-studio-code`, `aws-toolkit-vscode`, `amazon-q-for-jetbrains`, etc.). The code review API calls were sending only the bare SDK user-agent:

```
aws-sdk-js/1.0.0 ua/2.1 os/darwin#25.5.0 lang/js md/nodejs#22.20.0 api/codewhispererruntime#1.0.0 m/N,E
```

...without any IDE identifier, causing the UA allowlist check to fail.

## Root Cause

`QCodeAnalysisServer` in `toolServer.ts` creates its **own separate `CodeWhispererServiceToken`** instance for the code review tool, but it was passing `undefined` for `userContext` and omitting the `customUserAgent` parameter entirely (the 7th and 8th constructor args):

```typescript
new CodeWhispererServiceToken(
    credentialsProvider, workspace, logging,
    region, endpoint, sdkInitializator,
    undefined  // userContext - missing!
    // customUserAgent - not passed at all!
)
```

Meanwhile, `AmazonQTokenServiceManager.serviceFactory()` (used for chat/GAR) correctly passes both — which is why chat works but code review doesn't.

## Fix

Pass `getUserAgent()` and `makeUserContextObject()` to the `CodeWhispererServiceToken` constructor in `QCodeAnalysisServer`, matching the pattern used by `AmazonQTokenServiceManager.serviceFactory()`.

After the fix, the `user-agent` HTTP header includes the IDE identifier:
```
aws-sdk-js/1.0.0 ... AWS-Language-Servers AWS-CodeWhisperer/1.71.0 AmazonQ-For-VSCode/2.4.0 Code-Editor/1.101.2
```

## Impact

- **Affects:** All IDE plugins (VSCode, JetBrains, Eclipse, Visual Studio) using agentic code review with Kiro Enterprise subscriptions
- **No impact on Q Developer Pro/Free users** — the UA allowlist check only runs for Kiro Enterprise subscriptions; Q Dev users take a different auth path
- **Backwards compatible:** Adding the user-agent is purely additive metadata on the HTTP request

## Testing

- Verified locally with Kiro IDE + Amazon Q Plugin — code review tool now works with Kiro subscription
- Confirmed Q Developer Pro subscription continues to work (no regression)

## Related

- Similar fix for streaming client: aws/aws-toolkit-vscode#8586