### PR TITLE
chore: merge agentic version 1.77.0

### DIFF
--- a/app/aws-lsp-codewhisperer-runtimes/src/version.json
+++ b/app/aws-lsp-codewhisperer-runtimes/src/version.json
@@ -1,3 +1,3 @@
 {
-    "agenticChat": "1.76.0"
+    "agenticChat": "1.77.0"
 }


### PR DESCRIPTION
This merges the released changes for 1.77.0 into main.

MCM-157331621
Released tag: agentic-1.77.0 (6c0422c349746336aca09948c516fdc54a6df26f)