### PR TITLE
fix(amazonq): pass notification feature to the Q service manager

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServer.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServer.ts
@@ -19,7 +19,7 @@ const LOGGING_PREFIX = '[AMAZON Q SERVER]: '
 
 export const AmazonQServiceServerFactory =
     (serviceManager: (features: QServiceManagerFeatures) => AmazonQBaseServiceManager): Server =>
-    ({ credentialsProvider, lsp, workspace, logging, runtime, sdkInitializator }) => {
+    ({ credentialsProvider, lsp, workspace, logging, runtime, sdkInitializator, notification }) => {
         let amazonQServiceManager: AmazonQBaseServiceManager
 
         const log = (message: string) => {
@@ -39,6 +39,11 @@ export const AmazonQServiceServerFactory =
                 logging,
                 runtime,
                 sdkInitializator,
+                // Required for the service manager to be able to surface anything to the client. It is
+                // optional on QServiceManagerFeatures so that existing constructions (including test
+                // fixtures) keep compiling, which means omitting it here does not fail the build -- it
+                // just silently disables client-facing reporting.
+                notification,
             })
 
             /*

--- a/server/aws-lsp-codewhisperer/src/shared/qDevAccessBlockedNotifier.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/qDevAccessBlockedNotifier.test.ts
@@ -7,7 +7,7 @@ import { MessageType } from '@aws/language-server-runtimes/protocol'
 import { Logging, Notification } from '@aws/language-server-runtimes/server-interface'
 import * as assert from 'assert'
 import * as sinon from 'sinon'
-import { createQDevAccessBlockedNotifier } from './qDevAccessBlockedNotifier'
+import { createQDevAccessBlockedNotifier, Q_DEV_ACCESS_BLOCKED_NOTIFICATION_ID } from './qDevAccessBlockedNotifier'
 
 describe('createQDevAccessBlockedNotifier', function () {
     let showNotification: sinon.SinonStub
@@ -40,6 +40,8 @@ describe('createQDevAccessBlockedNotifier', function () {
         const params = showNotification.firstCall.args[0]
         assert.strictEqual(params.type, MessageType.Error)
         assert.strictEqual(params.content.text, serviceMessage)
+        // Clients key off the id rather than the message text, which is service-owned copy.
+        assert.strictEqual(params.id, Q_DEV_ACCESS_BLOCKED_NOTIFICATION_ID)
     })
 
     it('notifies at most once, since every request from a blocked identity fails', function () {

--- a/server/aws-lsp-codewhisperer/src/shared/qDevAccessBlockedNotifier.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/qDevAccessBlockedNotifier.ts
@@ -17,6 +17,12 @@ const FALLBACK_TEXT = 'Amazon Q Developer is not available for this account.'
 const TITLE = 'Amazon Q Developer'
 
 /**
+ * Stable identifier so clients can recognise this notification without inspecting its text. Clients
+ * must not match on the message: it is the service's own copy and is expected to change.
+ */
+export const Q_DEV_ACCESS_BLOCKED_NOTIFICATION_ID = 'qDevPluginAccessBlocked'
+
+/**
  * Builds the reaction to RTS blocking Q Developer plugin access for the current identity, for use as
  * {@link CodeWhispererServiceToken.onAccessBlocked}.
  *
@@ -56,6 +62,7 @@ export function createQDevAccessBlockedNotifier(
         try {
             logging.warn(`Q Developer plugin access is blocked for this identity: ${text}`)
             notification.showNotification({
+                id: Q_DEV_ACCESS_BLOCKED_NOTIFICATION_ID,
                 type: MessageType.Error,
                 content: {
                     title: TITLE,


### PR DESCRIPTION
Targets `feature/qdev-signup-message` (not `main`), so a new flare pre-release can be cut from that branch for IDE testing.

## Problem

The access-blocked notification added in #2794 never reaches the client. `AmazonQServiceServerFactory` destructures the features it forwards to the service manager, and `notification` was not among them:

```ts
({ credentialsProvider, lsp, workspace, logging, runtime, sdkInitializator }) => {
```

So `features.notification` was always `undefined`, the guard in `serviceFactory` never passed, `onAccessBlocked` was never assigned, and the notifier could not run. Confirmed empirically: signing in with a Builder ID that RTS blocks produced the denial (the service message came back through chat) but no notification, no sign-out, and no blocked screen.

`notification` is optional on `QServiceManagerFeatures` so existing constructions and test fixtures keep compiling — which is also why omitting it here did not fail the build. It silently disabled client-facing reporting instead. Commented at the call site so the next person adding a feature there doesn't repeat it.

## Also: stable notification id

The notification now carries `id: 'qDevPluginAccessBlocked'`.

Clients need to recognise it without inspecting its text. The message is the service's own copy and is expected to change, and `FEATURE_NOT_SUPPORTED` is reused across several RTS gates (`KIRO_USER_BLOCKED_EXCEPTION_MESSAGE`, `WCS_USER_BLOCKED_EXCEPTION_MESSAGE`), so the reason alone doesn't identify this gate either. Both IDE clients already prefer the id when present and only fall back to matching the title because the released server doesn't send one yet — this lets that fallback be removed.

## Testing

- `tsc --noEmit` clean, prettier clean, 6/6 notifier tests pass (one now asserts the id)
- A server bundle built from this branch (`webpack.config.prod.js`, entry `agent-standalone`) contains `qDevPluginAccessBlocked` and `isQDevPluginAccessBlockedError`; a bundle built from the previous branch head contains neither
- Verified end-to-end in VS Code by pointing `aws.dev.amazonqLsp.path` at that bundle

## Follow-up not included here

The observer is on the token client only; `streamingClientService.ts` has none. In practice sign-in detection still fires, because the gate denies every operation and the A/B config fetch goes through the token client moments after credentials arrive. But chat-time denials — which is where the message surfaces to the user today — are not observed. Happy to add that here or separately.
