### PR TITLE
feat: scope local build verification to the loaded beamed repo and add beam discovery/download

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxModels.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxModels.ts
@@ -118,6 +118,18 @@ export interface AtxGetTransformInfoRequest extends ExecuteCommandParams {
     SolutionRootPath: string
     GetCheckpoints?: boolean
     useOrchestratorAgent?: boolean
+    // Beam-to-IDE: when true, this job was beamed to the IDE and its source is
+    // ALREADY the transformed output. The prior transform job's per-step
+    // checkpoint diffs must NOT be re-applied (they're baked into the beamed
+    // source, and their checkpoint folders aren't in the beam bundle) — doing so
+    // produces "Checkpoint folder not available for step" + DiffApplyFailed and
+    // stalls the LBV loop. When set, getTransformInfo skips the completed-step
+    // artifact download/apply pass and only surfaces NEW LBV-round diffs.
+    IsBeam?: boolean
+    // Beam-to-IDE: comma-separated plan-step ids of the LOADED beamed repo's subtree. Used to
+    // select THIS repo's local-build-verification HITL instead of the first LBV HITL in the list
+    // (which may be a sibling's, shadowing the loaded repo's own). Empty/absent = first-match.
+    beamScopeStepIds?: string
 }
 
 export interface AtxGetTransformInfoResponse {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxNetTransformServer.ts
@@ -47,6 +47,9 @@ const AtxGetJobDashboardCommand = 'aws/atxTransform/getJobDashboard'
 const AtxGetJobReportCommand = 'aws/atxTransform/getJobReport'
 const AtxUploadCustomPlanCommand = 'aws/atxTransform/uploadCustomPlan'
 const AtxLoadOlderWorklogsCommand = 'aws/atxTransform/loadOlderWorklogs'
+// Beam to IDE
+const AtxListBeamedReposCommand = 'aws/atxTransform/listBeamedRepos'
+const AtxDownloadBeamArtifactCommand = 'aws/atxTransform/downloadBeamArtifact'
 
 export const AtxNetTransformServerToken =
     (): Server =>
@@ -170,12 +173,13 @@ export const AtxNetTransformServerToken =
                         return await atxTransformHandler.uploadPackages(request)
                     }
                     case AtxSendMessageCommand: {
-                        const { workspaceId, jobId, text, skipPolling } = params as any
+                        const { workspaceId, jobId, text, skipPolling, beamStepId } = params as any
                         return await atxTransformHandler.sendMessage({
                             workspaceId,
                             jobId,
                             text,
                             skipPolling,
+                            beamStepId,
                         })
                     }
                     case AtxListMessagesCommand: {
@@ -269,6 +273,32 @@ export const AtxNetTransformServerToken =
                             request.nextToken
                         )
                     }
+                    // ---- Beam to IDE ----
+                    case AtxListBeamedReposCommand: {
+                        // PascalCase params/return to match the C# ExecuteCommandParams convention.
+                        const { WorkspaceId, ParentJobId } = params as any
+                        if (!WorkspaceId || !ParentJobId) {
+                            throw new Error('WorkspaceId and ParentJobId are required for listBeamedRepos')
+                        }
+                        const repos = await atxTransformHandler.listBeamedRepos(WorkspaceId, ParentJobId)
+                        return { Repos: repos }
+                    }
+                    case AtxDownloadBeamArtifactCommand: {
+                        // PascalCase params to match the C# ExecuteCommandParams serialization
+                        // convention used by every other C#-backed ATX command (e.g. downloadArtifact).
+                        const { WorkspaceId, ParentJobId, BeamArtifactId, DestDir } = params as any
+                        if (!WorkspaceId || !ParentJobId || !BeamArtifactId || !DestDir) {
+                            throw new Error(
+                                'WorkspaceId, ParentJobId, BeamArtifactId and DestDir are required for downloadBeamArtifact'
+                            )
+                        }
+                        return await atxTransformHandler.downloadBeamArtifact(
+                            WorkspaceId,
+                            ParentJobId,
+                            BeamArtifactId,
+                            DestDir
+                        )
+                    }
                     default: {
                         throw new Error(`Unknown ATX FES command: ${params.command}`)
                     }
@@ -311,6 +341,8 @@ export const AtxNetTransformServerToken =
                             AtxGetJobReportCommand,
                             AtxUploadCustomPlanCommand,
                             AtxLoadOlderWorklogsCommand,
+                            AtxListBeamedReposCommand,
+                            AtxDownloadBeamArtifactCommand,
                         ],
                     },
                 },

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -530,6 +530,349 @@ export class ATXTransformHandler {
     }
 
     /**
+     * Beam to IDE — read the beam-map artifact from the parent web job and return
+     * the list of beamed repos. The web orchestrator uploads a JSON beam-map
+     * (category HITL_FROM_AGENT) listing repos the user chose to beam. We find it
+     * by listing the parent job's artifacts and picking the beam-map JSON.
+     */
+    async listBeamedRepos(workspaceId: string, parentJobId: string): Promise<any[]> {
+        try {
+            this.logging.log(`ATX: listBeamedRepos for parentJobId=${parentJobId}`)
+            if (!this.atxClient && !(await this.initializeAtxClient())) {
+                throw new Error('ATX client not initialized')
+            }
+
+            // Find the beam-map artifact under the parent job.
+            // NOTE: beam artifacts must be uploaded by the web orchestrator as
+            // CUSTOMER_OUTPUT — the FES client CategoryType enum does not expose
+            // HITL_FROM_AGENT as a listable filter value.
+            const command = new ListArtifactsCommand({
+                workspaceId: workspaceId,
+                jobFilter: {
+                    jobId: parentJobId,
+                    categoryType: 'CUSTOMER_OUTPUT',
+                },
+            })
+            await this.addAuthToCommand(command)
+            const result = (await this.atxClient!.send(command)) as any
+            const artifacts: any[] = result.artifacts || []
+
+            // DIAGNOSTIC: dump exactly what ListArtifacts returned so we can tell
+            // "artifact not in the list" from "filtered out by fileType/.json". Both
+            // otherwise produce the same silent 'no beam-map' verdict.
+            this.logging.log(
+                `[BEAM-PKG] listBeamedRepos: ListArtifacts returned ${artifacts.length} CUSTOMER_OUTPUT artifact(s) for job=${parentJobId}`
+            )
+            for (const a of artifacts) {
+                this.logging.log(
+                    `[BEAM-PKG]   artifact | id=${a.artifactId} fileType=${a.fileType} ` +
+                        `name=${a.name ?? a.fileName ?? ''} path=${a.fileMetadata?.path ?? ''} category=${a.categoryType ?? a.category ?? ''}`
+                )
+            }
+
+            // Enumerate transformed-code ZIP artifacts. Each transformed bundle has a path
+            // like "<repo>_<hash>/<repo>.zip"; the repo name is the path's first segment
+            // (minus the _<hash> suffix) and the artifactId is what the IDE downloads+extracts
+            // to open the solution. NOTE: in a multi-repo job, EVERY repo that transformed on
+            // web has such a zip — so this listing alone is NOT the set of *beamed* repos.
+            const ZIP_RE = /(^|\/)([^/]+?)_[0-9a-f]{6,}\/[^/]+\.zip$/i
+            const transformedZips = artifacts.filter(a => {
+                const p = (a.fileMetadata?.path || '').toLowerCase()
+                return p.endsWith('.zip')
+            })
+
+            // Build repoName -> {artifactId, path} from the transformed zips (deduped).
+            const zipByRepo = new Map<string, { artifactId: string; path: string }>()
+            for (const a of transformedZips) {
+                const path = a.fileMetadata?.path || ''
+                const m = path.match(ZIP_RE)
+                const repoName = m ? m[2] : (path.split('/')[0] || '').replace(/_[0-9a-f]{6,}$/i, '')
+                if (!repoName || !a.artifactId) continue
+                const key = repoName.toLowerCase()
+                if (!zipByRepo.has(key)) {
+                    zipByRepo.set(key, { artifactId: a.artifactId, path })
+                }
+            }
+
+            // Read the beam-map JSON. It is the AUTHORITATIVE list of which repos the user
+            // EXPLICITLY beamed (its repos[] holds only beamed repos, each with a stepId).
+            // We use it to FILTER the transformed zips down to just the beamed repos — NOT
+            // merely to enrich. Previously discovery returned every transformed zip and used
+            // the beam-map only for enrichment, so in a multi-repo job the IDE showed the
+            // Load button on repos that transformed but were never beamed.
+            // The beam-map artifact often has NO usable name/path/category in the ListArtifacts
+            // response (all empty — observed), so we cannot identify it by label. We instead
+            // scan candidate (non-.zip) artifacts and pick the one whose JSON has a `repos`
+            // array. CRITICAL: each download/parse is wrapped in its OWN try/catch — a single
+            // artifact that throws (or isn't JSON, e.g. an unrelated metadata.json / binary)
+            // must NOT abort the scan, or we miss the real beam-map that comes later in the list
+            // and wrongly fall back to zip-discovery (empty stepId). We scan ALL candidates and
+            // keep the LAST valid repos[] (beam-map is re-written on each beam; latest wins).
+            // Candidate beam-map artifacts = everything EXCEPT the transformed-source
+            // bundles. The beam-map is itself stored as a ZIP by FES (downloadJsonArtifact
+            // unzips + parses it), so we MUST NOT exclude by ".zip" extension — that would
+            // filter out the beam-map itself (the earlier bug: the beam-map 3b1f9c00 has a
+            // .zip path, so a plain !endsWith('.zip') filter skipped it entirely → fell back
+            // to zip-discovery with empty stepId). Instead, exclude only the transformed-
+            // source bundles, whose paths match "<repo>_<hash>/<repo>.zip" (ZIP_RE). Anything
+            // else (including an unnamed/empty-path zip = the beam-map) is a candidate.
+            let beamMapRepos: any[] | null = null
+            const candidates = artifacts.filter(a => {
+                const p = (a.fileMetadata?.path || '').toLowerCase()
+                return !ZIP_RE.test(p) // keep non-transformed-bundle artifacts (incl. the beam-map zip)
+            })
+            this.logging.log(
+                `[BEAM-PKG] beam-map scan: ${candidates.length} candidate artifact(s) (excluded transformed-source bundles)`
+            )
+            for (const a of candidates) {
+                if (!a.artifactId) continue
+                try {
+                    const map = await this.downloadJsonArtifact(workspaceId, parentJobId, a.artifactId)
+                    if (map && Array.isArray(map.repos)) {
+                        beamMapRepos = map.repos as any[]
+                        this.logging.log(
+                            `[BEAM-PKG] beam-map found (${beamMapRepos.length} repo(s)) artifact=${a.artifactId} — filtering discovery by beam-map membership`
+                        )
+                        // Do NOT break — keep scanning; a later artifact could be a newer beam-map.
+                        // (Cost is bounded: only empty-path/non-zip artifacts, a handful per job.)
+                    }
+                } catch (e) {
+                    // Non-fatal: this artifact wasn't the beam-map (not JSON, wrong shape, or
+                    // download hiccup). Keep scanning the rest.
+                    this.logging.log(`[BEAM-PKG] beam-map scan: skipped artifact ${a.artifactId}: ${String(e)}`)
+                }
+            }
+
+            const beamed: any[] = []
+
+            // Show-set: fetch the parent job's plan tree ONCE so we can stamp each beamed repo
+            // with whether its Local Build Verification is still open (the IDE shows only repos
+            // still awaiting LBV). Best-effort: if the plan can't be fetched, leave IsLbvOpen
+            // undefined and the IDE defaults it true (never hides a fresh transfer).
+            let planRoot: AtxPlanStep | null = null
+            try {
+                const plan = await this.getTransformationPlan(workspaceId, parentJobId, '', true)
+                planRoot = plan?.Root ?? null
+            } catch (e) {
+                this.logging.log(`[BEAM-PKG] listBeamedRepos: could not fetch plan for LBV-open status: ${String(e)}`)
+            }
+
+            if (beamMapRepos) {
+                // Beam-map present: include ONLY repos listed in it (the beamed ones). Pull the
+                // artifactId from the matching transformed zip; carry stepId/scenario/tfm from
+                // the beam-map entry.
+                for (const r of beamMapRepos) {
+                    const nr = this.normalizeBeamRepo(r)
+                    if (!nr.RepositoryName) continue
+                    const zip = zipByRepo.get(nr.RepositoryName.toLowerCase())
+                    // PREFER the transformed-source zip artifactId (stable + downloadable). The
+                    // beam-map's own BeamArtifactId is NOT reliable: web-orc re-writes the beam-map
+                    // each poll and the id it carries can point at a NON-source artifact with no
+                    // presigned download URL, which made the IDE's BeamArtifactId thrash and Load
+                    // fail with "No presigned URL for beam artifact". The source zip stays constant
+                    // and is always downloadable; fall back to the beam-map id only when there is
+                    // no matching transformed zip.
+                    const artifactId = zip?.artifactId || nr.BeamArtifactId || ''
+                    if (!artifactId) {
+                        this.logging.log(
+                            `[BEAM-PKG] beam-map repo '${nr.RepositoryName}' has no artifact (transformed zip or beam-map) — skipping`
+                        )
+                        continue
+                    }
+                    if (!zip?.artifactId && nr.BeamArtifactId) {
+                        this.logging.log(
+                            `[BEAM-PKG] beam-map repo '${nr.RepositoryName}': no transformed zip matched — falling back to beam-map artifactId ${nr.BeamArtifactId} (may not be downloadable)`
+                        )
+                    }
+                    const lbvOpen = planRoot ? this.isRepoLbvOpen(planRoot, nr.RepositoryName) : true
+                    beamed.push({
+                        RepositoryName: nr.RepositoryName,
+                        BeamArtifactId: artifactId,
+                        BeamStepId: nr.BeamStepId || '',
+                        BeamTargetFramework: nr.BeamTargetFramework || '',
+                        BeamScenario: nr.BeamScenario || 'transformed',
+                        IsLbvOpen: lbvOpen,
+                    })
+                    this.logging.log(
+                        `[BEAM-PKG] beamed repo (from beam-map) | repo=${nr.RepositoryName} artifact=${artifactId} stepId=${nr.BeamStepId || '<empty>'} scenario=${nr.BeamScenario || 'transformed'} lbvOpen=${lbvOpen}`
+                    )
+                }
+            } else {
+                // NO beam-map found. The beam-map artifact is UNRELIABLE — web-orc writes per-repo
+                // beam-STATUS artifacts (beam-status-<jobId>-<repo>.json) reliably but frequently
+                // does NOT write the beam-map. So DERIVE the beamed repos from the beam-status
+                // artifact FILENAMES instead: each names exactly one beamed repo. This is reliable
+                // (status always written), names the exact repos, and correctly yields ZERO for
+                // never-beamed jobs (no beam-status → not beamed) — so it still kills the old
+                // all-transformed-zips over-listing. Only fall back to beam-status when there's no
+                // beam-map (beam-map wins if present). Filename shape:
+                // "beam-status-<jobId>-<repo>.json" OR (for basename-uniqueness)
+                // "beam-status-<jobId>-<repo>-<8hexhash>.json". Capture the whole tail, then resolve
+                // the repo against the CANONICAL zip names (zipByRepo) —
+                // the reliable source — so we're not coupled to the exact label format:
+                //   1) the captured tail matches a zip as-is  -> use it (old no-hash format, or a
+                //      repo whose name legitimately ends in 8 hex),
+                //   2) else strip a trailing "-<8hex>" and match that -> use it (new hashed format).
+                // If neither resolves, fall through (logged below as "no matching transformed zip").
+                const statusRe = new RegExp(`beam-status-${parentJobId}-(.+)\\.json$`, 'i')
+                const statusRepos = new Set<string>()
+                for (const a of artifacts) {
+                    const p = a.fileMetadata?.path || ''
+                    const m = p.match(statusRe)
+                    if (!m || !m[1]) continue
+                    const tail = m[1]
+                    if (zipByRepo.has(tail.toLowerCase())) {
+                        statusRepos.add(tail)
+                    } else {
+                        const stripped = tail.replace(/-[0-9a-f]{8}$/i, '')
+                        statusRepos.add(zipByRepo.has(stripped.toLowerCase()) ? stripped : tail)
+                    }
+                }
+                if (statusRepos.size > 0) {
+                    for (const repoName of statusRepos) {
+                        const zip = zipByRepo.get(repoName.toLowerCase())
+                        if (!zip?.artifactId) {
+                            this.logging.log(
+                                `[BEAM-PKG] beam-status repo '${repoName}' has no matching transformed zip — skipping`
+                            )
+                            continue
+                        }
+                        const lbvOpen = planRoot ? this.isRepoLbvOpen(planRoot, repoName) : true
+                        beamed.push({
+                            RepositoryName: repoName,
+                            BeamArtifactId: zip.artifactId,
+                            BeamStepId: '',
+                            BeamTargetFramework: '',
+                            BeamScenario: 'transformed',
+                            IsLbvOpen: lbvOpen,
+                        })
+                        this.logging.log(
+                            `[BEAM-PKG] beamed repo (from beam-status) | repo=${repoName} artifact=${zip.artifactId} path=${zip.path} lbvOpen=${lbvOpen}`
+                        )
+                    }
+                    this.logging.log(
+                        `[BEAM-PKG] no beam-map for job=${parentJobId} — derived ${beamed.length} beamed repo(s) from beam-status artifacts`
+                    )
+                } else {
+                    // No beam-map AND no beam-status → this job was genuinely never beamed
+                    // (transform-only). Return zero; do NOT fall back to all transformed zips.
+                    this.logging.log(
+                        `[BEAM-PKG] no beam-map AND no beam-status for job=${parentJobId} — job was not beamed (0 beamed repos; ${zipByRepo.size} transformed zip(s) ignored)`
+                    )
+                }
+            }
+
+            this.logging.log(`[BEAM-PKG] listBeamedRepos: ${beamed.length} beamed repo(s) for job=${parentJobId}`)
+            return beamed
+        } catch (error) {
+            this.logging.error(`ATX: listBeamedRepos error: ${String(error)}`)
+            return []
+        }
+    }
+
+    /**
+     * Normalize a beam-map repo item into the PascalCase shape the C# IDE consumes,
+     * tolerant of key-name variants from the web writer (repoName/repo/name,
+     * artifactId/beamArtifactId, stepId/planStepId, targetFramework/tfm).
+     */
+    private normalizeBeamRepo(r: any): {
+        RepositoryName: string
+        BeamArtifactId: string
+        BeamStepId: string
+        BeamTargetFramework: string
+        BeamScenario: string
+    } {
+        r = r || {}
+        return {
+            RepositoryName: r.repoName ?? r.repositoryName ?? r.repo ?? r.name ?? '',
+            BeamArtifactId: r.artifactId ?? r.beamArtifactId ?? r.ArtifactId ?? '',
+            BeamStepId: r.stepId ?? r.planStepId ?? r.parentStepId ?? '',
+            BeamTargetFramework: r.targetFramework ?? r.tfm ?? r.target_framework ?? '',
+            BeamScenario: r.scenario ?? 'transformed',
+        }
+    }
+
+    /**
+     * Download a small JSON artifact and parse it. The artifact may be stored as
+     * raw JSON OR zipped (observed: FES stores the beam-map as a ZIP — the bytes
+     * start with the "PK" magic number, so a direct JSON.parse throws
+     * "Unexpected token 'P'"). So: fetch as a buffer, try JSON.parse first, and on
+     * failure unzip (AdmZip) and parse the first JSON entry inside.
+     */
+    private async downloadJsonArtifact(workspaceId: string, jobId: string, artifactId: string): Promise<any | null> {
+        try {
+            const dl = await this.createArtifactDownloadUrl(workspaceId, jobId, artifactId)
+            if (!dl?.s3PresignedUrl) return null
+            const response = await got.get(dl.s3PresignedUrl, {
+                headers: dl.requestHeaders || {},
+                responseType: 'buffer',
+                timeout: { request: 30000 },
+            })
+            const buf = Buffer.from(response.body)
+
+            // Direct JSON first (artifact stored raw).
+            try {
+                return JSON.parse(buf.toString('utf8'))
+            } catch {
+                // Not raw JSON — likely a ZIP (PK magic). Unzip and parse the first
+                // JSON entry (the beam-map is a single JSON file inside).
+                if (buf.length >= 2 && buf[0] === 0x50 && buf[1] === 0x4b) {
+                    const zip = new AdmZip(buf)
+                    for (const entry of zip.getEntries()) {
+                        if (entry.isDirectory) continue
+                        try {
+                            const parsed = JSON.parse(entry.getData().toString('utf8'))
+                            this.logging.log(
+                                `[BEAM-PKG] downloadJsonArtifact: parsed ${artifactId} from zip entry ${entry.entryName}`
+                            )
+                            return parsed
+                        } catch {
+                            // not this entry — try the next
+                        }
+                    }
+                }
+                throw new Error('artifact is neither raw JSON nor a zip containing JSON')
+            }
+        } catch (error) {
+            this.logging.log(`ATX: downloadJsonArtifact parse/download failed for ${artifactId}: ${String(error)}`)
+            return null
+        }
+    }
+
+    /**
+     * Beam to IDE — download the beam artifact (source + beam-flag + context zip)
+     * from the parent web job and extract it locally so the IDE can open the repo.
+     * Cross-job read works via the workspace-scoped artifact fallback.
+     */
+    async downloadBeamArtifact(
+        workspaceId: string,
+        parentJobId: string,
+        beamArtifactId: string,
+        destDir: string
+    ): Promise<{ Success: boolean; ExtractedPath?: string; Error?: string }> {
+        try {
+            this.logging.log(`[BEAM-PKG] downloadBeamArtifact ${beamArtifactId} -> ${destDir}`)
+            const dl = await this.createArtifactDownloadUrl(workspaceId, parentJobId, beamArtifactId)
+            if (!dl?.s3PresignedUrl) {
+                return { Success: false, Error: 'No presigned URL for beam artifact' }
+            }
+            // downloadAndExtractArchive both downloads AND unzips into destDir.
+            const extractedPath = await Utils.downloadAndExtractArchive(
+                dl.s3PresignedUrl,
+                dl.requestHeaders,
+                destDir,
+                'beam-artifact.zip',
+                this.logging
+            )
+            this.logging.log(`[BEAM-PKG] downloadBeamArtifact extracted -> ${extractedPath}`)
+            return { Success: true, ExtractedPath: extractedPath }
+        } catch (error) {
+            this.logging.error(`[BEAM-PKG] downloadBeamArtifact error: ${String(error)}`)
+            return { Success: false, Error: String(error) }
+        }
+    }
+
+    /**
      * Create artifact upload URL
      */
     async createArtifactUploadUrl(
@@ -798,48 +1141,91 @@ export class ATXTransformHandler {
         }
     }
 
+    // Beam to IDE diagnostics: running count of CreateArtifactDownloadUrl calls this
+    // session, so a call storm (which self-throttles FES and makes a real Load fail with the
+    // misleading "No presigned URL") is VISIBLE in the log. Reset only on process restart.
+    private _createDownloadUrlCallCount = 0
+
     async createArtifactDownloadUrl(
         workspaceId: string,
         jobId: string,
         artifactId: string
     ): Promise<{ s3PresignedUrl: string; requestHeaders?: any } | null> {
-        try {
-            this.logging.log(`ATX: Starting CreateArtifactDownloadUrl for job: ${jobId}`)
+        // Retry on throttling. The get-URL call is throttled by FES under load (a poll storm can
+        // exhaust the quota); a throttled call previously fell straight to null → "No presigned
+        // URL", failing a Load that would have succeeded on retry. Bounded exponential backoff
+        // makes Load resilient to transient throttling without masking a genuine absent-URL (that
+        // still returns null after retries).
+        const maxAttempts = 4
+        let lastErr: any = null
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                this._createDownloadUrlCallCount++
+                this.logging.log(
+                    `ATX: Starting CreateArtifactDownloadUrl for job: ${jobId} (artifact=${artifactId}, attempt=${attempt}/${maxAttempts}, sessionCalls=${this._createDownloadUrlCallCount})`
+                )
 
-            if (!this.atxClient && !(await this.initializeAtxClient())) {
-                throw new Error('ATX client not initialized')
-            }
+                if (!this.atxClient && !(await this.initializeAtxClient())) {
+                    throw new Error('ATX client not initialized')
+                }
 
-            const command = new CreateArtifactDownloadUrlCommand({
-                workspaceId: workspaceId,
-                jobId: jobId,
-                artifactId: artifactId,
-            })
+                const command = new CreateArtifactDownloadUrlCommand({
+                    workspaceId: workspaceId,
+                    jobId: jobId,
+                    artifactId: artifactId,
+                })
 
-            await this.addAuthToCommand(command)
-            const result = (await this.atxClient!.send(command)) as any
-            if (result && result.s3PreSignedUrl) {
-                this.logging.log(`ATX: CreateArtifactDownloadUrl completed successfully`)
+                await this.addAuthToCommand(command)
+                const result = (await this.atxClient!.send(command)) as any
+                if (result && result.s3PreSignedUrl) {
+                    this.logging.log(`ATX: CreateArtifactDownloadUrl completed successfully`)
 
-                const normalizedHeaders: Record<string, string> = {}
-                if (result.requestHeaders) {
-                    for (const [key, value] of Object.entries(result.requestHeaders)) {
-                        normalizedHeaders[key] = Array.isArray(value) ? value[0] : value
+                    const normalizedHeaders: Record<string, string> = {}
+                    if (result.requestHeaders) {
+                        for (const [key, value] of Object.entries(result.requestHeaders)) {
+                            normalizedHeaders[key] = Array.isArray(value) ? value[0] : value
+                        }
                     }
-                }
 
-                return {
-                    s3PresignedUrl: result.s3PreSignedUrl,
-                    requestHeaders: normalizedHeaders,
+                    return {
+                        s3PresignedUrl: result.s3PreSignedUrl,
+                        requestHeaders: normalizedHeaders,
+                    }
+                } else {
+                    // Genuine absent URL (not an error) — retrying won't help; return null now.
+                    this.logging.error(
+                        `ATX: CreateArtifactDownloadUrl failed - missing s3PreSignedUrl (artifact=${artifactId}) — NOT a throttle; not retrying`
+                    )
+                    return null
                 }
-            } else {
-                this.logging.error('ATX: CreateArtifactDownloadUrl failed - missing s3PreSignedUrl')
+            } catch (error) {
+                lastErr = error
+                // Distinguish throttling from other errors so the log tells us WHY a Load failed
+                // (was misattributed to "No presigned URL"). Retry only throttling.
+                const name = (error as any)?.name ?? ''
+                const msg = String(error)
+                const isThrottle =
+                    name === 'ThrottlingException' ||
+                    name === 'TooManyRequestsException' ||
+                    /throttl|too many requests|rate exceeded/i.test(msg)
+                if (isThrottle && attempt < maxAttempts) {
+                    const backoffMs = 250 * Math.pow(2, attempt - 1) // 250, 500, 1000ms
+                    this.logging.log(
+                        `ATX: CreateArtifactDownloadUrl THROTTLED (artifact=${artifactId}, attempt=${attempt}/${maxAttempts}) — retrying in ${backoffMs}ms`
+                    )
+                    await new Promise(r => setTimeout(r, backoffMs))
+                    continue
+                }
+                this.logging.error(
+                    `ATX: CreateArtifactDownloadUrl error (artifact=${artifactId}, throttle=${isThrottle}, attempt=${attempt}/${maxAttempts}): ${msg}`
+                )
                 return null
             }
-        } catch (error) {
-            this.logging.error(`ATX: CreateArtifactDownloadUrl error: ${String(error)}`)
-            return null
         }
+        this.logging.error(
+            `ATX: CreateArtifactDownloadUrl exhausted ${maxAttempts} attempts (artifact=${artifactId}): ${String(lastErr)}`
+        )
+        return null
     }
 
     async listHitls(workspaceId: string, jobId: string): Promise<any[] | null> {
@@ -1062,13 +1448,15 @@ export class ATXTransformHandler {
     async getHitlAgentArtifact(
         workspaceId: string,
         jobId: string,
-        solutionRootPath: string
+        solutionRootPath: string,
+        beamScopeStepIds?: string
     ): Promise<{
         PlanPath?: string
         ReportPath?: string
         MissingPackageJsonPath?: string
         HitlTag?: string
         TaskId?: string
+        StepId?: string
     } | null> {
         let hitl: any = null
         try {
@@ -1090,10 +1478,58 @@ export class ATXTransformHandler {
                 this.logging.log(`ATX: Found ${hitls.length} hitls (expected 1)`)
             }
 
+            // Beam-to-IDE: when the IDE tells us which repo it loaded (beamScopeStepIds =
+            // that repo's plan-step subtree), prefer the local-build-verification HITL whose stepId
+            // is IN that subtree. On a multi-repo beam job several repos have pending LBV HITLs;
+            // picking the plain first (below) may return a SIBLING's, shadowing the loaded repo's
+            // own HITL so it never builds unless loaded in list order. Tolerate any stepId field
+            // spelling (stepId/planStepId/parentStepId), same as the forwarding path.
+            const scopeStepIds = (beamScopeStepIds || '')
+                .split(',')
+                .map(s => s.trim())
+                .filter(s => s.length > 0)
+            const lbvHitls = hitls.filter(h => h.tag === 'local-build-verification')
+            let scopedLbv: any = null
+            if (scopeStepIds.length > 0 && lbvHitls.length > 0) {
+                scopedLbv = lbvHitls.find(h =>
+                    scopeStepIds.includes(String(h.stepId ?? h.planStepId ?? h.parentStepId ?? ''))
+                )
+                this.logging.log(
+                    `ATX: getHitlAgentArtifact beam-scoped LBV pick=${scopedLbv ? (scopedLbv.stepId ?? scopedLbv.planStepId ?? scopedLbv.parentStepId) : '<none in scope>'} of ${lbvHitls.length} LBV hitl(s) scope=[${scopeStepIds.join(',')}]`
+                )
+                // Scope is set and the pending HITL(s) are LBV, but NONE is in the loaded repo's
+                // subtree → they all belong to sibling repos. Return null so the IDE isn't handed a
+                // sibling's HITL it would only skip every poll. The loaded repo simply has no
+                // pending LBV yet (or its sub-agent hasn't raised one). Non-LBV HITLs (e.g.
+                // missing-packages) still fall through below and are handled normally.
+                if (!scopedLbv && lbvHitls.length === hitls.length) {
+                    this.logging.log(
+                        'ATX: getHitlAgentArtifact — all pending HITLs are sibling-repo LBV (none in loaded scope); returning none'
+                    )
+                    return null
+                }
+            }
+
+            // When beam scope is active but no in-scope LBV matched, an out-of-scope (sibling) LBV
+            // must NEVER be selectable by the fallback — otherwise a mixed pending set (sibling LBV +
+            // a non-LBV HITL like missing-packages) would let the plain `find(...=== lbv)` below
+            // return the sibling's LBV → the IDE builds its own solution and answers the sibling's
+            // HITL = false green. So drop all LBVs from the fallback pool when scope is set and none
+            // is in scope; only genuinely non-LBV HITLs remain eligible.
+            const fallbackPool =
+                scopeStepIds.length > 0 && !scopedLbv ? hitls.filter(h => h.tag !== 'local-build-verification') : hitls
+
             hitl =
-                hitls.find(h => h.tag === 'local-build-verification') ||
-                hitls.find(h => h.tag === 'missing-packages' || h.tag === 'handle_missing_packages_hitl') ||
-                hitls[0]
+                scopedLbv ||
+                fallbackPool.find(h => h.tag === 'local-build-verification') ||
+                fallbackPool.find(h => h.tag === 'missing-packages' || h.tag === 'handle_missing_packages_hitl') ||
+                fallbackPool[0]
+            if (!hitl) {
+                this.logging.log(
+                    'ATX: getHitlAgentArtifact — beam scope active, only out-of-scope sibling LBV(s) pending; returning none'
+                )
+                return null
+            }
             this.logging.log(
                 `ATX: getHitlAgentArtifact picked hitl tag: ${hitl.tag}, all tags: ${hitls.map(h => h.tag).join(',')}`
             )
@@ -1103,10 +1539,17 @@ export class ATXTransformHandler {
             this.cachedHitl = hitl.taskId
             const hitlTag = hitl.tag || null
 
-            // local-build-verification: IDE handles the build, no artifact download needed
+            // local-build-verification: IDE handles the build, no artifact download needed.
+            // Forward the HITL's plan-step id (the runtime tags it; FES returns it as planStepId)
+            // so a multi-repo beam IDE can tell WHICH repo's LBV this is and skip siblings' HITLs
+            // — without it the IDE answers every repo's HITL against whatever solution is open (a
+            // false-green). Tolerate any field spelling FES/agent use, same as the EXECUTING path.
             if (hitlTag === 'local-build-verification') {
-                this.logging.log('ATX: local-build-verification HITL — returning tag for IDE to handle')
-                return { HitlTag: hitlTag, TaskId: hitl.taskId }
+                const lbvStepId = hitl.stepId ?? hitl.planStepId ?? hitl.parentStepId ?? undefined
+                this.logging.log(
+                    `ATX: local-build-verification HITL — returning tag for IDE to handle | stepId=${lbvStepId ?? '<none>'}`
+                )
+                return { HitlTag: hitlTag, TaskId: hitl.taskId, StepId: lbvStepId }
             }
 
             // If no agent artifact, return tag and taskId without downloading
@@ -1258,7 +1701,8 @@ export class ATXTransformHandler {
                 const plan = await this.getTransformationPlan(
                     request.WorkspaceId,
                     request.TransformationJobId,
-                    request.SolutionRootPath
+                    request.SolutionRootPath,
+                    request.IsBeam === true
                 )
 
                 return {
@@ -1300,7 +1744,8 @@ export class ATXTransformHandler {
                 const plan = await this.getTransformationPlan(
                     request.WorkspaceId,
                     request.TransformationJobId,
-                    request.SolutionRootPath
+                    request.SolutionRootPath,
+                    request.IsBeam === true
                 )
 
                 // If GetCheckpoints is requested, populate HasCheckpoint field on steps
@@ -1335,15 +1780,87 @@ export class ATXTransformHandler {
                     : []
 
                 if (blockingHitls.length > 0) {
+                    // Beam-to-IDE: if the IDE sent its loaded-repo scope, prefer the
+                    // local-build-verification HITL in THAT repo's subtree over the first LBV in the
+                    // list (which may be a sibling's on a multi-repo beam job → shadows the loaded
+                    // repo). Same selection rule as getHitlAgentArtifact; applies to the EXECUTING
+                    // path too since a beam job surfaces its LBV HITL here.
+                    const execScopeStepIds = (request.beamScopeStepIds || '')
+                        .split(',')
+                        .map(s => s.trim())
+                        .filter(s => s.length > 0)
+                    const scopedExecLbv =
+                        execScopeStepIds.length > 0
+                            ? blockingHitls.find(
+                                  h =>
+                                      h.tag === 'local-build-verification' &&
+                                      execScopeStepIds.includes(
+                                          String(h.stepId ?? h.planStepId ?? h.parentStepId ?? '')
+                                      )
+                              )
+                            : null
+                    const execLbvHitls = blockingHitls.filter(h => h.tag === 'local-build-verification')
+                    if (execScopeStepIds.length > 0) {
+                        this.logging.log(
+                            `ATX: EXECUTING beam-scoped LBV pick=${scopedExecLbv ? (scopedExecLbv.stepId ?? scopedExecLbv.planStepId ?? scopedExecLbv.parentStepId) : '<none in scope>'} scope=[${execScopeStepIds.join(',')}]`
+                        )
+                        // Scope set and every blocking HITL is an out-of-scope LBV → they all belong
+                        // to sibling repos. Don't surface a sibling's HITL (the IDE would build the
+                        // loaded solution against it → false-green); report no pending HITL instead.
+                        // Mirrors the guard in getHitlAgentArtifact.
+                        if (!scopedExecLbv && execLbvHitls.length === blockingHitls.length) {
+                            this.logging.log(
+                                'ATX: EXECUTING — all pending HITLs are sibling-repo LBV (none in loaded scope); not surfacing'
+                            )
+                            return {
+                                TransformationJob: {
+                                    WorkspaceId: request.WorkspaceId,
+                                    JobId: request.TransformationJobId,
+                                    Status: jobStatus,
+                                } as AtxTransformationJob,
+                                TransformationPlan: plan,
+                            } as AtxGetTransformInfoResponse
+                        }
+                    }
+                    // As in getHitlAgentArtifact: when beam scope is active but no in-scope LBV
+                    // matched, an out-of-scope (sibling) LBV must NEVER be selectable — otherwise a
+                    // mixed pending set (sibling LBV + a non-LBV blocking HITL) lets the plain
+                    // find(...=== lbv) below surface the sibling's LBV → false green. Drop all LBVs
+                    // from the fallback pool in that case; only non-LBV blocking HITLs remain.
+                    const execFallbackPool =
+                        execScopeStepIds.length > 0 && !scopedExecLbv
+                            ? blockingHitls.filter(h => h.tag !== 'local-build-verification')
+                            : blockingHitls
                     const execHitl =
-                        blockingHitls.find(h => h.tag === 'local-build-verification') ||
-                        blockingHitls.find(
+                        scopedExecLbv ||
+                        execFallbackPool.find(h => h.tag === 'local-build-verification') ||
+                        execFallbackPool.find(
                             h => h.tag === 'missing-packages' || h.tag === 'handle_missing_packages_hitl'
                         ) ||
-                        blockingHitls.find(h => String(h.tag).endsWith('-checkpoint')) ||
-                        blockingHitls[0]
+                        execFallbackPool.find(h => String(h.tag).endsWith('-checkpoint')) ||
+                        execFallbackPool[0]
+                    if (!execHitl) {
+                        this.logging.log(
+                            'ATX: EXECUTING — beam scope active, only out-of-scope sibling LBV(s) pending; not surfacing'
+                        )
+                        return {
+                            TransformationJob: {
+                                WorkspaceId: request.WorkspaceId,
+                                JobId: request.TransformationJobId,
+                                Status: jobStatus,
+                            } as AtxTransformationJob,
+                            TransformationPlan: plan,
+                        } as AtxGetTransformInfoResponse
+                    }
+                    // Multi-repo beam scoping: forward the HITL's own plan stepId so the IDE can
+                    // tell which beamed repo this local-build-verification HITL belongs to. The
+                    // runtime now tags each LBV HITL with its plan-step id and FES returns it on
+                    // the HitlTask; without forwarding it here the IDE sees only the tag+taskId and
+                    // (on a multi-repo job) answers EVERY repo's HITL by building whatever solution
+                    // is open — a false-green. Tolerate any of the field spellings FES/agent use.
+                    const execHitlStepId = execHitl.stepId ?? execHitl.planStepId ?? execHitl.parentStepId ?? undefined
                     this.logging.log(
-                        `ATX: EXECUTING job has pending HITL — tag=${execHitl.tag} taskId=${execHitl.taskId}; surfacing AWAITING_HUMAN_INPUT to IDE`
+                        `ATX: EXECUTING job has pending HITL — tag=${execHitl.tag} taskId=${execHitl.taskId} stepId=${execHitlStepId ?? '<none>'}; surfacing AWAITING_HUMAN_INPUT to IDE`
                     )
                     return {
                         TransformationJob: {
@@ -1353,6 +1870,7 @@ export class ATXTransformHandler {
                         } as AtxTransformationJob,
                         HitlTag: execHitl.tag,
                         HitlTaskId: execHitl.taskId,
+                        StepInformation: execHitlStepId ? { StepId: execHitlStepId } : undefined,
                         TransformationPlan: plan,
                     } as AtxGetTransformInfoResponse
                 }
@@ -1377,7 +1895,8 @@ export class ATXTransformHandler {
                     plan = await this.getTransformationPlan(
                         request.WorkspaceId,
                         request.TransformationJobId,
-                        request.SolutionRootPath
+                        request.SolutionRootPath,
+                        request.IsBeam === true
                     )
                 } catch (e) {
                     // Plan not available yet
@@ -1496,18 +2015,24 @@ export class ATXTransformHandler {
      * 2. Execution phase: Plan exists, HITL raised for a specific step
      */
     private async handleAwaitingHumanInput(request: AtxGetTransformInfoRequest): Promise<AtxGetTransformInfoResponse> {
-        // Check for local-build-verification HITL first — it can happen with or without a plan
+        // Check for local-build-verification HITL first — it can happen with or without a plan.
+        // Beam-to-IDE: pass the loaded repo's scope so we surface THIS repo's LBV HITL, not
+        // the first in the list (which may be a sibling's on a multi-repo beam job).
         const hitlResponse = await this.getHitlAgentArtifact(
             request.WorkspaceId,
             request.TransformationJobId,
-            request.SolutionRootPath
+            request.SolutionRootPath,
+            request.beamScopeStepIds
         )
         if (hitlResponse?.HitlTag === 'local-build-verification') {
-            this.logging.log('ATX: local-build-verification HITL — returning directly to IDE')
+            this.logging.log(
+                `ATX: local-build-verification HITL — returning directly to IDE | stepId=${hitlResponse.StepId ?? '<none>'}`
+            )
             const plan = await this.getTransformationPlan(
                 request.WorkspaceId,
                 request.TransformationJobId,
-                request.SolutionRootPath
+                request.SolutionRootPath,
+                request.IsBeam === true
             )
             return {
                 TransformationJob: {
@@ -1518,6 +2043,10 @@ export class ATXTransformHandler {
                 TransformationPlan: plan,
                 HitlTag: 'local-build-verification',
                 HitlTaskId: hitlResponse.TaskId,
+                // Multi-repo beam scoping: forward the LBV HITL's plan-step id so the IDE answers
+                // only the loaded repo's HITL and skips siblings'. Undefined on single-repo/untagged
+                // jobs → IDE falls back to answering it (prior behavior).
+                StepInformation: hitlResponse.StepId ? { StepId: hitlResponse.StepId } : undefined,
             } as AtxGetTransformInfoResponse
         }
 
@@ -1525,7 +2054,8 @@ export class ATXTransformHandler {
         const plan = await this.getTransformationPlan(
             request.WorkspaceId,
             request.TransformationJobId,
-            request.SolutionRootPath
+            request.SolutionRootPath,
+            request.IsBeam === true
         )
 
         const hasPlan = plan.Root.Children.length > 0 && plan.Root.Children[0].Children.length > 0
@@ -1665,6 +2195,92 @@ export class ATXTransformHandler {
         }
 
         return null
+    }
+
+    /**
+     * Beam to IDE: decide whether a beamed repo's Local Build Verification is
+     * still OPEN (i.e. the repo is still waiting for the user to run LBV in the IDE), given the
+     * parent job's plan tree. Used by listBeamedRepos so the IDE shows only repos still awaiting
+     * LBV — a repo whose LBV has completed drops off the "Transferred to IDE" list.
+     *
+     * The web orchestrator names each beamed child node "<repo> (beamed)" under a "(Beamed) Batch"
+     * parent, with a "Local Build Verification" node beneath it. We find the repo's beamed node by
+     * name, then inspect its LBV descendant: OPEN = the LBV node exists and is non-terminal
+     * (PENDING_HUMAN_INPUT / IN_PROGRESS / NOT_STARTED); CLOSED = terminal (SUCCEEDED / COMPLETED /
+     * FAILED / STOPPED). Returns TRUE (open) when we can't resolve it — no plan yet, node not
+     * found, or no LBV child — so a freshly transferred repo is never hidden before its LBV status
+     * is known (the IDE mirrors this default). The caller skips this call entirely when no plan is
+     * available.
+     */
+    private isRepoLbvOpen(planRoot: AtxPlanStep, repoName: string): boolean {
+        const repoNode = this.findBeamedRepoNode(planRoot, repoName)
+        if (!repoNode) {
+            // unknown → default open (don't hide a fresh transfer)
+            this.logging.log(
+                `[BEAM-LBVOPEN] repo='${repoName}' → OPEN (default): no beamed repo node found in plan tree`
+            )
+            return true
+        }
+
+        const lbvNode = this.findLbvNode(repoNode)
+        if (!lbvNode) {
+            // no LBV node yet → still pending
+            this.logging.log(
+                `[BEAM-LBVOPEN] repo='${repoName}' → OPEN (default): repo node '${repoNode.StepName}' has no Local Build Verification child yet`
+            )
+            return true
+        }
+
+        const terminal = this.isTerminalStepStatus(lbvNode.Status)
+        // The decisive trace: repo → its LBV node status → open/closed verdict. On the next run this
+        // is how we PROVE the show-set actually flips: watch a repo go lbvStatus=IN_PROGRESS/
+        // PENDING_HUMAN_INPUT (OPEN) → SUCCEEDED (CLOSED) after Load, and confirm it then drops off.
+        this.logging.log(
+            `[BEAM-LBVOPEN] repo='${repoName}' node='${repoNode.StepName}' lbvNode='${lbvNode.StepName}' ` +
+                `lbvStatus=${lbvNode.Status} terminal=${terminal} → ${terminal ? 'CLOSED (will be hidden)' : 'OPEN (will show)'}`
+        )
+        return !terminal
+    }
+
+    /**
+     * Match the beamed repo's plan node. CRITICAL: the plan tree has MULTIPLE nodes named for a
+     * repo — the ORIGINAL TRANSFORM node named plain "<repo>" (top-level, SUCCEEDED, NO LBV child)
+     * AND the BEAM node named "<repo> (beamed)" (under "(Beamed) Batch", carrying the Local Build
+     * Verification child). We MUST prefer the "(beamed)" node — a naive first-match DFS hits the
+     * plain transform node first, finds no LBV child, and wrongly defaults the repo to LBV-open
+     * (making the whole show-set a no-op → every repo shows). So: search for the "(beamed)" node
+     * across the WHOLE tree first; only fall back to a plain "<repo>" match (single-repo/older
+     * jobs that name the beam node just "<repo>") if no "(beamed)" node exists anywhere.
+     */
+    private findBeamedRepoNode(step: AtxPlanStep, repoName: string): AtxPlanStep | null {
+        const beamed = this.findNodeByName(step, `${repoName} (beamed)`.toLowerCase())
+        if (beamed) return beamed
+        return this.findNodeByName(step, repoName.toLowerCase())
+    }
+
+    private findNodeByName(step: AtxPlanStep, lowerName: string): AtxPlanStep | null {
+        if ((step.StepName || '').toLowerCase() === lowerName) return step
+        for (const child of step.Children) {
+            const found = this.findNodeByName(child, lowerName)
+            if (found) return found
+        }
+        return null
+    }
+
+    /** Find the "Local Build Verification" node anywhere under the given node. */
+    private findLbvNode(step: AtxPlanStep): AtxPlanStep | null {
+        if ((step.StepName || '').toLowerCase().includes('local build verification')) return step
+        for (const child of step.Children) {
+            const found = this.findLbvNode(child)
+            if (found) return found
+        }
+        return null
+    }
+
+    /** Terminal step statuses (LBV done, one way or another). */
+    private isTerminalStepStatus(status: string): boolean {
+        const s = String(status || '').toUpperCase()
+        return s === 'SUCCEEDED' || s === 'COMPLETED' || s === 'FAILED' || s === 'STOPPED' || s === 'CANCELLED'
     }
 
     /**
@@ -2486,7 +3102,8 @@ export class ATXTransformHandler {
     async getTransformationPlan(
         workspaceId: string,
         jobId: string,
-        solutionRootPath: string
+        solutionRootPath: string,
+        isBeam: boolean = false
     ): Promise<AtxTransformationPlan> {
         try {
             const plan = await this.fetchPlanTree(workspaceId, jobId)
@@ -2496,7 +3113,23 @@ export class ATXTransformHandler {
                 this.logging.log(`ATX: Could not get worklogs for workspace: ${workspaceId}, job: ${jobId}`)
             })
 
-            // Download completed step artifacts if not already present (all modes)
+            // Download completed step artifacts if not already present.
+            //
+            // Beam-to-IDE (transformed): SKIP this pass. The beamed source is already
+            // the transformed output, so the prior transform job's completed-step
+            // checkpoint diffs are (a) already baked in and (b) not present in the beam
+            // bundle. Attempting to apply them logs "Checkpoint folder not available for
+            // step" and sets DiffApplyFailed on every poll, stalling the LBV loop. New
+            // LBV-round diffs are surfaced via the separate diff-artifact path, which is
+            // not gated here.
+            if (isBeam) {
+                this.logging.log(
+                    `ATX: [BEAM] skipping completed-step artifact apply for beamed job ${jobId} — source is already transformed`
+                )
+                this.logging.log(`ATX: Successfully built plan tree with ${plan.Root.Children.length} root steps`)
+                return plan
+            }
+
             const anyFailed = await this.downloadCompletedStepArtifacts(workspaceId, jobId, solutionRootPath, plan)
             if (anyFailed && this._currentDiffContext) {
                 this._currentDiffContext.failed = true
@@ -3695,16 +4328,31 @@ export class ATXTransformHandler {
         jobId?: string
         text: string
         skipPolling?: boolean
+        beamStepId?: string
     }): Promise<any> {
         try {
-            this.logging.log(`ATX: Sending chat message for workspace: ${request.workspaceId}`)
+            this.logging.log(
+                `ATX: Sending chat message for workspace: ${request.workspaceId}` +
+                    (request.beamStepId ? ` [BEAM-STEPID] beamStepId=${request.beamStepId}` : '')
+            )
 
             if (!this.atxClient && !(await this.initializeAtxClient())) {
                 throw new Error('ATX FES client not initialized')
             }
 
+            // Beam to IDE (chat routing): the beamed repo's stepId is the routing key the
+            // web orchestrator needs to forward this message to the right repo's sub-agent.
+            // Message-level metadata is stripped by the platform base agent before the
+            // orchestrator sees it (and the SDK ChatJobMetadata type rejects extra fields),
+            // and the LSP can't emit an A2A DataPart — so the only channel that reaches the
+            // orchestrator is the message TEXT. Prepend a machine-parseable token the
+            // orchestrator strips before the LLM sees it (same pattern as the beam marker).
+            // The IDE shows the user's clean text (it renders the message locally before
+            // send), so the token never appears in the user's chat panel.
+            const messageText = request.beamStepId ? `<<beamstep:${request.beamStepId}>> ${request.text}` : request.text
+
             const command = new SendMessageCommand({
-                text: request.text,
+                text: messageText,
                 idempotencyToken: uuidv4(),
                 metadata: {
                     resourcesOnScreen: {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -77,6 +77,43 @@ interface DiffApplyContext {
 }
 
 /**
+ * Beam to IDE wire/shape types. These pin the shapes flowing through beam discovery so the
+ * compiler catches drift instead of `any` silently accepting anything.
+ * NOTE: the field-name tolerance in normalizeBeamRepo/getStepId is a deliberate bridge to an
+ * as-yet-unversioned web-orchestrator contract (tracked: pin a versioned schema, #57).
+ */
+interface BeamMapRepo {
+    repoName?: string
+    repositoryName?: string
+    repo?: string
+    name?: string
+    artifactId?: string
+    beamArtifactId?: string
+    ArtifactId?: string
+    stepId?: string
+    planStepId?: string
+    parentStepId?: string
+    targetFramework?: string
+    tfm?: string
+    target_framework?: string
+    scenario?: string
+}
+
+/** The beamed-repo record returned to the IDE (PascalCase, as the C# client consumes it). */
+interface BeamedRepoInfo {
+    RepositoryName: string
+    BeamArtifactId: string
+    BeamStepId: string
+    BeamTargetFramework: string
+    BeamScenario: string
+    IsLbvOpen: boolean
+}
+
+// Bounds for the beam-map candidate scan (serial download+parse per candidate).
+const BEAM_MAP_SCAN_MAX_CANDIDATES = 25
+const BEAM_MAP_SCAN_BUDGET_MS = 15000
+
+/**
  * ATX Transform Handler - Business logic for ATX FES Transform operations
  * Parallel to RTS TransformHandler but uses AtxTokenServiceManager and ATX FES APIs
  */
@@ -535,7 +572,7 @@ export class ATXTransformHandler {
      * (category HITL_FROM_AGENT) listing repos the user chose to beam. We find it
      * by listing the parent job's artifacts and picking the beam-map JSON.
      */
-    async listBeamedRepos(workspaceId: string, parentJobId: string): Promise<any[]> {
+    async listBeamedRepos(workspaceId: string, parentJobId: string): Promise<BeamedRepoInfo[]> {
         try {
             this.logging.log(`ATX: listBeamedRepos for parentJobId=${parentJobId}`)
             if (!this.atxClient && !(await this.initializeAtxClient())) {
@@ -616,22 +653,55 @@ export class ATXTransformHandler {
             // to zip-discovery with empty stepId). Instead, exclude only the transformed-
             // source bundles, whose paths match "<repo>_<hash>/<repo>.zip" (ZIP_RE). Anything
             // else (including an unnamed/empty-path zip = the beam-map) is a candidate.
-            let beamMapRepos: any[] | null = null
-            const candidates = artifacts.filter(a => {
+            let beamMapRepos: BeamMapRepo[] | null = null
+            const allCandidates = artifacts.filter(a => {
                 const p = (a.fileMetadata?.path || '').toLowerCase()
                 return !ZIP_RE.test(p) // keep non-transformed-bundle artifacts (incl. the beam-map zip)
             })
+            // Bound the scan: each candidate is a serial download+parse, so an artifact-heavy
+            // job (logs, metadata) could otherwise stall the IDE's discovery UI. Cap the number
+            // scanned and enforce an overall deadline; the beam-map is written early and is
+            // small, so a bounded scan reliably finds it.
+            const candidates = allCandidates.slice(0, BEAM_MAP_SCAN_MAX_CANDIDATES)
+            if (allCandidates.length > candidates.length) {
+                this.logging.log(
+                    `[BEAM-PKG] beam-map scan: capping ${allCandidates.length} candidate(s) to ${candidates.length}`
+                )
+            }
+            const scanDeadline = Date.now() + BEAM_MAP_SCAN_BUDGET_MS
             this.logging.log(
                 `[BEAM-PKG] beam-map scan: ${candidates.length} candidate artifact(s) (excluded transformed-source bundles)`
             )
             for (const a of candidates) {
                 if (!a.artifactId) continue
+                if (Date.now() > scanDeadline) {
+                    this.logging.log(
+                        `[BEAM-PKG] beam-map scan: time budget (${BEAM_MAP_SCAN_BUDGET_MS}ms) exceeded — stopping scan`
+                    )
+                    break
+                }
                 try {
                     const map = await this.downloadJsonArtifact(workspaceId, parentJobId, a.artifactId)
-                    if (map && Array.isArray(map.repos)) {
-                        beamMapRepos = map.repos as any[]
+                    // Validate shape before trusting it: the beam-map is uploaded by the web
+                    // orchestrator, so a malformed, unexpectedly-shaped, or attacker-influenced
+                    // payload must NOT flow into normalizeBeamRepo (which drives which artifacts
+                    // get downloaded and which paths get written). Require repos to be an array
+                    // of objects; keep only entries that yield a non-empty string repo name, and
+                    // reject/skip anything else.
+                    if (map && Array.isArray((map as any).repos)) {
+                        const rawRepos = (map as any).repos as unknown[]
+                        const validRepos = rawRepos.filter(
+                            r => r != null && typeof r === 'object' && !!this.normalizeBeamRepo(r).RepositoryName
+                        )
+                        const rejected = rawRepos.length - validRepos.length
+                        if (rejected > 0) {
+                            this.logging.log(
+                                `[BEAM-PKG] beam-map validation: skipped ${rejected} malformed entr(y/ies) in artifact=${a.artifactId}`
+                            )
+                        }
+                        beamMapRepos = validRepos as BeamMapRepo[]
                         this.logging.log(
-                            `[BEAM-PKG] beam-map found (${beamMapRepos.length} repo(s)) artifact=${a.artifactId} — filtering discovery by beam-map membership`
+                            `[BEAM-PKG] beam-map found (${beamMapRepos.length} valid repo(s)) artifact=${a.artifactId} — filtering discovery by beam-map membership`
                         )
                         // Do NOT break — keep scanning; a later artifact could be a newer beam-map.
                         // (Cost is bounded: only empty-path/non-zip artifacts, a handful per job.)
@@ -643,7 +713,7 @@ export class ATXTransformHandler {
                 }
             }
 
-            const beamed: any[] = []
+            const beamed: BeamedRepoInfo[] = []
 
             // Show-set: fetch the parent job's plan tree ONCE so we can stamp each beamed repo
             // with whether its Local Build Verification is still open (the IDE shows only repos
@@ -714,7 +784,8 @@ export class ATXTransformHandler {
                 //      repo whose name legitimately ends in 8 hex),
                 //   2) else strip a trailing "-<8hex>" and match that -> use it (new hashed format).
                 // If neither resolves, fall through (logged below as "no matching transformed zip").
-                const statusRe = new RegExp(`beam-status-${parentJobId}-(.+)\\.json$`, 'i')
+                const escapedJobId = parentJobId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+                const statusRe = new RegExp(`beam-status-${escapedJobId}-(.+)\\.json$`, 'i')
                 const statusRepos = new Set<string>()
                 for (const a of artifacts) {
                     const p = a.fileMetadata?.path || ''
@@ -775,20 +846,47 @@ export class ATXTransformHandler {
      * tolerant of key-name variants from the web writer (repoName/repo/name,
      * artifactId/beamArtifactId, stepId/planStepId, targetFramework/tfm).
      */
-    private normalizeBeamRepo(r: any): {
-        RepositoryName: string
-        BeamArtifactId: string
-        BeamStepId: string
-        BeamTargetFramework: string
-        BeamScenario: string
-    } {
-        r = r || {}
+    /**
+     * The wire contract with the web orchestrator / FES is not yet pinned to a single
+     * spelling: a plan-step / HITL id arrives as stepId, planStepId, or parentStepId
+     * depending on the source. Centralize the coalescing here so every call site stays
+     * in sync and there's one place to update when the contract is versioned.
+     * TODO: replace with a versioned schema once the web-orc contract is pinned (#57).
+     */
+    private getStepId(obj: any): string | undefined {
+        if (obj == null || typeof obj !== 'object') return undefined
+        return obj.stepId ?? obj.planStepId ?? obj.parentStepId ?? undefined
+    }
+
+    /**
+     * Beam-to-IDE scoped LBV selection, shared by getHitlAgentArtifact and the EXECUTING
+     * path so the rule stays in one place. Given the pending HITLs and the loaded repo's
+     * scope step-ids, return the local-build-verification HITL in that repo's subtree, and
+     * whether the scope is active but EVERY pending HITL is a sibling LBV (none in scope) —
+     * in which case the caller returns "none" rather than hand the IDE a sibling's HITL.
+     */
+    private selectScopedLbvHitl(
+        hitls: any[],
+        scopeStepIds: string[]
+    ): { scopedLbv: any | null; allOutOfScopeLbv: boolean } {
+        const lbvHitls = hitls.filter(h => h.tag === 'local-build-verification')
+        if (scopeStepIds.length === 0 || lbvHitls.length === 0) {
+            return { scopedLbv: null, allOutOfScopeLbv: false }
+        }
+        const scopedLbv = lbvHitls.find(h => scopeStepIds.includes(String(this.getStepId(h) ?? ''))) ?? null
+        // Scope active + pending HITLs are ALL LBV but none in scope → all belong to siblings.
+        const allOutOfScopeLbv = !scopedLbv && lbvHitls.length === hitls.length
+        return { scopedLbv, allOutOfScopeLbv }
+    }
+
+    private normalizeBeamRepo(r: BeamMapRepo | null | undefined): Omit<BeamedRepoInfo, 'IsLbvOpen'> {
+        const o: BeamMapRepo = r || {}
         return {
-            RepositoryName: r.repoName ?? r.repositoryName ?? r.repo ?? r.name ?? '',
-            BeamArtifactId: r.artifactId ?? r.beamArtifactId ?? r.ArtifactId ?? '',
-            BeamStepId: r.stepId ?? r.planStepId ?? r.parentStepId ?? '',
-            BeamTargetFramework: r.targetFramework ?? r.tfm ?? r.target_framework ?? '',
-            BeamScenario: r.scenario ?? 'transformed',
+            RepositoryName: o.repoName ?? o.repositoryName ?? o.repo ?? o.name ?? '',
+            BeamArtifactId: o.artifactId ?? o.beamArtifactId ?? o.ArtifactId ?? '',
+            BeamStepId: this.getStepId(o) ?? '',
+            BeamTargetFramework: o.targetFramework ?? o.tfm ?? o.target_framework ?? '',
+            BeamScenario: o.scenario ?? 'transformed',
         }
     }
 
@@ -852,6 +950,13 @@ export class ATXTransformHandler {
     ): Promise<{ Success: boolean; ExtractedPath?: string; Error?: string }> {
         try {
             this.logging.log(`[BEAM-PKG] downloadBeamArtifact ${beamArtifactId} -> ${destDir}`)
+            // destDir must be an absolute path (the IDE passes a resolved workspace path).
+            // Reject relative/traversal input so extraction can't be aimed at an unexpected
+            // location; the zip-slip guard in extractAllEntriesTo then confines each entry
+            // within this dir.
+            if (!destDir || !path.isAbsolute(destDir) || destDir.includes('..')) {
+                return { Success: false, Error: 'Invalid destination directory for beam artifact' }
+            }
             const dl = await this.createArtifactDownloadUrl(workspaceId, parentJobId, beamArtifactId)
             if (!dl?.s3PresignedUrl) {
                 return { Success: false, Error: 'No presigned URL for beam artifact' }
@@ -1209,7 +1314,11 @@ export class ATXTransformHandler {
                     name === 'TooManyRequestsException' ||
                     /throttl|too many requests|rate exceeded/i.test(msg)
                 if (isThrottle && attempt < maxAttempts) {
-                    const backoffMs = 250 * Math.pow(2, attempt - 1) // 250, 500, 1000ms
+                    // Exponential base (250, 500, 1000ms) with jitter: under concurrent
+                    // throttling, unjittered lockstep retries amplify the thundering herd that
+                    // caused the throttle. Randomize to spread the retries out.
+                    const base = 250 * Math.pow(2, attempt - 1)
+                    const backoffMs = Math.round(base * (0.5 + Math.random()))
                     this.logging.log(
                         `ATX: CreateArtifactDownloadUrl THROTTLED (artifact=${artifactId}, attempt=${attempt}/${maxAttempts}) — retrying in ${backoffMs}ms`
                     )
@@ -1488,21 +1597,16 @@ export class ATXTransformHandler {
                 .split(',')
                 .map(s => s.trim())
                 .filter(s => s.length > 0)
-            const lbvHitls = hitls.filter(h => h.tag === 'local-build-verification')
-            let scopedLbv: any = null
-            if (scopeStepIds.length > 0 && lbvHitls.length > 0) {
-                scopedLbv = lbvHitls.find(h =>
-                    scopeStepIds.includes(String(h.stepId ?? h.planStepId ?? h.parentStepId ?? ''))
-                )
+            const { scopedLbv, allOutOfScopeLbv } = this.selectScopedLbvHitl(hitls, scopeStepIds)
+            if (scopeStepIds.length > 0) {
                 this.logging.log(
-                    `ATX: getHitlAgentArtifact beam-scoped LBV pick=${scopedLbv ? (scopedLbv.stepId ?? scopedLbv.planStepId ?? scopedLbv.parentStepId) : '<none in scope>'} of ${lbvHitls.length} LBV hitl(s) scope=[${scopeStepIds.join(',')}]`
+                    `ATX: getHitlAgentArtifact beam-scoped LBV pick=${scopedLbv ? this.getStepId(scopedLbv) : '<none in scope>'} scope=[${scopeStepIds.join(',')}]`
                 )
                 // Scope is set and the pending HITL(s) are LBV, but NONE is in the loaded repo's
                 // subtree → they all belong to sibling repos. Return null so the IDE isn't handed a
-                // sibling's HITL it would only skip every poll. The loaded repo simply has no
-                // pending LBV yet (or its sub-agent hasn't raised one). Non-LBV HITLs (e.g.
+                // sibling's HITL it would only skip every poll. Non-LBV HITLs (e.g.
                 // missing-packages) still fall through below and are handled normally.
-                if (!scopedLbv && lbvHitls.length === hitls.length) {
+                if (allOutOfScopeLbv) {
                     this.logging.log(
                         'ATX: getHitlAgentArtifact — all pending HITLs are sibling-repo LBV (none in loaded scope); returning none'
                     )
@@ -1545,7 +1649,7 @@ export class ATXTransformHandler {
             // — without it the IDE answers every repo's HITL against whatever solution is open (a
             // false-green). Tolerate any field spelling FES/agent use, same as the EXECUTING path.
             if (hitlTag === 'local-build-verification') {
-                const lbvStepId = hitl.stepId ?? hitl.planStepId ?? hitl.parentStepId ?? undefined
+                const lbvStepId = this.getStepId(hitl)
                 this.logging.log(
                     `ATX: local-build-verification HITL — returning tag for IDE to handle | stepId=${lbvStepId ?? '<none>'}`
                 )
@@ -1791,26 +1895,19 @@ export class ATXTransformHandler {
                         .split(',')
                         .map(s => s.trim())
                         .filter(s => s.length > 0)
-                    const scopedExecLbv =
-                        execScopeStepIds.length > 0
-                            ? blockingHitls.find(
-                                  h =>
-                                      h.tag === 'local-build-verification' &&
-                                      execScopeStepIds.includes(
-                                          String(h.stepId ?? h.planStepId ?? h.parentStepId ?? '')
-                                      )
-                              )
-                            : null
-                    const execLbvHitls = blockingHitls.filter(h => h.tag === 'local-build-verification')
+                    const { scopedLbv: scopedExecLbv, allOutOfScopeLbv: execAllOutOfScope } = this.selectScopedLbvHitl(
+                        blockingHitls,
+                        execScopeStepIds
+                    )
                     if (execScopeStepIds.length > 0) {
                         this.logging.log(
-                            `ATX: EXECUTING beam-scoped LBV pick=${scopedExecLbv ? (scopedExecLbv.stepId ?? scopedExecLbv.planStepId ?? scopedExecLbv.parentStepId) : '<none in scope>'} scope=[${execScopeStepIds.join(',')}]`
+                            `ATX: EXECUTING beam-scoped LBV pick=${scopedExecLbv ? this.getStepId(scopedExecLbv) : '<none in scope>'} scope=[${execScopeStepIds.join(',')}]`
                         )
                         // Scope set and every blocking HITL is an out-of-scope LBV → they all belong
                         // to sibling repos. Don't surface a sibling's HITL (the IDE would build the
                         // loaded solution against it → false-green); report no pending HITL instead.
                         // Mirrors the guard in getHitlAgentArtifact.
-                        if (!scopedExecLbv && execLbvHitls.length === blockingHitls.length) {
+                        if (execAllOutOfScope) {
                             this.logging.log(
                                 'ATX: EXECUTING — all pending HITLs are sibling-repo LBV (none in loaded scope); not surfacing'
                             )
@@ -1860,7 +1957,7 @@ export class ATXTransformHandler {
                     // the HitlTask; without forwarding it here the IDE sees only the tag+taskId and
                     // (on a multi-repo job) answers EVERY repo's HITL by building whatever solution
                     // is open — a false-green. Tolerate any of the field spellings FES/agent use.
-                    const execHitlStepId = execHitl.stepId ?? execHitl.planStepId ?? execHitl.parentStepId ?? undefined
+                    const execHitlStepId = this.getStepId(execHitl)
                     this.logging.log(
                         `ATX: EXECUTING job has pending HITL — tag=${execHitl.tag} taskId=${execHitl.taskId} stepId=${execHitlStepId ?? '<none>'}; surfacing AWAITING_HUMAN_INPUT to IDE`
                     )

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -1549,7 +1549,9 @@ export class ATXTransformHandler {
                 this.logging.log(
                     `ATX: local-build-verification HITL — returning tag for IDE to handle | stepId=${lbvStepId ?? '<none>'}`
                 )
-                return { HitlTag: hitlTag, TaskId: hitl.taskId, StepId: lbvStepId }
+                return lbvStepId !== undefined
+                    ? { HitlTag: hitlTag, TaskId: hitl.taskId, StepId: lbvStepId }
+                    : { HitlTag: hitlTag, TaskId: hitl.taskId }
             }
 
             // If no agent artifact, return tag and taskId without downloading

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -4124,3 +4124,185 @@ describe('ATXTransformHandler - final coverage push', () => {
         })
     })
 })
+
+describe('ATXTransformHandler - Beam to IDE', () => {
+    let handler: ATXTransformHandler
+    let serviceManager: AtxTokenServiceManager
+    let workspace: Workspace
+    let logging: Logging
+    let runtime: Runtime
+    let sendStub: sinon.SinonStub
+
+    beforeEach(() => {
+        serviceManager = sinon.createStubInstance(AtxTokenServiceManager) as any
+        workspace = {} as Workspace
+        logging = { log: sinon.stub(), error: sinon.stub(), info: sinon.stub() } as any
+        runtime = {} as Runtime
+        handler = new ATXTransformHandler(serviceManager, workspace, logging, runtime)
+        sinon.stub(handler as any, 'initializeAtxClient').resolves(true)
+        sinon.stub(handler as any, 'addAuthToCommand').resolves()
+        sendStub = sinon.stub()
+        ;(handler as any).atxClient = { send: sendStub }
+        // No plan by default → IsLbvOpen defaults true; individual tests can restub.
+        sinon.stub(handler as any, 'getTransformationPlan').resolves(null)
+    })
+
+    afterEach(() => {
+        sinon.restore()
+    })
+
+    // --- getStepId: the centralized field-coalescing helper (contract-tolerant) ---
+    describe('getStepId', () => {
+        it('coalesces stepId / planStepId / parentStepId in priority order', () => {
+            const g = (o: any) => (handler as any).getStepId(o)
+            expect(g({ stepId: 'a', planStepId: 'b', parentStepId: 'c' })).to.equal('a')
+            expect(g({ planStepId: 'b', parentStepId: 'c' })).to.equal('b')
+            expect(g({ parentStepId: 'c' })).to.equal('c')
+        })
+
+        it('returns undefined for null / non-object / no matching field', () => {
+            const g = (o: any) => (handler as any).getStepId(o)
+            expect(g(null)).to.be.undefined
+            expect(g(undefined)).to.be.undefined
+            expect(g('str')).to.be.undefined
+            expect(g({ other: 'x' })).to.be.undefined
+        })
+    })
+
+    // --- normalizeBeamRepo: tolerant wire-shape mapping ---
+    describe('normalizeBeamRepo', () => {
+        it('maps varied key spellings to the PascalCase IDE shape', () => {
+            const nr = (handler as any).normalizeBeamRepo({
+                repositoryName: 'alice',
+                beamArtifactId: 'art-9',
+                planStepId: 'step-1',
+                tfm: 'net8.0',
+                scenario: 'transformed',
+            })
+            expect(nr.RepositoryName).to.equal('alice')
+            expect(nr.BeamArtifactId).to.equal('art-9')
+            expect(nr.BeamStepId).to.equal('step-1')
+            expect(nr.BeamTargetFramework).to.equal('net8.0')
+            expect(nr.BeamScenario).to.equal('transformed')
+        })
+
+        it('defaults empty fields and scenario=transformed on a bare object', () => {
+            const nr = (handler as any).normalizeBeamRepo({})
+            expect(nr.RepositoryName).to.equal('')
+            expect(nr.BeamScenario).to.equal('transformed')
+        })
+    })
+
+    // --- listBeamedRepos: the core discovery function (empty / beam-map / beam-status / regex) ---
+    describe('listBeamedRepos', () => {
+        const zipArtifacts = (repo: string, hash = 'abc123') => [
+            { artifactId: `zip-${repo}`, fileMetadata: { path: `${repo}_${hash}/${repo}.zip` } },
+        ]
+
+        it('returns [] when the job has no artifacts (never beamed)', async () => {
+            sendStub.resolves({ artifacts: [] })
+            const result = await handler.listBeamedRepos('ws-1', 'job-1')
+            expect(result).to.deep.equal([])
+        })
+
+        it('returns [] when only transformed zips exist but no beam-map / beam-status', async () => {
+            sendStub.resolves({ artifacts: zipArtifacts('alice') })
+            const result = await handler.listBeamedRepos('ws-1', 'job-1')
+            // A transform-only job must NOT over-list its transformed zips as "beamed".
+            expect(result).to.deep.equal([])
+        })
+
+        it('filters discovery to beam-map membership when a beam-map is present', async () => {
+            sendStub.resolves({
+                artifacts: [
+                    ...zipArtifacts('alice'),
+                    ...zipArtifacts('bob'),
+                    { artifactId: 'beammap-1', fileMetadata: { path: '' } },
+                ],
+            })
+            sinon
+                .stub(handler as any, 'downloadJsonArtifact')
+                .resolves({ repos: [{ repoName: 'alice', stepId: 's1', scenario: 'transformed' }] })
+            const result = await handler.listBeamedRepos('ws-1', 'job-1')
+            expect(result.map((r: any) => r.RepositoryName)).to.deep.equal(['alice'])
+            expect(result[0].BeamArtifactId).to.equal('zip-alice')
+        })
+
+        it('rejects malformed beam-map entries (no usable repo name)', async () => {
+            sendStub.resolves({
+                artifacts: [...zipArtifacts('alice'), { artifactId: 'beammap-1', fileMetadata: { path: '' } }],
+            })
+            sinon
+                .stub(handler as any, 'downloadJsonArtifact')
+                .resolves({ repos: [{ repoName: 'alice' }, { junk: true }, null, 'not-an-object'] })
+            const result = await handler.listBeamedRepos('ws-1', 'job-1')
+            // Only the well-formed 'alice' entry survives validation.
+            expect(result.map((r: any) => r.RepositoryName)).to.deep.equal(['alice'])
+        })
+
+        it('falls back to beam-status filenames when no beam-map is present', async () => {
+            sendStub.resolves({
+                artifacts: [
+                    ...zipArtifacts('alice'),
+                    { artifactId: 'status-1', fileMetadata: { path: 'beam-status-job-1-alice.json' } },
+                ],
+            })
+            const result = await handler.listBeamedRepos('ws-1', 'job-1')
+            expect(result.map((r: any) => r.RepositoryName)).to.deep.equal(['alice'])
+            expect(result[0].BeamArtifactId).to.equal('zip-alice')
+        })
+
+        it('strips the -<8hex> suffix on beam-status filenames to resolve the repo', async () => {
+            sendStub.resolves({
+                artifacts: [
+                    ...zipArtifacts('alice'),
+                    { artifactId: 'status-1', fileMetadata: { path: 'beam-status-job-1-alice-0a1b2c3d.json' } },
+                ],
+            })
+            const result = await handler.listBeamedRepos('ws-1', 'job-1')
+            expect(result.map((r: any) => r.RepositoryName)).to.deep.equal(['alice'])
+        })
+
+        it('does not throw or mismatch when the jobId contains regex metacharacters', async () => {
+            const jobId = 'job.(v1)+[x]'
+            sendStub.resolves({
+                artifacts: [
+                    ...zipArtifacts('alice'),
+                    { artifactId: 'status-1', fileMetadata: { path: `beam-status-${jobId}-alice.json` } },
+                ],
+            })
+            // Without escaping, `new RegExp` would throw or mismatch on these metachars.
+            const result = await handler.listBeamedRepos('ws-1', jobId)
+            expect(result.map((r: any) => r.RepositoryName)).to.deep.equal(['alice'])
+        })
+
+        it('returns [] and logs on send failure (no throw)', async () => {
+            sendStub.rejects(new Error('FES down'))
+            const result = await handler.listBeamedRepos('ws-1', 'job-1')
+            expect(result).to.deep.equal([])
+            expect((logging.error as sinon.SinonStub).called).to.be.true
+        })
+    })
+
+    // --- downloadBeamArtifact: destDir path validation (zip-slip defense) ---
+    describe('downloadBeamArtifact', () => {
+        it('rejects a relative destDir', async () => {
+            const result = await handler.downloadBeamArtifact('ws-1', 'job-1', 'art-1', 'relative/dir')
+            expect(result.Success).to.be.false
+            expect(result.Error).to.match(/Invalid destination directory/)
+        })
+
+        it('rejects a destDir containing ".." traversal', async () => {
+            // Absolute but with an un-normalized ".." segment — must be rejected.
+            const bad = `${path.sep}root${path.sep}ws${path.sep}..${path.sep}evil`
+            const result = await handler.downloadBeamArtifact('ws-1', 'job-1', 'art-1', bad)
+            expect(result.Success).to.be.false
+            expect(result.Error).to.match(/Invalid destination directory/)
+        })
+
+        it('rejects an empty destDir', async () => {
+            const result = await handler.downloadBeamArtifact('ws-1', 'job-1', 'art-1', '')
+            expect(result.Success).to.be.false
+        })
+    })
+})

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/utils.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/utils.test.ts
@@ -458,6 +458,26 @@ describe('Utils', () => {
             expect(writeFileStub.calledOnce).to.be.true
         })
 
+        it('should block zip-slip entries that escape the extraction directory', async () => {
+            const mkdirStub = sinon.stub(fs.promises, 'mkdir').resolves()
+            const writeFileStub = sinon.stub(fs.promises, 'writeFile').resolves()
+
+            const entries = [
+                {
+                    entryName: `..${path.sep}..${path.sep}evil.txt`,
+                    isDirectory: false,
+                    getData: () => Buffer.from('malicious'),
+                },
+            ]
+
+            await Utils.extractAllEntriesTo(tempDir, entries as any, mockLogger)
+
+            // The traversal entry must be skipped — nothing written, and it's logged.
+            expect(writeFileStub.called).to.be.false
+            expect(mockLogger.error.calledOnce).to.be.true
+            expect(mockLogger.error.firstCall.args[0]).to.include('escaping extraction directory')
+        })
+
         it('should handle ENOENT error', async () => {
             const entries = [
                 {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/utils.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/utils.ts
@@ -232,9 +232,19 @@ export class Utils {
         zipEntries: AdmZip.IZipEntry[],
         logger: Logging
     ): Promise<void> {
+        // Resolve the extraction root once so every entry can be checked against it.
+        const extractRoot = path.resolve(pathContainingArchive)
         for (const entry of zipEntries) {
             try {
                 const entryPath = path.join(pathContainingArchive, entry.entryName)
+                // Zip-slip guard: reject any entry that resolves outside the extraction
+                // root (../ traversal or absolute paths). Archives can originate from a
+                // remote artifact, so a crafted entry must never write outside destDir.
+                const resolvedEntry = path.resolve(entryPath)
+                if (resolvedEntry !== extractRoot && !resolvedEntry.startsWith(extractRoot + path.sep)) {
+                    logger.error(`Blocked zip entry escaping extraction directory: ${entry.entryName}`)
+                    continue
+                }
                 if (entry.isDirectory) {
                     await fs.promises.mkdir(entryPath, { recursive: true })
                 } else {


### PR DESCRIPTION
# feat: scope local build verification to the loaded beamed repo and add beam discovery/download

## What this does

Adds the LSP support for **Beam to IDE** (AWS Transform .NET): the language server mediates between the IDE and the platform so a developer can pull a web-transformed repository into Visual Studio and run a real local build. Scoped entirely to the `netTransform` handler.

## What changed

- **Scoped build-verification HITL selection** (`getHitlAgentArtifact` + the EXECUTING path): when the IDE passes the loaded repo's scope, the handler returns **only that repo's** Local Build Verification request. Critically, when scope is set but no in-scope LBV matches, an out-of-scope (sibling) LBV is **excluded from the fallback** — so on a multi-repo beam the IDE is never handed a sibling repo's build-verification request (the root of "false green"). Includes the mixed pending-HITL case (sibling LBV coexisting with a non-LBV HITL).
- **Beam discovery + artifact download**: `listBeamedRepos` (derives beamed repos from the per-repo beam-status artifacts, tolerant of the status-label naming) and `downloadBeamArtifact`.
- **Chat scoping marker**: prepends the routing token to outbound chat so the orchestrator scopes context to the loaded repo (the IDE strips it at display).
- Removed a vestigial, uncalled `createBeamJob` command to keep the surface clean.

## Files

Exactly three files, all under `server/aws-lsp-codewhisperer/src/language-server/netTransform/`:
- `atxTransformHandler.ts` — scoping guard, discovery, download, marker.
- `atxNetTransformServer.ts` — command registration/routing.
- `atxModels.ts` — new request/response types (additive).

## Additive by design

New request/response fields are optional; the scoping logic is a **no-op when no beam scope is provided** — a normal (non-beam) transform selects HITLs exactly as before (verified: with no scope, the new fallback collapses to the original selection). One shared helper (`createArtifactDownloadUrl`) gained throttle-retry resilience — behavior-preserving on success and on missing-URL, only adds a retry on transient throttling.

## Testing

- **Beam, live (multi-repo):** discovery returns the beamed repos; per-repo LBV isolation held; no sibling leak; builds completed cleanly.
- **Non-beam, live:** normal transform HITL selection unchanged (no scope sent → original path).

## Transparency note for reviewers

The mixed-HITL exclusion (sibling LBV + a non-LBV HITL pending simultaneously) is covered by unit tests and closed in code, but did not naturally occur in the live runs — the IDE-side deferral independently covers the same case and was exercised live. It's defense-in-depth: either layer prevents a false green.

## Related

Coordinated with the IDE change (Beam to IDE feature) and the web orchestrator / runtime changes for the shared-job beam flow.


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
