### PR TITLE
fix: repoint CODEOWNERS and package repository URLs to the new org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aws/flare
+* @Amazon-Q-Developer/sync-team-dae-production-eng-team

--- a/chat-client/package.json
+++ b/chat-client/package.json
@@ -5,7 +5,7 @@
     "main": "out/index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-servers"
+        "url": "https://github.com/Amazon-Q-Developer/language-servers"
     },
     "files": [
         "build",

--- a/core/aws-lsp-core/package.json
+++ b/core/aws-lsp-core/package.json
@@ -5,7 +5,7 @@
     "main": "out/index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-servers"
+        "url": "https://github.com/Amazon-Q-Developer/language-servers"
     },
     "author": "Amazon Web Services",
     "license": "Apache-2.0",

--- a/server/aws-lsp-antlr4/package.json
+++ b/server/aws-lsp-antlr4/package.json
@@ -5,7 +5,7 @@
     "main": "out/index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-servers"
+        "url": "https://github.com/Amazon-Q-Developer/language-servers"
     },
     "author": "Amazon Web Services",
     "engines": {

--- a/server/aws-lsp-codewhisperer/package.json
+++ b/server/aws-lsp-codewhisperer/package.json
@@ -5,7 +5,7 @@
     "main": "out/index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-servers"
+        "url": "https://github.com/Amazon-Q-Developer/language-servers"
     },
     "author": "Amazon Web Services",
     "license": "Apache-2.0",

--- a/server/aws-lsp-identity/package.json
+++ b/server/aws-lsp-identity/package.json
@@ -5,7 +5,7 @@
     "main": "./out/index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-servers"
+        "url": "https://github.com/Amazon-Q-Developer/language-servers"
     },
     "author": "Amazon Web Services",
     "license": "Apache-2.0",

--- a/server/aws-lsp-json/package.json
+++ b/server/aws-lsp-json/package.json
@@ -5,7 +5,7 @@
     "main": "out/index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-servers"
+        "url": "https://github.com/Amazon-Q-Developer/language-servers"
     },
     "author": "Amazon Web Services",
     "license": "Apache-2.0",

--- a/server/aws-lsp-notification/package.json
+++ b/server/aws-lsp-notification/package.json
@@ -5,7 +5,7 @@
     "main": "./out/index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-servers"
+        "url": "https://github.com/Amazon-Q-Developer/language-servers"
     },
     "author": "Amazon Web Services",
     "license": "Apache-2.0",

--- a/server/aws-lsp-partiql/package.json
+++ b/server/aws-lsp-partiql/package.json
@@ -6,7 +6,7 @@
     "version": "0.0.23",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-servers"
+        "url": "https://github.com/Amazon-Q-Developer/language-servers"
     },
     "main": "out/index.js",
     "types": "out/index.d.ts",

--- a/server/aws-lsp-yaml/package.json
+++ b/server/aws-lsp-yaml/package.json
@@ -5,7 +5,7 @@
     "main": "out/index.js",
     "repository": {
         "type": "git",
-        "url": "https://github.com/aws/language-servers"
+        "url": "https://github.com/Amazon-Q-Developer/language-servers"
     },
     "author": "Amazon Web Services",
     "license": "Apache-2.0",


### PR DESCRIPTION
## Problem

The repo was transferred from `aws/language-servers` to `Amazon-Q-Developer/language-servers` (P490405625). Two things still reference the old org.

**CODEOWNERS is broken.** `.github/CODEOWNERS` is `* @aws/flare`. Team grants do not follow a repo across orgs, so GitHub cannot resolve that team. `main` still requires code owner review with 2 approvals, so reviewer assignment does not work.

**Package metadata is stale.** All nine workspace `package.json` files still declare `repository.url` as `github.com/aws/language-servers`. Publishing uses OIDC trusted publishing (`id-token: write` in `release-please.yaml`, no stored npm token) and the packages carry SLSA provenance attestations. npm validates `repository.url` against the OIDC claims of the building repository when generating provenance, so a stale URL fails the publish step.

## Solution

Point CODEOWNERS at `@Amazon-Q-Developer/sync-team-dae-production-eng-team`, which already has push access on the repo, and update `repository.url` in all nine workspaces.

Seven of the nine are published (`chat-client`, `lsp-core`, `lsp-antlr4`, `lsp-codewhisperer`, `lsp-json`, `lsp-partiql`, `lsp-yaml`). `aws-lsp-identity` and `aws-lsp-notification` are not on npm, but are included so the metadata is correct if they are ever published.

The `@aws/*` package names are deliberately unchanged — that is the npm scope, unrelated to the GitHub org, and renaming would break every consumer.

## Testing

`prettier --check` passes on all nine JSON files, JSON validity confirmed, and git-secrets passed. No build impact — `repository.url` is registry metadata and is not read by TypeScript or the bundler.

## Merge sequencing

This is typed `fix:`, so merging will cause release-please to open a release PR bumping the seven published packages. That is intended, since the corrected URLs only take effect once published, and it is safe: merging this PR publishes nothing.

Before merging **that** release PR, the npm **trusted publisher** config for all seven packages must be repointed from `aws` to `Amazon-Q-Developer`. Both are required — the trusted publisher match gates the publish, and `repository.url` gates provenance generation within it.

## Separately tracked

Two other items from this migration are outside this repo:

1. The IAM role `arn:aws:iam::550160095699:role/LanguageServersGitHubActionsReadRole` used by `integration-tests.yml` has a trust policy conditioned on `repo:aws/language-servers:ref:refs/heads/{main,feature/*,release/agentic/*}`, which no longer matches the OIDC subject. Integration tests cannot assume it until the new-org subjects are added.
2. The GitHub bot's repo-owner override map needs a `language-servers` entry, otherwise `GitFeatureSync` silently stops opening "Merge main into feature/*" PRs.
