### PR TITLE
fix: stop pinned context leaking to new chat windows

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.test.ts
@@ -65,6 +65,33 @@ describe('ChatDatabase', () => {
         sinon.restore()
     })
 
+    describe('pinned context', () => {
+        beforeEach(async () => {
+            await chatDb.databaseInitialize(0)
+        })
+
+        it('does not mutate the shared DEFAULT_PINNED_CONTEXT when pinning in a tab', () => {
+            const defaultLengthBefore = util.DEFAULT_PINNED_CONTEXT.length
+            const customContext = { id: 'custom-folder-ctx', command: 'myFolder', label: 'folder' } as any
+
+            // Create the tab first (with tabContext but no pinnedContext yet) so that
+            // addPinnedContext initializes pinnedContext from the shared default — the
+            // code path that previously aliased and then mutated DEFAULT_PINNED_CONTEXT.
+            chatDb.setRules('tab-1', { folders: {}, rules: {} } as any)
+            chatDb.addPinnedContext('tab-1', customContext)
+
+            // The shared module-level default must not be polluted by pinning in a tab,
+            // otherwise every new chat window would inherit the custom pinned item.
+            assert.strictEqual(util.DEFAULT_PINNED_CONTEXT.length, defaultLengthBefore)
+            assert.ok(!util.DEFAULT_PINNED_CONTEXT.some((c: any) => c.id === 'custom-folder-ctx'))
+
+            // A brand-new tab must only receive the default pinned context, not the item
+            // that was pinned in a different tab.
+            const freshTabPinned = chatDb.getPinnedContext('tab-2-fresh')
+            assert.ok(!freshTabPinned.some((c: any) => c.id === 'custom-folder-ctx'))
+        })
+    })
+
     describe('replaceWithSummary', () => {
         it('should create a new history with summary message', async () => {
             await chatDb.databaseInitialize(0)

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/chatDb/chatDb.ts
@@ -269,7 +269,9 @@ export class ChatDatabase {
             const historyId = this.getOrCreateHistoryId(tabId)
             if (historyId) {
                 const tab = collection.findOne({ historyId })
-                return tab?.tabContext?.pinnedContext || DEFAULT_PINNED_CONTEXT
+                // Return a copy of the default so callers cannot mutate the shared
+                // module-level DEFAULT_PINNED_CONTEXT array.
+                return tab?.tabContext?.pinnedContext || [...DEFAULT_PINNED_CONTEXT]
             }
         }
         return []
@@ -313,7 +315,10 @@ export class ChatDatabase {
                         tab.tabContext = {}
                     }
                     if (!tab.tabContext.pinnedContext) {
-                        tab.tabContext.pinnedContext = DEFAULT_PINNED_CONTEXT
+                        // Use a copy: DEFAULT_PINNED_CONTEXT is a shared module-level array,
+                        // and the unshift/push below would otherwise mutate it, polluting the
+                        // default pinned context for every new tab/chat window.
+                        tab.tabContext.pinnedContext = [...DEFAULT_PINNED_CONTEXT]
                     }
                     // Only add context item if its not already in this tab's pinned context
                     if (!tab.tabContext.pinnedContext.find(c => c.id === context.id)) {


### PR DESCRIPTION
## Problem

Pinned context cannot be un-pinned: after pinning context in a chat, opening a new chat window still shows the pinned item, and un-pinning does not stick.

## Root cause

`DEFAULT_PINNED_CONTEXT` is a shared module-level array (the default pinned context — the active file — used for tabs that have none). In `ChatDatabase.addPinnedContext`, when a tab had no pinned context yet, the code aliased that shared array and then mutated it:

```ts
if (!tab.tabContext.pinnedContext) {
    tab.tabContext.pinnedContext = DEFAULT_PINNED_CONTEXT   // shared reference
}
// ...
tab.tabContext.pinnedContext.unshift(context)  // mutates DEFAULT_PINNED_CONTEXT
```

So pinning context in one tab permanently added it to the global default. Every **new chat window** reads `DEFAULT_PINNED_CONTEXT` for its initial pinned context, so it inherited the leaked item — and un-pinning in the original tab could not remove it from the polluted default. `getPinnedContext` also returned the shared default array by reference.

## Fix

Copy the default array instead of aliasing it:

- `addPinnedContext`: initialize a tab's pinned context with `[...DEFAULT_PINNED_CONTEXT]`.
- `getPinnedContext`: return `[...DEFAULT_PINNED_CONTEXT]` so callers can't mutate the shared default.

## Testing

- Added a regression test in `chatDb.test.ts` asserting that pinning a custom context in a tab does not mutate `DEFAULT_PINNED_CONTEXT` and that a brand-new tab does not inherit the item.
- The test was confirmed to fail against the previous (aliasing) implementation and pass with this change.
- Ran the `chatDb` unit tests: 24 passing. `prettier --check` passes; `eslint` reports no new issues.
