### PR TITLE
fix(amazonq): cover merged env and headers in MCP consent fingerprint

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.test.ts
@@ -8,6 +8,8 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import {
+    effectiveEnv,
+    effectiveHeaders,
     fingerprintServerConfig,
     fingerprintWorkspace,
     hasApproval,
@@ -73,6 +75,71 @@ describe('mcpConsentStore', () => {
             const a: MCPServerConfig = { url: 'https://a.example' }
             const b: MCPServerConfig = { url: 'https://b.example' }
             expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        // __additionalEnv__ / __additionalHeaders__ are merged into the spawn env/headers,
+        // so they must be covered by the fingerprint alongside the raw fields — otherwise a
+        // post-approval config edit to those fields would not re-prompt.
+        it('differs when __additionalEnv__ is added', () => {
+            const a: MCPServerConfig = { command: 'npx', args: ['-y', 's'], env: { LOG_LEVEL: 'info' } }
+            const b: MCPServerConfig = {
+                ...a,
+                __additionalEnv__: { EXTRA: '1' },
+            }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        it('differs when __additionalEnv__ overrides an existing env value', () => {
+            const a: MCPServerConfig = { command: 'sh', args: [], env: { FOO: '1' } }
+            const b: MCPServerConfig = { command: 'sh', args: [], env: { FOO: '1' }, __additionalEnv__: { FOO: '2' } }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        it('differs when headers change', () => {
+            const a: MCPServerConfig = { url: 'https://a.example', headers: { Authorization: 'Bearer good' } }
+            const b: MCPServerConfig = { url: 'https://a.example', headers: { Authorization: 'Bearer attacker' } }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        it('differs when __additionalHeaders__ overrides an existing header', () => {
+            const a: MCPServerConfig = { url: 'https://a.example', headers: { Authorization: 'Bearer good' } }
+            const b: MCPServerConfig = {
+                url: 'https://a.example',
+                headers: { Authorization: 'Bearer good' },
+                __additionalHeaders__: { Authorization: 'Bearer attacker' },
+            }
+            expect(fingerprintServerConfig(a)).to.not.equal(fingerprintServerConfig(b))
+        })
+
+        // Consent is about what will execute, not how the config is spelled: two configs
+        // that spawn the process with the identical effective env share a fingerprint.
+        it('hashes the merged spawn env, so the same effective env matches either field', () => {
+            const viaEnv: MCPServerConfig = { command: 'sh', args: [], env: { FOO: '1' } }
+            const viaAdditional: MCPServerConfig = { command: 'sh', args: [], __additionalEnv__: { FOO: '1' } }
+            expect(fingerprintServerConfig(viaEnv)).to.equal(fingerprintServerConfig(viaAdditional))
+        })
+
+        it('is stable regardless of __additionalEnv__ key order', () => {
+            const a: MCPServerConfig = { command: 'sh', args: [], __additionalEnv__: { A: '1', B: '2' } }
+            const b: MCPServerConfig = { command: 'sh', args: [], __additionalEnv__: { B: '2', A: '1' } }
+            expect(fingerprintServerConfig(a)).to.equal(fingerprintServerConfig(b))
+        })
+    })
+
+    describe('effectiveEnv / effectiveHeaders', () => {
+        it('merges __additionalEnv__ over env, matching the spawn-time merge', () => {
+            const cfg: MCPServerConfig = { env: { A: '1', B: '2' }, __additionalEnv__: { B: 'override', C: '3' } }
+            expect(effectiveEnv(cfg)).to.deep.equal({ A: '1', B: 'override', C: '3' })
+        })
+
+        it('merges __additionalHeaders__ over headers', () => {
+            const cfg: MCPServerConfig = { headers: { X: '1' }, __additionalHeaders__: { X: '2', Y: '3' } }
+            expect(effectiveHeaders(cfg)).to.deep.equal({ X: '2', Y: '3' })
+        })
+
+        it('returns an empty object when nothing is set', () => {
+            expect(effectiveEnv({})).to.deep.equal({})
+            expect(effectiveHeaders({})).to.deep.equal({})
         })
     })
 
@@ -183,9 +250,32 @@ describe('mcpConsentStore', () => {
             const storeDir = path.join(tmpHome, '.aws', 'amazonq')
             fs.mkdirSync(storeDir, { recursive: true })
             fs.writeFileSync(path.join(storeDir, 'mcp-approvals.json'), JSON.stringify({ version: 999, approvals: [] }))
-            // record should still work (overwrites with v1)
+            // record should still work (overwrites with the current version)
             await recordApproval(workspace, logger, 'poc', cfg, configPath)
             expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.true
+        })
+
+        // STORE_VERSION 1 -> 2: v1 fingerprints were computed over a narrower field set and
+        // cannot be trusted to cover the merged env/headers, so they are discarded and the
+        // user is re-prompted once per workspace-scoped server after upgrade.
+        it('discards legacy v1 approvals so the user is re-prompted once after upgrade', async () => {
+            const storeDir = path.join(tmpHome, '.aws', 'amazonq')
+            fs.mkdirSync(storeDir, { recursive: true })
+            fs.writeFileSync(
+                path.join(storeDir, 'mcp-approvals.json'),
+                JSON.stringify({
+                    version: 1,
+                    approvals: [
+                        {
+                            serverName: 'poc',
+                            fingerprint: fingerprintServerConfig(cfg),
+                            workspaceHash: fingerprintWorkspace(configPath),
+                            approvedAt: new Date().toISOString(),
+                        },
+                    ],
+                })
+            )
+            expect(await hasApproval(workspace, logger, 'poc', cfg, configPath)).to.be.false
         })
 
         it('treats a malformed store as empty', async () => {

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpConsentStore.ts
@@ -9,7 +9,11 @@ import type { Workspace, Logging } from '@aws/language-server-runtimes/server-in
 import type { MCPServerConfig } from './mcpTypes'
 
 const APPROVALS_FILE = 'mcp-approvals.json'
-const STORE_VERSION = 1
+// v2: the fingerprint now covers the fully-merged spawn environment and headers
+// (see fingerprintServerConfig). Bumping the version discards v1 approvals, which
+// were computed over a narrower field set, so every workspace-scoped server is
+// re-consented once after upgrade.
+const STORE_VERSION = 2
 
 interface Approval {
     serverName: string
@@ -23,17 +27,49 @@ interface ApprovalStore {
     approvals: Approval[]
 }
 
+function sortedRecord(rec?: Record<string, string>): Record<string, string> {
+    return rec ? Object.fromEntries(Object.entries(rec).sort(([a], [b]) => a.localeCompare(b))) : {}
+}
+
+/**
+ * The environment the stdio transport will actually spawn the server with, as far
+ * as the config controls it. Mirrors the merge in McpManager (`cfg.env` overlaid by
+ * `cfg.__additionalEnv__`).
+ *
+ * `__additionalEnv__` carries workspace/agent-level `env` for registry servers and is
+ * NOT folded into `cfg.env`, so it must be merged here or it escapes the fingerprint.
+ */
+export function effectiveEnv(cfg: MCPServerConfig): Record<string, string> {
+    return sortedRecord({ ...(cfg.env ?? {}), ...(cfg.__additionalEnv__ ?? {}) })
+}
+
+/**
+ * The headers the HTTP/SSE transport will actually send, as far as the config
+ * controls it. Mirrors the merge in McpManager (`cfg.headers` overlaid by
+ * `cfg.__additionalHeaders__`).
+ */
+export function effectiveHeaders(cfg: MCPServerConfig): Record<string, string> {
+    return sortedRecord({ ...(cfg.headers ?? {}), ...(cfg.__additionalHeaders__ ?? {}) })
+}
+
 /**
  * SHA-256 of a canonical JSON form of the server's execution-relevant fields.
- * Any change to command/args/env/url yields a new fingerprint, invalidating
+ * Any change to command/args/env/url/headers yields a new fingerprint, invalidating
  * prior approvals — so mutation of the config re-prompts.
+ *
+ * `env` and `headers` are hashed in their *merged* form (see effectiveEnv /
+ * effectiveHeaders) so every field that reaches the spawned process is covered by
+ * consent. Two configs that spawn an identical process share a fingerprint regardless
+ * of which field supplied a value: consent is about what will execute, not how the
+ * config is spelled.
  */
 export function fingerprintServerConfig(cfg: MCPServerConfig): string {
     const canonical = {
         command: cfg.command ?? null,
         args: cfg.args ?? [],
-        env: cfg.env ? Object.fromEntries(Object.entries(cfg.env).sort(([a], [b]) => a.localeCompare(b))) : {},
+        env: effectiveEnv(cfg),
         url: cfg.url ?? null,
+        headers: effectiveHeaders(cfg),
     }
     return 'sha256:' + createHash('sha256').update(JSON.stringify(canonical)).digest('hex')
 }

--- a/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/agenticChat/tools/mcp/mcpManager.ts
@@ -42,7 +42,14 @@ import { Mutex } from 'async-mutex'
 import path = require('path')
 import { URI } from 'vscode-uri'
 import { MessageType } from '@aws/language-server-runtimes/protocol'
-import { hasApproval, recordApproval, removeApproval, fingerprintServerConfig } from './mcpConsentStore'
+import {
+    hasApproval,
+    recordApproval,
+    removeApproval,
+    fingerprintServerConfig,
+    effectiveEnv,
+    effectiveHeaders,
+} from './mcpConsentStore'
 import { sanitizeInput } from '../../../../shared/utils'
 import { ProfileStatusMonitor } from './profileStatusMonitor'
 import { OAuthClient } from './mcpOauthClient'
@@ -440,6 +447,17 @@ export class McpManager {
             )
             if (!approved) {
                 const cmdLine = [cfg.command ?? cfg.url ?? '(none)', ...(cfg.args ?? [])].join(' ').slice(0, 200)
+                // Surface the environment variables and headers the server will actually be
+                // launched with. Names only, never values: a config may legitimately hold
+                // tokens, and this string is shown in a dialog and written to logs. Values are
+                // covered by the fingerprint, so any value change re-prompts.
+                const envKeys = Object.keys(effectiveEnv(cfg))
+                const headerNames = Object.keys(effectiveHeaders(cfg))
+                const envLine =
+                    envKeys.length > 0
+                        ? `Environment variables: ${envKeys.join(', ').slice(0, 200)}\n`
+                        : `Environment variables: (none)\n`
+                const headerLine = headerNames.length > 0 ? `Headers: ${headerNames.join(', ').slice(0, 200)}\n` : ''
                 const allowBtn = { title: 'Allow for this server' }
                 const denyBtn = { title: 'Deny' }
                 let choice: { title: string } | null | undefined
@@ -451,8 +469,13 @@ export class McpManager {
                             `A workspace configuration file wants to start an MCP server.\n` +
                             `Server: ${serverName}\n` +
                             `Command: ${cmdLine}\n` +
+                            envLine +
+                            headerLine +
                             `Source: ${configPath}\n\n` +
-                            `Running this server executes the above command on your machine. ` +
+                            `Running this server executes the above command on your machine, ` +
+                            `with the environment variables listed above. ` +
+                            `Review them in the configuration file if you are unsure — variables such as ` +
+                            `NODE_OPTIONS can cause additional code to run. ` +
                             `Only allow if you trust the authors of this workspace.\n\n` +
                             `Your choice will be remembered for this workspace. ` +
                             `If you allow, you won't be asked again unless the server configuration changes.`,


### PR DESCRIPTION
Aligns the MCP server consent check with the effective (merged) server configuration used at launch, surfaces the relevant config details in the consent prompt, and re-confirms existing approvals once via a store version bump. Includes regression tests.