### PR TITLE
Forward generate_unit_tests choice into ATX job objective

### DIFF
--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/atxTransformHandler.ts
@@ -472,6 +472,7 @@ export class ATXTransformHandler {
         jobName?: string
         targetFramework?: string
         interactiveMode?: InteractiveMode
+        generateUnitTests?: boolean
     }): Promise<{ jobId: string; status: string } | null> {
         try {
             this.logging.log(`ATX: Starting CreateJob for workspace: ${request.workspaceId}`)
@@ -492,6 +493,13 @@ export class ATXTransformHandler {
             const objective: any = {
                 target_framework: request.targetFramework || 'net10.0',
                 interactive_mode: interactiveModeValue,
+            }
+
+            // The customer's up-front unit-test choice. Only a real boolean counts as a choice:
+            // clients that cannot express one omit the field, and the backend keeps legacy behavior.
+            // Do NOT default this to false here - an explicit false is a decline, not "no choice".
+            if (typeof request.generateUnitTests === 'boolean') {
+                objective.generate_unit_tests = request.generateUnitTests
             }
 
             const orchestratorAgent = getAtxOrchestratorAgent()
@@ -693,6 +701,7 @@ export class ATXTransformHandler {
                 jobName: request.jobName || 'Transform Job',
                 targetFramework: (request.startTransformRequest as any).TargetFramework,
                 interactiveMode: request.interactiveMode,
+                generateUnitTests: (request.startTransformRequest as any).GenerateUnitTests,
             })
 
             if (!createJobResponse?.jobId) {

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/models.ts
@@ -23,6 +23,9 @@ export interface StartTransformRequest extends ExecuteCommandParams {
     TransformNetStandardProjects: boolean
     EnableRazorViewTransform: boolean
     EnableWebFormsTransform: boolean
+    // Customer's up-front unit-test choice, forwarded to the ATX job objective as
+    // `generate_unit_tests`. Optional: absent means "no choice sent" (legacy behavior).
+    GenerateUnitTests?: boolean
     PackageReferences?: PackageReferenceMetadata[]
     DmsArn?: string
     DatabaseSettings?: DatabaseSettings

--- a/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
+++ b/server/aws-lsp-codewhisperer/src/language-server/netTransform/tests/atxTransformHandler.test.ts
@@ -2055,6 +2055,47 @@ describe('ATXTransformHandler - lifecycle (startTransform & helpers)', () => {
             const objective = JSON.parse(command.input.objective)
             expect(objective.interactive_mode).to.equal('auto')
         })
+
+        it('should include generate_unit_tests:true in objective when opted in', async () => {
+            sendStub.resolves({ jobId: 'j', status: 'CREATED' })
+
+            await handler.createJob({ workspaceId: 'ws-1', generateUnitTests: true })
+
+            const command = sendStub.firstCall.args[0]
+            const objective = JSON.parse(command.input.objective)
+            expect(objective.generate_unit_tests).to.equal(true)
+        })
+
+        it('should include generate_unit_tests:false in objective on explicit decline', async () => {
+            sendStub.resolves({ jobId: 'j', status: 'CREATED' })
+
+            await handler.createJob({ workspaceId: 'ws-1', generateUnitTests: false })
+
+            const command = sendStub.firstCall.args[0]
+            const objective = JSON.parse(command.input.objective)
+            expect(objective.generate_unit_tests).to.equal(false)
+        })
+
+        it('should omit generate_unit_tests from objective when no choice is sent', async () => {
+            sendStub.resolves({ jobId: 'j', status: 'CREATED' })
+
+            await handler.createJob({ workspaceId: 'ws-1' })
+
+            const command = sendStub.firstCall.args[0]
+            const objective = JSON.parse(command.input.objective)
+            expect(objective).to.not.have.property('generate_unit_tests')
+        })
+
+        it('should omit generate_unit_tests when the value is not a real boolean', async () => {
+            sendStub.resolves({ jobId: 'j', status: 'CREATED' })
+
+            // A mistyped/non-boolean value must read as "no choice sent", not a decision.
+            await handler.createJob({ workspaceId: 'ws-1', generateUnitTests: 'true' as any })
+
+            const command = sendStub.firstCall.args[0]
+            const objective = JSON.parse(command.input.objective)
+            expect(objective).to.not.have.property('generate_unit_tests')
+        })
     })
 
     describe('createArtifactUploadUrl', () => {


### PR DESCRIPTION
Reads `GenerateUnitTests` from the incoming `StartTransformRequest` and includes it in the ATX CreateJob objective as `generate_unit_tests` **only when it is a real boolean** \u2014 so clients that omit it keep legacy behavior and an explicit `false` remains a decline. Adds 4 unit tests (true / false / omitted / non-boolean).

Pairs with the aws-toolkit-visual-studio-staging PR of the same feature. Matches shipped backend contract CR-298620129 (`isinstance(x, bool)`). `ATXTransformHandler` tests: 291 passing.