### PR TITLE
fix(amazonq): extend GovCloud block to AgenticChatController

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.test.ts
@@ -486,6 +486,28 @@ describe('AgenticChatController', () => {
             chatController.onTabAdd({ tabId: mockTabId })
         })
 
+        describe('GovCloud region block', () => {
+            it('short-circuits with an unsupported-region response when client region is us-gov-west-1', async () => {
+                testFeatures.setClientParams({
+                    initializationOptions: {
+                        aws: {
+                            region: 'us-gov-west-1',
+                            awsClientCapabilities: { q: { developerProfiles: false } },
+                        },
+                    },
+                } as any)
+
+                const result = await chatController.onChatPrompt(
+                    { tabId: mockTabId, prompt: { prompt: 'Hello' } },
+                    mockCancellationToken
+                )
+
+                assert.ok(!(result instanceof ResponseError))
+                assert.ok((result as ChatResult).body?.includes('GovCloud'))
+                assert.ok((result as ChatResult).body?.includes('us-gov-west-1'))
+            })
+        })
+
         describe('Prompt ID', () => {
             let setCurrentPromptIdStub: sinon.SinonStub
 
@@ -2123,6 +2145,28 @@ describe('AgenticChatController', () => {
     })
 
     describe('onInlineChatPrompt', () => {
+        describe('GovCloud region block', () => {
+            it('short-circuits with an unsupported-region response when client region is us-gov-east-1', async () => {
+                testFeatures.setClientParams({
+                    initializationOptions: {
+                        aws: {
+                            region: 'us-gov-east-1',
+                            awsClientCapabilities: { q: { developerProfiles: false } },
+                        },
+                    },
+                } as any)
+
+                const result = await chatController.onInlineChatPrompt(
+                    { prompt: { prompt: 'Hello' } },
+                    mockCancellationToken
+                )
+
+                assert.ok(!(result instanceof ResponseError))
+                assert.ok((result as InlineChatResult).body?.includes('GovCloud'))
+                assert.ok((result as InlineChatResult).body?.includes('us-gov-east-1'))
+            })
+        })
+
         it('read all the response streams and return compiled results', async () => {
             const chatResultPromise = chatController.onInlineChatPrompt(
                 { prompt: { prompt: 'Hello' } },

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -103,7 +103,12 @@ import {
 } from '../../shared/telemetry/types'
 import { Features, LspHandlers, Result } from '../types'
 import { ChatEventParser, ChatResultWithMetadata } from '../chat/chatEventParser'
-import { createAuthFollowUpResult, getAuthFollowUpType, getDefaultChatResponse } from '../chat/utils'
+import {
+    createAuthFollowUpResult,
+    getAuthFollowUpType,
+    getDefaultChatResponse,
+    getGovCloudUnsupportedResponse,
+} from '../chat/utils'
 import { ChatSessionManagementService } from '../chat/chatSessionManagementService'
 import { ChatTelemetryController } from '../chat/telemetry/chatTelemetryController'
 import { QuickAction } from '../chat/quickActions'
@@ -860,6 +865,12 @@ export class AgenticChatController implements ChatHandlers {
     }
 
     async onChatPrompt(params: ChatParams, token: CancellationToken): Promise<ChatResult | ResponseError<ChatResult>> {
+        const clientRegion = this.#features.lsp.getClientInitializeParams()?.initializationOptions?.aws?.region
+        const maybeGovResponse = getGovCloudUnsupportedResponse(clientRegion)
+        if (maybeGovResponse) {
+            return maybeGovResponse
+        }
+
         // Phase 1: Initial Setup - This happens only once
         params.prompt.prompt = sanitizeInput(params.prompt.prompt || '', true)
 
@@ -3747,6 +3758,12 @@ export class AgenticChatController implements ChatHandlers {
         params: InlineChatParams,
         token: CancellationToken
     ): Promise<InlineChatResult | ResponseError<InlineChatResult>> {
+        const clientRegion = this.#features.lsp.getClientInitializeParams()?.initializationOptions?.aws?.region
+        const maybeGovResponse = getGovCloudUnsupportedResponse(clientRegion)
+        if (maybeGovResponse) {
+            return maybeGovResponse as InlineChatResult
+        }
+
         // TODO: This metric needs to be removed later, just added for now to be able to create a ChatEventParser object
         const metric = new Metric<AddMessageEvent>({
             cwsprChatConversationType: 'Chat',

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/chatController.ts
@@ -37,12 +37,7 @@ import {
 } from '../../shared/telemetry/types'
 import { Features, LspHandlers, Result } from '../types'
 import { ChatEventParser, ChatResultWithMetadata } from './chatEventParser'
-import {
-    createAuthFollowUpResult,
-    getAuthFollowUpType,
-    getDefaultChatResponse,
-    getGovCloudUnsupportedResponse,
-} from './utils'
+import { createAuthFollowUpResult, getAuthFollowUpType, getDefaultChatResponse } from './utils'
 import { ChatSessionManagementService } from './chatSessionManagementService'
 import { ChatTelemetryController } from './telemetry/chatTelemetryController'
 import { QuickAction } from './quickActions'
@@ -134,12 +129,6 @@ export class ChatController implements ChatHandlers {
     }
 
     async onChatPrompt(params: ChatParams, token: CancellationToken): Promise<ChatResult | ResponseError<ChatResult>> {
-        const clientRegion = this.#features.lsp.getClientInitializeParams()?.initializationOptions?.aws?.region
-        const maybeGovResponse = getGovCloudUnsupportedResponse(clientRegion)
-        if (maybeGovResponse) {
-            return maybeGovResponse
-        }
-
         const maybeDefaultResponse = getDefaultChatResponse(params.prompt.prompt)
 
         if (maybeDefaultResponse) {
@@ -281,12 +270,6 @@ export class ChatController implements ChatHandlers {
         params: InlineChatParams,
         token: CancellationToken
     ): Promise<InlineChatResult | ResponseError<InlineChatResult>> {
-        const clientRegion = this.#features.lsp.getClientInitializeParams()?.initializationOptions?.aws?.region
-        const maybeGovResponse = getGovCloudUnsupportedResponse(clientRegion)
-        if (maybeGovResponse) {
-            return maybeGovResponse as InlineChatResult
-        }
-
         // TODO: This metric needs to be removed later, just added for now to be able to create a ChatEventParser object
         const metric = new Metric<AddMessageEvent>({
             cwsprChatConversationType: 'Chat',


### PR DESCRIPTION
## Problem

Follow-up to #2776. Issue with the previous PR:

1. That PR guarded `ChatController.onChatPrompt` / `.onInlineChatPrompt`, but the shipped runtime for amazon-q-vscode and JetBrains (`agent-standalone.js` via the `qAgenticChatServer` manifest) uses `AgenticChatController`. `AgenticChatController implements ChatHandlers` — no inheritance from `ChatController` — so the guard needs to be applied there for the block to actually take effect in production.

## Solution

- Reuse the existing `getGovCloudUnsupportedResponse` helper from `chat/utils.ts` and add the same short-circuit at the top of `AgenticChatController.onChatPrompt` and `.onInlineChatPrompt`.
- Revert the `ChatController` changes introduced in #2776. Leaves `getGovCloudUnsupportedResponse` and `GOV_REGIONS` in `chat/utils.ts` (still exported), since `AgenticChatController` consumes them.

Net effect of #2776 + this PR on the branch: only `AgenticChatController`, `utils.ts` (helper), `utils.test.ts` (helper tests), and `agenticChatController.test.ts` are touched. `chatController.ts` is unchanged relative to `main`.

## Testing

- New tests in `agenticChatController.test.ts` cover `us-gov-west-1` for chat and `us-gov-east-1` for inline chat.
- `npm run compile` clean.
- Full `agenticChatController.test.ts` suite (97 tests) and `utils.test.ts` suite (8 tests) pass locally.
- Manually verified end-to-end in a local VS Code Extension Development Host with `AWS_REGION=us-east-1` (via a temporary `us-east-1` entry in `GOV_REGIONS`, since GovCloud is not reachable from a developer laptop). The chat panel returns the "not supported in AWS GovCloud" message instead of hitting the service.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
