### PR TITLE
fix(amazonq): make cmd.exe builtin detection locale-independent

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.test.ts
@@ -62,6 +62,17 @@ describe('ExecuteBash Tool', () => {
         )
     })
 
+    it('pass validation for a cmd.exe builtin without an executable on PATH', async function () {
+        // Builtins like 'assoc' have no .exe that 'where' can resolve, so they must be
+        // recognized as internal commands. This is only meaningful on Windows.
+        if (process.platform !== 'win32') {
+            this.skip()
+            return
+        }
+        const execBash = new ExecuteBash(features)
+        await execBash.validate({ command: 'assoc' })
+    })
+
     it('validate and invokes the command', async () => {
         const execBash = new ExecuteBash(features)
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/executeBash.ts
@@ -751,8 +751,64 @@ export class ExecuteBash {
         }
     }
 
+    // cmd.exe internal commands that have no executable on PATH, so 'where' cannot find them.
+    // Kept as a static set because probing 'cmd.exe /c help <cmd>' is locale-dependent: the
+    // "not supported" marker is localized (e.g. German Windows), which made every unknown
+    // command pass validation on non-English systems.
+    private static readonly CMD_BUILTINS = new Set([
+        'assoc',
+        'break',
+        'call',
+        'cd',
+        'chdir',
+        'cls',
+        'color',
+        'copy',
+        'date',
+        'del',
+        'dir',
+        'dpath',
+        'echo',
+        'endlocal',
+        'erase',
+        'exit',
+        'for',
+        'ftype',
+        'goto',
+        'if',
+        'md',
+        'mkdir',
+        'mklink',
+        'move',
+        'path',
+        'pause',
+        'popd',
+        'prompt',
+        'pushd',
+        'rd',
+        'rem',
+        'ren',
+        'rename',
+        'rmdir',
+        'set',
+        'setlocal',
+        'shift',
+        'start',
+        'time',
+        'title',
+        'type',
+        'ver',
+        'verify',
+        'vol',
+    ])
+
     private static async resolveWindowsCommand(logger: Logging, cmd: string): Promise<void> {
-        // 1. Check for external command or alias
+        // 1. Check for built-in command
+        if (ExecuteBash.CMD_BUILTINS.has(cmd.toLowerCase())) {
+            return
+        }
+
+        // 2. Check for external command or alias
         try {
             const whereProc = new processUtils.ChildProcess(logger, 'where', [cmd], {
                 collect: true,
@@ -766,22 +822,6 @@ export class ExecuteBash {
             }
         } catch (err) {
             logger.debug(`'where ${cmd}' failed: ${(err as Error).message}`)
-        }
-
-        // 2. Check for built-in command
-        try {
-            const helpProc = new processUtils.ChildProcess(logger, 'cmd.exe', ['/c', 'help', cmd], {
-                collect: true,
-                waitForStreams: true,
-            })
-            const result = await helpProc.run()
-            const output = result.stdout.trim()
-
-            if (output && !output.includes('This command is not supported by the help utility')) {
-                return
-            }
-        } catch (err) {
-            logger.debug(`'help ${cmd}' failed: ${(err as Error).message}`)
         }
 
         throw new Error(`Command '${cmd}' not found as executable or Windows built-in command`)


### PR DESCRIPTION
## Problem

On non-English Windows systems, `executeBash` command validation is broken:
every unknown command passes validation as a supposed cmd.exe builtin.

`resolveWindowsCommand` probes `cmd.exe /c help <cmd>` and checks the output
for the English marker `"This command is not supported by the help utility"`.
That string is localized, so e.g. on a German-locale system the marker never
matches and any command that `where` cannot find is accepted as a builtin.

This is visible in the existing test suite: `"whichCommand cannot find the
first arg"` (`executeBash.test.ts`) fails on a de-DE Windows machine against
current `main` with `Missing expected rejection`, because `noSuchCmd`
incorrectly passes validation.

## Solution

Replace the locale-dependent `help` probe with a static set of cmd.exe
internal commands, checked before falling back to `where` for external
commands. As a side effect this saves one child-process spawn when
validating non-builtin commands.

Added a win32-gated test asserting that a builtin without an executable on
PATH (`assoc`) passes validation.

**Testing:** ran the full `executeBash.test.ts` suite on German-locale
Windows 11: 57 passing with this change; without it, the existing
`noSuchCmd` test fails as described above.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.