### PR TITLE
fix(amazonq): narrow tool-use   truncation detection and classify retries in telemetry

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -182,6 +182,8 @@ import {
     RESPONSE_TIMEOUT_PARTIAL_MSG,
     INCOMPLETE_TOOL_USE_RETRY_LIMIT_MSG,
     MAX_INCOMPLETE_TOOL_USE_RETRIES,
+    INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_RETRYING,
+    INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_EXHAUSTED,
     COMPACTION_BODY,
     COMPACTION_HEADER_BODY,
     DEFAULT_MACOS_RUN_SHORTCUT,
@@ -1696,6 +1698,21 @@ export class AgenticChatController implements ChatHandlers {
                     status: ToolResultStatus.ERROR,
                     content: [{ text: result.error }],
                 }))
+                // Classify the failure *before* emitting telemetry. An incomplete tool-use input is
+                // retried inside this loop and usually recovers within the same user turn, so it is
+                // not a user-visible failure and should not depress a per-call success rate. Because
+                // the retry budget is bounded we already know here whether this iteration will be
+                // retried, which lets us distinguish the transient case from the terminal give-up.
+                const isIncompleteToolUse = result.error.startsWith('ToolUse input is invalid JSON:')
+                let willRetryIncompleteToolUse = false
+                let invokeLlmReason: string | undefined
+                if (isIncompleteToolUse) {
+                    consecutiveIncompleteToolUses++
+                    willRetryIncompleteToolUse = consecutiveIncompleteToolUses <= MAX_INCOMPLETE_TOOL_USE_RETRIES
+                    invokeLlmReason = willRetryIncompleteToolUse
+                        ? INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_RETRYING
+                        : INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_EXHAUSTED
+                }
                 this.#telemetryController.emitAgencticLoop_InvokeLLM(
                     response.$metadata.requestId!,
                     conversationId,
@@ -1711,11 +1728,11 @@ export class AgenticChatController implements ChatHandlers {
                     this.#timeBetweenChunks,
                     session.pairProgrammingMode,
                     this.#abTestingAllocation?.experimentName,
-                    this.#abTestingAllocation?.userVariation
+                    this.#abTestingAllocation?.userVariation,
+                    invokeLlmReason
                 )
-                if (result.error.startsWith('ToolUse input is invalid JSON:')) {
-                    consecutiveIncompleteToolUses++
-                    if (consecutiveIncompleteToolUses > MAX_INCOMPLETE_TOOL_USE_RETRIES) {
+                if (isIncompleteToolUse) {
+                    if (!willRetryIncompleteToolUse) {
                         // The model has failed to produce a complete tool request several times
                         // in a row. Retrying again is unlikely to help and would keep the agent
                         // loop running, so stop and surface a real error to the user instead.

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatController.ts
@@ -180,6 +180,8 @@ import {
     OUTPUT_LIMIT_EXCEEDS_PARTIAL_MSG,
     RESPONSE_TIMEOUT_MS,
     RESPONSE_TIMEOUT_PARTIAL_MSG,
+    INCOMPLETE_TOOL_USE_RETRY_LIMIT_MSG,
+    MAX_INCOMPLETE_TOOL_USE_RETRIES,
     COMPACTION_BODY,
     COMPACTION_HEADER_BODY,
     DEFAULT_MACOS_RUN_SHORTCUT,
@@ -1427,6 +1429,9 @@ export class AgenticChatController implements ChatHandlers {
         let iterationCount = 0
         let shouldDisplayMessage = true
         let currentRequestCount = 0
+        // Number of consecutive responses that produced an incomplete tool-use input. Bounded
+        // so a model that keeps truncating cannot keep the agent loop running indefinitely.
+        let consecutiveIncompleteToolUses = 0
         const pinnedContext = additionalContext?.filter(item => item.pinned)
 
         metric.recordStart()
@@ -1645,6 +1650,8 @@ export class AgenticChatController implements ChatHandlers {
             let toolResults: ToolResult[]
             session.setConversationType('AgenticChatWithToolUse')
             if (result.success) {
+                // A complete tool use was received, so the incomplete-input streak is over.
+                consecutiveIncompleteToolUses = 0
                 // Process tool uses and update the request input for the next iteration
                 toolResults = await this.processToolUses(
                     pendingToolUses,
@@ -1707,6 +1714,22 @@ export class AgenticChatController implements ChatHandlers {
                     this.#abTestingAllocation?.userVariation
                 )
                 if (result.error.startsWith('ToolUse input is invalid JSON:')) {
+                    consecutiveIncompleteToolUses++
+                    if (consecutiveIncompleteToolUses > MAX_INCOMPLETE_TOOL_USE_RETRIES) {
+                        // The model has failed to produce a complete tool request several times
+                        // in a row. Retrying again is unlikely to help and would keep the agent
+                        // loop running, so stop and surface a real error to the user instead.
+                        this.#features.logging.error(
+                            `Giving up after ${consecutiveIncompleteToolUses} consecutive incomplete tool uses: ${result.error}`
+                        )
+                        await chatResultStream.updateOngoingProgressResult('Error')
+                        finalResult = {
+                            success: false,
+                            error: INCOMPLETE_TOOL_USE_RETRY_LIMIT_MSG,
+                            data: result.data,
+                        }
+                        break
+                    }
                     content =
                         'Your toolUse input is incomplete, try again. If the error happens consistently, break this task down into multiple tool uses with smaller input. Do not apologize.'
                     shouldDisplayMessage = false
@@ -4670,8 +4693,10 @@ export class AgenticChatController implements ChatHandlers {
 
         // Use finalize() (not getResult()) so a tool use whose stream ended before its
         // terminating `stop` event is surfaced as an incomplete-input error and retried,
-        // rather than being silently dropped and reported as a successful turn.
-        return chatEventParser.finalize()
+        // rather than being silently dropped and reported as a successful turn. The abort
+        // state is passed in so a timed-out/cancelled request is not misreported as a
+        // truncated tool input.
+        return chatEventParser.finalize({ aborted: abortSignal?.aborted === true })
     }
 
     /**

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.test.ts
@@ -356,4 +356,42 @@ describe('AgenticChatEventParser', () => {
         assert.strictEqual(result.data?.toolUses['tool-1'].stop, true)
         assert.deepStrictEqual(result.data?.toolUses['tool-1'].input, { path: 'out.py', fileText: 'print(1)' })
     })
+
+    it('finalize does not flag an unterminated tool use when no input was received', () => {
+        const chatEventParser = new AgenticChatEventParser(mockMessageId, new Metric<AddMessageEvent>(), logging)
+
+        // The model announced a tool use but never streamed any input before the stream ended.
+        // There is nothing to truncate, so this must be dropped rather than retried.
+        chatEventParser.processPartialEvent({
+            toolUseEvent: {
+                toolUseId: 'tool-1',
+                name: 'fsWrite',
+                input: '',
+                stop: false,
+            },
+        })
+
+        const result = chatEventParser.finalize()
+        assert.strictEqual(result.success, true)
+        assert.strictEqual(result.data?.toolUses['tool-1'].stop, false)
+    })
+
+    it('finalize does not flag an unterminated tool use when the request was aborted', () => {
+        const chatEventParser = new AgenticChatEventParser(mockMessageId, new Metric<AddMessageEvent>(), logging)
+
+        chatEventParser.processPartialEvent({
+            toolUseEvent: {
+                toolUseId: 'tool-1',
+                name: 'fsWrite',
+                input: '{"path":"out.py","fileText":"import os',
+                stop: false,
+            },
+        })
+
+        // An aborted request (response-processing timeout or cancellation) is expected to end
+        // without a stop event, so it must not be reported as a truncated tool input.
+        const result = chatEventParser.finalize({ aborted: true })
+        assert.strictEqual(result.success, true)
+        assert.strictEqual(result.data?.toolUses['tool-1'].stop, false)
+    })
 })

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/agenticChatEventParser.ts
@@ -241,28 +241,48 @@ export class AgenticChatEventParser implements ChatResult {
      * uses are treated as pending) and completes the turn without ever running the tool — a
      * silent no-op with no error and no retry.
      *
-     * To avoid that, treat any still-unstopped tool use as incomplete/truncated input:
-     * record an error (reusing the malformed-JSON prefix so it is handled by the existing
-     * recovery branch) and mark it `stop` so it survives the pending-tool-use filter and the
-     * model is re-prompted to split the work into smaller tool uses.
+     * To avoid that, a genuinely *truncated tool input* is recorded as an error (reusing the
+     * malformed-JSON prefix so it is handled by the existing recovery branch) and marked
+     * `stop` so it survives the pending-tool-use filter and the model is re-prompted to split
+     * the work into smaller tool uses.
+     *
+     * Two other situations also reach this point and must keep the previous behaviour of being
+     * dropped, otherwise a benign end-of-stream is reported as a failure and re-prompted —
+     * which inflates failure metrics and can re-run the agent loop without making progress:
+     *
+     *  - the request was aborted (response-processing timeout or cancellation): the missing
+     *    `stop` event is expected, and the abort is already surfaced by its own path;
+     *  - no tool input was received at all: the model never committed to a tool call, so
+     *    there is nothing to truncate and nothing to retry.
      */
-    public finalize(): Result<ChatResultWithMetadata, string> {
+    public finalize(options?: { aborted?: boolean }): Result<ChatResultWithMetadata, string> {
         for (const toolUseId of Object.keys(this.toolUses)) {
             const toolUse = this.toolUses[toolUseId]
-            if (!toolUse.stop) {
-                const received = typeof toolUse.input === 'string' ? toolUse.input.length : 0
-                this.#logging.error(
-                    `ToolUse ${toolUseId} (${toolUse.name}) stream ended before a stop event after ${received} characters; input was truncated`
+            if (toolUse.stop) {
+                continue
+            }
+
+            const partialInput = typeof toolUse.input === 'string' ? toolUse.input : ''
+
+            if (options?.aborted || partialInput.length === 0) {
+                // Leave the tool use unstopped so it is filtered out downstream, as before.
+                this.#logging.debug(
+                    `ToolUse ${toolUseId} (${toolUse.name}) ended without a stop event and is not a truncated input (aborted=${!!options?.aborted}, receivedCharacters=${partialInput.length}); dropping it`
                 )
-                // Reuse the malformed-JSON error prefix so this routes into the same recovery
-                // branch in the agentic loop. Keep the message short so the (potentially very
-                // large) partial input is not echoed back to the model in the tool result.
-                this.error = `ToolUse input is invalid JSON: incomplete tool input, stream ended after ${received} characters before completion.`
-                this.toolUses[toolUseId] = {
-                    ...toolUse,
-                    input: {},
-                    stop: true,
-                }
+                continue
+            }
+
+            this.#logging.error(
+                `ToolUse ${toolUseId} (${toolUse.name}) stream ended before a stop event after ${partialInput.length} characters; input was truncated`
+            )
+            // Reuse the malformed-JSON error prefix so this routes into the same recovery
+            // branch in the agentic loop. Keep the message short so the (potentially very
+            // large) partial input is not echoed back to the model in the tool result.
+            this.error = `ToolUse input is invalid JSON: incomplete tool input, stream ended after ${partialInput.length} characters before completion.`
+            this.toolUses[toolUseId] = {
+                ...toolUse,
+                input: {},
+                stop: true,
             }
         }
         return this.getResult()

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
@@ -8,7 +8,7 @@ export const INCOMPLETE_TOOL_USE_RETRY_LIMIT_MSG =
 // Retry limits
 // Maximum number of consecutive responses with an incomplete tool-use input that will be
 // retried before giving up and surfacing an error to the user.
-export const MAX_INCOMPLETE_TOOL_USE_RETRIES = 2
+export const MAX_INCOMPLETE_TOOL_USE_RETRIES = 3
 
 // Time Constants
 export const LOADING_THRESHOLD_MS = 2000

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
@@ -2,6 +2,13 @@
 export const GENERIC_ERROR_MS = 'An unexpected error occurred, check the logs for more information.'
 export const OUTPUT_LIMIT_EXCEEDS_PARTIAL_MSG = 'output exceeds maximum character limit of'
 export const RESPONSE_TIMEOUT_PARTIAL_MSG = 'Response processing timed out after'
+export const INCOMPLETE_TOOL_USE_RETRY_LIMIT_MSG =
+    'Amazon Q could not complete a tool request because its input was cut off repeatedly. Try asking for a smaller change, or generating the content in sections.'
+
+// Retry limits
+// Maximum number of consecutive responses with an incomplete tool-use input that will be
+// retried before giving up and surfacing an error to the user.
+export const MAX_INCOMPLETE_TOOL_USE_RETRIES = 2
 
 // Time Constants
 export const LOADING_THRESHOLD_MS = 2000

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
@@ -18,8 +18,8 @@ export const MAX_INCOMPLETE_TOOL_USE_RETRIES = 3
 // give-up, which the user does see, as a genuine failure. `result` stays 'Failed' in both cases
 // so raw failure counts remain intact for diagnostics.
 //
-// NOTE: these string values are consumed by ToolkitTelemetryLambda (CloudWatchUtils.kt) to emit a
-// separate EMF counter. Do not rename either value without updating that transform first.
+// NOTE: these string values form part of the telemetry contract and are consumed by a downstream
+// metrics pipeline. Do not rename either value without updating that consumer first.
 export const INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_RETRYING = 'INCOMPLETE_TOOL_USE_RETRYING'
 export const INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_EXHAUSTED = 'INCOMPLETE_TOOL_USE_EXHAUSTED'
 

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/constants/constants.ts
@@ -10,6 +10,19 @@ export const INCOMPLETE_TOOL_USE_RETRY_LIMIT_MSG =
 // retried before giving up and surfacing an error to the user.
 export const MAX_INCOMPLETE_TOOL_USE_RETRIES = 3
 
+// Telemetry reason codes reported on the amazonq_invokeLLM metric.
+//
+// An incomplete tool-use input is retried inside the agent loop and usually recovers within the
+// same user turn, so it is not a user-visible failure. These codes let downstream metrics exclude
+// those transient iterations from per-call success rates while still counting the terminal
+// give-up, which the user does see, as a genuine failure. `result` stays 'Failed' in both cases
+// so raw failure counts remain intact for diagnostics.
+//
+// NOTE: these string values are consumed by ToolkitTelemetryLambda (CloudWatchUtils.kt) to emit a
+// separate EMF counter. Do not rename either value without updating that transform first.
+export const INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_RETRYING = 'INCOMPLETE_TOOL_USE_RETRYING'
+export const INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_EXHAUSTED = 'INCOMPLETE_TOOL_USE_EXHAUSTED'
+
 // Time Constants
 export const LOADING_THRESHOLD_MS = 2000
 export const CLIENT_TIMEOUT_MS = 245_000

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.test.ts
@@ -5,6 +5,10 @@ import { CONVERSATION_ID_METRIC_KEY, ChatTelemetryController } from './chatTelem
 import assert = require('assert')
 import { ChatUIEventName } from './clientTelemetry'
 import { TelemetryService } from '../../../shared/telemetry/telemetryService'
+import {
+    INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_EXHAUSTED,
+    INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_RETRYING,
+} from '../../agenticChat/constants/constants'
 
 describe('TelemetryController', () => {
     const mockTabId = 'mockTabId'
@@ -160,6 +164,60 @@ describe('TelemetryController', () => {
                 credentialStartUrl: undefined,
                 result: 'Succeeded',
             },
+        })
+    })
+
+    describe('emitAgencticLoop_InvokeLLM reason', () => {
+        // The `reason` field lets downstream metrics tell a transient, self-recovering agent-loop
+        // failure apart from a terminal one, so it must survive the emit unchanged.
+        const emitInvokeLLM = (reason?: string) =>
+            telemetryController.emitAgencticLoop_InvokeLLM(
+                'mockRequestId',
+                mockConversationId,
+                'AgenticChatWithToolUse',
+                undefined,
+                undefined,
+                'Failed',
+                '1.0.0',
+                'mockModelId',
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                reason
+            )
+
+        it('forwards the reason when one is supplied', () => {
+            emitInvokeLLM(INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_RETRYING)
+
+            sinon.assert.calledOnce(testFeatures.telemetry.emitMetric)
+            const emitted = testFeatures.telemetry.emitMetric.firstCall.firstArg
+            assert.strictEqual(emitted.name, ChatTelemetryEventName.AgencticLoop_InvokeLLM)
+            assert.strictEqual(emitted.data.reason, INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_RETRYING)
+            // `result` must stay 'Failed' so raw failure counts are unchanged for diagnostics.
+            assert.strictEqual(emitted.data.result, 'Failed')
+        })
+
+        it('distinguishes the terminal give-up from the retrying case', () => {
+            emitInvokeLLM(INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_EXHAUSTED)
+
+            const emitted = testFeatures.telemetry.emitMetric.firstCall.firstArg
+            assert.strictEqual(emitted.data.reason, INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_EXHAUSTED)
+            assert.notStrictEqual(
+                INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_EXHAUSTED,
+                INVOKE_LLM_REASON_INCOMPLETE_TOOL_USE_RETRYING
+            )
+        })
+
+        it('leaves reason undefined for failures with no specific classification', () => {
+            emitInvokeLLM(undefined)
+
+            const emitted = testFeatures.telemetry.emitMetric.firstCall.firstArg
+            assert.strictEqual(emitted.data.reason, undefined)
+            assert.strictEqual(emitted.data.result, 'Failed')
         })
     })
 

--- a/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/chat/telemetry/chatTelemetryController.ts
@@ -197,7 +197,8 @@ export class ChatTelemetryController {
         cwsprChatTimeBetweenChunks?: number[],
         agenticCodingMode?: boolean,
         experimentName?: string,
-        userVariation?: string
+        userVariation?: string,
+        reason?: string
     ) {
         this.#telemetry.emitMetric({
             name: ChatTelemetryEventName.AgencticLoop_InvokeLLM,
@@ -218,6 +219,7 @@ export class ChatTelemetryController {
                 modelId,
                 experimentName: experimentName,
                 userVariation: userVariation,
+                reason,
             },
         })
     }

--- a/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
+++ b/server/aws-lsp-codewhisperer/src/shared/telemetry/types.ts
@@ -253,6 +253,13 @@ export type AgencticLoop_InvokeLLMEvent = {
     enabled?: boolean
     languageServerVersion?: string
     latency?: string
+    /**
+     * Classifies *why* a call failed, for failures that are handled inside the agent loop and are
+     * therefore not user-visible. Used by downstream metrics to exclude transient, self-recovering
+     * iterations from per-call success rates. Absent when `result` is 'Succeeded', and absent for
+     * failures that have no specific classification.
+     */
+    reason?: string
 }
 
 export type ToolUseSuggestedEvent = {


### PR DESCRIPTION
## Issue

Three related problems in how the agentic chat loop handles a response stream that ends without a terminating tool-use `stop` event.

**1. Truncation detection was too broad.** Every such stream was treated as a truncated tool input. But a stream also ends without `stop` when:

- the request was aborted — response-processing timeout, or user cancellation — where the missing `stop` is expected and the abort is already reported by its own path; and
- the model announced a tool use but streamed no input at all, so there is nothing to truncate and nothing to retry.

Reporting those as failures and re-prompting the model produces failed intermediate stream events for turns that were never broken, and can re-run the agent loop without making progress.

**2. Retries were unbounded.** The incomplete-tool-use retry path had no iteration limit, so repeated truncation could keep the loop running indefinitely.

**3. The telemetry could not distinguish the cases.** Every retried iteration emits `amazonq_invokeLLM` with `result='Failed'`, with nothing to separate a transient iteration that recovers inside the same user turn from a terminal failure the user actually sees. Any per-call success rate built on that metric therefore degrades precisely when error handling becomes more honest, even though users are unaffected.

## Changes

**`finalize()` only reports genuine truncation.** It now requires that partial input was actually received *and* that the request was not aborted. Other unterminated tool uses are left unstopped and filtered out downstream, exactly as they were before this behaviour was introduced. The abort state is passed into `finalize()` from the response processor.

**Retries are bounded.** `MAX_INCOMPLETE_TOOL_USE_RETRIES = 3`, so at most 4 attempts in total. On exceeding the limit the loop stops and surfaces an actionable error to the user instead of retrying indefinitely.

**Failures are classified for telemetry.** `amazonq_invokeLLM` now carries a `reason` alongside the existing `result`:

| `reason` | meaning |
|---|---|
| `INCOMPLETE_TOOL_USE_RETRYING` | retry budget remains; transient, normally recovers in the same turn |
| `INCOMPLETE_TOOL_USE_EXHAUSTED` | retries used up; the user sees an error |

`result` stays `'Failed'` in both cases, so raw failure counts are unchanged and remain available for diagnostics. Downstream consumers can exclude the transient class from per-call success rates while still counting the terminal give-up.

The classification is computed *before* the emit. Because the retry budget is bounded, whether an iteration will be retried is already known at that point, so no post-hoc correlation is needed.

Genuine truncation still routes into the existing recovery path and is retried.

## Why two reason values rather than one truncation flag

Excluding all truncation from a success rate would also hide the case where the agent retries, exhausts its budget and gives up — which the user does experience as an error. Keeping the terminal case distinct avoids trading one blind spot for another, which is the mistake that motivated this change in the first place.

## Compatibility

`reason` is a new optional field and `result` semantics are unchanged, so existing consumers are unaffected. The two string values are read by the downstream telemetry transform to emit a separate counter, so renaming either requires updating that transform first — noted in a comment on the constants.

Retry behaviour is unchanged by the telemetry commit: incrementing the counter before the emit and testing `count <= MAX_INCOMPLETE_TOOL_USE_RETRIES` preserves the existing off-by-one.

## Testing

- `agenticChatEventParser.test.ts` — 10/10 pass, including new cases for the aborted path and the zero-input path.
- `chatTelemetryController.test.ts` — 20/20 pass, including 3 new cases covering `reason` forwarding, the retrying/exhausted distinction, and that `result` stays `'Failed'`.
- `tsc --noEmit` clean for all changed files.

Not covered: no end-to-end agent-loop test asserts the `RETRYING` to `EXHAUSTED` transition at the retry-limit boundary. The existing controller test harness stubs the streaming client and could support one — happy to add it if reviewers want that boundary locked down.
