### PR TITLE
fix(amazonq): give the IAM and token servers distinct serverInfo names

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServer.test.ts
@@ -10,8 +10,14 @@ import {
     Server,
     UpdateConfigurationParams,
 } from '@aws/language-server-runtimes/server-interface'
-import { AmazonQServiceServerFactory } from './amazonQServer'
+import {
+    AMAZON_Q_SERVICE_SERVER_IAM_NAME,
+    AMAZON_Q_SERVICE_SERVER_TOKEN_NAME,
+    AmazonQServiceServerFactory,
+} from './amazonQServer'
 import { BaseAmazonQServiceManager } from './amazonQServiceManager/BaseAmazonQServiceManager'
+
+const TEST_SERVER_NAME = 'Test Amazon Q Server'
 
 describe('AmazonQServiceServer', () => {
     let features: TestFeatures
@@ -24,7 +30,7 @@ describe('AmazonQServiceServer', () => {
         initBaseTestServiceManagerSpy = sinon.spy(initBaseTestServiceManager)
 
         TestAmazonQServiceManager.resetInstance()
-        server = AmazonQServiceServerFactory(() => initBaseTestServiceManagerSpy(features))
+        server = AmazonQServiceServerFactory(() => initBaseTestServiceManagerSpy(features), TEST_SERVER_NAME)
     })
 
     afterEach(() => {
@@ -53,13 +59,22 @@ describe('AmazonQServiceServer', () => {
         const result = (await initializer({} as InitializeParams, {} as CancellationToken)) as PartialInitializeResult
 
         // The runtime only builds a notification router for servers that declare serverInfo, and
-        // notification.showNotification() is a silent no-op without one. Dropping this makes every
-        // server-initiated notification disappear with nothing but a debug line to show for it.
-        //
-        // The name is asserted exactly because it is not cosmetic: it is encoded into the id of each
-        // notification the client sends back, so renaming it strands followups for notifications
-        // already on screen.
-        expect(result.serverInfo?.name).to.equal('AWS Language Server for Amazon Q Developer')
+        // notification.showNotification() is a silent no-op without one.
+        expect(result.serverInfo?.name).to.equal(TEST_SERVER_NAME)
+    })
+
+    it('gives the IAM and token servers distinct serverInfo names', () => {
+        // Regression guard. Runtimes such as agent-standalone register BOTH of these servers, and the
+        // runtime rejects initialize with `Duplicate servers defined` when two servers report the same
+        // name -- which fails the entire language server, not just the duplicate. A shared name here
+        // made every such runtime fall back to whatever server the client had bundled, visible only as
+        // a client-side warning, so Q kept working while silently running a different server.
+        const names = [AMAZON_Q_SERVICE_SERVER_IAM_NAME, AMAZON_Q_SERVICE_SERVER_TOKEN_NAME]
+
+        for (const name of names) {
+            expect(name).to.be.a('string').and.not.empty
+        }
+        expect(new Set(names).size, `server names must be unique: ${names.join(', ')}`).to.equal(names.length)
     })
 
     it('hooks handleDidChangeConfiguration to didChangeConfiguration and onInitialized handlers', async () => {
@@ -130,7 +145,7 @@ describe('AmazonQServiceServer', () => {
             throw new Error('Service manager initialization failed')
         }
 
-        const errorServer = AmazonQServiceServerFactory(errorFactory)
+        const errorServer = AmazonQServiceServerFactory(errorFactory, TEST_SERVER_NAME)
 
         expect(() => {
             errorServer(features)

--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServer.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServer.ts
@@ -17,8 +17,15 @@ import {
 
 const LOGGING_PREFIX = '[AMAZON Q SERVER]: '
 
+/**
+ * @param serverName Value for the server's `serverInfo.name`. Required, and required to be unique
+ * across every server registered in the same runtime: the runtime rejects `initialize` outright with
+ * `Duplicate servers defined` if two servers report the same name, which takes down the whole language
+ * server rather than the offending one. This factory is instantiated more than once per runtime (IAM
+ * and token), so a shared constant here breaks every bundle that registers both.
+ */
 export const AmazonQServiceServerFactory =
-    (serviceManager: (features: QServiceManagerFeatures) => AmazonQBaseServiceManager): Server =>
+    (serviceManager: (features: QServiceManagerFeatures) => AmazonQBaseServiceManager, serverName: string): Server =>
     ({ credentialsProvider, lsp, workspace, logging, runtime, sdkInitializator, notification }) => {
         let amazonQServiceManager: AmazonQBaseServiceManager
 
@@ -69,7 +76,7 @@ export const AmazonQServiceServerFactory =
                 // internally to route notification followups back to the originating server, so the
                 // name must stay stable.
                 serverInfo: {
-                    name: 'AWS Language Server for Amazon Q Developer',
+                    name: serverName,
                 },
             }
         })
@@ -123,5 +130,18 @@ export const AmazonQServiceServerFactory =
         return () => {}
     }
 
-export const AmazonQServiceServerIAM = AmazonQServiceServerFactory(initBaseIAMServiceManager)
-export const AmazonQServiceServerToken = AmazonQServiceServerFactory(initBaseTokenServiceManager)
+// Must stay distinct from each other, and from every other server registered in the same runtime, or
+// the runtime fails initialize with `Duplicate servers defined`. Must also stay stable over time: they
+// are encoded into the id of every notification the client echoes back, so renaming strands followups
+// for notifications already on screen. Exported so the uniqueness can be asserted in tests.
+export const AMAZON_Q_SERVICE_SERVER_IAM_NAME = 'AWS Language Server for Amazon Q Developer (IAM)'
+export const AMAZON_Q_SERVICE_SERVER_TOKEN_NAME = 'AWS Language Server for Amazon Q Developer (Token)'
+
+export const AmazonQServiceServerIAM = AmazonQServiceServerFactory(
+    initBaseIAMServiceManager,
+    AMAZON_Q_SERVICE_SERVER_IAM_NAME
+)
+export const AmazonQServiceServerToken = AmazonQServiceServerFactory(
+    initBaseTokenServiceManager,
+    AMAZON_Q_SERVICE_SERVER_TOKEN_NAME
+)


### PR DESCRIPTION
Targets `feature/qdev-signup-message`, like #2794 / #2796 / #2797. **This is a hotfix for a regression I introduced in #2797 — that branch currently breaks the language server.**

## Problem

#2797 added `serverInfo` with a single hardcoded name. But `AmazonQServiceServerFactory` is instantiated twice — `AmazonQServiceServerIAM` and `AmazonQServiceServerToken` — and runtimes including `agent-standalone` register **both** (`agent-standalone.ts:43-44`). Two servers reporting the same name makes `lspRouter` reject `initialize` outright:

```js
const dupServerNames = findDuplicates(responsesList.map(r => r.serverInfo?.name))
if (dupServerNames) return new ResponseError(ErrorCodes.InternalError, `Duplicate servers defined: ...`)
```

That fails the entire language server, not just the duplicate.

Observed in VS Code against the published pre-release:

```
[warning] amazonqLsp: Failed to start downloaded LSP, falling back to bundled LSP:
          Duplicate servers defined: AWS Language Server for Amazon Q Developer
```

The client then silently ran its **bundled** server instead. Q kept working, so the only symptom was that none of the access-blocked reporting existed — no notification, no sign-out, no blocked screen — plus one client-side warning. The running server's UA gives it away: bare `AWS-CodeWhisperer/1.74.0` instead of the prerelease.

## Fix

`serverName` is now a **required** factory parameter rather than a shared constant — a default is exactly what allowed two instantiations to collide silently. The names are exported so uniqueness is assertable, and must stay stable, since the name is encoded into the id of every notification the client echoes back.

## Why it escaped review and CI

I explicitly considered this failure mode when reviewing #2797 and cleared it incorrectly: I grepped `serverInfo: {` **declarations** (three, all distinct) and never checked how many times each is **instantiated**. One declaration used twice collides with itself.

No existing test registers two servers from a single runtime, so every suite stayed green. The regression test here closes the specific gap; a broader test that composes a runtime and asserts all `serverInfo` names are unique would be stronger, and I'm happy to add it if you'd prefer that shape.

## Testing

- New test asserts the two names are distinct. **Verified it bites:** reintroducing the collision → 7 passing / 2 failing; with the fix → 8 passing / 1 failing.
- `tsc --noEmit` clean, prettier clean.
- Rebuilt the `agent-standalone` bundle from this branch, confirmed both distinct names plus `qDevPluginAccessBlocked`, installed it over the resolved flare directory in VS Code, and confirmed the server now initializes instead of falling back.

Pre-existing failure on this branch, unchanged by this commit: `amazonQServer.test.ts` → "hooks onUpdateConfiguration handler to LSP server".

## Please prioritise

Until this merges, `feature/qdev-signup-message` produces a server that no client can start, and clients fail over to their bundled server without surfacing anything to the user. JetBrains also needs a fresh pre-release cut after merge — it re-validates artifact hashes, so it cannot be patched locally the way VS Code can.
