### PR TITLE
fix(amazonq): declare serverInfo so notifications reach the client

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServer.test.ts
@@ -6,6 +6,7 @@ import {
     CancellationToken,
     CredentialsType,
     InitializeParams,
+    PartialInitializeResult,
     Server,
     UpdateConfigurationParams,
 } from '@aws/language-server-runtimes/server-interface'
@@ -41,6 +42,24 @@ describe('AmazonQServiceServer', () => {
 
         features.doSendInitializeRequest({} as InitializeParams, {} as CancellationToken)
         sinon.assert.calledOnce(initBaseTestServiceManagerSpy)
+    })
+
+    it('declares serverInfo so the runtime can deliver notifications to the client', async () => {
+        server(features)
+
+        // Invoke the registered initializer directly: doSendInitializeRequest returns void, so the
+        // result is only reachable through the handler the server registered.
+        const initializer = features.lsp.addInitializer.args[0]?.[0]
+        const result = (await initializer({} as InitializeParams, {} as CancellationToken)) as PartialInitializeResult
+
+        // The runtime only builds a notification router for servers that declare serverInfo, and
+        // notification.showNotification() is a silent no-op without one. Dropping this makes every
+        // server-initiated notification disappear with nothing but a debug line to show for it.
+        //
+        // The name is asserted exactly because it is not cosmetic: it is encoded into the id of each
+        // notification the client sends back, so renaming it strands followups for notifications
+        // already on screen.
+        expect(result.serverInfo?.name).to.equal('AWS Language Server for Amazon Q Developer')
     })
 
     it('hooks handleDidChangeConfiguration to didChangeConfiguration and onInitialized handlers', async () => {

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServer.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServer.ts
@@ -63,6 +63,14 @@ export const AmazonQServiceServerFactory =
             return {
                 capabilities: {},
                 awsServerCapabilities: {},
+                // Required for anything to reach the client through the notification feature. The
+                // runtime only builds a notification router when a server declares serverInfo, and
+                // showNotification is a silent no-op without one. Not exposed to clients; it is used
+                // internally to route notification followups back to the originating server, so the
+                // name must stay stable.
+                serverInfo: {
+                    name: 'AWS Language Server for Amazon Q Developer',
+                },
             }
         })
 

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.test.ts
@@ -238,6 +238,15 @@ describe('AmazonQTokenServiceManager', () => {
             assert(codewhispererServiceStub.generateSuggestions.calledOnce)
         })
 
+        it('gives the streaming client an access-blocked observer', async () => {
+            const streamingClient = amazonQTokenServiceManager.getStreamingClient()
+
+            // Chat runs through the streaming client, so without this it is the one surface where a
+            // blocked identity shows up and the one place nothing observes it. The token client is
+            // a stub in this harness, so only the streaming side is asserted here.
+            assert.strictEqual(typeof streamingClient.onAccessBlocked, 'function')
+        })
+
         it('should initialize service with region set by client', async () => {
             features.setClientParams({
                 processId: 0,

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServiceManager/AmazonQTokenServiceManager.ts
@@ -76,6 +76,7 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
     private region?: string
     private endpoint?: string
     private regionChangeListeners: Array<(region: string) => void> = []
+    private cachedQDevAccessBlockedNotifier?: (error: unknown) => void
 
     /**
      * Internal state of Service connection, based on status of bearer token and Amazon Q Developer profile selection.
@@ -525,12 +526,34 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
         return this.cachedStreamingClient
     }
 
+    /**
+     * One notifier shared by the token and streaming clients, so a blocked identity produces a single
+     * notification regardless of which client observes it first (the notifier dedupes per instance).
+     *
+     * Deliberately scoped to the current service generation and cleared by
+     * {@link resetCodewhispererService}: signing out and back in with another blocked identity must
+     * notify again, which a manager-lifetime notifier would suppress.
+     */
+    private getQDevAccessBlockedNotifier(): ((error: unknown) => void) | undefined {
+        if (!this.features.notification) {
+            return undefined
+        }
+
+        this.cachedQDevAccessBlockedNotifier ??= createQDevAccessBlockedNotifier(
+            this.features.notification,
+            this.features.logging
+        )
+
+        return this.cachedQDevAccessBlockedNotifier
+    }
+
     private resetCodewhispererService() {
         this.logging.log('Resetting Q-only services')
         this.cachedCodewhispererService?.abortInflightRequests()
         this.cachedCodewhispererService = undefined
         this.cachedStreamingClient?.abortInflightRequests()
         this.cachedStreamingClient = undefined
+        this.cachedQDevAccessBlockedNotifier = undefined
         this.activeIdcProfile = undefined
         this.region = undefined
         this.endpoint = undefined
@@ -597,9 +620,7 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
 
         service.customizationArn = this.configurationCache.getProperty('customizationArn')
         service.profileArn = this.activeIdcProfile?.arn
-        if (this.features.notification) {
-            service.onAccessBlocked = createQDevAccessBlockedNotifier(this.features.notification, this.features.logging)
-        }
+        service.onAccessBlocked = this.getQDevAccessBlockedNotifier()
         service.shareCodeWhispererContentWithAWS = this.configurationCache.getProperty(
             'shareCodeWhispererContentWithAWS'
         )
@@ -638,6 +659,9 @@ export class AmazonQTokenServiceManager extends BaseAmazonQServiceManager<
             endpoint,
             this.getCustomUserAgent()
         )
+        // Chat runs through the streaming client, so it needs the same observer as the token client --
+        // otherwise a blocked identity goes unnoticed unless some other client happens to be called.
+        streamingClient.onAccessBlocked = this.getQDevAccessBlockedNotifier()
         streamingClient.profileArn = this.activeIdcProfile?.arn
         streamingClient.shareCodeWhispererContentWithAWS = this.configurationCache.getProperty(
             'shareCodeWhispererContentWithAWS'

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -18,7 +18,7 @@ import {
     Logging,
     IamCredentials,
 } from '@aws/language-server-runtimes/server-interface'
-import { getBearerTokenFromProvider, isUsageLimitError } from './utils'
+import { getBearerTokenFromProvider, isUsageLimitError, isQDevPluginAccessBlockedError } from './utils'
 import { CLIENT_TIMEOUT_MS, MAX_REQUEST_ATTEMPTS } from '../language-server/agenticChat/constants/constants'
 
 import { AmazonQUsageLimitError } from './amazonQServiceManager/errors'
@@ -72,6 +72,12 @@ export abstract class StreamingClientServiceBase {
 }
 
 export class StreamingClientServiceToken extends StreamingClientServiceBase {
+    /**
+     * Observes Q Developer plugin access-blocked rejections. Assigned by the service manager after
+     * construction, so the middleware below reads it at call time rather than capturing it.
+     */
+    public onAccessBlocked?: (error: unknown) => void
+
     client: CodeWhispererStreaming
     public profileArn?: string
     private retryClassifier: QRetryClassifier
@@ -130,6 +136,33 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
             },
             {
                 step: 'build',
+            }
+        )
+
+        // Observe access-blocked rejections without altering behaviour: the error is always rethrown
+        // so callers see it exactly as before. Registered on the outermost (initialize) step so it
+        // fires once per operation, after the SDK's retries are exhausted, rather than once per
+        // attempt. Chat runs through this client, so without it a blocked identity goes unnoticed
+        // unless some other client happens to be called.
+        this.client.middlewareStack.add(
+            next => async args => {
+                try {
+                    return await next(args)
+                } catch (e) {
+                    if (isQDevPluginAccessBlockedError(e)) {
+                        try {
+                            this.onAccessBlocked?.(e)
+                        } catch (observerError) {
+                            logging.debug(
+                                `onAccessBlocked observer threw, ignoring: ${(observerError as Error)?.message}`
+                            )
+                        }
+                    }
+                    throw e
+                }
+            },
+            {
+                step: 'initialize',
             }
         )
     }


### PR DESCRIPTION
Targets `feature/qdev-signup-message`, same as #2794 and #2796.

## Problem

After #2796 the notification still never reached the client. The runtime only constructs a notification router for servers that declare `serverInfo`:

```js
if (initializeResult?.serverInfo) {
    this.notificationRouter = new RouterByServerName(initializeResult.serverInfo.name, this.encoding)
}
```

`AmazonQServiceServer`'s initializer returned only `capabilities` and `awsServerCapabilities`, so no router was built and `showNotification` took this branch:

```js
if (!this.notificationRouter) {
    this.logger.log(`Notifications are not supported: serverInfo is not defined`)
}
this.notificationRouter?.send(...)   // no-op
```

Observed in VS Code against prod RTS with a blocked Builder ID — the block was detected and logged, then silently discarded:

```
[Warn] lserver: Q Developer plugin access is blocked for this identity: Please visit https://kiro.dev/ ...
       lserver: Notifications are not supported: serverInfo is not defined
```

Two servers in this repo already do this correctly (`aws-lsp-identity`, `aws-lsp-notification`); this follows their convention.

## Why it took three PRs

Each layer failed silently and independently:

| PR | Layer | Failure mode |
|---|---|---|
| #2794 | detect the denial | worked |
| #2796 | pass `notification` to the service manager | optional feature, so omitting it compiled and disabled reporting |
| this | declare `serverInfo` | no router, so `showNotification` is a no-op |

Nothing threw at any layer. Worth considering whether `showNotification` should warn rather than `log` when it drops a notification — a server author has no way to notice today. Happy to raise that against the runtime separately.

## Testing

- Regression test added asserting the initializer returns `serverInfo`. The failure mode is silent, so without a test this regresses invisibly.
- The name is asserted **exactly**, deliberately: `RouterByServerName` encodes it into the id of every notification the client echoes back, so renaming it strands followups for notifications already on screen.
- `tsc --noEmit` clean, prettier clean, eslint clean (0 errors).
- Verified end-to-end in VS Code with a server bundle built from this branch installed into the resolved flare directory.

**Pre-existing failure, not from this change:** `amazonQServer.test.ts` → "hooks onUpdateConfiguration handler to LSP server" fails on this branch before my change (6 passing/1 failing before, 7/1 after). Left alone as unrelated, but it should be looked at.

## Correction to #2796

I claimed there that clients could match on `id === 'qDevPluginAccessBlocked'`. That is wrong. `RouterByServerName.send()` replaces the id with base64 of `{"serverName":...,"id":...}` before it reaches the client, so the raw string never arrives. `id` is the runtime's followup-routing token, not a semantic identifier. The id is still worth keeping (it is what makes followups routable), but clients cannot match on it as a plain string — both IDE clients currently identify the notification by title, and I'll follow up on a durable way to identify it.
