### PR TITLE
test(amazonq): address review findings on the access-blocked observer

### DIFF
--- a/server/aws-lsp-codewhisperer/src/shared/amazonQServer.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/amazonQServer.test.ts
@@ -14,6 +14,8 @@ import {
     AMAZON_Q_SERVICE_SERVER_IAM_NAME,
     AMAZON_Q_SERVICE_SERVER_TOKEN_NAME,
     AmazonQServiceServerFactory,
+    AmazonQServiceServerIAM,
+    AmazonQServiceServerToken,
 } from './amazonQServer'
 import { BaseAmazonQServiceManager } from './amazonQServiceManager/BaseAmazonQServiceManager'
 
@@ -63,17 +65,39 @@ describe('AmazonQServiceServer', () => {
         expect(result.serverInfo?.name).to.equal(TEST_SERVER_NAME)
     })
 
-    it('gives the IAM and token servers distinct serverInfo names', () => {
-        // Regression guard. Runtimes such as agent-standalone register BOTH of these servers, and the
-        // runtime rejects initialize with `Duplicate servers defined` when two servers report the same
-        // name -- which fails the entire language server, not just the duplicate. A shared name here
-        // made every such runtime fall back to whatever server the client had bundled, visible only as
-        // a client-side warning, so Q kept working while silently running a different server.
-        const names = [AMAZON_Q_SERVICE_SERVER_IAM_NAME, AMAZON_Q_SERVICE_SERVER_TOKEN_NAME]
+    it('gives the IAM and token servers distinct serverInfo names', async () => {
+        // Regression guard, asserted against the real exported servers rather than the constants, so
+        // it also catches the same name being passed to both factory calls.
+        //
+        // Runtimes such as agent-standalone register BOTH of these servers, and the runtime rejects
+        // initialize with `Duplicate servers defined` when two servers report the same name -- which
+        // fails the entire language server, not just the duplicate. A shared name here made every such
+        // runtime fall back to whatever server the client had bundled, visible only as a client-side
+        // warning, so Q kept working while silently running a different server.
+        const names: (string | undefined)[] = []
 
-        for (const name of names) {
-            expect(name).to.be.a('string').and.not.empty
+        for (const qServer of [AmazonQServiceServerIAM, AmazonQServiceServerToken]) {
+            const serverFeatures = new TestFeatures()
+            try {
+                // The service managers refuse to initialize before the LSP connection has, so the
+                // client params have to be in place before the initializer runs.
+                serverFeatures.setClientParams({} as InitializeParams)
+                qServer(serverFeatures)
+
+                const initializer = serverFeatures.lsp.addInitializer.args[0]?.[0]
+                const result = (await initializer(
+                    {} as InitializeParams,
+                    {} as CancellationToken
+                )) as PartialInitializeResult
+
+                names.push(result.serverInfo?.name)
+            } finally {
+                serverFeatures.dispose()
+                TestAmazonQServiceManager.resetInstance()
+            }
         }
+
+        expect(names).to.deep.equal([AMAZON_Q_SERVICE_SERVER_IAM_NAME, AMAZON_Q_SERVICE_SERVER_TOKEN_NAME])
         expect(new Set(names).size, `server names must be unique: ${names.join(', ')}`).to.equal(names.length)
     })
 

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.test.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.test.ts
@@ -142,6 +142,32 @@ describe('StreamingClientServiceToken', () => {
         expect(streamingClientServiceDefault['shareCodeWhispererContentWithAWS']).to.be.undefined
     })
 
+    describe('access-blocked observer', () => {
+        it('registers exactly one named middleware on the initialize step', () => {
+            // Guards the wiring rather than the callback: the harness stubs
+            // CodeWhispererStreaming.prototype.sendMessage, which bypasses the middleware stack, so a
+            // behavioural test here would pass without the middleware existing at all.
+            //
+            // The name matters. Without it a second registration stacks another observer instead of
+            // replacing the first, which would report the same block twice.
+            const registered = streamingClientService.client.middlewareStack
+                .identify()
+                .filter(entry => entry.includes('detectQDevPluginAccessBlocked'))
+
+            expect(registered).to.have.lengthOf(1)
+            expect(registered[0]).to.contain('initialize')
+        })
+
+        it('exposes a settable observer for the service manager to assign', () => {
+            // Assigned after construction, so the middleware has to read it at call time. If this
+            // became readonly or were dropped, chat-time blocks would go unobserved.
+            const observer = () => {}
+            streamingClientService.onAccessBlocked = observer
+
+            expect(streamingClientService.onAccessBlocked).to.equal(observer)
+        })
+    })
+
     describe('generateAssistantResponse', () => {
         const MOCKED_GENERATE_RESPONSE_REQUEST = {
             conversationState: {

--- a/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/streamingClientService.ts
@@ -163,6 +163,10 @@ export class StreamingClientServiceToken extends StreamingClientServiceBase {
             },
             {
                 step: 'initialize',
+                // Named so a second registration replaces this one rather than stacking another
+                // observer, and so the middleware is identifiable in SDK stack introspection. Matches
+                // the token client's registration.
+                name: 'detectQDevPluginAccessBlocked',
             }
         )
     }


### PR DESCRIPTION
Targets `feature/qdev-signup-message`, so #2800 picks these up automatically.

Follow-ups from the review of #2800. No behaviour change for users — one wiring fix and two test improvements.

## 1. Name the streaming client's middleware

The token client registers its observer with `name: 'detectQDevPluginAccessBlocked'`; the streaming client did not. Without a name, a second registration **stacks another observer** instead of replacing the first, which would report the same block twice, and the middleware is anonymous in SDK stack introspection.

## 2. Assert name uniqueness against the real servers, not the constants

The previous test compared `AMAZON_Q_SERVICE_SERVER_IAM_NAME` and `..._TOKEN_NAME`. That guards the constants but **cannot catch the same name being passed to both factory calls** — which is exactly the mistake that shipped and caused `Duplicate servers defined`.

The test now invokes both real exported servers' initializers and asserts the names they actually report are distinct. Verified it bites: making the two names identical fails it (7 passing / 2 failing, versus 8 / 1 with the fix).

Reviewers asked for a composition-level test that walks every server registered by `agent-standalone`. That is the stronger form and I agree with it, but it belongs in the runtimes app package rather than here, since that is where the composition lives. Raising it separately rather than stretching this PR.

## 3. Two tests for the streaming observer

These assert the **wiring**, deliberately not the callback: the existing harness stubs `CodeWhispererStreaming.prototype.sendMessage`, which bypasses the middleware stack entirely, so a behavioural test written there would pass even if the middleware did not exist. Rather than write a test that proves nothing, they assert what is actually verifiable at this level — that exactly one named middleware is registered on the `initialize` step, and that the observer property is settable after construction (it must be, since the service manager assigns it later).

## Testing

`shared` group: **337 passing / 45 failing**, against **334 / 45** before — the three new tests, no new failures. The 45 are pre-existing and unchanged (`utils.test.ts` and the `onUpdateConfiguration` case). `tsc` and prettier clean.

## Review findings deliberately not addressed here

- **Observer errors are logged at `debug`.** Two reviewers suggested `warn`. Left alone for symmetry with the token client, which has shipped that way; changing one and not the other would be worse. Worth doing to both, separately.
- **`showNotification` logs at info when it drops a notification for want of a router.** This is in the runtimes package and was one of the three silent failures behind #2796/#2797. Belongs in a runtimes change.
- **A snapshot assertion pinning the exact server-name strings.** The names are embedded in notification followup ids, so a rename strands in-flight followups. Reasonable, but the JSDoc already states the constraint and the value is now asserted via the real servers.
