### PR TITLE
fix(amazonq): retry truncated tool-use streams instead of dropping them silently

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -4668,7 +4668,10 @@ export class AgenticChatController implements ChatHandlers {
             cwsprChatResponseLength: chatEventParser.body?.length ?? 0,
         })
 
-        return chatEventParser.getResult()
+        // Use finalize() (not getResult()) so a tool use whose stream ended before its
+        // terminating `stop` event is surfaced as an incomplete-input error and retried,
+        // rather than being silently dropped and reported as a successful turn.
+        return chatEventParser.finalize()
     }
 
     /**

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.test.ts
@@ -304,4 +304,56 @@ describe('AgenticChatEventParser', () => {
 
         assert.deepStrictEqual(chatEventParser.getResult(), { success: true, data: expectedData })
     })
+
+    it('finalize flags an unterminated tool use (no stop event) as incomplete and marks it stopped', () => {
+        const chatEventParser = new AgenticChatEventParser(mockMessageId, new Metric<AddMessageEvent>(), logging)
+
+        // A tool use whose input streams in fragments but never receives a `stop` event
+        // (e.g. the response hit the output-token limit mid tool-input).
+        chatEventParser.processPartialEvent({
+            toolUseEvent: {
+                toolUseId: 'tool-1',
+                name: 'fsWrite',
+                input: '{"path":"out.py","fileText":"import os',
+                stop: false,
+            },
+        })
+        const midStream = chatEventParser.processPartialEvent({
+            toolUseEvent: {
+                toolUseId: 'tool-1',
+                name: 'fsWrite',
+                input: '\\nprint(1)',
+                stop: false,
+            },
+        })
+
+        // Mid-stream this looks like a clean success and would be filtered out (dropped) by the loop.
+        assert.strictEqual(midStream.success, true)
+        assert.strictEqual(midStream.data?.toolUses['tool-1'].stop, false)
+
+        // After the stream ends, finalize() surfaces it as an error and marks it stopped so it
+        // survives the pending-tool-use filter and is routed into the existing retry path.
+        const result = chatEventParser.finalize()
+        assert.strictEqual(result.success, false)
+        assert.ok(result.error?.startsWith('ToolUse input is invalid JSON:'))
+        assert.strictEqual(result.data?.toolUses['tool-1'].stop, true)
+    })
+
+    it('finalize leaves a properly stopped tool use untouched', () => {
+        const chatEventParser = new AgenticChatEventParser(mockMessageId, new Metric<AddMessageEvent>(), logging)
+
+        chatEventParser.processPartialEvent({
+            toolUseEvent: {
+                toolUseId: 'tool-1',
+                name: 'fsWrite',
+                input: '{"path":"out.py","fileText":"print(1)"}',
+                stop: true,
+            },
+        })
+
+        const result = chatEventParser.finalize()
+        assert.strictEqual(result.success, true)
+        assert.strictEqual(result.data?.toolUses['tool-1'].stop, true)
+        assert.deepStrictEqual(result.data?.toolUses['tool-1'].input, { path: 'out.py', fileText: 'print(1)' })
+    })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -229,4 +229,42 @@ export class AgenticChatEventParser implements ChatResult {
                   data: chatResultWithMetadata,
               }
     }
+
+    /**
+     * Finalizes parsing after the response stream has been fully consumed.
+     *
+     * A tool use only becomes executable once its terminating `stop` event arrives — that
+     * is also the only point at which its streamed input is JSON-parsed. If the stream ends
+     * before that event (for example, the response reaches the output-token limit mid
+     * tool-input), the tool use is left with `stop === false` and no error is recorded, so
+     * `getResult()` reports success. The agentic loop then filters it out (only stopped tool
+     * uses are treated as pending) and completes the turn without ever running the tool — a
+     * silent no-op with no error and no retry.
+     *
+     * To avoid that, treat any still-unstopped tool use as incomplete/truncated input:
+     * record an error (reusing the malformed-JSON prefix so it is handled by the existing
+     * recovery branch) and mark it `stop` so it survives the pending-tool-use filter and the
+     * model is re-prompted to split the work into smaller tool uses.
+     */
+    public finalize(): Result<ChatResultWithMetadata, string> {
+        for (const toolUseId of Object.keys(this.toolUses)) {
+            const toolUse = this.toolUses[toolUseId]
+            if (!toolUse.stop) {
+                const received = typeof toolUse.input === 'string' ? toolUse.input.length : 0
+                this.#logging.error(
+                    `ToolUse ${toolUseId} (${toolUse.name}) stream ended before a stop event after ${received} characters; input was truncated`
+                )
+                // Reuse the malformed-JSON error prefix so this routes into the same recovery
+                // branch in the agentic loop. Keep the message short so the (potentially very
+                // large) partial input is not echoed back to the model in the tool result.
+                this.error = `ToolUse input is invalid JSON: incomplete tool input, stream ended after ${received} characters before completion.`
+                this.toolUses[toolUseId] = {
+                    ...toolUse,
+                    input: {},
+                    stop: true,
+                }
+            }
+        }
+        return this.getResult()
+    }
 }


### PR DESCRIPTION
## Problem

When the model streams a tool use (for example an `fsWrite`) whose input is large, the tool-use content block can end **without its terminating `stop` event** — e.g. the response reaches the output-token limit partway through the tool input. When that happens today, the agentic chat flow:

- never runs the tool (the write / action never happens),
- shows no error to the user, and
- reports the turn as a successful completion.

From the user's perspective the turn appears to finish having done nothing, or leaves an in-progress tool card that never resolves. Because no error is surfaced and no retry is triggered, waiting does not help — the agent loop has already ended.

## Root cause

Tool-use input is accumulated as streamed string fragments in `AgenticChatEventParser`. The input is JSON-parsed — and the **only** point at which an error is recorded for a tool use — inside `if (toolUseEvent.stop)`:

```ts
this.toolUses[toolUseId] = {
    ...this.toolUses[toolUseId],
    toolUseId,
    name,
    input: `${this.toolUses[toolUseId]?.input || ''}${input || ''}`,
    stop: !!toolUseEvent.stop,
}

if (toolUseEvent.stop) {
    try {
        parsedInput = JSON.parse(/* accumulated input */)
    } catch (err) {
        this.error = `ToolUse input is invalid JSON: ...`
    }
}
```

If the stream ends before `stop` arrives, `error` is never set, so `getResult()` returns `success: true`. `#processAgenticChatResponse` returns that result unchanged once the stream is consumed. Back in the agentic loop, `#getPendingToolUses` keeps only tool uses whose `stop === true`:

```ts
return Object.values(toolUses).filter(toolUse => toolUse.stop)
```

so the unterminated tool use is filtered out, `pendingToolUses` is empty, the loop records the turn as `Succeeded`, and breaks — without ever executing the tool.

The recovery path that already exists for an incomplete tool use — re-prompting the model to "break this task down into multiple tool uses with smaller input" — is only reachable when `stop` **did** arrive but the accumulated JSON failed to parse. A missing `stop` never reaches it.

## Fix

Treat a tool use that is still un-`stop`ped when the stream ends as incomplete input, and route it into the recovery path that already exists:

- Add `AgenticChatEventParser.finalize()`, called once the response stream has been fully consumed. For any tool use with `stop === false` it records an incomplete-input error (reusing the `ToolUse input is invalid JSON:` prefix) and marks the tool use `stop: true` so it survives `#getPendingToolUses`.
- Call `finalize()` at the end of `#processAgenticChatResponse` instead of `getResult()`.

Because the tool use now carries an error and survives the pending filter, the loop enters its existing failure branch: it surfaces a real error, sets the in-progress tool card to `Error`, produces a `tool_result` for the tool use (preserving the tool_use/tool_result pairing), and re-prompts the model to retry with smaller input. A silent no-op becomes a self-correcting turn with a visible error.

The error message is intentionally short and does **not** echo the (potentially very large) partial input back to the model.

User cancellation is unaffected: aborts throw before `finalize()` runs, so cancelled turns are still reported as cancelled rather than as truncation errors.

## Tests

Added unit tests in `agenticChatEventParser.test.ts`:

- a tool use whose input streams in fragments but never receives `stop` is reported as success mid-stream (reproducing the silent drop), then `finalize()` surfaces it as an error and marks it stopped;
- a normally `stop`-terminated tool use is left untouched by `finalize()`.

`agenticChatEventParser.test.ts` (ts-mocha): 8 passing.

### Before fix:
<img width="1150" height="1288" alt="image" src="https://github.com/user-attachments/assets/6e377577-7300-4b89-b39f-04fc86d69922" />


### After fix:
<img width="1208" height="1764" alt="image" src="https://github.com/user-attachments/assets/4e8e2c9c-712f-47d8-a5d4-5cf46a847137" />

