### PR TITLE
chore(amazonq): authenticate agentic-chat E2E tests via a dedicated OIDC role

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -81,8 +81,8 @@ jobs:
                   npm run test-integ -w integration-tests/q-agentic-chat-server
               env:
                   TEST_SSO_TOKEN: ${{ env.TEST_SSO_TOKEN }}
-                  TEST_SSO_START_URL: ${{ secrets.TEST_SSO_START_URL }}
-                  TEST_PROFILE_ARN: ${{ secrets.TEST_PROFILE_ARN }}
+                  TEST_SSO_START_URL: ${{ secrets.INTEG_TEST_SSO_START_URL }}
+                  TEST_PROFILE_ARN: ${{ secrets.INTEG_TEST_PROFILE_ARN }}
                   TEST_RUNTIME_FILE: ${{ github.workspace }}/downloaded-artifacts/aws-lsp-codewhisperer.js
                   # Tags LSP CI traffic so RTS ServiceMetrics/dashboards can segment or exclude it (BI).
                   AWS_SDK_UA_APP_ID: lsp-integ-ci

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,26 +52,37 @@ jobs:
             - name: Configure AWS Credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:
-                  role-to-assume: arn:aws:iam::964765661569:role/GitHubActionsTokenRefresherRole
-                  role-session-name: language-servers-github
+                  # DEXP-owned GitHub-OIDC read role in the gamma-IAD canary account (550160095699):
+                  # least-privilege (GetSecretValue on SSOTokenSecret + kms:Decrypt on its key), no lambda.
+                  role-to-assume: arn:aws:iam::550160095699:role/LanguageServersGitHubActionsReadRole
+                  role-session-name: lsp-integ-ci
                   aws-region: us-east-1
             - name: Build
               run: |
                   npm ci
                   npm run compile
-            - name: Refresh Token
-              run: aws lambda invoke --function-name TokenRefresherLambda --region us-east-1 --payload '{}' response.json
             - name: Get SSO Token
-              uses: aws-actions/aws-secretsmanager-get-secrets@v2
-              with:
-                  secret-ids: |
-                      ,SsoTokenSecret
-                  parse-json-secrets: true
+              # SSOTokenSecret is minted by the canary SSORefreshTokenLambda and self-refreshes
+              # every ~5 min, so no lambda invoke is needed. Public repo: mask the token in logs.
+              run: |
+                  SECRET_JSON="$(aws secretsmanager get-secret-value \
+                    --secret-id SSOTokenSecret \
+                    --region us-east-1 \
+                    --query SecretString --output text)"
+                  TEST_SSO_TOKEN="$(printf '%s' "$SECRET_JSON" | jq -r '.createTokenResponseByUser["canaryGammaIAD"].accessToken')"
+                  if [ -z "$TEST_SSO_TOKEN" ] || [ "$TEST_SSO_TOKEN" = "null" ]; then
+                    echo "::error::Failed to extract accessToken for canaryGammaIAD from SSOTokenSecret"
+                    exit 1
+                  fi
+                  echo "::add-mask::$TEST_SSO_TOKEN"
+                  echo "TEST_SSO_TOKEN=$TEST_SSO_TOKEN" >> "$GITHUB_ENV"
             - name: Run Integration Tests
               run: |
                   npm run test-integ -w integration-tests/q-agentic-chat-server
               env:
-                  TEST_SSO_TOKEN: ${{ env.SSOTOKEN }}
+                  TEST_SSO_TOKEN: ${{ env.TEST_SSO_TOKEN }}
                   TEST_SSO_START_URL: ${{ secrets.TEST_SSO_START_URL }}
                   TEST_PROFILE_ARN: ${{ secrets.TEST_PROFILE_ARN }}
                   TEST_RUNTIME_FILE: ${{ github.workspace }}/downloaded-artifacts/aws-lsp-codewhisperer.js
+                  # Tags LSP CI traffic so RTS ServiceMetrics/dashboards can segment or exclude it (BI).
+                  AWS_SDK_UA_APP_ID: lsp-integ-ci


### PR DESCRIPTION
## What
Re-point the `q-agentic-chat-server` integration tests (`.github/workflows/integration-tests.yml`) at a team-owned SSO bearer token, authenticated via a dedicated least-privilege GitHub-OIDC role, replacing the previous token-refresher role + lambda that has been removed.

## Changes
- **Configure AWS Credentials** now assumes the read-only OIDC role `arn:aws:iam::550160095699:role/LanguageServersGitHubActionsReadRole` (us-east-1), session name `lsp-integ-ci`.
- **Removed** the `Refresh Token` step (`aws lambda invoke ... TokenRefresherLambda`): the token secret is refreshed out-of-band every ~5 min, and the new role intentionally has no `lambda:InvokeFunction`.
- **Get SSO Token** now does a raw `secretsmanager:GetSecretValue` + `jq` extraction of the access token into `TEST_SSO_TOKEN`, and masks it with `::add-mask::` (public repo).
- Tags traffic with `AWS_SDK_UA_APP_ID=lsp-integ-ci` so the token provider's dashboards can attribute/exclude CI traffic.

## Security
- OIDC trust is scoped to this repo with a tightened `sub` (branch refs, not `:*`) and `aud=sts.amazonaws.com`.
- Least-privilege: `secretsmanager:GetSecretValue` on one secret + `kms:Decrypt` on its key. No write, no lambda.
- Token masked in logs; only non-secret identifiers (account id, role ARN, secret name) appear, consistent with the prior setup.


## Testing
`integration-tests.yml` runs post-merge via `workflow_run` (not a PR gate). Once unblocked, we'll trigger a post-merge run and confirm the OIDC assume succeeds, the token is masked, and `q-agentic-chat-server` passes across the OS matrix. For `workflow_run` events the OIDC `sub` ref will be verified against the trust policy on that first run.


