### PR TITLE
fix: show MCP config file paths correctly in error messages

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.test.ts
@@ -1489,8 +1489,37 @@ describe('McpManager error handling', () => {
         // Test that getConfigLoadErrors returns the expected error messages
         const errors = mgr.getConfigLoadErrors()
         expect(errors).to.not.be.undefined
-        expect(errors).to.include('File: file1.json, Error: File not found error')
-        expect(errors).to.include('File: serverA, Error: Missing command error')
+        expect(errors).to.include('File: `file1.json`, Error: File not found error')
+        expect(errors).to.include('File: `serverA`, Error: Missing command error')
+    })
+
+    it('wraps file paths in code spans so Windows paths render correctly in markdown', async () => {
+        // A Windows path segment like "\.aws" would have its backslash stripped when
+        // rendered as markdown unless the path is wrapped in a code span.
+        const windowsPath = 'C:\\Users\\me\\.aws\\amazonq\\mcp.json'
+        const mockErrors = new Map<string, string>([[windowsPath, 'Invalid JSON error']])
+
+        loadStub = sinon.stub(mcpUtils, 'loadAgentConfig').resolves({
+            servers: new Map(),
+            serverNameMapping: new Map(),
+            errors: mockErrors,
+            agentConfig: {
+                name: 'test-agent',
+                description: 'Test agent',
+                mcpServers: {},
+                tools: [],
+                allowedTools: [],
+                toolsSettings: {},
+                includedFiles: [],
+                resources: [],
+            },
+        })
+
+        const mgr = await McpManager.init([], features)
+        await mgr.discoverAllServers()
+
+        const errors = mgr.getConfigLoadErrors()
+        expect(errors).to.include(`File: \`${windowsPath}\`, Error: Invalid JSON error`)
     })
 
     it('returns undefined when no errors exist', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -1630,7 +1630,10 @@ export class McpManager {
                 if (server === 'registry') {
                     return error
                 }
-                return `File: ${server}, Error: ${error}`
+                // Wrap the file path/server name in a code span. This message is rendered
+                // as markdown in the UI, so an unescaped Windows path (e.g. a segment like
+                // "\.aws") would have its backslash stripped and be shown incorrectly.
+                return `File: \`${server}\`, Error: ${error}`
             })
             .join('\n\n')
     }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts
@@ -74,7 +74,7 @@ export async function loadMcpServerConfigs(
         try {
             rawText = (await workspace.fs.readFile(fsPath)).toString()
         } catch (e: any) {
-            const errorMsg = `Failed to read MCP config at ${fsPath}: ${e.message}`
+            const errorMsg = `Failed to read MCP config at \`${fsPath}\`: ${e.message}`
             logging.warn(errorMsg)
             configErrors.set(`${fsPath}`, errorMsg)
             continue
@@ -84,14 +84,14 @@ export async function loadMcpServerConfigs(
         try {
             json = JSON.parse(rawText)
         } catch (e: any) {
-            const errorMsg = `Invalid JSON in MCP config at ${fsPath}: ${e.message}`
+            const errorMsg = `Invalid JSON in MCP config at \`${fsPath}\`: ${e.message}`
             logging.warn(errorMsg)
             configErrors.set(`${fsPath}`, errorMsg)
             continue
         }
 
         if (!json.mcpServers || typeof json.mcpServers !== 'object') {
-            const errorMsg = `MCP config at ${fsPath} missing or invalid 'mcpServers' field`
+            const errorMsg = `MCP config at \`${fsPath}\` missing or invalid 'mcpServers' field`
             logging.warn(errorMsg)
             configErrors.set(`${fsPath}`, errorMsg)
             continue


### PR DESCRIPTION
## Problem

When MCP config loading fails, the error is shown to the user (in the MCP servers view / status), and the message embeds the config file path. That message is rendered as **markdown**, so a Windows path segment such as `\.aws` has its backslash stripped (`\.` is a markdown escape). The path is therefore displayed incorrectly — e.g. `C:\Users\me\.aws\amazonq\mcp.json` shows as `C:\Users\me.aws\amazonq\mcp.json`.

This misleads users into thinking Amazon Q is looking at the wrong path (a reported case: a user concluded "it's a path issue, the file doesn't exist" when the path was actually correct and their `mcp.json` was simply empty — "Unexpected end of JSON input").

## Fix

Wrap the file path in a markdown code span (backticks) so it renders verbatim, including backslashes:

- `server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpUtils.ts`: the "Failed to read", "Invalid JSON", and "missing/invalid `mcpServers`" messages now wrap the path as `` `<path>` ``.
- `mcpManager.ts` (`getConfigLoadErrors`): the `File: <path>` prefix now wraps the path/server key as `` File: `<path>` ``.

## Testing

- Updated `mcpManager.test.ts` assertions for the new `File: `\`…\``` format.
- Added a test asserting a Windows path containing a `\.aws` segment is wrapped in a code span (so its backslash survives markdown rendering).
- Ran the MCP unit tests (`mcpManager.test.ts` + `mcpUtils.test.ts`): 112 passing.
- `prettier --check` passes; `eslint` reports no new issues (only pre-existing warnings unrelated to this change).

## Notes

- This corrects the misleading path *display*; the underlying config errors (e.g. empty/invalid `mcp.json`) are unchanged and still reported.
