### PR TITLE
feat(amazonq): surface Q Developer plugin access-blocked rejections to the client

### DIFF
--- a/server/aws-lsp-codewhisperer/src/client/token/codewhisperer.ts
+++ b/server/aws-lsp-codewhisperer/src/client/token/codewhisperer.ts
@@ -1,6 +1,7 @@
 import { CodeWhispererRuntimeClient, CodeWhispererRuntimeClientConfig } from '@amzn/codewhisperer-runtime'
 import { SDKInitializator, Logging, CredentialsProvider } from '@aws/language-server-runtimes/server-interface'
 import { HttpResponse, HttpRequest } from '@smithy/types'
+import { isQDevPluginAccessBlockedError } from '../../shared/utils'
 
 export interface CodeWhispererTokenClientConfigurationOptions extends CodeWhispererRuntimeClientConfig {
     // Add any custom options if needed
@@ -11,7 +12,8 @@ export function createCodeWhispererTokenClient(
     sdkInitializator: SDKInitializator,
     logging: Logging,
     credentialsProvider: CredentialsProvider,
-    shareCodeWhispererContentWithAWS: () => boolean
+    shareCodeWhispererContentWithAWS: () => boolean,
+    onAccessBlocked?: (error: unknown) => void
 ): CodeWhispererRuntimeClient {
     logging.log(
         `Passing client for class CodeWhispererRuntimeClient to sdkInitializator (v3) for additional setup (e.g. proxy)`
@@ -58,6 +60,46 @@ export function createCodeWhispererTokenClient(
             priority: 'high',
         }
     )
+
+    // Observe (never alter) errors that indicate RTS has blocked Q Developer plugin access for this
+    // identity. RTS gates plugin traffic before the activity runs, so a blocked identity fails *every*
+    // operation this way -- observing centrally here is what lets callers react to the first failure
+    // instead of each call site having to classify the error itself.
+    //
+    // Deliberately a pure passthrough:
+    //   - the original error is always rethrown unchanged, so error handling and retry behaviour of
+    //     every existing operation are untouched;
+    //   - the observer is invoked inside its own try/catch, so a faulty observer cannot convert a
+    //     service error into a different one or mask it;
+    //   - when no observer is supplied the middleware only rethrows, so existing callers that do not
+    //     pass one behave exactly as before.
+    //
+    // Registered on the outermost (initialize) step so the error is observed once per operation, after
+    // the SDK's retries are exhausted, rather than once per attempt.
+    if (onAccessBlocked) {
+        client.middlewareStack.add(
+            next => async args => {
+                try {
+                    return await next(args)
+                } catch (e) {
+                    if (isQDevPluginAccessBlockedError(e)) {
+                        try {
+                            onAccessBlocked(e)
+                        } catch (observerError) {
+                            logging.debug(
+                                `onAccessBlocked observer threw, ignoring: ${(observerError as Error)?.message}`
+                            )
+                        }
+                    }
+                    throw e
+                }
+            },
+            {
+                step: 'initialize',
+                name: 'detectQDevPluginAccessBlocked',
+            }
+        )
+    }
 
     return client
 }

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -10,6 +10,7 @@ import {
     CancellationTokenSource,
 } from '@aws/language-server-runtimes/server-interface'
 import { CodeWhispererServiceToken } from '../codeWhispererService'
+import { createQDevAccessBlockedNotifier } from '../qDevAccessBlockedNotifier'
 import {
     AmazonQError,
     AmazonQServiceAlreadyInitializedError,
@@ -596,6 +597,9 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
 
         service.customizationArn = this.configurationCache.getProperty('customizationArn')
         service.profileArn = this.activeIdcProfile?.arn
+        if (this.features.notification) {
+            service.onAccessBlocked = createQDevAccessBlockedNotifier(this.features.notification, this.features.logging)
+        }
         service.shareCodeWhispererContentWithAWS = this.configurationCache.getProperty(
             'shareCodeWhispererContentWithAWS'
         )

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/BaseAmazonQServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/BaseAmazonQServiceManager.ts
@@ -8,6 +8,7 @@ import {
     SDKInitializator,
     UpdateConfigurationParams,
     Workspace,
+    Notification,
 } from '@aws/language-server-runtimes/server-interface'
 import { CodeWhispererServiceBase } from '../codeWhispererService'
 import {
@@ -26,6 +27,12 @@ export interface QServiceManagerFeatures {
     sdkInitializator: SDKInitializator
     workspace: Workspace
     atxCredentialsProvider?: CredentialsProvider
+    /**
+     * Optional so that existing constructors of this type (including tests that build a partial
+     * features object) keep compiling unchanged. Servers pass the full runtime `Features`, which always
+     * includes it; when it is absent the features that depend on it simply stay inert.
+     */
+    notification?: Notification
 }
 
 export type AmazonQBaseServiceManager = BaseAmazonQServiceManager<CodeWhispererServiceBase, StreamingClientServiceBase>

--- a/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/codeWhispererService.ts
@@ -415,6 +415,20 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
     #abTestingFetchingTimeout: NodeJS.Timeout | undefined
     #features: FeatureEvaluation[] | undefined
 
+    /**
+     * Invoked when any request from this client is rejected because RTS has blocked Q Developer plugin
+     * access for this identity (see {@link isQDevPluginAccessBlockedError}).
+     *
+     * Assigned after construction -- deliberately, so that whoever owns the client lifecycle (and has
+     * access to the client-facing features needed to surface it) can supply the reaction without this
+     * service taking a dependency on it. Follows the same late-binding approach already used for
+     * `shareCodeWhispererContentWithAWS`. When unset, detection is inert.
+     *
+     * The service error itself is always still thrown to the caller; this is purely an observation
+     * hook and must not be used to suppress it.
+     */
+    public onAccessBlocked?: (error: unknown) => void
+
     constructor(
         private credentialsProvider: CredentialsProvider,
         workspace: Workspace,
@@ -446,7 +460,8 @@ export class CodeWhispererServiceToken extends CodeWhispererServiceBase {
             sdkInitializator,
             logging,
             credentialsProvider,
-            () => this.shareCodeWhispererContentWithAWS
+            () => this.shareCodeWhispererContentWithAWS,
+            error => this.onAccessBlocked?.(error)
         )
         this.userContext = userContext
         this.scheduleABTestingFetching()

--- a/server/aws-lsp-codewhisperer/src/shared/qDevAccessBlockedNotifier.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/qDevAccessBlockedNotifier.test.ts
@@ -1,0 +1,82 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MessageType } from '@aws/language-server-runtimes/protocol'
+import { Logging, Notification } from '@aws/language-server-runtimes/server-interface'
+import * as assert from 'assert'
+import * as sinon from 'sinon'
+import { createQDevAccessBlockedNotifier } from './qDevAccessBlockedNotifier'
+
+describe('createQDevAccessBlockedNotifier', function () {
+    let showNotification: sinon.SinonStub
+    let notification: Notification
+    let logging: Logging
+
+    // The real service message, from ExceptionConstants.BUILDER_ID_ACCOUNT_LINK_BLOCKED_EXCEPTION_MESSAGE.
+    const serviceMessage =
+        'Please visit https://kiro.dev/ to purchase a Kiro subscription, which can be used with Amazon Q Developer.'
+
+    beforeEach(function () {
+        showNotification = sinon.stub()
+        notification = {
+            showNotification,
+            onNotificationFollowup: sinon.stub(),
+        } as unknown as Notification
+        logging = {
+            log: sinon.stub(),
+            info: sinon.stub(),
+            warn: sinon.stub(),
+            error: sinon.stub(),
+            debug: sinon.stub(),
+        } as unknown as Logging
+    })
+
+    it('surfaces the service message verbatim as an error notification', function () {
+        createQDevAccessBlockedNotifier(notification, logging)(new Error(serviceMessage))
+
+        sinon.assert.calledOnce(showNotification)
+        const params = showNotification.firstCall.args[0]
+        assert.strictEqual(params.type, MessageType.Error)
+        assert.strictEqual(params.content.text, serviceMessage)
+    })
+
+    it('notifies at most once, since every request from a blocked identity fails', function () {
+        const notify = createQDevAccessBlockedNotifier(notification, logging)
+
+        notify(new Error(serviceMessage))
+        notify(new Error(serviceMessage))
+        notify(new Error(serviceMessage))
+
+        sinon.assert.calledOnce(showNotification)
+    })
+
+    it('dedupes per instance, so a new connection can notify again', function () {
+        createQDevAccessBlockedNotifier(notification, logging)(new Error(serviceMessage))
+        createQDevAccessBlockedNotifier(notification, logging)(new Error(serviceMessage))
+
+        sinon.assert.calledTwice(showNotification)
+    })
+
+    it('falls back to generic text when the service gave no message', function () {
+        createQDevAccessBlockedNotifier(notification, logging)(new Error(''))
+
+        const params = showNotification.firstCall.args[0]
+        assert.ok(params.content.text.length > 0)
+        assert.notStrictEqual(params.content.text, '')
+    })
+
+    it('does not throw when showNotification throws', function () {
+        // Invoked from a client middleware error path: it must never be able to replace or mask the
+        // service error that is being propagated to the caller.
+        showNotification.throws(new Error('client exploded'))
+
+        assert.doesNotThrow(() => createQDevAccessBlockedNotifier(notification, logging)(new Error(serviceMessage)))
+    })
+
+    it('does not throw for a non-Error argument', function () {
+        assert.doesNotThrow(() => createQDevAccessBlockedNotifier(notification, logging)(undefined))
+        sinon.assert.calledOnce(showNotification)
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/shared/qDevAccessBlockedNotifier.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/qDevAccessBlockedNotifier.ts
@@ -1,0 +1,69 @@
+/*!
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logging, Notification } from '@aws/language-server-runtimes/server-interface'
+import { MessageType } from '@aws/language-server-runtimes/protocol'
+
+/**
+ * Fallback text, used only if the service somehow rejects the request without a message. Normally the
+ * service's own message is shown verbatim: RTS reuses `FEATURE_NOT_SUPPORTED` across several gates, so
+ * the reason tells us *that* access is blocked while only the message says *why* and what to do about
+ * it. Substituting our own copy here would risk telling the customer the wrong thing.
+ */
+const FALLBACK_TEXT = 'Amazon Q Developer is not available for this account.'
+
+const TITLE = 'Amazon Q Developer'
+
+/**
+ * Builds the reaction to RTS blocking Q Developer plugin access for the current identity, for use as
+ * {@link CodeWhispererServiceToken.onAccessBlocked}.
+ *
+ * Surfaces the service's message through the existing `showNotification` channel. That channel was
+ * chosen deliberately for backwards compatibility: the language server ships ahead of the plugins, and
+ * every plugin version already in the market will pick up this server. Because
+ * `showNotification` is a no-op in the runtime unless the client advertised
+ * `initializationOptions.aws.awsClientCapabilities.window.notifications`, older plugins that know
+ * nothing about this are unaffected -- they neither receive nor need to handle anything new. Plugins
+ * that do advertise it get the real reason surfaced instead of failing silently. No new protocol
+ * message, and no client-side change, is required for that to hold.
+ *
+ * Notifies at most once per instance. RTS gates plugin traffic before the activity runs, so a blocked
+ * identity fails *every* request; without this the customer would get one notification per API call.
+ * The dedupe is intentionally scoped to the instance rather than the process: a new service instance is
+ * built when the connection changes, so switching accounts correctly gets a fresh notification rather
+ * than being silently suppressed.
+ *
+ * Never throws -- it is invoked from a client middleware error path, and must not be able to interfere
+ * with the service error being propagated to the caller.
+ */
+export function createQDevAccessBlockedNotifier(
+    notification: Notification,
+    logging: Logging
+): (error: unknown) => void {
+    let alreadyNotified = false
+
+    return (error: unknown) => {
+        if (alreadyNotified) {
+            return
+        }
+        alreadyNotified = true
+
+        const serviceMessage = (error as Error | undefined)?.message?.trim()
+        const text = serviceMessage && serviceMessage.length > 0 ? serviceMessage : FALLBACK_TEXT
+
+        try {
+            logging.warn(`Q Developer plugin access is blocked for this identity: ${text}`)
+            notification.showNotification({
+                type: MessageType.Error,
+                content: {
+                    title: TITLE,
+                    text,
+                },
+            })
+        } catch (e) {
+            logging.debug(`Failed to surface Q Developer access-blocked notification: ${(e as Error)?.message}`)
+        }
+    }
+}

--- a/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.test.ts
@@ -1,3 +1,4 @@
+import { AccessDeniedException, AccessDeniedExceptionReason } from '@amzn/codewhisperer-runtime'
 import {
     ServiceQuotaExceededException,
     ThrottlingException,
@@ -18,6 +19,7 @@ import {
     getUnmodifiedAcceptedTokens,
     isAwsThrottlingError,
     isUsageLimitError,
+    isQDevPluginAccessBlockedError,
     isStringOrNull,
     safeGet,
     getFileExtensionName,
@@ -500,6 +502,85 @@ describe('isAwsThrottlingError', function () {
         ;(errorWithMetadata as any).$metadata = {}
         ;(errorWithMetadata as any).name = 'ThrottlingException'
         assert.strictEqual(isAwsThrottlingError(errorWithMetadata), true)
+    })
+})
+
+describe('isQDevPluginAccessBlockedError', function () {
+    function accessDenied(reason?: string, message = 'denied'): AccessDeniedException {
+        return new AccessDeniedException({
+            message,
+            reason: reason as AccessDeniedExceptionReason,
+            $metadata: {},
+        })
+    }
+
+    it('true for AccessDeniedException with reason FEATURE_NOT_SUPPORTED', function () {
+        // The real service message, from
+        // ExceptionConstants.BUILDER_ID_ACCOUNT_LINK_BLOCKED_EXCEPTION_MESSAGE.
+        const e = accessDenied(
+            'FEATURE_NOT_SUPPORTED',
+            'Please visit https://kiro.dev/ to purchase a Kiro subscription, which can be used with Amazon Q Developer.'
+        )
+        assert.strictEqual(isQDevPluginAccessBlockedError(e), true)
+    })
+
+    it('false for TEMPORARILY_SUSPENDED, which is transient and must keep its retry path', function () {
+        assert.strictEqual(isQDevPluginAccessBlockedError(accessDenied('TEMPORARILY_SUSPENDED')), false)
+    })
+
+    it('false for the other modeled AccessDeniedException reasons', function () {
+        assert.strictEqual(
+            isQDevPluginAccessBlockedError(accessDenied('UNAUTHORIZED_CUSTOMIZATION_RESOURCE_ACCESS')),
+            false
+        )
+        assert.strictEqual(
+            isQDevPluginAccessBlockedError(accessDenied('UNAUTHORIZED_WORKSPACE_CONTEXT_FEATURE_ACCESS')),
+            false
+        )
+    })
+
+    it('false for AccessDeniedException with no reason', function () {
+        // Observed in practice: ListAvailableProfiles rejects every Builder ID caller with
+        // "AWS Builder ID is not supported for this operation" and no reason. That is a request-shape
+        // rejection, not the access block, and must not be treated as one.
+        assert.strictEqual(
+            isQDevPluginAccessBlockedError(
+                accessDenied(undefined, 'AWS Builder ID is not supported for this operation.')
+            ),
+            false
+        )
+    })
+
+    it('false for a different exception type carrying a matching reason', function () {
+        const e = new ServiceException({
+            name: 'ValidationException',
+            message: 'nope',
+            $fault: 'client',
+            $metadata: {},
+        })
+        ;(e as any).reason = 'FEATURE_NOT_SUPPORTED'
+        assert.strictEqual(isQDevPluginAccessBlockedError(e), false)
+    })
+
+    it('unwraps the cause chain', function () {
+        const root = accessDenied('FEATURE_NOT_SUPPORTED')
+        const wrapped = new Error('outer', { cause: new Error('inner', { cause: root }) })
+        assert.strictEqual(isQDevPluginAccessBlockedError(wrapped), true)
+    })
+
+    it('terminates on a cyclic cause chain', function () {
+        const a: any = new Error('a')
+        const b: any = new Error('b')
+        a.cause = b
+        b.cause = a
+        assert.strictEqual(isQDevPluginAccessBlockedError(a), false)
+    })
+
+    it('false for non-error values', function () {
+        assert.strictEqual(isQDevPluginAccessBlockedError(undefined), false)
+        assert.strictEqual(isQDevPluginAccessBlockedError(null), false)
+        assert.strictEqual(isQDevPluginAccessBlockedError('FEATURE_NOT_SUPPORTED'), false)
+        assert.strictEqual(isQDevPluginAccessBlockedError({}), false)
     })
 })
 

--- a/server/aws-lsp-codewhisperer/src/shared/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/utils.ts
@@ -14,6 +14,7 @@ import {
     MISSING_BEARER_TOKEN_ERROR,
     SAGEMAKER_UNIFIED_STUDIO_SERVICE,
 } from './constants'
+import { AccessDeniedExceptionReason } from '@amzn/codewhisperer-runtime'
 import {
     CodeWhispererStreamingServiceException,
     Origin,
@@ -42,6 +43,52 @@ export function isAwsError(error: unknown): error is Error & { code: string; tim
 
     // AWS SDK v3 errors extend ServiceException
     return error instanceof ServiceException || (error instanceof Error && '$metadata' in error)
+}
+
+/**
+ * Whether `e` (or anything in its cause chain) is Amazon Q Developer refusing this identity because
+ * Builder ID plugin access is blocked.
+ *
+ * RTS gates Q Developer plugin traffic (identified by the shared
+ * `AWS-Language-Servers-AWS-CodeWhisperer` language-server user-agent token) in
+ * `QDevPluginAccessGateHandler`: Builder ID identities created on or after 2026-07-25 are denied with
+ * an `AccessDeniedException` whose reason is `FEATURE_NOT_SUPPORTED`. IdC (Enterprise) identities are
+ * exempt from that gate, so in practice this only fires for Builder ID callers.
+ *
+ * Because the gate runs before the activity, *every* API call from a blocked identity fails this way --
+ * there is no need to probe a specific operation, the first request is enough to detect it.
+ *
+ * The match is deliberately narrow: it requires the reason to be exactly `FEATURE_NOT_SUPPORTED`. The
+ * other modeled reasons -- `UNAUTHORIZED_CUSTOMIZATION_RESOURCE_ACCESS`,
+ * `UNAUTHORIZED_WORKSPACE_CONTEXT_FEATURE_ACCESS` and `TEMPORARILY_SUSPENDED` -- must NOT match. The
+ * last especially: it is transient and recoverable, so treating it as a permanent block would strand a
+ * user whose access is coming back.
+ *
+ * Matching is by exception `name` rather than `instanceof` because the same modeled exception is
+ * generated separately into the runtime and streaming clients, and because callers frequently rethrow
+ * it wrapped. The cause chain is walked for the same reason, with a visited set so a cyclic chain
+ * terminates.
+ *
+ * Note that `FEATURE_NOT_SUPPORTED` is not unique to this gate (other handlers reuse it), so callers
+ * should surface the service's own message rather than substituting their own copy.
+ */
+export function isQDevPluginAccessBlockedError(e: unknown): boolean {
+    const seen = new Set<unknown>()
+    let current: unknown = e
+
+    while (current !== undefined && current !== null && !seen.has(current)) {
+        seen.add(current)
+
+        const name = (current as { name?: unknown }).name
+        const reason = (current as { reason?: unknown }).reason
+        if (name === 'AccessDeniedException' && reason === AccessDeniedExceptionReason.FEATURE_NOT_SUPPORTED) {
+            return true
+        }
+
+        current = (current as { cause?: unknown }).cause
+    }
+
+    return false
 }
 
 export function isAwsThrottlingError(e: unknown): e is ThrottlingException {


### PR DESCRIPTION
## Problem

Requests whose user-agent carries the shared `AWS-Language-Servers-AWS-CodeWhisperer` language-server token are checked, and **Builder ID identities created on or after 2026-07-25** are denied with `AccessDeniedException` and `reason=FEATURE_NOT_SUPPORTED`. IdC identities are exempt. Enforcement is live.

Because the gate runs *before* the activity, a blocked identity fails **every** operation. Today none of that is classified, so the customer gets a silently non-functional plugin with no indication why. The first failure is the A/B config fetch moments after credentials arrive:

```
abconfig error: AccessDeniedException: Please visit https://kiro.dev/ to purchase a Kiro
subscription, which can be used with Amazon Q Developer. To manage an existing Q Developer
Pro subscription, use the AWS Console.
```

## Solution

Detect the rejection centrally and surface the service's own message over the existing `showNotification` channel.

- `isQDevPluginAccessBlockedError()` classifies it.
- A passthrough middleware on the token client observes it.
- `CodeWhispererServiceToken.onAccessBlocked` lets the owner of the client lifecycle react.
- `createQDevAccessBlockedNotifier()` surfaces the message.

## Rollout safety

The language server ships ahead of the plugins, and **every plugin version already in the market will pick up this server**, so this had to be non-destructive to clients that know nothing about it.

The runtime already gates `showNotification` on the client-advertised `awsClientCapabilities.window.notifications` capability:

```js
showNotification: params => {
    if (this.clientSupportsNotifications) { ... }
}
```

So older plugins receive nothing and are unaffected; plugins that advertise the capability get the real reason instead of a silent failure. **No new protocol message and no client change are required.**

The error path is untouched as well — the middleware always rethrows the original error unchanged.

## Design notes for reviewers

**Classification is deliberately narrow.** `reason` must be exactly `FEATURE_NOT_SUPPORTED`, so the other modeled reasons don't match — `TEMPORARILY_SUSPENDED` especially, since it is transient and recoverable, and treating it as permanent would strand a user whose access is returning.

Two negative tests encode rejections observed in production that must **not** match:

| Observed | Must classify as |
|---|---|
| `AccessDeniedException`, `reason=FEATURE_NOT_SUPPORTED` | blocked |
| `AccessDeniedException`, `reason=undefined`, *"AWS Builder ID is not supported for this operation."* (`ListAvailableProfiles` rejects every Builder ID caller this way — a request-shape error, not the gate) | not blocked |
| `AccessDeniedException`, `reason=TEMPORARILY_SUSPENDED` | not blocked |

**Matching is by exception `name`, not `instanceof`** — the same modeled exception is generated separately into the runtime and streaming clients, and callers rethrow it wrapped. The cause chain is walked for the same reason, with a visited set so a cyclic chain terminates.

**Middleware is on the outermost `initialize` step**, so the error is observed once per operation after retries are exhausted rather than once per attempt. The observer runs inside its own try/catch so it cannot mask a service error, and when no observer is supplied the middleware isn't registered at all — leaving `AtxTokenServiceManager` and `toolServer`, which construct services without one, behaviourally identical.

**The observer is a late-bound property**, not a constructor parameter, mirroring the existing `shareCodeWhispererContentWithAWS` closure in the same constructor. No call-site signature changes.

**The service message is shown verbatim.** `FEATURE_NOT_SUPPORTED` is reused across several RTS gates (`KIRO_USER_BLOCKED_EXCEPTION_MESSAGE`, `WCS_USER_BLOCKED_EXCEPTION_MESSAGE`), so the reason tells us *that* access is blocked while only the message says *why*. Substituting our own copy risks telling the customer the wrong thing.

**Notifies at most once per instance**, otherwise a blocked identity produces one notification per API call. Dedupe is scoped to the instance rather than the process, so switching accounts notifies again instead of being suppressed.

`notification` is added to `QServiceManagerFeatures` as **optional** so every existing construction site, including partial test fixtures, keeps compiling and stays inert without it.

## Out of scope

Signing out and showing a blocking screen remain the plugin's responsibility and are not attempted here — the server has no such authority. Only the token/bearer client is wired, since the gate is Builder ID and therefore bearer-only.

## Testing

- 14 new unit tests pass (8 classifier, 6 notifier)
- `tsc --noEmit`, prettier and eslint clean
- Every suite covering a touched module was baselined against a `git worktree` at `HEAD` with the identical command:

| Suite | HEAD | This branch |
|---|---|---|
| `codeWhispererService` | 9 pass / 3 fail | 9 pass / 3 fail |
| `AmazonQTokenServiceManager` | 34 pass / 2 pending / 3 fail | 34 pass / 2 pending / 3 fail |
| `BaseAmazonQServiceManager` | 4 pass / 2 fail | 4 pass / 2 fail |
| `utils` | 81 pass / 11 fail | 89 pass / 11 fail |
| `qDevAccessBlockedNotifier` | — | 6 pass / 0 fail |

Identical pre-existing failures on both sides (artifacts of invoking mocha directly rather than through `npm run test:unit`), plus 14 new passing.
