### PR TITLE
feat(amazonq): block chat in AWS GovCloud regions

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -37,7 +37,12 @@ import {
 } from '../../shared/telemetry/types'
 import { Features, LspHandlers, Result } from '../types'
 import { ChatEventParser, ChatResultWithMetadata } from './chatEventParser'
-import { createAuthFollowUpResult, getAuthFollowUpType, getDefaultChatResponse } from './utils'
+import {
+    createAuthFollowUpResult,
+    getAuthFollowUpType,
+    getDefaultChatResponse,
+    getGovCloudUnsupportedResponse,
+} from './utils'
 import { ChatSessionManagementService } from './chatSessionManagementService'
 import { ChatTelemetryController } from './telemetry/chatTelemetryController'
 import { QuickAction } from './quickActions'
@@ -129,6 +134,12 @@ export class ChatController implements ChatHandlers {
     }
 
     async onChatPrompt(params: ChatParams, token: CancellationToken): Promise<ChatResult | ResponseError<ChatResult>> {
+        const clientRegion = this.#features.lsp.getClientInitializeParams()?.initializationOptions?.aws?.region
+        const maybeGovResponse = getGovCloudUnsupportedResponse(clientRegion)
+        if (maybeGovResponse) {
+            return maybeGovResponse
+        }
+
         const maybeDefaultResponse = getDefaultChatResponse(params.prompt.prompt)
 
         if (maybeDefaultResponse) {
@@ -270,6 +281,12 @@ export class ChatController implements ChatHandlers {
         params: InlineChatParams,
         token: CancellationToken
     ): Promise<InlineChatResult | ResponseError<InlineChatResult>> {
+        const clientRegion = this.#features.lsp.getClientInitializeParams()?.initializationOptions?.aws?.region
+        const maybeGovResponse = getGovCloudUnsupportedResponse(clientRegion)
+        if (maybeGovResponse) {
+            return maybeGovResponse as InlineChatResult
+        }
+
         // TODO: This metric needs to be removed later, just added for now to be able to create a ChatEventParser object
         const metric = new Metric<AddMessageEvent>({
             cwsprChatConversationType: 'Chat',

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/utils.test.ts
@@ -1,0 +1,77 @@
+import * as assert from 'assert'
+import { getGovCloudUnsupportedResponse } from './utils'
+
+describe('getGovCloudUnsupportedResponse', () => {
+    let savedAwsRegion: string | undefined
+    let savedAwsDefaultRegion: string | undefined
+
+    beforeEach(() => {
+        savedAwsRegion = process.env.AWS_REGION
+        savedAwsDefaultRegion = process.env.AWS_DEFAULT_REGION
+        delete process.env.AWS_REGION
+        delete process.env.AWS_DEFAULT_REGION
+    })
+
+    afterEach(() => {
+        if (savedAwsRegion === undefined) {
+            delete process.env.AWS_REGION
+        } else {
+            process.env.AWS_REGION = savedAwsRegion
+        }
+        if (savedAwsDefaultRegion === undefined) {
+            delete process.env.AWS_DEFAULT_REGION
+        } else {
+            process.env.AWS_DEFAULT_REGION = savedAwsDefaultRegion
+        }
+    })
+
+    it('returns undefined when no region is available', () => {
+        assert.strictEqual(getGovCloudUnsupportedResponse(undefined), undefined)
+    })
+
+    it('returns undefined for a non-GovCloud client region', () => {
+        assert.strictEqual(getGovCloudUnsupportedResponse('us-east-1'), undefined)
+    })
+
+    it('returns a block response for us-gov-east-1 via client region', () => {
+        const result = getGovCloudUnsupportedResponse('us-gov-east-1')
+        assert.ok(result)
+        assert.ok(result!.body?.includes('us-gov-east-1'))
+        assert.ok(result!.body?.includes('GovCloud'))
+        assert.ok(result!.messageId)
+    })
+
+    it('returns a block response for us-gov-west-1 via client region', () => {
+        const result = getGovCloudUnsupportedResponse('us-gov-west-1')
+        assert.ok(result)
+        assert.ok(result!.body?.includes('us-gov-west-1'))
+    })
+
+    it('falls back to AWS_REGION when client region is undefined', () => {
+        process.env.AWS_REGION = 'us-gov-west-1'
+        const result = getGovCloudUnsupportedResponse(undefined)
+        assert.ok(result)
+        assert.ok(result!.body?.includes('us-gov-west-1'))
+    })
+
+    it('falls back to AWS_DEFAULT_REGION when client region and AWS_REGION are undefined', () => {
+        process.env.AWS_DEFAULT_REGION = 'us-gov-east-1'
+        const result = getGovCloudUnsupportedResponse(undefined)
+        assert.ok(result)
+        assert.ok(result!.body?.includes('us-gov-east-1'))
+    })
+
+    it('prefers client region over env vars', () => {
+        process.env.AWS_REGION = 'us-gov-west-1'
+        process.env.AWS_DEFAULT_REGION = 'us-gov-east-1'
+        // Client region is a non-GovCloud region, so the block should NOT trigger
+        // despite env vars pointing at GovCloud regions.
+        assert.strictEqual(getGovCloudUnsupportedResponse('us-west-2'), undefined)
+    })
+
+    it('prefers AWS_REGION over AWS_DEFAULT_REGION', () => {
+        process.env.AWS_REGION = 'us-east-1' // non-GovCloud
+        process.env.AWS_DEFAULT_REGION = 'us-gov-west-1'
+        assert.strictEqual(getGovCloudUnsupportedResponse(undefined), undefined)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/utils.ts
@@ -90,3 +90,43 @@ export function getDefaultChatResponse(prompt?: string): ChatResult | undefined 
 
     return undefined
 }
+
+/**
+ * AWS GovCloud regions. Amazon Q is not supported in these regions.
+ * Mirror of GOV_REGIONS in amazon-q-developer-cli
+ * (crates/chat-cli/src/util/consts.rs).
+ */
+const GOV_REGIONS: readonly string[] = ['us-gov-east-1', 'us-gov-west-1']
+
+/**
+ * Returns a chat response indicating Amazon Q is not supported in GovCloud,
+ * or undefined if the current region is not a GovCloud region.
+ *
+ * Region resolution order:
+ *   1. `initializationOptions.aws.region` sent by the LSP client
+ *   2. `AWS_REGION` process env var
+ *   3. `AWS_DEFAULT_REGION` process env var (AWS SDK fallback convention)
+ *
+ * The env vars are populated by SageMaker AI CodeEditor spaces and other
+ * AWS-managed environments; both are logged under `[SageMaker Debug]` when
+ * the LSP is spawned. See `createServerOptions` in amazon-q-vscode.
+ *
+ * Parallels amazon-q-developer-cli's startup gate in
+ * crates/chat-cli/src/cli/mod.rs:
+ *
+ *     if let Ok(region) = get_aws_region() {
+ *         if GOV_REGIONS.contains(&region.as_str()) {
+ *             bail!("AWS GovCloud ({region}) is not supported.")
+ *         }
+ *     }
+ */
+export function getGovCloudUnsupportedResponse(clientRegion?: string): ChatResult | undefined {
+    const region = clientRegion ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION
+    if (region && GOV_REGIONS.includes(region)) {
+        return {
+            messageId: uuid(),
+            body: `Amazon Q is not supported in AWS GovCloud (${region}).`,
+        }
+    }
+    return undefined
+}


### PR DESCRIPTION
## Problem

Amazon Q is not supported in AWS GovCloud, but the LSP was still forwarding chat and inline-chat requests to the service. Customers running in GovCloud saw confusing errors ("The security token included in the request is invalid.", etc.) instead of a clear "not supported" message.

Parallels the startup gate already in `amazon-q-developer-cli` (`crates/chat-cli/src/cli/mod.rs`), which currently rejects with:

    error: AWS GovCloud (us-gov-west-1) is not supported.

Reference: https://github.com/aws/amazon-q-developer-cli/blame/15cc8f3cd18c4272925ce1c7053268eedff1ea0a/crates/chat-cli/src/cli/mod.rs#L249

## Solution

Short-circuit `onChatPrompt` and `onInlineChatPrompt` in `ChatController` when the resolved region is in `GOV_REGIONS` (`us-gov-east-1`, `us-gov-west-1`). Region resolution order:

1. `initializationOptions.aws.region` sent by the LSP client
2. `AWS_REGION` process env var
3. `AWS_DEFAULT_REGION` process env var (AWS SDK fallback convention)

The env-var fallback works out of the box in AWS-managed environments like SageMaker AI CodeEditor spaces, where `AWS_REGION` is populated on session start and inherited by the LSP child process. No client-side changes are strictly required for the block to activate in those environments.

## Testing

- New `utils.test.ts` covers 8 cases: no region, non-GovCloud region, both GovCloud regions, `AWS_REGION` fallback, `AWS_DEFAULT_REGION` fallback, and precedence between the three sources.
- `npm run compile` clean.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
