### PR TITLE
netTransform: surface backend interactive mode in getTransformInfo

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxModels.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxModels.ts
@@ -146,6 +146,10 @@ export interface AtxGetTransformInfoResponse {
     MissingPackageJsonPath?: string | null
     DiffApplyFailed?: boolean
     DiffApplyFailedStepIds?: string[]
+    // Interactive mode as resolved from the backend job objective (interactive_mode).
+    // Surfaced so the IDE can restore the correct mode instead of relying on its local
+    // settings store, which may be missing/stale (e.g. cold restart on another machine).
+    InteractiveMode?: InteractiveMode
 }
 
 /**

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -1770,6 +1770,12 @@ export class ATXTransformHandler {
                 result.DiffApplyFailed = true
                 result.DiffApplyFailedStepIds = diffContext.failedStepIds
             }
+            // Surface the backend-resolved interactive mode (from job.objective) on every
+            // response so the IDE can restore it. Single injection point covers all internal
+            // return paths. cachedInteractiveMode is populated in _getTransformInfoInternal.
+            if (result && this.cachedInteractiveMode) {
+                result.InteractiveMode = this.cachedInteractiveMode
+            }
             return result
         } finally {
             this._currentDiffContext = null


### PR DESCRIPTION
getTransformInfo already resolves the interactive mode from the job objective (cachedInteractiveMode) but never returned it. Add the InteractiveMode field to AtxGetTransformInfoResponse and populate it at the getTransformInfo wrapper so the IDE can restore the correct mode after a restart instead of trusting its local settings store.

Paired with the IDE change in aws-toolkit-visual-studio-staging.

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots if applicable
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
